### PR TITLE
[ENH](garbage_collector): add MCMR support for log GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3885,6 +3885,8 @@ dependencies = [
  "clap",
  "figment",
  "futures",
+ "gcloud-gax",
+ "gcloud-spanner",
  "humantime",
  "indicatif",
  "itertools 0.13.0",

--- a/rust/garbage_collector/Cargo.toml
+++ b/rust/garbage_collector/Cargo.toml
@@ -40,6 +40,8 @@ tracing-subscriber = { workspace = true }
 indicatif = { workspace = true }
 sqlx = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+google-cloud-gax = { workspace = true }
+google-cloud-spanner = { workspace = true }
 
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }

--- a/rust/garbage_collector/src/bin/garbage_collector_tool.rs
+++ b/rust/garbage_collector/src/bin/garbage_collector_tool.rs
@@ -15,7 +15,8 @@ use clap::Parser;
 use futures::StreamExt;
 use garbage_collector_library::{
     config::GarbageCollectorConfig,
-    garbage_collector_orchestrator_v2::GarbageCollectorOrchestrator, types::CleanupMode,
+    garbage_collector_orchestrator_v2::GarbageCollectorOrchestrator,
+    mcmr::instantiate_regions_and_topologies, types::CleanupMode,
 };
 use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
@@ -189,7 +190,7 @@ async fn main() {
             let registry = chroma_config::registry::Registry::new();
             let config = GarbageCollectorConfig::load_from_path(&config_path);
 
-            let log_client = Log::try_from_config(&(config.log, system.clone()), &registry)
+            let log_client = Log::try_from_config(&(config.log.clone(), system.clone()), &registry)
                 .await
                 .unwrap();
 
@@ -199,7 +200,8 @@ async fn main() {
 
             let dispatcher_handle = system.start_component(dispatcher);
 
-            let storage_client = Storage::try_from_config(&config.storage_config, &registry)
+            let storage_client = config
+                .instantiate_storage(&registry)
                 .await
                 .expect("Failed to create storage client");
 
@@ -218,6 +220,12 @@ async fn main() {
                     .await
                     .unwrap();
             let root_manager = RootManager::new(storage_client.clone(), root_manager_cache);
+            let regions_and_topologies = instantiate_regions_and_topologies(
+                config.regions_and_topologies.clone(),
+                &registry,
+            )
+            .await
+            .expect("Failed to create regions_and_topologies");
 
             let mut collections = sysdb_client
                 .get_collections(GetCollectionsOptions {
@@ -254,6 +262,7 @@ async fn main() {
                 system.clone(),
                 storage_client,
                 log_client,
+                regions_and_topologies,
                 root_manager,
                 cleanup_mode.into(),
                 config.min_versions_to_keep,
@@ -287,7 +296,8 @@ async fn main() {
             let registry = chroma_config::registry::Registry::new();
             let config = GarbageCollectorConfig::load_from_path(&config_path);
 
-            let storage_client = Storage::try_from_config(&config.storage_config, &registry)
+            let storage_client = config
+                .instantiate_storage(&registry)
                 .await
                 .expect("Failed to create storage client");
 

--- a/rust/garbage_collector/src/config.rs
+++ b/rust/garbage_collector/src/config.rs
@@ -1,7 +1,10 @@
 use chroma_cache::CacheConfig;
 use chroma_config::helpers::deserialize_duration_from_seconds;
+use chroma_config::{registry::Registry, Configurable};
+use chroma_error::{ChromaError, ErrorCodes};
 use chroma_log::config::LogConfig;
 use chroma_storage::config::StorageConfig;
+use chroma_storage::Storage;
 use chroma_system::DispatcherConfig;
 use chroma_tracing::{OtelFilter, OtelFilterLevel};
 use chroma_types::CollectionUuid;
@@ -11,7 +14,9 @@ use std::{
     time::Duration,
 };
 
+use crate::mcmr::RegionsAndTopologiesConfig;
 use crate::types::CleanupMode;
+use thiserror::Error;
 
 const DEFAULT_CONFIG_PATH: &str = "./garbage_collector_config.yaml";
 
@@ -54,8 +59,11 @@ pub struct GarbageCollectorConfig {
     pub sysdb_config: chroma_sysdb::GrpcSysDbConfig,
     #[serde(default)]
     pub mcmr_sysdb_config: Option<chroma_sysdb::GrpcSysDbConfig>,
+    #[serde(default)]
+    pub regions_and_topologies: Option<RegionsAndTopologiesConfig>,
     pub dispatcher_config: DispatcherConfig,
-    pub storage_config: StorageConfig,
+    #[serde(default)]
+    pub storage_config: Option<StorageConfig>,
     #[serde(default)]
     pub(super) default_mode: CleanupMode,
     #[serde(default)]
@@ -83,6 +91,24 @@ pub struct GarbageCollectorConfig {
     pub max_attached_functions_to_gc_per_run: i32,
 }
 
+#[derive(Debug, Error)]
+pub enum GarbageCollectorConfigError {
+    #[error(
+        "storage_config and regions_and_topologies are mutually exclusive; exactly one must be set"
+    )]
+    StorageAndRegionsMutuallyExclusive,
+    #[error("exactly one of storage_config or regions_and_topologies must be set")]
+    MissingStorageAndRegions,
+    #[error("preferred region {preferred_region} not found in regions_and_topologies")]
+    MissingPreferredRegion { preferred_region: String },
+}
+
+impl ChromaError for GarbageCollectorConfigError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::InvalidArgument
+    }
+}
+
 impl GarbageCollectorConfig {
     fn default_min_versions_to_keep() -> u32 {
         2
@@ -101,6 +127,16 @@ impl GarbageCollectorConfig {
     }
 
     pub fn load_from_path(path: &str) -> Self {
+        println!("loading config from {path}");
+        println!(
+            r#"Full config is:
+================================================================================
+{}
+================================================================================
+"#,
+            std::fs::read_to_string(path)
+                .expect("should be able to open and read config to string")
+        );
         // Unfortunately, figment doesn't support environment variables with underscores. So we have to map and replace them.
         // Excluding our own environment variables, which are prefixed with CHROMA_.
         let mut f = figment::Figment::from(Env::prefixed("CHROMA_GC_").map(|k| match k {
@@ -152,13 +188,76 @@ impl GarbageCollectorConfig {
     fn enable_log_gc_for_tenant_threshold() -> String {
         "00000000-0000-0000-0000-000000000000".to_string()
     }
+
+    pub fn validate_storage_xor(&self) -> Result<(), Box<dyn ChromaError>> {
+        let storage_set = self.storage_config.is_some();
+        let regions_set = self.regions_and_topologies.is_some();
+
+        match (storage_set, regions_set) {
+            (true, true) => Err(Box::new(
+                GarbageCollectorConfigError::StorageAndRegionsMutuallyExclusive,
+            )),
+            (false, false) => Err(Box::new(
+                GarbageCollectorConfigError::MissingStorageAndRegions,
+            )),
+            (true, false) | (false, true) => Ok(()),
+        }
+    }
+
+    pub async fn instantiate_storage(
+        &self,
+        registry: &Registry,
+    ) -> Result<Storage, Box<dyn ChromaError>> {
+        self.validate_storage_xor()?;
+        if let Some(storage_config) = &self.storage_config {
+            return Storage::try_from_config(storage_config, registry).await;
+        }
+
+        let regions_and_topologies =
+            self.regions_and_topologies
+                .as_ref()
+                .ok_or_else(|| -> Box<dyn ChromaError> {
+                    Box::new(GarbageCollectorConfigError::MissingStorageAndRegions)
+                })?;
+        let preferred_region = regions_and_topologies
+            .preferred_region_config()
+            .ok_or_else(|| -> Box<dyn ChromaError> {
+                Box::new(GarbageCollectorConfigError::MissingPreferredRegion {
+                    preferred_region: regions_and_topologies.preferred.to_string(),
+                })
+            })?;
+
+        Storage::try_from_config(&preferred_region.storage, registry).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use chroma_storage::config::S3CredentialsConfig;
+    use chroma_storage::config::{LocalStorageConfig, S3CredentialsConfig};
+    use chroma_types::{MultiCloudMultiRegionConfiguration, ProviderRegion, RegionName};
+
+    use crate::mcmr::RegionalStorageConfig;
 
     use super::*;
+
+    fn local_storage_config(root: String) -> StorageConfig {
+        StorageConfig::Local(LocalStorageConfig { root })
+    }
+
+    fn regions_and_topologies(storage: StorageConfig) -> RegionsAndTopologiesConfig {
+        let region_name = RegionName::new("test-region").unwrap();
+        MultiCloudMultiRegionConfiguration::new(
+            region_name.clone(),
+            vec![ProviderRegion::new(
+                region_name,
+                "test-provider",
+                "test-location",
+                RegionalStorageConfig { storage },
+            )],
+            vec![],
+        )
+        .unwrap()
+    }
 
     #[test]
     fn test_load_config() {
@@ -180,7 +279,7 @@ mod tests {
         assert_eq!(config.dispatcher_config.num_worker_threads, 4);
         assert_eq!(config.dispatcher_config.dispatcher_queue_size, 100);
         assert_eq!(config.dispatcher_config.worker_queue_size, 100);
-        match config.storage_config {
+        match config.storage_config.expect("storage_config should be set") {
             StorageConfig::S3(storage_config) => {
                 assert_eq!(storage_config.bucket, "chroma-storage");
                 if let S3CredentialsConfig::Minio = storage_config.credentials {
@@ -196,5 +295,90 @@ mod tests {
             }
             _ => panic!("Expected S3 storage config"),
         }
+    }
+
+    #[test]
+    fn validate_storage_xor_allows_storage_only() {
+        let config = GarbageCollectorConfig {
+            storage_config: Some(StorageConfig::default()),
+            regions_and_topologies: None,
+            ..Default::default()
+        };
+
+        config
+            .validate_storage_xor()
+            .expect("storage-only config should pass");
+    }
+
+    #[test]
+    fn validate_storage_xor_allows_regions_only() {
+        let config = GarbageCollectorConfig {
+            storage_config: None,
+            regions_and_topologies: Some(regions_and_topologies(StorageConfig::default())),
+            ..Default::default()
+        };
+
+        config
+            .validate_storage_xor()
+            .expect("regions-only config should pass");
+    }
+
+    #[test]
+    fn validate_storage_xor_rejects_both_sources() {
+        let config = GarbageCollectorConfig {
+            storage_config: Some(StorageConfig::default()),
+            regions_and_topologies: Some(regions_and_topologies(StorageConfig::default())),
+            ..Default::default()
+        };
+
+        let err = config
+            .validate_storage_xor()
+            .expect_err("both storage config sources should fail");
+        assert!(
+            err.to_string()
+                .contains("storage_config and regions_and_topologies are mutually exclusive"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_storage_xor_rejects_neither_source() {
+        let config = GarbageCollectorConfig {
+            storage_config: None,
+            regions_and_topologies: None,
+            ..Default::default()
+        };
+
+        let err = config
+            .validate_storage_xor()
+            .expect_err("missing storage config sources should fail");
+        assert!(
+            err.to_string()
+                .contains("exactly one of storage_config or regions_and_topologies must be set"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn instantiate_storage_uses_preferred_region_when_storage_config_is_absent() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config = GarbageCollectorConfig {
+            storage_config: None,
+            regions_and_topologies: Some(regions_and_topologies(local_storage_config(
+                temp_dir.path().to_str().unwrap().to_string(),
+            ))),
+            ..Default::default()
+        };
+        let registry = Registry::new();
+
+        let storage = config
+            .instantiate_storage(&registry)
+            .await
+            .expect("preferred region local storage should instantiate");
+
+        assert!(
+            matches!(storage, Storage::Local(_)),
+            "expected preferred region local storage, got {storage:?}"
+        );
     }
 }

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::operators::truncate_dirty_log::{
     TruncateDirtyLogError, TruncateDirtyLogOperator, TruncateDirtyLogOutput,
@@ -35,12 +36,15 @@ use thiserror::Error;
 use tracing::{span, Instrument, Level, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+use crate::mcmr::{instantiate_regions_and_topologies, RegionsAndTopologies};
+
 #[allow(dead_code)]
 pub(crate) struct GarbageCollector {
     config: GarbageCollectorConfig,
     sysdb_client: SysDb,
     storage: Storage,
     logs: Log,
+    regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
     dispatcher: Option<ComponentHandle<Dispatcher>>,
     system: Option<System>,
     assignment_policy: Box<dyn AssignmentPolicy>,
@@ -78,6 +82,7 @@ impl GarbageCollector {
         sysdb_client: SysDb,
         storage: Storage,
         logs: Log,
+        regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
         assignment_policy: Box<dyn AssignmentPolicy>,
         root_manager: RootManager,
     ) -> Self {
@@ -88,6 +93,7 @@ impl GarbageCollector {
             sysdb_client,
             storage,
             logs,
+            regions_and_topologies,
             dispatcher: None,
             system: None,
             assignment_policy,
@@ -141,6 +147,7 @@ impl GarbageCollector {
                 dispatcher.clone(),
                 self.storage.clone(),
                 self.logs.clone(),
+                self.regions_and_topologies.clone(),
                 collection_id,
                 database_name,
             );
@@ -267,6 +274,7 @@ impl GarbageCollector {
                 system.clone(),
                 self.storage.clone(),
                 self.logs.clone(),
+                self.regions_and_topologies.clone(),
                 self.root_manager.clone(),
                 cleanup_mode,
                 self.config.min_versions_to_keep,
@@ -746,13 +754,16 @@ impl Configurable<(GarbageCollectorConfig, System)> for GarbageCollector {
             config.mcmr_sysdb_config.clone(),
         );
         let sysdb_client = SysDb::try_from_config(&sysdb_config, registry).await?;
-        let storage = Storage::try_from_config(&config.storage_config, registry).await?;
+        let storage = config.instantiate_storage(registry).await?;
 
         let assignment_policy =
             Box::<dyn AssignmentPolicy>::try_from_config(&config.assignment_policy, registry)
                 .await?;
 
         let logs = Log::try_from_config(&(config.log.clone(), system.clone()), registry).await?;
+        let regions_and_topologies =
+            instantiate_regions_and_topologies(config.regions_and_topologies.clone(), registry)
+                .await?;
 
         let root_manager_cache =
             chroma_cache::from_config_persistent(&config.root_cache_config).await?;
@@ -763,6 +774,7 @@ impl Configurable<(GarbageCollectorConfig, System)> for GarbageCollector {
             sysdb_client,
             storage,
             logs,
+            regions_and_topologies,
             assignment_policy,
             root_manager,
         ))
@@ -988,8 +1000,9 @@ mod tests {
                 num_channels: 1,
             },
             mcmr_sysdb_config: None,
+            regions_and_topologies: None,
             dispatcher_config: DispatcherConfig::default(),
-            storage_config: s3_config_for_localhost_with_bucket_name("chroma-storage").await,
+            storage_config: Some(s3_config_for_localhost_with_bucket_name("chroma-storage").await),
             default_mode: CleanupMode::DryRunV2,
             tenant_mode_overrides: Some(tenant_mode_overrides),
             assignment_policy: chroma_config::assignment::config::AssignmentPolicyConfig::default(),
@@ -1212,7 +1225,7 @@ mod tests {
                 num_channels: 1,
             },
             dispatcher_config: DispatcherConfig::default(),
-            storage_config: s3_config_for_localhost_with_bucket_name("chroma-storage").await,
+            storage_config: Some(s3_config_for_localhost_with_bucket_name("chroma-storage").await),
             default_mode: CleanupMode::DeleteV2,
             tenant_mode_overrides: None,
             assignment_policy: chroma_config::assignment::config::AssignmentPolicyConfig::default(),

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -49,6 +49,8 @@ use tokio::sync::oneshot::{error::RecvError, Sender};
 use tracing::Span;
 use wal3::LogPosition;
 
+use crate::mcmr::RegionsAndTopologies;
+
 #[derive(Debug)]
 pub struct GarbageCollectorOrchestrator {
     collection_id: CollectionUuid,
@@ -61,6 +63,7 @@ pub struct GarbageCollectorOrchestrator {
     system: System,
     storage: Storage,
     logs: Log,
+    regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
     root_manager: RootManager,
     result_channel: Option<Sender<Result<GarbageCollectorResponse, GarbageCollectorError>>>,
     cleanup_mode: CleanupMode,
@@ -98,6 +101,7 @@ impl GarbageCollectorOrchestrator {
         system: System,
         storage: Storage,
         logs: Log,
+        regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
         root_manager: RootManager,
         cleanup_mode: CleanupMode,
         min_versions_to_keep: u32,
@@ -116,6 +120,7 @@ impl GarbageCollectorOrchestrator {
             system,
             storage,
             logs,
+            regions_and_topologies,
             root_manager,
             cleanup_mode,
             result_channel: None,
@@ -564,6 +569,7 @@ impl GarbageCollectorOrchestrator {
                 mode: self.cleanup_mode,
                 storage: self.storage.clone(),
                 logs: self.logs.clone(),
+                regions_and_topologies: self.regions_and_topologies.clone(),
                 enable_dangerous_option_to_ignore_min_versions_for_wal3: self
                     .enable_dangerous_option_to_ignore_min_versions_for_wal3,
             }),
@@ -1394,6 +1400,7 @@ mod tests {
             system.clone(),
             storage,
             logs,
+            None,
             root_manager,
             crate::types::CleanupMode::DeleteV2,
             1,

--- a/rust/garbage_collector/src/lib.rs
+++ b/rust/garbage_collector/src/lib.rs
@@ -26,6 +26,7 @@ mod construct_version_graph_orchestrator;
 mod garbage_collector_component;
 pub mod garbage_collector_orchestrator_v2;
 mod log_only_orchestrator;
+pub mod mcmr;
 
 #[cfg(test)]
 pub(crate) mod helper;

--- a/rust/garbage_collector/src/log_only_orchestrator.rs
+++ b/rust/garbage_collector/src/log_only_orchestrator.rs
@@ -1,4 +1,5 @@
 use crate::garbage_collector_orchestrator_v2::GarbageCollectorError;
+use crate::mcmr::RegionsAndTopologies;
 use crate::operators::delete_unused_logs::{
     DeleteUnusedLogsError, DeleteUnusedLogsInput, DeleteUnusedLogsOperator, DeleteUnusedLogsOutput,
 };
@@ -12,6 +13,7 @@ use chroma_system::{
 };
 use chroma_types::{CollectionUuid, DatabaseName};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use tokio::sync::oneshot::Sender;
 use tracing::{Level, Span};
 
@@ -20,6 +22,7 @@ pub struct HardDeleteLogOnlyGarbageCollectorOrchestrator {
     context: OrchestratorContext,
     storage: Storage,
     logs: Log,
+    regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
     result_channel: Option<Sender<Result<GarbageCollectorResponse, GarbageCollectorError>>>,
     collection_to_destroy: CollectionUuid,
     database_name: Option<DatabaseName>,
@@ -31,6 +34,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
         dispatcher: ComponentHandle<Dispatcher>,
         storage: Storage,
         logs: Log,
+        regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
         collection_to_destroy: CollectionUuid,
         database_name: Option<DatabaseName>,
     ) -> Self {
@@ -38,6 +42,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
             context: OrchestratorContext::new(dispatcher),
             storage,
             logs,
+            regions_and_topologies,
             result_channel: None,
             collection_to_destroy,
             database_name,
@@ -98,6 +103,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
                 mode: CleanupMode::DeleteV2,
                 storage: self.storage.clone(),
                 logs: self.logs.clone(),
+                regions_and_topologies: self.regions_and_topologies.clone(),
                 enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
             }),
             DeleteUnusedLogsInput {
@@ -202,6 +208,7 @@ mod tests {
             dispatcher_handle.clone(),
             storage.clone(),
             logs.clone(),
+            None,
             collection_to_destroy,
             None,
         );
@@ -245,6 +252,7 @@ mod tests {
             dispatcher_handle,
             storage.clone(),
             logs.clone(),
+            None,
             collection_to_destroy,
             None,
         );

--- a/rust/garbage_collector/src/mcmr.rs
+++ b/rust/garbage_collector/src/mcmr.rs
@@ -1,0 +1,141 @@
+use std::{fmt::Debug, sync::Arc, time::Duration};
+
+use chroma_config::{
+    registry::Registry,
+    spanner::{SpannerChannelConfig, SpannerConfig, SpannerSessionPoolConfig},
+    Configurable,
+};
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_storage::{config::StorageConfig, Storage};
+use chroma_types::MultiCloudMultiRegionConfiguration;
+use google_cloud_gax::conn::Environment;
+use google_cloud_spanner::client::{
+    ChannelConfig, Client as SpannerClient, ClientConfig as SpannerClientConfig,
+};
+use google_cloud_spanner::session::SessionConfig;
+use thiserror::Error;
+use tracing::Level;
+use wal3::ReplicatedFragmentOptions;
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
+pub struct RegionalStorageConfig {
+    pub storage: StorageConfig,
+}
+
+#[derive(Clone, Debug)]
+pub struct RegionalStorage {
+    pub storage: Storage,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
+pub struct TopologicalStorageConfig {
+    pub spanner: SpannerConfig,
+    pub repl: ReplicatedFragmentOptions,
+}
+
+#[derive(Clone)]
+pub struct TopologicalStorage {
+    pub spanner: SpannerClient,
+    pub repl: ReplicatedFragmentOptions,
+}
+
+impl std::fmt::Debug for TopologicalStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TopologicalStorage")
+            .field("spanner", &"SpannerClient { ... }")
+            .field("repl", &self.repl)
+            .finish()
+    }
+}
+
+pub type RegionsAndTopologiesConfig =
+    MultiCloudMultiRegionConfiguration<RegionalStorageConfig, TopologicalStorageConfig>;
+pub type RegionsAndTopologies =
+    MultiCloudMultiRegionConfiguration<RegionalStorage, TopologicalStorage>;
+
+#[derive(Debug, Error)]
+pub enum RegionsAndTopologiesError {
+    #[error("spanner error: {0}")]
+    Spanner(#[from] google_cloud_spanner::client::Error),
+    #[error("spanner auth error")]
+    SpannerAuth(#[from] google_cloud_spanner::admin::google_cloud_auth::error::Error),
+}
+
+impl ChromaError for RegionsAndTopologiesError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
+}
+
+fn to_session_config(cfg: &SpannerSessionPoolConfig) -> SessionConfig {
+    let mut config = SessionConfig::default();
+    config.session_get_timeout = Duration::from_secs(cfg.session_get_timeout_secs);
+    config.max_opened = cfg.max_opened;
+    config.min_opened = cfg.min_opened;
+    config
+}
+
+fn to_channel_config(cfg: &SpannerChannelConfig) -> ChannelConfig {
+    ChannelConfig {
+        num_channels: cfg.num_channels,
+        connect_timeout: Duration::from_secs(cfg.connect_timeout_secs),
+        timeout: Duration::from_secs(cfg.timeout_secs),
+        http2_keep_alive_interval: Some(Duration::from_secs(cfg.http2_keep_alive_interval_secs)),
+        keep_alive_timeout: Some(Duration::from_secs(cfg.keep_alive_timeout_secs)),
+        keep_alive_while_idle: Some(cfg.keep_alive_while_idle),
+    }
+}
+
+pub async fn instantiate_regions_and_topologies(
+    config: Option<RegionsAndTopologiesConfig>,
+    registry: &Registry,
+) -> Result<Option<Arc<RegionsAndTopologies>>, Box<dyn ChromaError>> {
+    let Some(config) = config else {
+        return Ok(None);
+    };
+
+    let runtime = config
+        .try_cast_async(
+            |region| async move {
+                Ok::<RegionalStorage, Box<dyn ChromaError>>(RegionalStorage {
+                    storage: Storage::try_from_config(&region.storage, registry).await?,
+                })
+            },
+            |topology| async move {
+                let database_path = topology.spanner.database_path().clone();
+                let session_config = to_session_config(topology.spanner.session_pool());
+                let channel_config = to_channel_config(topology.spanner.channel());
+                let config = match &topology.spanner {
+                    SpannerConfig::Emulator(emulator) => SpannerClientConfig {
+                        environment: Environment::Emulator(emulator.grpc_endpoint()),
+                        session_config,
+                        channel_config,
+                        ..Default::default()
+                    },
+                    SpannerConfig::Gcp(_) => {
+                        let mut config = SpannerClientConfig::default().with_auth().await.map_err(
+                            |err| -> Box<dyn ChromaError> {
+                                tracing::event!(Level::ERROR, name = "auth error", error = ?err);
+                                Box::new(RegionsAndTopologiesError::from(err)) as _
+                            },
+                        )?;
+                        config.session_config = session_config;
+                        config.channel_config = channel_config;
+                        config
+                    }
+                };
+                let repl = topology.repl.clone();
+                Ok::<TopologicalStorage, Box<dyn ChromaError>>(TopologicalStorage {
+                    spanner: SpannerClient::new(database_path, config).await.map_err(
+                        |err| -> Box<dyn ChromaError> {
+                            Box::new(RegionsAndTopologiesError::from(err)) as _
+                        },
+                    )?,
+                    repl,
+                })
+            },
+        )
+        .await?;
+
+    Ok(Some(Arc::new(runtime)))
+}

--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -8,16 +8,19 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_log::Log;
 use chroma_storage::Storage;
 use chroma_system::{Operator, OperatorType};
-use chroma_types::{CollectionUuid, DatabaseName};
+use chroma_types::{CollectionUuid, DatabaseName, TopologyName};
 use futures::future::try_join_all;
 use thiserror::Error;
 use tracing::Level;
 use wal3::{
-    create_s3_factories, FragmentSeqNo, GarbageCollectionOptions, GarbageCollector, LogPosition,
-    LogReaderOptions, LogWriterOptions, ManifestManager, S3FragmentManagerFactory,
-    S3ManifestManagerFactory, SnapshotOptions, ThrottleOptions,
+    create_repl_factories, create_s3_factories, FragmentSeqNo, FragmentUuid,
+    GarbageCollectionOptions, GarbageCollectionState, GarbageCollector, LogPosition,
+    LogReaderOptions, LogWriterOptions, ManifestManager, ManifestManagerFactory,
+    ReplicatedFragmentManagerFactory, ReplicatedManifestManagerFactory, S3FragmentManagerFactory,
+    S3ManifestManagerFactory, SnapshotOptions, StorageWrapper, ThrottleOptions,
 };
 
+use crate::mcmr::RegionsAndTopologies;
 use crate::types::CleanupMode;
 
 #[derive(Clone, Debug)]
@@ -26,6 +29,7 @@ pub struct DeleteUnusedLogsOperator {
     pub mode: CleanupMode,
     pub storage: Storage,
     pub logs: Log,
+    pub regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
     pub enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
 }
 
@@ -45,6 +49,20 @@ pub enum DeleteUnusedLogsError {
         collection_id: CollectionUuid,
         err: wal3::Error,
     },
+    #[error("missing MCMR regions_and_topologies config for database {database_name}")]
+    MissingRegionsAndTopologies { database_name: String },
+    #[error("invalid topology {topology} for database {database_name}")]
+    InvalidTopology {
+        database_name: String,
+        topology: String,
+    },
+    #[error("topology {topology} not found in regions_and_topologies config")]
+    MissingTopology { topology: String },
+    #[error("preferred region {preferred_region} is not present in topology {topology}")]
+    PreferredRegionNotInTopology {
+        preferred_region: String,
+        topology: String,
+    },
     #[error(transparent)]
     Gc(#[from] chroma_log::GarbageCollectError),
 }
@@ -52,6 +70,208 @@ pub enum DeleteUnusedLogsError {
 impl ChromaError for DeleteUnusedLogsError {
     fn code(&self) -> ErrorCodes {
         ErrorCodes::Internal
+    }
+}
+
+struct ReplTopologyContext {
+    storage_wrappers: Arc<Vec<StorageWrapper>>,
+    region_names: Vec<String>,
+    preferred_index: usize,
+    spanner: Arc<google_cloud_spanner::client::Client>,
+    repl_options: wal3::ReplicatedFragmentOptions,
+}
+
+#[async_trait]
+trait CollectionGarbageCollector: Send {
+    async fn garbage_collect_phase1_compute_garbage(
+        &self,
+        options: &GarbageCollectionOptions,
+        keep_at_least: Option<LogPosition>,
+    ) -> Result<Option<GarbageCollectionState>, wal3::Error>;
+
+    async fn garbage_collect_phase3_delete_garbage(
+        &self,
+        options: &GarbageCollectionOptions,
+        gc_state: &GarbageCollectionState,
+    ) -> Result<(), wal3::Error>;
+}
+
+#[async_trait]
+impl<P, FP, MP> CollectionGarbageCollector for GarbageCollector<P, FP, MP>
+where
+    P: wal3::FragmentPointer + Send + Sync + 'static,
+    FP: wal3::FragmentManagerFactory<FragmentPointer = P> + Send + Sync + 'static,
+    MP: wal3::ManifestManagerFactory<FragmentPointer = P> + Send + Sync + 'static,
+{
+    async fn garbage_collect_phase1_compute_garbage(
+        &self,
+        options: &GarbageCollectionOptions,
+        keep_at_least: Option<LogPosition>,
+    ) -> Result<Option<GarbageCollectionState>, wal3::Error> {
+        GarbageCollector::garbage_collect_phase1_compute_garbage(self, options, keep_at_least).await
+    }
+
+    async fn garbage_collect_phase3_delete_garbage(
+        &self,
+        options: &GarbageCollectionOptions,
+        gc_state: &GarbageCollectionState,
+    ) -> Result<(), wal3::Error> {
+        GarbageCollector::garbage_collect_phase3_delete_garbage(self, options, gc_state).await
+    }
+}
+
+impl DeleteUnusedLogsOperator {
+    fn repl_topology_context(
+        &self,
+        database_name: Option<&DatabaseName>,
+        collection_id: CollectionUuid,
+    ) -> Result<Option<ReplTopologyContext>, DeleteUnusedLogsError> {
+        let Some(database_name) = database_name else {
+            return Ok(None);
+        };
+        let Some(topology) = database_name.topology() else {
+            return Ok(None);
+        };
+        let Some(regions_and_topologies) = &self.regions_and_topologies else {
+            return Err(DeleteUnusedLogsError::MissingRegionsAndTopologies {
+                database_name: database_name.as_ref().to_string(),
+            });
+        };
+
+        let topology_name = TopologyName::new(topology.clone()).map_err(|_| {
+            DeleteUnusedLogsError::InvalidTopology {
+                database_name: database_name.as_ref().to_string(),
+                topology: topology.clone(),
+            }
+        })?;
+        let Some((regions, topology_config)) =
+            regions_and_topologies.lookup_topology(&topology_name)
+        else {
+            return Err(DeleteUnusedLogsError::MissingTopology {
+                topology: topology_name.to_string(),
+            });
+        };
+
+        let prefix = collection_id.storage_prefix_for_log();
+        let mut storage_wrappers = Vec::with_capacity(regions.len());
+        let mut region_names = Vec::with_capacity(regions.len());
+        for region in regions {
+            region_names.push(region.name().to_string());
+            storage_wrappers.push(StorageWrapper::new(
+                region.name().to_string(),
+                region.config.storage.clone(),
+                prefix.clone(),
+            ));
+        }
+
+        let preferred_index = storage_wrappers
+            .iter()
+            .position(|region| region.region.as_str() == regions_and_topologies.preferred.as_str())
+            .ok_or_else(|| DeleteUnusedLogsError::PreferredRegionNotInTopology {
+                preferred_region: regions_and_topologies.preferred.to_string(),
+                topology: topology_name.to_string(),
+            })?;
+
+        Ok(Some(ReplTopologyContext {
+            storage_wrappers: Arc::new(storage_wrappers),
+            region_names,
+            preferred_index,
+            spanner: Arc::new(topology_config.config.spanner.clone()),
+            repl_options: topology_config.config.repl.clone(),
+        }))
+    }
+
+    async fn open_collection_garbage_collector(
+        &self,
+        database_name: Option<&DatabaseName>,
+        collection_id: CollectionUuid,
+        storage: Arc<Storage>,
+    ) -> Result<Box<dyn CollectionGarbageCollector>, DeleteUnusedLogsError> {
+        let prefix = collection_id.storage_prefix_for_log();
+        let options = LogWriterOptions::default();
+
+        if let Some(repl) = self.repl_topology_context(database_name, collection_id)? {
+            let (fragment_manager_factory, manifest_manager_factory) = create_repl_factories(
+                options.clone(),
+                repl.repl_options,
+                repl.preferred_index,
+                repl.storage_wrappers,
+                repl.spanner,
+                repl.region_names,
+                collection_id.0,
+            );
+            let writer =
+                GarbageCollector::<
+                    FragmentUuid,
+                    ReplicatedFragmentManagerFactory,
+                    ReplicatedManifestManagerFactory,
+                >::open(options, fragment_manager_factory, manifest_manager_factory)
+                .await
+                .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })?;
+            Ok(Box::new(writer))
+        } else {
+            let (fragment_manager_factory, manifest_manager_factory) = create_s3_factories(
+                options.clone(),
+                LogReaderOptions::default(),
+                storage,
+                prefix,
+                "garbage collection service".to_string(),
+                Arc::new(()),
+                Arc::new(()),
+            );
+            let writer =
+                GarbageCollector::<
+                    (FragmentSeqNo, LogPosition),
+                    S3FragmentManagerFactory,
+                    S3ManifestManagerFactory,
+                >::open(options, fragment_manager_factory, manifest_manager_factory)
+                .await
+                .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })?;
+            Ok(Box::new(writer))
+        }
+    }
+
+    async fn destroy_collection_log(
+        &self,
+        database_name: Option<&DatabaseName>,
+        collection_id: CollectionUuid,
+        storage: Arc<Storage>,
+    ) -> Result<(), DeleteUnusedLogsError> {
+        let prefix = collection_id.storage_prefix_for_log();
+
+        if let Some(repl) = self.repl_topology_context(database_name, collection_id)? {
+            let local_region = repl.region_names[repl.preferred_index].clone();
+            let preferred_storage =
+                Arc::new(repl.storage_wrappers[repl.preferred_index].storage.clone());
+            let manifest_manager_factory = ReplicatedManifestManagerFactory::new(
+                repl.spanner,
+                repl.region_names,
+                local_region,
+                collection_id.0,
+            );
+            let manifest_manager = manifest_manager_factory
+                .open_publisher()
+                .await
+                .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })?;
+            wal3::destroy(preferred_storage, &prefix, &manifest_manager)
+                .await
+                .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })
+        } else {
+            let manifest_manager = ManifestManager::new(
+                ThrottleOptions::default(),
+                SnapshotOptions::default(),
+                storage.clone(),
+                prefix.clone(),
+                "destroy service".to_string(),
+                Arc::new(()),
+                Arc::new(()),
+            )
+            .await
+            .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })?;
+            wal3::destroy(storage, &prefix, &manifest_manager)
+                .await
+                .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })
+        }
     }
 }
 
@@ -80,35 +300,27 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
             {
                 let collection_id = *collection_id;
                 let storage_clone = storage_arc.clone();
+                let database_name = input.database_name.clone();
                 let mut logs = self.logs.clone();
                 log_gc_futures.push(async move {
-                    let prefix = collection_id.storage_prefix_for_log();
-                    let options = LogWriterOptions::default();
-                    let (fragment_manager_factory, manifest_manager_factory) = create_s3_factories(
-                        options.clone(),
-                        LogReaderOptions::default(),
-                        storage_clone.clone(),
-                        prefix.clone(),
-                        "garbage collection service".to_string(),
-                        Arc::new(()),
-                        Arc::new(()),
-                    );
-                    let writer = match GarbageCollector::<
-                        (FragmentSeqNo, LogPosition),
-                        S3FragmentManagerFactory,
-                        S3ManifestManagerFactory,
-                    >::open(
-                        options,
-                        fragment_manager_factory,
-                        manifest_manager_factory,
-                    )
-                    .await
+                    let writer = match self
+                        .open_collection_garbage_collector(
+                            database_name.as_ref(),
+                            collection_id,
+                            storage_clone.clone(),
+                        )
+                        .await
                     {
                         Ok(log_writer) => log_writer,
-                        Err(wal3::Error::UninitializedLog) => return Ok(()),
+                        Err(DeleteUnusedLogsError::Wal3 {
+                            collection_id: _,
+                            err: wal3::Error::UninitializedLog,
+                        }) => return Ok(()),
                         Err(err) => {
-                            tracing::error!("Unable to initialize log writer for collection [{collection_id}]: {err}");
-                            return Err(DeleteUnusedLogsError::Wal3{ collection_id, err})
+                            tracing::error!(
+                                "Unable to initialize log writer for collection [{collection_id}]: {err}"
+                            );
+                            return Err(err);
                         }
                     };
                     // NOTE(rescrv):  Once upon a time, we had a bug where we would not pass the
@@ -127,32 +339,61 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                     // times.
                     let mut min_log_offset = Some(*minimum_log_offset_to_keep);
                     let mut gc_state = wal3::GarbageCollectionState::empty();
-                    for _ in 0..if self.enable_dangerous_option_to_ignore_min_versions_for_wal3 { 2 } else { 1 } {
+                    for _ in 0..if self.enable_dangerous_option_to_ignore_min_versions_for_wal3 {
+                        2
+                    } else {
+                        1
+                    } {
                         // See README.md in wal3 for a description of why this happens in three phases.
-                        match writer.garbage_collect_phase1_compute_garbage(&GarbageCollectionOptions::default(), min_log_offset).await {
-                            Ok(Some(state)) => { gc_state = state; },
+                        match writer
+                            .garbage_collect_phase1_compute_garbage(
+                                &GarbageCollectionOptions::default(),
+                                min_log_offset,
+                            )
+                            .await
+                        {
+                            Ok(Some(state)) => {
+                                gc_state = state;
+                            }
                             Ok(None) => return Ok(()),
-                            Err(wal3::Error::CorruptGarbage(c)) if c.starts_with("First to keep does not overlap manifest") => {
+                            Err(wal3::Error::CorruptGarbage(c))
+                                if c.starts_with("First to keep does not overlap manifest") =>
+                            {
                                 if self.enable_dangerous_option_to_ignore_min_versions_for_wal3 {
                                     tracing::event!(Level::WARN, name = "encountered enable_dangerous_option_to_ignore_min_versions_for_wal3 path", collection_id =? collection_id);
                                     min_log_offset.take();
                                 }
                             }
                             Err(err) => {
-                                tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
-                                return Err(DeleteUnusedLogsError::Wal3{ collection_id, err});
+                                tracing::error!(
+                                    "Unable to garbage collect log for collection [{collection_id}]: {err}"
+                                );
+                                return Err(DeleteUnusedLogsError::Wal3 { collection_id, err });
                             }
                         };
                     }
-                    if let Err(err) = logs.garbage_collect_phase2(input.database_name.clone(), collection_id).await {
-                        tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
+                    if let Err(err) = logs
+                        .garbage_collect_phase2(database_name.clone(), collection_id)
+                        .await
+                    {
+                        tracing::error!(
+                            "Unable to garbage collect log for collection [{collection_id}]: {err}"
+                        );
                         return Err(DeleteUnusedLogsError::Gc(err));
                     };
                     match self.mode {
                         CleanupMode::DeleteV2 => {
-                            if let Err(err) = writer.garbage_collect_phase3_delete_garbage(&GarbageCollectionOptions::default(), &gc_state).await {
-                                tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
-                                return Err(DeleteUnusedLogsError::Wal3{ collection_id, err});
+                            if let Err(err) = writer
+                                .garbage_collect_phase3_delete_garbage(
+                                    &GarbageCollectionOptions::default(),
+                                    &gc_state,
+                                )
+                                .await
+                            {
+                                tracing::error!(
+                                    "Unable to garbage collect log for collection [{collection_id}]: {err}"
+                                );
+                                return Err(DeleteUnusedLogsError::Wal3 { collection_id, err });
                             };
                         }
                         mode => {
@@ -176,38 +417,26 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                     for collection_id in &input.collections_to_destroy {
                         let collection_id = *collection_id;
                         let storage_clone = storage_arc.clone();
+                        let database_name = input.database_name.clone();
                         log_destroy_futures.push(async move {
-                            let prefix = collection_id.storage_prefix_for_log();
-                            let manifest_manager = match ManifestManager::new(
-                                ThrottleOptions::default(),
-                                SnapshotOptions::default(),
-                                storage_clone.clone(),
-                                prefix.clone(),
-                                "destroy service".to_string(),
-                                Arc::new(()),
-                                Arc::new(()),
-                            )
-                            .await
+                            match self
+                                .destroy_collection_log(
+                                    database_name.as_ref(),
+                                    collection_id,
+                                    storage_clone.clone(),
+                                )
+                                .await
                             {
-                                Ok(mm) => mm,
-                                Err(wal3::Error::UninitializedLog) => return Ok(()),
-                                Err(err) => {
-                                    tracing::error!(
-                                        "Unable to create manifest manager for collection [{collection_id}]: {err:?}"
-                                    );
-                                    return Err(DeleteUnusedLogsError::Wal3 {
-                                        collection_id,
-                                        err,
-                                    });
-                                }
-                            };
-                            match wal3::destroy(storage_clone, &prefix, &manifest_manager).await {
                                 Ok(()) => Ok(()),
+                                Err(DeleteUnusedLogsError::Wal3 {
+                                    collection_id: _,
+                                    err: wal3::Error::UninitializedLog,
+                                }) => Ok(()),
                                 Err(err) => {
                                     tracing::error!(
                                         "Unable to destroy log for collection [{collection_id}]: {err:?}"
                                     );
-                                    Err(DeleteUnusedLogsError::Wal3 { collection_id, err })
+                                    Err(err)
                                 }
                             }
                         })

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -335,6 +335,7 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                                 system.clone(),
                                 state.storage.clone(),
                                 state.logs.clone(),
+                                None,
                                 state.root_manager.clone(),
                                 CleanupMode::DeleteV2,
                                 min_versions_to_keep as u32,

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -138,6 +138,10 @@ impl S3Storage {
                     }
                     _ => match inner.code() {
                         Some("SlowDown") => StorageError::Backoff,
+                        Some("NoSuchKey") => StorageError::NotFound {
+                            path: key.to_string(),
+                            source: Arc::new(inner),
+                        },
                         Some("AccessDenied") => {
                             tracing::error!(
                                 bucket = %self.bucket,
@@ -179,9 +183,16 @@ impl S3Storage {
             Err(e) => match e {
                 SdkError::ServiceError(err) => {
                     let inner = err.into_err();
-                    Err(StorageError::Generic {
-                        source: Arc::new(inner),
-                    })
+                    if inner.is_not_found() || inner.code() == Some("NoSuchKey") {
+                        Err(StorageError::NotFound {
+                            path: key.to_string(),
+                            source: Arc::new(inner),
+                        })
+                    } else {
+                        Err(StorageError::Generic {
+                            source: Arc::new(inner),
+                        })
+                    }
                 }
                 _ => Err(StorageError::Generic {
                     source: Arc::new(e),
@@ -396,6 +407,10 @@ impl S3Storage {
                         let code = inner.code().map(|code| code.to_string());
                         match code.as_deref() {
                             Some("SlowDown") => Err(StorageError::Backoff),
+                            Some("NoSuchKey") => Err(StorageError::NotFound {
+                                path: key.to_string(),
+                                source: Arc::new(inner),
+                            }),
                             Some("AccessDenied") => Err(StorageError::PermissionDenied {
                                 path: key.to_string(),
                                 source: Arc::new(inner),
@@ -801,6 +816,11 @@ impl S3Storage {
                     path: key.to_string(),
                     source: Arc::new(err),
                 }
+            } else if err.meta().code() == Some("NoSuchKey") {
+                StorageError::NotFound {
+                    path: key.to_string(),
+                    source: Arc::new(err),
+                }
             } else if err.meta().code() == Some("SlowDown") {
                 StorageError::Backoff
             } else {
@@ -989,7 +1009,7 @@ impl S3Storage {
                 SdkError::ServiceError(err) => {
                     let inner = err.into_err();
                     match inner.code() {
-                        Some("NotFound") => Err(StorageError::NotFound {
+                        Some("NotFound") | Some("NoSuchKey") => Err(StorageError::NotFound {
                             path: key.to_string(),
                             source: Arc::new(inner),
                         }),
@@ -1068,6 +1088,11 @@ impl S3Storage {
             Err(e) => {
                 if e.code() == Some("SlowDown") {
                     Err(StorageError::Backoff)
+                } else if e.code() == Some("NoSuchKey") {
+                    Err(StorageError::NotFound {
+                        path: String::new(),
+                        source: Arc::new(e),
+                    })
                 } else {
                     Err(StorageError::Generic {
                         source: Arc::new(e),
@@ -1120,10 +1145,18 @@ impl S3Storage {
         {
             Ok(_) => Ok(()),
             Err(e) => {
-                tracing::error!(error = %e, src = %src_key, dst = %dst_key, "Failed to copy object");
-                Err(StorageError::Generic {
-                    source: Arc::new(e.into_service_error()),
-                })
+                let inner = e.into_service_error();
+                tracing::error!(error = %inner, src = %src_key, dst = %dst_key, "Failed to copy object");
+                if inner.meta().code() == Some("NoSuchKey") {
+                    Err(StorageError::NotFound {
+                        path: src_key.to_string(),
+                        source: Arc::new(inner),
+                    })
+                } else {
+                    Err(StorageError::Generic {
+                        source: Arc::new(inner),
+                    })
+                }
             }
         }
     }

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -50,6 +50,20 @@ pub struct DeletedObjects {
     pub errors: Vec<StorageError>,
 }
 
+fn not_found_deleted_objects(
+    keys: Vec<String>,
+    source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+) -> DeletedObjects {
+    let mut out = DeletedObjects::default();
+    for key in keys {
+        out.errors.push(StorageError::NotFound {
+            path: key,
+            source: Arc::clone(&source),
+        });
+    }
+    out
+}
+
 #[derive(Clone)]
 pub struct S3Storage {
     pub(crate) bucket: String,
@@ -1036,11 +1050,16 @@ impl S3Storage {
     ) -> Result<DeletedObjects, StorageError> {
         self.metrics.s3_delete_many_count.add(1, &[]);
 
-        let mut objects = vec![];
-        for key in keys {
+        let keys = keys
+            .into_iter()
+            .map(|key| key.as_ref().to_string())
+            .collect::<Vec<_>>();
+
+        let mut objects = Vec::with_capacity(keys.len());
+        for key in &keys {
             objects.push(
                 ObjectIdentifier::builder()
-                    .key(key.as_ref())
+                    .key(key.as_str())
                     .build()
                     .map_err(|err| StorageError::Generic {
                         source: Arc::new(err),
@@ -1071,7 +1090,7 @@ impl S3Storage {
                 for error in resp.errors() {
                     out.errors.push(if Some("NoSuchKey") == error.code() {
                         StorageError::NotFound {
-                            path: error.key.clone().unwrap_or(String::new()),
+                            path: error.key.clone().unwrap_or_else(|| keys.join(",")),
                             source: Arc::new(StorageError::Message {
                                 message: format!("{error:#?}"),
                             }),
@@ -1089,10 +1108,8 @@ impl S3Storage {
                 if e.code() == Some("SlowDown") {
                     Err(StorageError::Backoff)
                 } else if e.code() == Some("NoSuchKey") {
-                    Err(StorageError::NotFound {
-                        path: String::new(),
-                        source: Arc::new(e),
-                    })
+                    let source: Arc<dyn std::error::Error + Send + Sync + 'static> = Arc::new(e);
+                    Ok(not_found_deleted_objects(keys, source))
                 } else {
                     Err(StorageError::Generic {
                         source: Arc::new(e),
@@ -1396,6 +1413,29 @@ mod tests {
     use rand::{distributions::Alphanumeric, Rng, SeedableRng};
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_not_found_deleted_objects_preserves_requested_keys() {
+        let source: Arc<dyn std::error::Error + Send + Sync + 'static> =
+            Arc::new(StorageError::Message {
+                message: "NoSuchKey".to_string(),
+            });
+        let deleted_objects =
+            not_found_deleted_objects(vec!["first".to_string(), "second".to_string()], source);
+
+        assert!(deleted_objects.deleted.is_empty());
+        assert_eq!(deleted_objects.errors.len(), 2);
+
+        let paths = deleted_objects
+            .errors
+            .iter()
+            .map(|err| match err {
+                StorageError::NotFound { path, .. } => path.as_str(),
+                other => panic!("expected NotFound error, got {other:?}"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(paths, vec!["first", "second"]);
+    }
 
     fn get_s3_client() -> aws_sdk_s3::Client {
         // Set up credentials assuming minio is running locally

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -1967,10 +1967,10 @@ mod tests {
             "confirm_same should return error for nonexistent file"
         );
         match result.unwrap_err() {
-            StorageError::Generic { source: _ } => {
-                // This is expected - the head operation will fail on nonexistent file
+            StorageError::NotFound { path, .. } => {
+                assert_eq!(path, "nonexistent-file");
             }
-            other => panic!("Expected Generic error, got: {:?}", other),
+            other => panic!("Expected NotFound error, got: {:?}", other),
         }
     }
 

--- a/rust/wal3/src/destroy.rs
+++ b/rust/wal3/src/destroy.rs
@@ -101,6 +101,7 @@ async fn destroy_dangling_fragments(storage: &Arc<Storage>, prefix: &str) -> Res
             Ok(possible_fragments) => possible_fragments,
             Err(err) => return Err(Error::StorageError(err)),
         };
+        tracing::info!(possible_fragments = ?possible_fragments, "possible fragments");
         if possible_fragments.is_empty() {
             return Ok(());
         }

--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -276,11 +276,16 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
     }
 
     async fn read_json_file(&self, path: &str) -> Result<(Arc<Vec<u8>>, Option<ETag>), Error> {
-        Ok(
-            crate::interfaces::read_raw_bytes(path, self.fragment_uploader.storages().await)
-                .await
-                .map_err(Arc::new)?,
-        )
+        let preferred = self.fragment_uploader.preferred_storage_wrapper().await;
+        let path = crate::fragment_path(&preferred.prefix, path);
+        Ok(preferred
+            .storage
+            .get_with_e_tag(
+                &path,
+                chroma_storage::GetOptions::new(StorageRequestPriority::P0),
+            )
+            .await
+            .map_err(Arc::new)?)
     }
 
     async fn preferred_storage(&self) -> Storage {
@@ -343,8 +348,16 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
                 .await
             {
                 Ok(e_tag) => return Ok(e_tag),
-                Err(StorageError::AlreadyExists { path: _, source: _ })
-                | Err(StorageError::Precondition { path: _, source: _ }) => {
+                Err(StorageError::AlreadyExists { path: _, source: _ }) => {
+                    return Err(Error::LogContentionFailure);
+                }
+                Err(StorageError::Precondition { path: _, source: _ }) => {
+                    return Err(Error::LogContentionFailure);
+                }
+                Err(StorageError::NotFound { path: _, source: _ }) => {
+                    // NotFound means another process deleted gc/GARBAGE between our
+                    // load (which obtained the ETag) and this conditional put.  Treat
+                    // it as contention so callers retry with a fresh load.
                     return Err(Error::LogContentionFailure);
                 }
                 Err(e) => {
@@ -366,8 +379,22 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
         e_tag: &ETag,
     ) -> Result<(), Error> {
         let empty = crate::Garbage::empty();
-        self.write_garbage(options, Some(e_tag), &empty).await?;
-        Ok(())
+        match self.write_garbage(options, Some(e_tag), &empty).await {
+            Ok(_) => Ok(()),
+            Err(Error::LogContentionFailure) => {
+                // The GARBAGE file was modified or deleted by another process between
+                // our load and this reset.  Either the file was deleted (nothing to
+                // reset) or overwritten with new content from a concurrent GC cycle
+                // (the new content will be processed in a future cycle).  Both cases
+                // are safe to treat as success.
+                tracing::info!("garbage reset skipped: file was concurrently modified or deleted");
+                Ok(())
+            }
+            Err(err) => {
+                tracing::error!(error =% err, "could not write garbage");
+                Err(err)
+            }
+        }
     }
 }
 
@@ -444,12 +471,15 @@ pub async fn upload_parquet(
 mod tests {
     use std::sync::Arc;
 
-    use chroma_storage::s3_client_for_test_with_new_bucket;
+    use chroma_storage::{s3_client_for_test_with_new_bucket, test_storage, PutOptions};
 
     use super::*;
     use crate::interfaces::s3::manifest_manager::ManifestManager;
     use crate::interfaces::s3::S3FragmentUploader;
-    use crate::{FragmentSeqNo, LogWriterOptions, SnapshotOptions, ThrottleOptions};
+    use crate::{
+        FragmentSeqNo, FragmentUuid, LogWriterOptions, SnapshotOptions, StorageWrapper,
+        ThrottleOptions,
+    };
 
     #[tokio::test]
     async fn test_k8s_integration_upload_parquet_returns_retry_on_already_exists() {
@@ -551,5 +581,80 @@ mod tests {
         assert_eq!(vec![vec![1]], work[0].0);
         // Check batch 2
         assert_eq!(vec![vec![2, 3]], work[1].0);
+    }
+
+    struct DualStorageUploader {
+        preferred: usize,
+        storages: Arc<Vec<StorageWrapper>>,
+    }
+
+    #[async_trait::async_trait]
+    impl FragmentUploader<FragmentUuid> for DualStorageUploader {
+        async fn upload_parquet(
+            &self,
+            _pointer: &FragmentUuid,
+            _messages: Vec<Vec<u8>>,
+            _cmek: Option<Cmek>,
+            _epoch_micros: u64,
+        ) -> Result<UploadResult, Error> {
+            unreachable!("upload_parquet is not used in this test")
+        }
+
+        async fn preferred_storage(&self) -> Storage {
+            self.storages[self.preferred].storage.clone()
+        }
+
+        async fn preferred_prefix(&self) -> String {
+            self.storages[self.preferred].prefix.clone()
+        }
+
+        async fn preferred_storage_wrapper(&self) -> &StorageWrapper {
+            &self.storages[self.preferred]
+        }
+
+        async fn storages(&self) -> &[StorageWrapper] {
+            &self.storages
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_json_file_uses_only_preferred_storage() {
+        let (_preferred_dir, preferred_storage) = test_storage();
+        let (_replica_dir, replica_storage) = test_storage();
+        let prefix = "test-read-json-file-preferred".to_string();
+        let path = format!("{prefix}/gc/GARBAGE");
+
+        replica_storage
+            .put_bytes(
+                &path,
+                br#"{"first_to_keep":1}"#.to_vec(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("write to replica storage");
+
+        let fragment_uploader = DualStorageUploader {
+            preferred: 0,
+            storages: Arc::new(vec![
+                StorageWrapper::new(
+                    "preferred".to_string(),
+                    preferred_storage.clone(),
+                    prefix.clone(),
+                ),
+                StorageWrapper::new("replica".to_string(), replica_storage, prefix),
+            ]),
+        };
+        let batch_manager = BatchManager::new(LogWriterOptions::default(), fragment_uploader)
+            .expect("batch manager");
+
+        let err = batch_manager
+            .read_json_file("gc/GARBAGE")
+            .await
+            .expect_err("preferred storage miss should not fall back to replicas");
+
+        assert!(
+            matches!(&err, Error::StorageError(storage_err) if matches!(&**storage_err, StorageError::NotFound { .. })),
+            "expected preferred-storage NotFound, got {err:?}"
+        );
     }
 }

--- a/rust/wal3/src/interfaces/mod.rs
+++ b/rust/wal3/src/interfaces/mod.rs
@@ -6,9 +6,9 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use setsum::Setsum;
 use tracing::Span;
 
-use chroma_storage::{
-    admissioncontrolleds3::StorageRequestPriority, ETag, GetOptions, Storage, StorageError,
-};
+#[cfg(test)]
+use chroma_storage::{admissioncontrolleds3::StorageRequestPriority, GetOptions, StorageError};
+use chroma_storage::{ETag, Storage};
 use chroma_types::Cmek;
 
 use crate::{
@@ -909,43 +909,13 @@ pub fn checksum_parquet(
     }
 }
 
-async fn read_raw_bytes(
-    path: &str,
-    storages: &[repl::StorageWrapper],
-) -> Result<(Arc<Vec<u8>>, Option<ETag>), StorageError> {
-    let mut err: Option<StorageError> = None;
-    for storage in storages.iter() {
-        let path = crate::fragment_path(&storage.prefix, path);
-        match storage
-            .storage
-            .get_with_e_tag(&path, GetOptions::new(StorageRequestPriority::P0))
-            .await
-        {
-            Ok((parquet, e_tag)) => return Ok((parquet, e_tag)),
-            Err(e @ StorageError::NotFound { .. }) => err = Some(e),
-            Err(e) => {
-                tracing::error!("reading from region {} failed", storage.region);
-                err = Some(e);
-            }
-        }
-    }
-    if let Some(err) = err {
-        Err(err)
-    } else {
-        Err(StorageError::NotFound {
-            path: path.into(),
-            source: Arc::new(std::io::Error::other("replicas exhausted")),
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
     use crate::{FragmentSeqNo, LogPosition};
-    use chroma_storage::Storage;
+    use chroma_storage::{test_storage, PutOptions, Storage};
 
     const TEST_EPOCH_MICROS: u64 = 1234567890123456;
 

--- a/rust/wal3/src/interfaces/mod.rs
+++ b/rust/wal3/src/interfaces/mod.rs
@@ -6,8 +6,6 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use setsum::Setsum;
 use tracing::Span;
 
-#[cfg(test)]
-use chroma_storage::{admissioncontrolleds3::StorageRequestPriority, GetOptions, StorageError};
 use chroma_storage::{ETag, Storage};
 use chroma_types::Cmek;
 
@@ -915,7 +913,7 @@ mod tests {
 
     use super::*;
     use crate::{FragmentSeqNo, LogPosition};
-    use chroma_storage::{test_storage, PutOptions, Storage};
+    use chroma_storage::Storage;
 
     const TEST_EPOCH_MICROS: u64 = 1234567890123456;
 

--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -1372,6 +1372,7 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
 
     async fn destroy(&self) -> Result<(), Error> {
         let log_id = self.log_id.to_string();
+        tracing::info!(log_id = %log_id, "destroying");
         let exp_backoff = ExponentialBackoff::new(2_000.0, 1_500.0);
         let mut last_err: Option<String> = None;
         for _ in 0..3 {

--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -1405,7 +1405,7 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                         );
                         stmt2.add_param("log_id", &log_id);
                         let mut iter = tx.query(stmt2).await?;
-                        let mut preserve_the_shared_pieces = false;
+                        let mut preserve_shared_pieces = false;
                         while let Some(row) = iter.next().await? {
                             let region = row.column_by_name::<String>("region")?;
                             if region == local_region {
@@ -1414,11 +1414,11 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                                 Key::composite(&[&log_id, &region]),
                             ));
                             } else {
-                                preserve_the_shared_pieces = true;
+                                preserve_shared_pieces = true;
                             }
                         }
 
-                        if !preserve_the_shared_pieces {
+                        if !preserve_shared_pieces {
                             // Query all fragment idents to delete from fragments.
                             let mut stmt3 =
                                 Statement::new("SELECT ident FROM fragments WHERE log_id = @log_id");

--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -1380,12 +1380,14 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                 .spanner
                 .read_write_transaction(|tx| {
                     let log_id = log_id.clone();
+                    let local_region = self.local_region.clone();
                     Box::pin(async move {
                         // First, query all fragment idents and regions to delete from fragment_regions.
                         let mut stmt1 = Statement::new(
-                            "SELECT ident, region FROM fragment_regions WHERE log_id = @log_id",
+                            "SELECT ident, region FROM fragment_regions WHERE log_id = @log_id AND region = @local_region",
                         );
                         stmt1.add_param("log_id", &log_id);
+                        stmt1.add_param("local_region", &local_region);
                         let mut iter = tx.query(stmt1).await?;
                         let mut mutations = vec![];
                         while let Some(row) = iter.next().await? {
@@ -1397,32 +1399,38 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                             ));
                         }
 
-                        // Query all fragment idents to delete from fragments.
-                        let mut stmt2 =
-                            Statement::new("SELECT ident FROM fragments WHERE log_id = @log_id");
-                        stmt2.add_param("log_id", &log_id);
-                        let mut iter = tx.query(stmt2).await?;
-                        while let Some(row) = iter.next().await? {
-                            let ident = row.column_by_name::<String>("ident")?;
-                            mutations.push(delete("fragments", Key::composite(&[&log_id, &ident])));
-                        }
-
                         // Query all regions to delete from manifest_regions.
-                        let mut stmt3 = Statement::new(
+                        let mut stmt2 = Statement::new(
                             "SELECT region FROM manifest_regions WHERE log_id = @log_id",
                         );
-                        stmt3.add_param("log_id", &log_id);
-                        let mut iter = tx.query(stmt3).await?;
+                        stmt2.add_param("log_id", &log_id);
+                        let mut iter = tx.query(stmt2).await?;
+                        let mut preserve_the_shared_pieces = false;
                         while let Some(row) = iter.next().await? {
                             let region = row.column_by_name::<String>("region")?;
+                            if region == local_region {
                             mutations.push(delete(
                                 "manifest_regions",
                                 Key::composite(&[&log_id, &region]),
                             ));
+                            } else {
+                                preserve_the_shared_pieces = true;
+                            }
                         }
 
-                        // Delete from manifests.
-                        mutations.push(delete("manifests", Key::new(&log_id)));
+                        if !preserve_the_shared_pieces {
+                            // Query all fragment idents to delete from fragments.
+                            let mut stmt3 =
+                                Statement::new("SELECT ident FROM fragments WHERE log_id = @log_id");
+                            stmt3.add_param("log_id", &log_id);
+                            let mut iter = tx.query(stmt3).await?;
+                            while let Some(row) = iter.next().await? {
+                                let ident = row.column_by_name::<String>("ident")?;
+                                mutations.push(delete("fragments", Key::composite(&[&log_id, &ident])));
+                            }
+                            // Delete from manifests.
+                            mutations.push(delete("manifests", Key::new(&log_id)));
+                        }
 
                         tx.buffer_write(mutations);
                         Ok::<_, google_cloud_spanner::client::Error>(())

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -819,6 +819,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 }
                 Ok(None) => None,
                 Err(err) => {
+                    tracing::error!(error =% err, "could not install garbage");
                     return Err(err);
                 }
             };
@@ -856,6 +857,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 | Err(Error::LogContentionRetry)
                 | Err(Error::LogContentionDurable) => {}
                 Err(err) => {
+                    tracing::error!(error =% err, "could not install garbage");
                     return Err(err);
                 }
             };

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -310,7 +310,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
-  collection_soft_delete_grace_period_seconds: 60
+  collection_soft_delete_grace_period_seconds: 60 # GC any soft deleted collection older than this.
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]
@@ -330,11 +330,60 @@ garbage_collector:
     num_worker_threads: 4
     dispatcher_queue_size: 10000
     worker_queue_size: 10000
-  storage_config:
-    s3:
-      bucket: "chroma-storage"
-      connect_timeout_ms: 60000
-      request_timeout_ms: 60000 # 1 minute
+  regions_and_topologies:
+    preferred: tilt-config-1
+    regions:
+    - name: tilt-config-1
+      provider: tilt
+      region: config-1
+      config:
+        storage:
+          admission_controlled_s3:
+            s3_config:
+              bucket: "chroma-storage"
+              credentials: "Minio"
+              connect_timeout_ms: 5000
+              request_timeout_ms: 60000 # 1 minute
+              upload_part_size_bytes: 536870912 # 512MiB
+              download_part_size_bytes: 8388608 # 8MiB
+            rate_limiting_policy:
+              count_based_policy:
+                max_concurrent_requests: 500
+                bandwidth_allocation: [1.0]
+    - name: tilt-config-2
+      provider: tilt
+      region: config-2
+      config:
+        storage:
+          admission_controlled_s3:
+            s3_config:
+              bucket: "chroma-storage2"
+              credentials: "Minio"
+              connect_timeout_ms: 5000
+              request_timeout_ms: 30000 # 1 minute
+              upload_part_size_bytes: 536870912 # 512MiB
+              download_part_size_bytes: 8388608 # 8MiB
+            rate_limiting_policy:
+              count_based_policy:
+                max_concurrent_requests: 30
+                bandwidth_allocation: [0.7, 0.3]
+    topologies:
+    - name: tilt-spanning
+      regions:
+      - tilt-config-1
+      - tilt-config-2
+      config:
+        repl:
+          minimum_allowed_replication_factor: 1
+          minimum_failures_to_exclude_replica: 100
+        spanner:
+          emulator:
+            host: "spanner.chroma.svc.cluster.local"
+            grpc_port: 9010
+            rest_port: 9020
+            project: "local-project"
+            instance: "test-instance"
+            database: "local-logdb-database"
   assignment_policy:
     rendezvous_hashing:
       hasher: Murmur3

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -311,7 +311,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
-  collection_soft_delete_grace_period_seconds: 60
+  collection_soft_delete_grace_period_seconds: 60 # GC any soft deleted collection older than this.
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]
@@ -331,11 +331,60 @@ garbage_collector:
     num_worker_threads: 4
     dispatcher_queue_size: 10000
     worker_queue_size: 10000
-  storage_config:
-    s3:
-      bucket: "chroma-storage2"
-      connect_timeout_ms: 60000
-      request_timeout_ms: 60000 # 1 minute
+  regions_and_topologies:
+    preferred: tilt-config-2
+    regions:
+    - name: tilt-config-1
+      provider: tilt
+      region: config-1
+      config:
+        storage:
+          admission_controlled_s3:
+            s3_config:
+              bucket: "chroma-storage"
+              credentials: "Minio"
+              connect_timeout_ms: 5000
+              request_timeout_ms: 60000 # 1 minute
+              upload_part_size_bytes: 536870912 # 512MiB
+              download_part_size_bytes: 8388608 # 8MiB
+            rate_limiting_policy:
+              count_based_policy:
+                max_concurrent_requests: 500
+                bandwidth_allocation: [1.0]
+    - name: tilt-config-2
+      provider: tilt
+      region: config-2
+      config:
+        storage:
+          admission_controlled_s3:
+            s3_config:
+              bucket: "chroma-storage2"
+              credentials: "Minio"
+              connect_timeout_ms: 5000
+              request_timeout_ms: 30000 # 1 minute
+              upload_part_size_bytes: 536870912 # 512MiB
+              download_part_size_bytes: 8388608 # 8MiB
+            rate_limiting_policy:
+              count_based_policy:
+                max_concurrent_requests: 30
+                bandwidth_allocation: [0.7, 0.3]
+    topologies:
+    - name: tilt-spanning
+      regions:
+      - tilt-config-1
+      - tilt-config-2
+      config:
+        repl:
+          minimum_allowed_replication_factor: 1
+          minimum_failures_to_exclude_replica: 100
+        spanner:
+          emulator:
+            host: "spanner.chroma.svc.cluster.local"
+            grpc_port: 9010
+            rest_port: 9020
+            project: "local-project"
+            instance: "test-instance"
+            database: "local-logdb-database"
   assignment_policy:
     rendezvous_hashing:
       hasher: Murmur3


### PR DESCRIPTION
## Description of changes

Enable the garbage collector to operate on replicated logs in
multi-cloud multi-region (MCMR) deployments:

- Add mcmr module with RegionsAndTopologies types to instantiate
  per-region storage and per-topology spanner clients
- Make storage_config optional; add regions_and_topologies as the
  MCMR alternative with XOR validation
- Introduce CollectionGarbageCollector trait to abstract S3 vs
  replicated GC in delete_unused_logs operator
- Map S3 NoSuchKey errors to StorageError::NotFound consistently
  across all S3 operations
- Read gc/GARBAGE only from preferred storage instead of falling
  back across replicas, treating concurrent deletion as contention
- Update chroma_mcmr.yaml and chroma_mcmr2.yaml to use the new
  regions_and_topologies config format
- Fix `destroy` in wal3 to only destroy the local region unless it's the
  last region.

## Test plan

CI + an upcoming test

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
