### PR TITLE
[BUG]: Rename database on soft delete

### DIFF
--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -185,11 +185,8 @@ func (tc *Catalog) DeleteDatabase(ctx context.Context, deleteDatabase *model.Del
 		if len(databases) == 0 {
 			return common.ErrDatabaseNotFound
 		}
-		err = tc.metaDomain.DatabaseDb(txCtx).SoftDelete(databases[0].ID)
-		if err != nil {
-			return err
-		}
 
+		// Cascade-soft-delete collections BEFORE renaming the database.
 		collections, err := tc.metaDomain.CollectionDb(txCtx).GetCollections(nil, nil, deleteDatabase.Tenant, deleteDatabase.Name, nil, nil, false)
 		if err != nil {
 			return err
@@ -209,6 +206,10 @@ func (tc *Catalog) DeleteDatabase(ctx context.Context, deleteDatabase *model.Del
 			if err != nil {
 				return err
 			}
+		}
+
+		if err := tc.metaDomain.DatabaseDb(txCtx).SoftDelete(databases[0].ID); err != nil {
+			return err
 		}
 
 		return nil
@@ -594,7 +595,11 @@ func (tc *Catalog) hardDeleteCollection(ctx context.Context, deleteCollection *m
 			return err
 		}
 
-		collectionEntry, err := tc.metaDomain.CollectionDb(txCtx).GetCollectionWithoutMetadata(types.FromUniqueID(collectionID), &deleteCollection.DatabaseName, nil)
+		// Look up by collection ID only. The database that owns this collection may
+		// have been soft-deleted (and thus renamed to "_deleted_<name>_<id>"), in
+		// which case joining on databases.name with the caller-supplied name would
+		// return nothing. Collection IDs are globally unique, so the lookup is safe.
+		collectionEntry, err := tc.metaDomain.CollectionDb(txCtx).GetCollectionWithoutMetadata(types.FromUniqueID(collectionID), nil, nil)
 		if err != nil {
 			return err
 		}

--- a/go/pkg/sysdb/metastore/db/dao/database.go
+++ b/go/pkg/sysdb/metastore/db/dao/database.go
@@ -108,9 +108,12 @@ func (s *databaseDb) Insert(database *dbmodel.Database) error {
 func (s *databaseDb) SoftDelete(databaseID string) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Table("databases").
-			Where("id = ?", databaseID).
-			Update("is_deleted", true).
-			Update("updated_at", time.Now()).
+			Where("id = ? AND is_deleted = ?", databaseID, false).
+			Updates(map[string]interface{}{
+				"name":       gorm.Expr("CONCAT('_deleted_', name, '_', id::text)"),
+				"is_deleted": true,
+				"updated_at": time.Now(),
+			}).
 			Error; err != nil {
 			return err
 		}

--- a/go/pkg/sysdb/metastore/db/dao/database_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/database_test.go
@@ -1,0 +1,99 @@
+package dao
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbmodel"
+	"github.com/chroma-core/chroma/go/pkg/types"
+	"github.com/pingcap/log"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+)
+
+type DatabaseDbTestSuite struct {
+	suite.Suite
+	db       *gorm.DB
+	Db       *databaseDb
+	TenantDb *tenantDb
+	t        *testing.T
+}
+
+func (suite *DatabaseDbTestSuite) SetupSuite() {
+	log.Info("setup suite")
+	suite.db, _ = dbcore.ConfigDatabaseForTesting()
+	suite.Db = &databaseDb{db: suite.db}
+	suite.TenantDb = &tenantDb{db: suite.db}
+}
+
+// TestDatabaseDb_SoftDeleteRenamesRow verifies that SoftDelete renames the
+// database row to "_deleted_<name>_<id>" and flips is_deleted, mirroring the
+// collection soft-delete pattern. This frees the original name for reuse.
+func (suite *DatabaseDbTestSuite) TestDatabaseDb_SoftDeleteRenamesRow() {
+	tenantID := "testSoftDeleteRenamesRow_tenant"
+	suite.Require().NoError(suite.TenantDb.Insert(&dbmodel.Tenant{ID: tenantID}))
+	defer suite.db.Delete(&dbmodel.Tenant{}, "id = ?", tenantID)
+
+	dbID := types.NewUniqueID().String()
+	originalName := "testSoftDeleteRenamesRow_db"
+	suite.Require().NoError(suite.Db.Insert(&dbmodel.Database{
+		ID:       dbID,
+		Name:     originalName,
+		TenantID: tenantID,
+	}))
+	defer suite.db.Unscoped().Delete(&dbmodel.Database{}, "id = ?", dbID)
+
+	// Sanity check: active lookups find the database by its original name.
+	active, err := suite.Db.GetDatabases(tenantID, originalName)
+	suite.Require().NoError(err)
+	suite.Require().Len(active, 1)
+	suite.Require().Equal(dbID, active[0].ID)
+
+	// Soft delete the database.
+	suite.Require().NoError(suite.Db.SoftDelete(dbID))
+
+	// Row should no longer be returned by the active-name lookup.
+	active, err = suite.Db.GetDatabases(tenantID, originalName)
+	suite.Require().NoError(err)
+	suite.Require().Empty(active)
+
+	// Fetch the raw row (bypassing the is_deleted=false filter) and assert the
+	// rename + is_deleted flag.
+	var raw dbmodel.Database
+	suite.Require().NoError(
+		suite.db.Table("databases").Where("id = ?", dbID).First(&raw).Error,
+	)
+	expectedName := fmt.Sprintf("_deleted_%s_%s", originalName, dbID)
+	suite.Require().Equal(expectedName, raw.Name)
+	suite.Require().True(raw.IsDeleted)
+
+	// The original name is now free: inserting a new database with the same
+	// (tenant_id, name) must succeed despite the uniqueIndex on that pair.
+	newID := types.NewUniqueID().String()
+	suite.Require().NoError(suite.Db.Insert(&dbmodel.Database{
+		ID:       newID,
+		Name:     originalName,
+		TenantID: tenantID,
+	}))
+	defer suite.db.Unscoped().Delete(&dbmodel.Database{}, "id = ?", newID)
+
+	active, err = suite.Db.GetDatabases(tenantID, originalName)
+	suite.Require().NoError(err)
+	suite.Require().Len(active, 1)
+	suite.Require().Equal(newID, active[0].ID)
+
+	// Re-soft-deleting an already soft-deleted database must be a no-op: the
+	// name must NOT gain another "_deleted_" prefix.
+	suite.Require().NoError(suite.Db.SoftDelete(dbID))
+	suite.Require().NoError(
+		suite.db.Table("databases").Where("id = ?", dbID).First(&raw).Error,
+	)
+	suite.Require().Equal(expectedName, raw.Name)
+}
+
+func TestDatabaseDbTestSuite(t *testing.T) {
+	testSuite := new(DatabaseDbTestSuite)
+	testSuite.t = t
+	suite.Run(t, testSuite)
+}


### PR DESCRIPTION
## Description of changes

Renames database name on soft delete. Makes sure to do this renaming + soft delete after cascading soft deletes to owned collections.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_