### PR TITLE
[ENH]: Add workflow to build and publish service container images

### DIFF
--- a/.github/actions/build_service_images/action.yaml
+++ b/.github/actions/build_service_images/action.yaml
@@ -1,0 +1,261 @@
+name: 'Build Service Images'
+description: 'Build and publish Chroma service images via docker-bake.hcl, with a short-circuit that skips the build when every target already exists in every configured registry.'
+inputs:
+  COMMIT_SHA:
+    description: 'Full commit SHA to build. Defaults to the currently-checked-out commit.'
+    required: false
+    default: ''
+  SHORT_SHA_LENGTH:
+    description: 'Length of commit SHAs to use in image tags'
+    required: false
+    default: '7'
+  PUSH:
+    description: 'Flag for whether to push built images, must be a string set to "true" to push'
+    required: false
+    default: 'false'
+  FORCE:
+    description: 'If "true", skip the short-circuit check and always rebuild/push.'
+    required: false
+    default: 'false'
+  AWS_REGION:
+    description: 'AWS region of ECR'
+    required: false
+    default: ''
+  AWS_ECR_OIDC_ARN:
+    description: 'AWS ARN of the OIDC role to assume for logging into ECR'
+    required: false
+    default: ''
+  GCP_WORKLOAD_IDENTITY_PROVIDER:
+    description: 'GCP workload identity provider'
+    required: false
+    default: ''
+  GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL:
+    description: 'GCP service account email'
+    required: false
+    default: ''
+  GCP_ARTIFACT_REGISTRY_REGION:
+    description: 'GCP artifact registry region'
+    required: false
+    default: ''
+  GCP_ARTIFACT_REGISTRY_PROJECT_ID:
+    description: 'GCP artifact registry project ID'
+    required: false
+    default: ''
+  GCP_ARTIFACT_REGISTRY_NAME:
+    description: 'GCP artifact registry name'
+    required: false
+    default: ''
+  DOCKERHUB_USERNAME:
+    description: 'DockerHub username for authentication'
+    required: false
+    default: ''
+  DOCKERHUB_TOKEN:
+    description: 'DockerHub token for authentication'
+    required: false
+    default: ''
+  ADDRESS_SANITIZER:
+    description: 'Enable Address Sanitizer for builds. Set to "1" to enable.'
+    required: false
+    default: ''
+  ENABLE_AVX512:
+    description: 'Enable AVX512 for builds. Set to "1" to enable.'
+    required: false
+    default: ''
+
+outputs:
+  skipped:
+    description: 'Whether the build+push was skipped because all target images already exist.'
+    value: ${{ steps.short-circuit.outputs.skipped }}
+  commit_short_sha:
+    description: 'Short commit SHA used for image tags.'
+    value: ${{ steps.short-shas.outputs.COMMIT_SHORT_SHA }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Blacksmith Docker cache
+      uses: useblacksmith/setup-docker-builder@v1
+
+    - name: Resolve commit SHA
+      shell: bash
+      id: resolve-sha
+      run: |
+        set -euo pipefail
+        if [[ -n "${{ inputs.COMMIT_SHA }}" ]]; then
+          echo "COMMIT_SHA=${{ inputs.COMMIT_SHA }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Compute short commit SHA
+      shell: bash
+      id: short-shas
+      run: |
+        set -euo pipefail
+        COMMIT_SHORT_SHA=$(echo "${{ steps.resolve-sha.outputs.COMMIT_SHA }}" | cut -c1-${{ inputs.SHORT_SHA_LENGTH }})
+        echo "COMMIT_SHORT_SHA=$COMMIT_SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+    - name: Configure AWS Credentials
+      if: inputs.PUSH == 'true' && inputs.AWS_REGION != '' && inputs.AWS_ECR_OIDC_ARN != ''
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: ${{ inputs.AWS_ECR_OIDC_ARN }}
+        aws-region: ${{ inputs.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      if: inputs.PUSH == 'true' && inputs.AWS_REGION != '' && inputs.AWS_ECR_OIDC_ARN != ''
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - name: Authenticate to Google Cloud
+      if: inputs.PUSH == 'true' && inputs.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && inputs.GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL != ''
+      id: auth-gcp
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ inputs.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ inputs.GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL }}
+
+    - name: Configure Docker for GCP Artifact Registry
+      if: inputs.PUSH == 'true' && inputs.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && inputs.GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL != ''
+      shell: bash
+      run: gcloud auth configure-docker '${{ inputs.GCP_ARTIFACT_REGISTRY_REGION }}-docker.pkg.dev' --quiet
+
+    - name: Login to DockerHub
+      if: inputs.PUSH == 'true' && inputs.DOCKERHUB_USERNAME != '' && inputs.DOCKERHUB_TOKEN != ''
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.DOCKERHUB_USERNAME }}
+        password: ${{ inputs.DOCKERHUB_TOKEN }}
+
+    - name: Resolve registries
+      shell: bash
+      id: get-registries
+      run: |
+        set -euo pipefail
+
+        if [[ "${{ inputs.PUSH }}" == "true" ]] && [[ -n "${{ inputs.AWS_REGION }}" ]] && [[ -n "${{ inputs.AWS_ECR_OIDC_ARN }}" ]]; then
+          echo "REGISTRY_AWS=${{ steps.login-ecr.outputs.registry }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "REGISTRY_AWS=local" >> "$GITHUB_OUTPUT"
+        fi
+
+        if [[ "${{ inputs.PUSH }}" == "true" ]] && [[ -n "${{ inputs.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ]] && [[ -n "${{ inputs.GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL }}" ]]; then
+          echo "REGISTRY_GCP=${{ inputs.GCP_ARTIFACT_REGISTRY_REGION }}-docker.pkg.dev/${{ inputs.GCP_ARTIFACT_REGISTRY_PROJECT_ID }}/${{ inputs.GCP_ARTIFACT_REGISTRY_NAME }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "REGISTRY_GCP=local" >> "$GITHUB_OUTPUT"
+        fi
+
+        if [[ "${{ inputs.PUSH }}" == "true" ]] && [[ -n "${{ inputs.DOCKERHUB_USERNAME }}" ]] && [[ -n "${{ inputs.DOCKERHUB_TOKEN }}" ]]; then
+          echo "REGISTRY_DOCKERHUB=chromadb" >> "$GITHUB_OUTPUT"
+        else
+          echo "REGISTRY_DOCKERHUB=local" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Derives the set of image refs to probe from `docker buildx bake
+    # --print`, so adding a new target to docker-bake.hcl doesn't require
+    # editing this step. LOCAL_BUILD=false ensures the printed tags are
+    # registry-qualified (the bake file only emits unqualified local tags
+    # when LOCAL_BUILD=="true").
+    - name: Short-circuit if images already exist
+      id: short-circuit
+      shell: bash
+      env:
+        LOCAL_BUILD: 'false'
+        REGISTRY_AWS: ${{ steps.get-registries.outputs.REGISTRY_AWS }}
+        REGISTRY_GCP: ${{ steps.get-registries.outputs.REGISTRY_GCP }}
+        REGISTRY_DOCKERHUB: ${{ steps.get-registries.outputs.REGISTRY_DOCKERHUB }}
+        COMMIT_SHORT_SHA: ${{ steps.short-shas.outputs.COMMIT_SHORT_SHA }}
+        ADDRESS_SANITIZER: ${{ inputs.ADDRESS_SANITIZER }}
+        ENABLE_AVX512: ${{ inputs.ENABLE_AVX512 }}
+        FORCE: ${{ inputs.FORCE }}
+        PUSH: ${{ inputs.PUSH }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$PUSH" != "true" ]]; then
+          echo "PUSH != true; short-circuit check disabled."
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "$FORCE" == "true" ]]; then
+          echo "FORCE=true; skipping short-circuit check."
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        mapfile -t refs < <(
+          docker buildx bake --print -f docker-bake.hcl \
+            | jq -r '.target | to_entries[].value.tags[]?'
+        )
+
+        if [[ ${#refs[@]} -eq 0 ]]; then
+          echo "::error::No image tags emitted by docker-bake.hcl; refusing to short-circuit."
+          exit 1
+        fi
+
+        all_present=true
+        for ref in "${refs[@]}"; do
+          if docker buildx imagetools inspect "$ref" >/dev/null 2>&1; then
+            echo "found: $ref"
+          else
+            echo "missing: $ref"
+            all_present=false
+          fi
+        done
+
+        if [[ "$all_present" == "true" ]]; then
+          echo "All images already present at tag ${COMMIT_SHORT_SHA}; skipping build+push."
+          echo "skipped=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Build pass: fails fast on real build errors. The push is split out
+    # below so registry flakes (DockerHub especially) can retry without
+    # rebuilding.
+    - name: Build service images
+      if: steps.short-circuit.outputs.skipped != 'true'
+      uses: docker/bake-action@v5
+      with:
+        push: false
+        files: docker-bake.hcl
+      env:
+        LOCAL_BUILD: ${{ inputs.PUSH == 'true' && 'false' || 'true' }}
+        REGISTRY_AWS: ${{ steps.get-registries.outputs.REGISTRY_AWS }}
+        REGISTRY_GCP: ${{ steps.get-registries.outputs.REGISTRY_GCP }}
+        REGISTRY_DOCKERHUB: ${{ steps.get-registries.outputs.REGISTRY_DOCKERHUB }}
+        COMMIT_SHORT_SHA: ${{ steps.short-shas.outputs.COMMIT_SHORT_SHA }}
+        ADDRESS_SANITIZER: ${{ inputs.ADDRESS_SANITIZER }}
+        ENABLE_AVX512: ${{ inputs.ENABLE_AVX512 }}
+
+    # Retry to absorb transient registry failures. Buildx cache + registry
+    # layer dedup make retries cheap — only whatever failed gets re-pushed.
+    - name: Push service images
+      if: inputs.PUSH == 'true' && steps.short-circuit.outputs.skipped != 'true'
+      shell: bash
+      env:
+        LOCAL_BUILD: ${{ inputs.PUSH == 'true' && 'false' || 'true' }}
+        REGISTRY_AWS: ${{ steps.get-registries.outputs.REGISTRY_AWS }}
+        REGISTRY_GCP: ${{ steps.get-registries.outputs.REGISTRY_GCP }}
+        REGISTRY_DOCKERHUB: ${{ steps.get-registries.outputs.REGISTRY_DOCKERHUB }}
+        COMMIT_SHORT_SHA: ${{ steps.short-shas.outputs.COMMIT_SHORT_SHA }}
+        ADDRESS_SANITIZER: ${{ inputs.ADDRESS_SANITIZER }}
+        ENABLE_AVX512: ${{ inputs.ENABLE_AVX512 }}
+      run: |
+        set -euo pipefail
+
+        attempts=4
+        delay=30
+        for i in $(seq 1 "$attempts"); do
+          if docker buildx bake --push -f docker-bake.hcl; then
+            exit 0
+          fi
+          if [[ "$i" -lt "$attempts" ]]; then
+            echo "::warning::docker buildx bake --push failed on attempt $i/$attempts; retrying in ${delay}s..."
+            sleep "$delay"
+            delay=$((delay * 2))
+          fi
+        done
+        echo "::error::docker buildx bake --push failed after $attempts attempts"
+        exit 1

--- a/.github/actions/build_service_images/action.yaml
+++ b/.github/actions/build_service_images/action.yaml
@@ -5,10 +5,6 @@ inputs:
     description: 'Full commit SHA to build. Defaults to the currently-checked-out commit.'
     required: false
     default: ''
-  SHORT_SHA_LENGTH:
-    description: 'Length of commit SHAs to use in image tags'
-    required: false
-    default: '7'
   PUSH:
     description: 'Flag for whether to push built images, must be a string set to "true" to push'
     required: false
@@ -78,22 +74,17 @@ runs:
 
     - name: Resolve commit SHA
       shell: bash
-      id: resolve-sha
-      run: |
-        set -euo pipefail
-        if [[ -n "${{ inputs.COMMIT_SHA }}" ]]; then
-          echo "COMMIT_SHA=${{ inputs.COMMIT_SHA }}" >> "$GITHUB_OUTPUT"
-        else
-          echo "COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Compute short commit SHA
-      shell: bash
       id: short-shas
+      env:
+        COMMIT_SHA_INPUT: ${{ inputs.COMMIT_SHA }}
       run: |
         set -euo pipefail
-        COMMIT_SHORT_SHA=$(echo "${{ steps.resolve-sha.outputs.COMMIT_SHA }}" | cut -c1-${{ inputs.SHORT_SHA_LENGTH }})
-        echo "COMMIT_SHORT_SHA=$COMMIT_SHORT_SHA" >> "$GITHUB_OUTPUT"
+        if [[ -n "$COMMIT_SHA_INPUT" ]]; then
+          COMMIT_SHA="$COMMIT_SHA_INPUT"
+        else
+          COMMIT_SHA=$(git rev-parse HEAD)
+        fi
+        echo "COMMIT_SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
     - name: Configure AWS Credentials
       if: inputs.PUSH == 'true' && inputs.AWS_REGION != '' && inputs.AWS_ECR_OIDC_ARN != ''

--- a/.github/actions/build_service_images/action.yaml
+++ b/.github/actions/build_service_images/action.yaml
@@ -15,40 +15,31 @@ inputs:
     default: 'false'
   AWS_REGION:
     description: 'AWS region of ECR'
-    required: false
-    default: ''
+    required: true
   AWS_ECR_OIDC_ARN:
     description: 'AWS ARN of the OIDC role to assume for logging into ECR'
-    required: false
-    default: ''
+    required: true
   GCP_WORKLOAD_IDENTITY_PROVIDER:
     description: 'GCP workload identity provider'
-    required: false
-    default: ''
+    required: true
   GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL:
     description: 'GCP service account email'
-    required: false
-    default: ''
+    required: true
   GCP_ARTIFACT_REGISTRY_REGION:
     description: 'GCP artifact registry region'
-    required: false
-    default: ''
+    required: true
   GCP_ARTIFACT_REGISTRY_PROJECT_ID:
     description: 'GCP artifact registry project ID'
-    required: false
-    default: ''
+    required: true
   GCP_ARTIFACT_REGISTRY_NAME:
     description: 'GCP artifact registry name'
-    required: false
-    default: ''
+    required: true
   DOCKERHUB_USERNAME:
     description: 'DockerHub username for authentication'
-    required: false
-    default: ''
+    required: true
   DOCKERHUB_TOKEN:
     description: 'DockerHub token for authentication'
-    required: false
-    default: ''
+    required: true
   ADDRESS_SANITIZER:
     description: 'Enable Address Sanitizer for builds. Set to "1" to enable.'
     required: false
@@ -87,19 +78,19 @@ runs:
         echo "COMMIT_SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
     - name: Configure AWS Credentials
-      if: inputs.PUSH == 'true' && inputs.AWS_REGION != '' && inputs.AWS_ECR_OIDC_ARN != ''
+      if: inputs.PUSH == 'true'
       uses: aws-actions/configure-aws-credentials@v3
       with:
         role-to-assume: ${{ inputs.AWS_ECR_OIDC_ARN }}
         aws-region: ${{ inputs.AWS_REGION }}
 
     - name: Login to Amazon ECR
-      if: inputs.PUSH == 'true' && inputs.AWS_REGION != '' && inputs.AWS_ECR_OIDC_ARN != ''
+      if: inputs.PUSH == 'true'
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
 
     - name: Authenticate to Google Cloud
-      if: inputs.PUSH == 'true' && inputs.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && inputs.GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL != ''
+      if: inputs.PUSH == 'true'
       id: auth-gcp
       uses: google-github-actions/auth@v2
       with:
@@ -107,12 +98,14 @@ runs:
         service_account: ${{ inputs.GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL }}
 
     - name: Configure Docker for GCP Artifact Registry
-      if: inputs.PUSH == 'true' && inputs.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && inputs.GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL != ''
+      if: inputs.PUSH == 'true'
       shell: bash
-      run: gcloud auth configure-docker '${{ inputs.GCP_ARTIFACT_REGISTRY_REGION }}-docker.pkg.dev' --quiet
+      env:
+        GCP_AR_REGION: ${{ inputs.GCP_ARTIFACT_REGISTRY_REGION }}
+      run: gcloud auth configure-docker "${GCP_AR_REGION}-docker.pkg.dev" --quiet
 
     - name: Login to DockerHub
-      if: inputs.PUSH == 'true' && inputs.DOCKERHUB_USERNAME != '' && inputs.DOCKERHUB_TOKEN != ''
+      if: inputs.PUSH == 'true'
       uses: docker/login-action@v3
       with:
         username: ${{ inputs.DOCKERHUB_USERNAME }}
@@ -121,25 +114,23 @@ runs:
     - name: Resolve registries
       shell: bash
       id: get-registries
+      env:
+        PUSH: ${{ inputs.PUSH }}
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        GCP_AR_REGION: ${{ inputs.GCP_ARTIFACT_REGISTRY_REGION }}
+        GCP_AR_PROJECT: ${{ inputs.GCP_ARTIFACT_REGISTRY_PROJECT_ID }}
+        GCP_AR_NAME: ${{ inputs.GCP_ARTIFACT_REGISTRY_NAME }}
       run: |
         set -euo pipefail
 
-        if [[ "${{ inputs.PUSH }}" == "true" ]] && [[ -n "${{ inputs.AWS_REGION }}" ]] && [[ -n "${{ inputs.AWS_ECR_OIDC_ARN }}" ]]; then
-          echo "REGISTRY_AWS=${{ steps.login-ecr.outputs.registry }}" >> "$GITHUB_OUTPUT"
+        if [[ "$PUSH" == "true" ]]; then
+          printf '%s\n' "REGISTRY_AWS=${ECR_REGISTRY}" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "REGISTRY_GCP=${GCP_AR_REGION}-docker.pkg.dev/${GCP_AR_PROJECT}/${GCP_AR_NAME}" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "REGISTRY_DOCKERHUB=chromadb" >> "$GITHUB_OUTPUT"
         else
-          echo "REGISTRY_AWS=local" >> "$GITHUB_OUTPUT"
-        fi
-
-        if [[ "${{ inputs.PUSH }}" == "true" ]] && [[ -n "${{ inputs.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ]] && [[ -n "${{ inputs.GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL }}" ]]; then
-          echo "REGISTRY_GCP=${{ inputs.GCP_ARTIFACT_REGISTRY_REGION }}-docker.pkg.dev/${{ inputs.GCP_ARTIFACT_REGISTRY_PROJECT_ID }}/${{ inputs.GCP_ARTIFACT_REGISTRY_NAME }}" >> "$GITHUB_OUTPUT"
-        else
-          echo "REGISTRY_GCP=local" >> "$GITHUB_OUTPUT"
-        fi
-
-        if [[ "${{ inputs.PUSH }}" == "true" ]] && [[ -n "${{ inputs.DOCKERHUB_USERNAME }}" ]] && [[ -n "${{ inputs.DOCKERHUB_TOKEN }}" ]]; then
-          echo "REGISTRY_DOCKERHUB=chromadb" >> "$GITHUB_OUTPUT"
-        else
-          echo "REGISTRY_DOCKERHUB=local" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "REGISTRY_AWS=local" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "REGISTRY_GCP=local" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "REGISTRY_DOCKERHUB=local" >> "$GITHUB_OUTPUT"
         fi
 
     # Derives the set of image refs to probe from `docker buildx bake

--- a/.github/workflows/_build_release_service_images.yml
+++ b/.github/workflows/_build_release_service_images.yml
@@ -1,0 +1,126 @@
+name: Build and publish service images
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit-sha:
+        description: 'Full commit SHA to build. Defaults to the currently-checked-out commit.'
+        required: false
+        default: ''
+      address_sanitizer:
+        description: 'Enable Address Sanitizer for builds. Set to "1" to enable.'
+        required: false
+        default: ''
+      enable_avx512:
+        description: 'Enable AVX512 for builds. Set to "1" to enable.'
+        required: false
+        default: ''
+      force:
+        description: 'Skip the short-circuit check and always rebuild/push.'
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      commit-sha:
+        description: 'Full commit SHA to build. Defaults to the currently-checked-out commit.'
+        type: string
+        required: false
+        default: ''
+      address_sanitizer:
+        description: 'Enable Address Sanitizer for builds. Set to "1" to enable.'
+        type: string
+        required: false
+        default: ''
+      enable_avx512:
+        description: 'Enable AVX512 for builds. Set to "1" to enable.'
+        type: string
+        required: false
+        default: ''
+      force:
+        description: 'Skip the short-circuit check and always rebuild/push.'
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'DockerHub username for authentication'
+        required: false
+      DOCKERHUB_TOKEN:
+        description: 'DockerHub token for authentication'
+        required: false
+    outputs:
+      skipped:
+        description: 'Whether the build+push was skipped because all images already existed.'
+        value: ${{ jobs.build.outputs.skipped }}
+      commit_short_sha:
+        description: 'Short commit SHA used for the image tags.'
+        value: ${{ jobs.build.outputs.commit_short_sha }}
+
+env:
+  AWS_REGION: us-east-1
+
+# Avoid two concurrent runs building the same commit. A second trigger
+# waits for the first; when it runs, the short-circuit will hit and it
+# exits quickly.
+concurrency:
+  group: build-service-images-${{ inputs.commit-sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      skipped: ${{ steps.bake.outputs.skipped }}
+      commit_short_sha: ${{ steps.bake.outputs.commit_short_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-sha || github.sha }}
+
+      - name: Build and publish
+        id: bake
+        uses: ./.github/actions/build_service_images
+        with:
+          COMMIT_SHA: ${{ inputs.commit-sha || github.sha }}
+          PUSH: 'true'
+          FORCE: ${{ inputs.force && 'true' || 'false' }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_OIDC_ARN: ${{ vars.AWS_ECR_OIDC_ARN }}
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL: ${{ vars.GCP_GITHUB_ACTIONS_SERVICE_ACCOUNT_EMAIL }}
+          GCP_ARTIFACT_REGISTRY_REGION: ${{ vars.GCP_ARTIFACT_REGISTRY_REGION }}
+          GCP_ARTIFACT_REGISTRY_PROJECT_ID: ${{ vars.GCP_ARTIFACT_REGISTRY_PROJECT_ID }}
+          GCP_ARTIFACT_REGISTRY_NAME: ${{ vars.GCP_ARTIFACT_REGISTRY_NAME }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          ADDRESS_SANITIZER: ${{ inputs.address_sanitizer }}
+          ENABLE_AVX512: ${{ inputs.enable_avx512 }}
+
+  notify-slack-on-failure:
+    name: Notify Slack on build failure
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    needs:
+      - build
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          token: '${{ secrets.SLACK_BOT_TOKEN }}'
+          method: chat.postMessage
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: |
+              :x: *Service Image Build Failed!*
+              *Workflow:* ${{ github.workflow }}
+              *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+              *Ref:* <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.ref_name }}>
+              *Author:* ${{ github.actor }}
+              *Commit SHA:* ${{ inputs.commit-sha || github.sha }}
+              *Address Sanitizer:* ${{ inputs.address_sanitizer || 'disabled' }}
+              *AVX512:* ${{ inputs.enable_avx512 || 'disabled' }}

--- a/.github/workflows/_build_release_service_images.yml
+++ b/.github/workflows/_build_release_service_images.yml
@@ -49,6 +49,12 @@ on:
       DOCKERHUB_TOKEN:
         description: 'DockerHub token for authentication'
         required: false
+      SLACK_BOT_TOKEN:
+        description: 'Slack bot token for failure notifications'
+        required: true
+      SLACK_CHANNEL_ID:
+        description: 'Slack channel ID for failure notifications'
+        required: true
     outputs:
       skipped:
         description: 'Whether the build+push was skipped because all images already existed.'

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -13,8 +13,9 @@ target "compactor-service" {
   context    = "."
   dockerfile = "rust/Dockerfile"
   args = {
-    "RELEASE_MODE"  = "1"
-    "ENABLE_AVX512" = "${ENABLE_AVX512}"
+    "RELEASE_MODE"      = "1"
+    "ENABLE_AVX512"     = "${ENABLE_AVX512}"
+    "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "compaction_service"
   tags = flatten([
@@ -78,7 +79,8 @@ target "heap-tender-service" {
   context    = "."
   dockerfile = "rust/Dockerfile"
   args = {
-    "RELEASE_MODE" = "1"
+    "RELEASE_MODE"      = "1"
+    "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "heap_tender_service"
   tags = flatten([
@@ -99,8 +101,9 @@ target "query-service" {
   context    = "."
   dockerfile = "rust/Dockerfile"
   args = {
-    "RELEASE_MODE"  = "1"
-    "ENABLE_AVX512" = "${ENABLE_AVX512}"
+    "RELEASE_MODE"      = "1"
+    "ENABLE_AVX512"     = "${ENABLE_AVX512}"
+    "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "query_service"
   tags = flatten([
@@ -121,7 +124,8 @@ target "garbage-collector" {
   context    = "."
   dockerfile = "rust/Dockerfile"
   args = {
-    "RELEASE_MODE" = "1"
+    "RELEASE_MODE"      = "1"
+    "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "garbage_collector"
   tags = flatten([
@@ -178,7 +182,8 @@ target "rust-sysdb-migration" {
   context    = "."
   dockerfile = "rust/Dockerfile"
   args = {
-    "RELEASE_MODE" = "1"
+    "RELEASE_MODE"      = "1"
+    "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "rust-sysdb-migration"
   tags = flatten([
@@ -199,7 +204,8 @@ target "rust-sysdb-service" {
   context    = "."
   dockerfile = "rust/Dockerfile"
   args = {
-    "RELEASE_MODE" = "1"
+    "RELEASE_MODE"      = "1"
+    "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "sysdb_service"
   tags = flatten([
@@ -220,7 +226,8 @@ target "load-service" {
   context    = "."
   dockerfile = "rust/Dockerfile"
   args = {
-    "RELEASE_MODE" = "1"
+    "RELEASE_MODE"      = "1"
+    "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "load_service"
   tags = flatten([

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,18 +18,11 @@ target "compactor-service" {
     "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "compaction_service"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/compactor-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/compactor-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/compactor-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["compactor-service:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["compactor-service:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/compactor-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/compactor-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/compactor-service:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 target "rust-frontend-service-oss" {
@@ -39,18 +32,11 @@ target "rust-frontend-service-oss" {
     "RELEASE_MODE" = "1"
   }
   target = "cli"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/rust-frontend-service-oss:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/rust-frontend-service-oss:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/rust-frontend-service-oss:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["rust-frontend-service-oss:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["rust-frontend-service-oss:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/rust-frontend-service-oss:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/rust-frontend-service-oss:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/rust-frontend-service-oss:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 target "rust-log-service" {
@@ -61,18 +47,11 @@ target "rust-log-service" {
     "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "log_service"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/rust-log-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/rust-log-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/rust-log-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["rust-log-service:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["rust-log-service:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/rust-log-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/rust-log-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/rust-log-service:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 target "heap-tender-service" {
@@ -83,18 +62,11 @@ target "heap-tender-service" {
     "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "heap_tender_service"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/heap-tender-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/heap-tender-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/heap-tender-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["heap-tender-service:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["heap-tender-service:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/heap-tender-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/heap-tender-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/heap-tender-service:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 target "query-service" {
@@ -106,18 +78,11 @@ target "query-service" {
     "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "query_service"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/query-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/query-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/query-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["query-service:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["query-service:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/query-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/query-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/query-service:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 target "garbage-collector" {
@@ -128,54 +93,33 @@ target "garbage-collector" {
     "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "garbage_collector"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/garbage-collector-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/garbage-collector-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/garbage-collector-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["garbage-collector-service:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["garbage-collector-service:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/garbage-collector-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/garbage-collector-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/garbage-collector-service:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 target "sysdb-migration" {
   context    = "."
   dockerfile = "go/Dockerfile.migration"
   target     = "sysdb-migration"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/sysdb-migration:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/sysdb-migration:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/sysdb-migration:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["sysdb-migration:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["sysdb-migration:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/sysdb-migration:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/sysdb-migration:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/sysdb-migration:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 target "sysdb-service" {
   context    = "."
   dockerfile = "go/Dockerfile"
   target     = "sysdb"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/sysdb-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/sysdb-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/sysdb-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["sysdb-service:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["sysdb-service:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/sysdb-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/sysdb-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/sysdb-service:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 target "rust-sysdb-migration" {
@@ -186,18 +130,11 @@ target "rust-sysdb-migration" {
     "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "rust-sysdb-migration"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/rust-sysdb-migration:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/rust-sysdb-migration:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/rust-sysdb-migration:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["rust-sysdb-migration:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["rust-sysdb-migration:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/rust-sysdb-migration:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/rust-sysdb-migration:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/rust-sysdb-migration:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 target "rust-sysdb-service" {
@@ -208,18 +145,11 @@ target "rust-sysdb-service" {
     "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "sysdb_service"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/rust-sysdb-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/rust-sysdb-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/rust-sysdb-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["rust-sysdb-service:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["rust-sysdb-service:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/rust-sysdb-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/rust-sysdb-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/rust-sysdb-service:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 target "load-service" {
@@ -230,18 +160,11 @@ target "load-service" {
     "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "load_service"
-  tags = flatten([
-    REGISTRY_AWS != "local" ? [
-      "${REGISTRY_AWS}/load-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_GCP != "local" ? [
-      "${REGISTRY_GCP}/load-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    REGISTRY_DOCKERHUB != "local" ? [
-      "${REGISTRY_DOCKERHUB}/load-service:${COMMIT_SHORT_SHA}"
-    ] : [],
-    LOCAL_BUILD == "true" ? ["load-service:${COMMIT_SHORT_SHA}"] : [],
-  ])
+  tags = LOCAL_BUILD == "true" ? ["load-service:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/load-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/load-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/load-service:${COMMIT_SHORT_SHA}",
+  ]
 }
 
 group "default" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,254 @@
+# Bake targets for Chroma service images published by this repo.
+# Context is the repo root; each target maps to a stage in rust/Dockerfile,
+# go/Dockerfile, or go/Dockerfile.migration.
+variable "LOCAL_BUILD" {}
+variable "REGISTRY_AWS" {}
+variable "REGISTRY_GCP" {}
+variable "REGISTRY_DOCKERHUB" {}
+variable "COMMIT_SHORT_SHA" {}
+variable "ADDRESS_SANITIZER" {}
+variable "ENABLE_AVX512" {}
+
+target "compactor-service" {
+  context    = "."
+  dockerfile = "rust/Dockerfile"
+  args = {
+    "RELEASE_MODE"  = "1"
+    "ENABLE_AVX512" = "${ENABLE_AVX512}"
+  }
+  target = "compaction_service"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/compactor-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/compactor-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/compactor-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["compactor-service:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+target "rust-frontend-service-oss" {
+  context    = "."
+  dockerfile = "rust/Dockerfile"
+  args = {
+    "RELEASE_MODE" = "1"
+  }
+  target = "cli"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/rust-frontend-service-oss:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/rust-frontend-service-oss:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/rust-frontend-service-oss:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["rust-frontend-service-oss:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+target "rust-log-service" {
+  context    = "."
+  dockerfile = "rust/Dockerfile"
+  args = {
+    "RELEASE_MODE"      = "1"
+    "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
+  }
+  target = "log_service"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/rust-log-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/rust-log-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/rust-log-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["rust-log-service:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+target "heap-tender-service" {
+  context    = "."
+  dockerfile = "rust/Dockerfile"
+  args = {
+    "RELEASE_MODE" = "1"
+  }
+  target = "heap_tender_service"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/heap-tender-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/heap-tender-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/heap-tender-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["heap-tender-service:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+target "query-service" {
+  context    = "."
+  dockerfile = "rust/Dockerfile"
+  args = {
+    "RELEASE_MODE"  = "1"
+    "ENABLE_AVX512" = "${ENABLE_AVX512}"
+  }
+  target = "query_service"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/query-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/query-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/query-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["query-service:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+target "garbage-collector" {
+  context    = "."
+  dockerfile = "rust/Dockerfile"
+  args = {
+    "RELEASE_MODE" = "1"
+  }
+  target = "garbage_collector"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/garbage-collector-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/garbage-collector-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/garbage-collector-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["garbage-collector-service:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+target "sysdb-migration" {
+  context    = "."
+  dockerfile = "go/Dockerfile.migration"
+  target     = "sysdb-migration"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/sysdb-migration:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/sysdb-migration:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/sysdb-migration:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["sysdb-migration:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+target "sysdb-service" {
+  context    = "."
+  dockerfile = "go/Dockerfile"
+  target     = "sysdb"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/sysdb-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/sysdb-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/sysdb-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["sysdb-service:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+target "rust-sysdb-migration" {
+  context    = "."
+  dockerfile = "rust/Dockerfile"
+  args = {
+    "RELEASE_MODE" = "1"
+  }
+  target = "rust-sysdb-migration"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/rust-sysdb-migration:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/rust-sysdb-migration:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/rust-sysdb-migration:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["rust-sysdb-migration:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+target "rust-sysdb-service" {
+  context    = "."
+  dockerfile = "rust/Dockerfile"
+  args = {
+    "RELEASE_MODE" = "1"
+  }
+  target = "sysdb_service"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/rust-sysdb-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/rust-sysdb-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/rust-sysdb-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["rust-sysdb-service:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+target "load-service" {
+  context    = "."
+  dockerfile = "rust/Dockerfile"
+  args = {
+    "RELEASE_MODE" = "1"
+  }
+  target = "load_service"
+  tags = flatten([
+    REGISTRY_AWS != "local" ? [
+      "${REGISTRY_AWS}/load-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_GCP != "local" ? [
+      "${REGISTRY_GCP}/load-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    REGISTRY_DOCKERHUB != "local" ? [
+      "${REGISTRY_DOCKERHUB}/load-service:${COMMIT_SHORT_SHA}"
+    ] : [],
+    LOCAL_BUILD == "true" ? ["load-service:${COMMIT_SHORT_SHA}"] : [],
+  ])
+}
+
+group "default" {
+  targets = [
+    "compactor-service",
+    "rust-frontend-service-oss",
+    "rust-log-service",
+    "heap-tender-service",
+    "query-service",
+    "garbage-collector",
+    "sysdb-migration",
+    "sysdb-service",
+    "rust-sysdb-migration",
+    "rust-sysdb-service",
+    "load-service",
+  ]
+}


### PR DESCRIPTION
## Description of changes

Adds the plumbing for this repo to build and push its own service container images (compactor-service, query-service, rust-log-service, sysdb-service, garbage-collector-service, etc.). Nothing calls the workflow yet — this is the dormant foundation for later wiring.

- docker-bake.hcl: 11 service targets covering the Rust and Go service stages in rust/Dockerfile, go/Dockerfile, and go/Dockerfile.migration. HCL variables (REGISTRY_AWS/GCP/DOCKERHUB, LOCAL_BUILD, COMMIT_SHORT_SHA, ADDRESS_SANITIZER, ENABLE_AVX512) drive registry fan-out and tag generation, with conditional blocks so unset registries are skipped.

- .github/actions/build_service_images: composite action that auths to ECR (OIDC), GCP Artifact Registry (Workload Identity), and Docker Hub, then bakes and pushes with a 4x exponential-backoff retry on push. Includes a short-circuit that runs "docker buildx bake --print" and probes every emitted tag via "docker buildx imagetools inspect"; if all targets already exist in every configured registry, the build and push steps are skipped. Deriving the probe set from bake --print means new targets added to docker-bake.hcl are picked up without editing the action.

- .github/workflows/_build_release_service_images.yml: reusable workflow (workflow_call + workflow_dispatch) that wraps the action. Concurrency group keyed on commit SHA so duplicate triggers for the same commit serialize and then short-circuit. Emits "skipped" and "commit_short_sha" outputs for callers.

## Test plan

Manually run for a couple of different SHAs, double-check:
- [ ] The short-circuit works correctly
- [ ] It is able to authenticate to the upstream registries (todo: add those secrets)
- [ ] It is able to push images to the upstream registries

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
