### PR TITLE
[ENH](test): parameterize multi-region config

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -121,7 +121,6 @@ jobs:
         shell: bash
         env:
           CHROMA_THIN_CLIENT: "1"
-          MULTI_REGION: "true"
           ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -559,9 +559,9 @@ users:
                 yield item
 
 
-def fastapi_fixture_admin_and_singleton_tenant_db_user() -> Generator[
-    System, None, None
-]:
+def fastapi_fixture_admin_and_singleton_tenant_db_user(
+    singleton_database: str = "singleton_database",
+) -> Generator[System, None, None]:
     # Check if we should connect to existing server instead of spawning a new one
     if os.getenv("CHROMA_SERVER_HOST") and not NOT_CLUSTER_ONLY:
         # Connect to existing Tilt instance using the same pattern as basic_http_client
@@ -587,7 +587,7 @@ def fastapi_fixture_admin_and_singleton_tenant_db_user() -> Generator[
     # Original behavior: spawn isolated server
     with tempfile.NamedTemporaryFile("w", suffix=".authn", delete=False) as f:
         f.write(
-            """
+            f"""
 users:
   - id: admin
     tokens:
@@ -595,7 +595,7 @@ users:
   - id: singleton_user
     tenant: singleton_tenant
     databases:
-      - singleton_database
+      - {singleton_database}
     tokens:
       - singleton-token
 """

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -15,6 +15,7 @@ from hypothesis.stateful import (
     run_state_machine_as_test,
     MultipleResults,
 )
+from chromadb.test.conftest import multi_region_test
 import chromadb.test.property.invariants as invariants
 from typing import Any, Dict, Mapping, Optional
 import numpy
@@ -241,6 +242,7 @@ class CollectionStateMachine(RuleBasedStateMachine):
         return self._model
 
 
+@multi_region_test
 def test_collections(caplog: pytest.LogCaptureFixture, client: ClientAPI) -> None:
     caplog.set_level(logging.ERROR)
     run_state_machine_as_test(lambda: CollectionStateMachine(client))  # type: ignore

--- a/chromadb/test/property/test_collections_with_database_tenant.py
+++ b/chromadb/test/property/test_collections_with_database_tenant.py
@@ -3,12 +3,12 @@ from typing import Dict, Optional, Tuple
 import pytest
 from chromadb.api import AdminAPI
 import chromadb.api.types as types
-from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT
+from chromadb.config import DEFAULT_TENANT
 from chromadb.test.conftest import (
     ClientFactories,
-    MULTI_REGION_ENABLED,
     DEFAULT_MCMR_DATABASE,
     MULTI_REGION_TOPOLOGY,
+    multi_region_test,
 )
 
 from chromadb.test.property.test_collections import CollectionStateMachine
@@ -22,11 +22,6 @@ from hypothesis.stateful import (
 )
 import chromadb.test.property.strategies as strategies
 
-EFFECTIVE_DEFAULT_DATABASE = (
-    DEFAULT_MCMR_DATABASE if MULTI_REGION_ENABLED else DEFAULT_DATABASE
-)
-
-
 class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
     """A collection state machine test that includes tenant and database information,
     and switches between them."""
@@ -39,12 +34,20 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
     admin_client: AdminAPI
     curr_tenant: str
     curr_database: str
+    effective_default_database: str
+    uses_multi_region_database: bool
 
     tenants = Bundle("tenants")
     databases = Bundle("databases")
 
-    def __init__(self, client_factories: ClientFactories):
-        client = client_factories.create_client()
+    def __init__(
+        self,
+        client_factories: ClientFactories,
+        database_name: str,
+    ) -> None:
+        self.effective_default_database = database_name
+        self.uses_multi_region_database = database_name == DEFAULT_MCMR_DATABASE
+        client = client_factories.create_client(database=database_name)
         super().__init__(client)
         self.client = client
         self.admin_client = client_factories.create_admin_client_from_system()
@@ -54,8 +57,8 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
         self.client.reset()
         self.tenant_to_database_to_model = {}
         self.curr_tenant = DEFAULT_TENANT
-        self.curr_database = EFFECTIVE_DEFAULT_DATABASE
-        self.client.set_tenant(DEFAULT_TENANT, EFFECTIVE_DEFAULT_DATABASE)
+        self.curr_database = self.effective_default_database
+        self.client.set_tenant(DEFAULT_TENANT, self.effective_default_database)
         self.set_tenant_model(self.curr_tenant, {})
         self.set_database_model_for_tenant(self.curr_tenant, self.curr_database, {})
 
@@ -72,14 +75,18 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
         # When we create a tenant, create a default database for it just for testing
         # since the state machine could call collection operations before creating a
         # database
-        self.admin_client.create_database(EFFECTIVE_DEFAULT_DATABASE, tenant=tenant)
+        self.admin_client.create_database(
+            self.effective_default_database, tenant=tenant
+        )
         self.set_tenant_model(tenant, {})
-        self.set_database_model_for_tenant(tenant, EFFECTIVE_DEFAULT_DATABASE, {})
+        self.set_database_model_for_tenant(
+            tenant, self.effective_default_database, {}
+        )
         return multiple(tenant)
 
     @rule(target=databases, name=strategies.tenant_database_name)
     def create_database(self, name: str) -> MultipleResults:  # [Tuple[str, str]]:
-        if MULTI_REGION_ENABLED:
+        if self.uses_multi_region_database:
             name = f"{MULTI_REGION_TOPOLOGY}+{name}"
         database = self.overwrite_database(name)
         tenant = self.overwrite_tenant(self.curr_tenant)
@@ -106,9 +113,9 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
 
     @rule(tenant=tenants)
     def set_tenant(self, tenant: str) -> None:
-        self.set_api_tenant_database(tenant, EFFECTIVE_DEFAULT_DATABASE)
+        self.set_api_tenant_database(tenant, self.effective_default_database)
         self.curr_tenant = tenant
-        self.curr_database = EFFECTIVE_DEFAULT_DATABASE
+        self.curr_database = self.effective_default_database
 
     # These methods allow other tests, namely
     # test_collections_with_database_tenant_override.py, to swap out the model
@@ -157,8 +164,15 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
         return self.tenant_to_database_to_model[self.curr_tenant][self.curr_database]
 
 
+@multi_region_test
 def test_collections(
-    caplog: pytest.LogCaptureFixture, client_factories: ClientFactories
+    caplog: pytest.LogCaptureFixture,
+    client_factories: ClientFactories,
+    database_name: str,
 ) -> None:
     caplog.set_level(logging.ERROR)
-    run_state_machine_as_test(lambda: TenantDatabaseCollectionStateMachine(client_factories))  # type: ignore
+    run_state_machine_as_test(
+        lambda: TenantDatabaseCollectionStateMachine(
+            client_factories, database_name=database_name
+        )
+    )  # type: ignore

--- a/chromadb/test/property/test_collections_with_database_tenant_overwrite.py
+++ b/chromadb/test/property/test_collections_with_database_tenant_overwrite.py
@@ -11,14 +11,15 @@ import uuid
 import logging
 import os
 import pytest
-from chromadb.api import AdminAPI
+from chromadb.api import AdminAPI, ServerAPI
 from chromadb.api.client import AdminClient, Client
 from chromadb.config import Settings, System
 from chromadb.test.conftest import (
     ClientFactories,
+    DEFAULT_MCMR_DATABASE,
     fastapi_fixture_admin_and_singleton_tenant_db_user,
-    MULTI_REGION_ENABLED,
     MULTI_REGION_TOPOLOGY,
+    multi_region_test,
     NOT_CLUSTER_ONLY,
 )
 from chromadb.test.property.test_collections_with_database_tenant import (
@@ -30,9 +31,13 @@ import chromadb.api.types as types
 
 # See conftest.py
 SINGLETON_TENANT = "singleton_tenant"
-SINGLETON_DATABASE = "singleton_database"
-if MULTI_REGION_ENABLED:
-    SINGLETON_DATABASE = f"{MULTI_REGION_TOPOLOGY}+singleton_database"
+SINGLETON_DATABASE_NAME = "singleton_database"
+
+
+def singleton_database_name(database_name: str) -> str:
+    if database_name == DEFAULT_MCMR_DATABASE:
+        return f"{MULTI_REGION_TOPOLOGY}+{SINGLETON_DATABASE_NAME}"
+    return SINGLETON_DATABASE_NAME
 
 
 class SingletonTenantDatabaseCollectionStateMachine(
@@ -42,17 +47,20 @@ class SingletonTenantDatabaseCollectionStateMachine(
     singleton_admin_client: AdminAPI
     root_client: Client
     root_admin_client: AdminAPI
+    singleton_database: str
 
     def __init__(
         self,
         singleton_client: Client,
         root_client: Client,
         client_factories: ClientFactories,
+        database_name: str,
     ) -> None:
-        super().__init__(client_factories)
+        super().__init__(client_factories, database_name=database_name)
         self.root_client = root_client
         self.root_admin_client = self.admin_client
 
+        self.singleton_database = singleton_database_name(database_name)
         self.singleton_client = singleton_client
         self.singleton_admin_client = AdminClient.from_system(singleton_client._system)
 
@@ -66,10 +74,14 @@ class SingletonTenantDatabaseCollectionStateMachine(
         super().initialize()
 
         self.root_admin_client.create_tenant(SINGLETON_TENANT)
-        self.root_admin_client.create_database(SINGLETON_DATABASE, SINGLETON_TENANT)
+        self.root_admin_client.create_database(
+            self.singleton_database, SINGLETON_TENANT
+        )
 
         self.set_tenant_model(SINGLETON_TENANT, {})
-        self.set_database_model_for_tenant(SINGLETON_TENANT, SINGLETON_DATABASE, {})
+        self.set_database_model_for_tenant(
+            SINGLETON_TENANT, self.singleton_database, {}
+        )
 
     @invariant()
     def check_api_and_admin_client_are_in_sync(self) -> None:
@@ -84,22 +96,18 @@ class SingletonTenantDatabaseCollectionStateMachine(
             self.client = self.root_client
             self.admin_client = self.root_admin_client
             # When switching back to root, restore the previous tenant/database context
-            # Use EFFECTIVE_DEFAULT_DATABASE for consistency with base class
-            from chromadb.test.property.test_collections_with_database_tenant import (
-                EFFECTIVE_DEFAULT_DATABASE,
-            )
             from chromadb.config import DEFAULT_TENANT
 
-            self.client.set_tenant(DEFAULT_TENANT, EFFECTIVE_DEFAULT_DATABASE)
+            self.client.set_tenant(DEFAULT_TENANT, self.effective_default_database)
             self.curr_tenant = DEFAULT_TENANT
-            self.curr_database = EFFECTIVE_DEFAULT_DATABASE
+            self.curr_database = self.effective_default_database
         else:
             self.client = self.singleton_client
             self.admin_client = self.singleton_admin_client
             # Set to singleton tenant/database context and update state
-            self.client.set_tenant(SINGLETON_TENANT, SINGLETON_DATABASE)
+            self.client.set_tenant(SINGLETON_TENANT, self.singleton_database)
             self.curr_tenant = SINGLETON_TENANT
-            self.curr_database = SINGLETON_DATABASE
+            self.curr_database = self.singleton_database
 
     @overrides
     def set_api_tenant_database(self, tenant: str, database: str) -> None:
@@ -147,7 +155,7 @@ class SingletonTenantDatabaseCollectionStateMachine(
     @overrides
     def overwrite_database(self, database: str) -> str:
         if self.client == self.singleton_client:
-            return SINGLETON_DATABASE
+            return self.singleton_database
         return database
 
     @overrides
@@ -162,18 +170,22 @@ class SingletonTenantDatabaseCollectionStateMachine(
         return self.tenant_to_database_to_model[self.curr_tenant][self.curr_database]
 
 
-def _singleton_and_root_clients() -> Tuple[Client, Client, ClientFactories]:
-    api_fixture = fastapi_fixture_admin_and_singleton_tenant_db_user()
+def _singleton_and_root_clients(
+    database_name: str,
+) -> Tuple[Client, Client, ClientFactories]:
+    singleton_database = singleton_database_name(database_name)
+    api_fixture = fastapi_fixture_admin_and_singleton_tenant_db_user(
+        singleton_database=singleton_database
+    )
     sys: System = next(api_fixture)
     sys.reset_state()
 
     # When connecting to external Tilt, also reset the server
     if os.getenv("CHROMA_SERVER_HOST") and not NOT_CLUSTER_ONLY:
-        root_client_for_reset = ClientFactories(sys).create_client()
-        root_client_for_reset.reset()
+        sys.instance(ServerAPI).reset()
 
     client_factories = ClientFactories(sys)
-    root_client = client_factories.create_client()
+    root_client = client_factories.create_client(database=database_name)
     root_client.reset()
     _root_admin_client = client_factories.create_admin_client_from_system()
 
@@ -181,39 +193,49 @@ def _singleton_and_root_clients() -> Tuple[Client, Client, ClientFactories]:
     # before we can instantiate a Client which connects to them. This also
     # means we need to manually populate state in the state machine.
     _root_admin_client.create_tenant(SINGLETON_TENANT)
-    _root_admin_client.create_database(SINGLETON_DATABASE, SINGLETON_TENANT)
+    _root_admin_client.create_database(singleton_database, SINGLETON_TENANT)
 
     singleton_settings = Settings(**dict(sys.settings))
     singleton_settings.chroma_client_auth_credentials = "singleton-token"
     singleton_system = System(singleton_settings)
     singleton_system.start()
-    singleton_client = Client.from_system(singleton_system)
+    singleton_client = Client.from_system(
+        singleton_system, tenant=SINGLETON_TENANT, database=singleton_database
+    )
 
     return singleton_client, root_client, client_factories
 
 
+@multi_region_test
 def test_collections_with_tenant_database_overwrite(
     caplog: pytest.LogCaptureFixture,
+    database_name: str,
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    singleton_client, root_client, client_factories = _singleton_and_root_clients()
+    singleton_client, root_client, client_factories = _singleton_and_root_clients(
+        database_name
+    )
     run_state_machine_as_test(
         lambda: SingletonTenantDatabaseCollectionStateMachine(
-            singleton_client, root_client, client_factories
+            singleton_client, root_client, client_factories, database_name
         )
     )  # type: ignore
 
 
+@multi_region_test
 def test_repeat_failure(
     caplog: pytest.LogCaptureFixture,
+    database_name: str,
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    singleton_client, root_client, client_factories = _singleton_and_root_clients()
+    singleton_client, root_client, client_factories = _singleton_and_root_clients(
+        database_name
+    )
 
     state = SingletonTenantDatabaseCollectionStateMachine(
-        singleton_client, root_client, client_factories
+        singleton_client, root_client, client_factories, database_name
     )
     state.initialize()
     state.check_api_and_admin_client_are_in_sync()


### PR DESCRIPTION
## Description of changes

Replace module-level multi-region globals with per-test
parameterization via the @multi_region_test decorator:
- Remove EFFECTIVE_DEFAULT_DATABASE and SINGLETON_DATABASE constants
  in favor of database_name parameter passed through test functions
- Make fastapi_fixture_admin_and_singleton_tenant_db_user accept a
  singleton_database parameter for configurable auth setup
- Add singleton_database_name() helper to derive the database name
  from the test configuration
- Add @multi_region_test to collection property test functions
- Remove MULTI_REGION env var from CI non-cluster python-tests workflow

This eliminates implicit global state for these tests so multi-region
behavior is controlled per-test through pytest parameterization rather
than environment variables read at module import time.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
