### PR TITLE
[codex] Add Azure OpenAI regression coverage

### DIFF
--- a/chromadb/test/ef/test_openai_ef.py
+++ b/chromadb/test/ef/test_openai_ef.py
@@ -1,4 +1,7 @@
 import os
+import sys
+import types
+from unittest.mock import Mock
 
 import pytest
 
@@ -36,3 +39,51 @@ def test_with_incorrect_api_key() -> None:
     ef = OpenAIEmbeddingFunction(api_key="incorrect_api_key", dimensions=64)
     with pytest.raises(Exception, match="Incorrect API key provided"):
         ef(["hello world"])
+
+
+def test_azure_openai_requires_deployment_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    openai_stub = types.SimpleNamespace(OpenAI=Mock(), AzureOpenAI=Mock())
+    monkeypatch.setitem(sys.modules, "openai", openai_stub)
+
+    with pytest.raises(
+        ValueError, match="deployment_id must be specified for Azure OpenAI"
+    ):
+        OpenAIEmbeddingFunction(
+            api_key="test-api-key",
+            api_type="azure",
+            api_base="https://example.openai.azure.com",
+            api_version="2024-02-01",
+        )
+
+
+def test_azure_openai_passes_deployment_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_client = object()
+    azure_client = object()
+
+    openai_stub = types.SimpleNamespace(
+        OpenAI=Mock(return_value=default_client),
+        AzureOpenAI=Mock(return_value=azure_client),
+    )
+    monkeypatch.setitem(sys.modules, "openai", openai_stub)
+
+    ef = OpenAIEmbeddingFunction(
+        api_key="test-api-key",
+        api_type="azure",
+        api_base="https://example.openai.azure.com",
+        api_version="2024-02-01",
+        deployment_id="text-embedding-3-small",
+        default_headers={"x-test-header": "value"},
+    )
+
+    assert ef.client is azure_client
+    openai_stub.AzureOpenAI.assert_called_once_with(
+        api_key="test-api-key",
+        api_version="2024-02-01",
+        azure_endpoint="https://example.openai.azure.com",
+        azure_deployment="text-embedding-3-small",
+        default_headers={"x-test-header": "value"},
+    )

--- a/docs/mintlify/integrations/embedding-models/openai.mdx
+++ b/docs/mintlify/integrations/embedding-models/openai.mdx
@@ -31,7 +31,7 @@ openai_ef = embedding_functions.OpenAIEmbeddingFunction(
 )
 ```
 
-To use the OpenAI embedding models on other platforms such as Azure, you can use the `api_base` and `api_type` parameters:
+To use the OpenAI embedding models on other platforms such as Azure, you should also provide the Azure deployment name and API version:
 
 ```python
 import chromadb.utils.embedding_functions as embedding_functions
@@ -40,9 +40,12 @@ openai_ef = embedding_functions.OpenAIEmbeddingFunction(
     api_base="YOUR_API_BASE_PATH",
     api_type="azure",
     api_version="YOUR_API_VERSION",
+    deployment_id="YOUR_AZURE_DEPLOYMENT",
     model_name="text-embedding-3-small"
 )
 ```
+
+For Azure OpenAI setup details, see Microsoft's [API versioning documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning).
 
 </Tab>
 


### PR DESCRIPTION
## Summary
Adds regression coverage for the Azure OpenAI configuration path in `OpenAIEmbeddingFunction` and updates the OpenAI integration docs to show the required Azure deployment parameter.

## What Changed
- adds a test that asserts Azure OpenAI raises a clear error when `deployment_id` is omitted
- adds a test that verifies `deployment_id` is forwarded as `azure_deployment` when the Azure client is created
- updates the Azure docs example to include `deployment_id`
- links the docs to Microsoft's Azure OpenAI API versioning reference

## Why
Issue #1770 reports that Azure OpenAI needs the deployment name to be passed through. The implementation on `main` already enforces that correctly, but the docs still omitted the deployment parameter and there was no regression coverage around the Azure-specific constructor path.

## Validation
- `python -m pytest --noconftest D:\oss\chroma\chromadb\test\ef\test_openai_ef.py`
