### PR TITLE
[TST] refactor repair collection log offset test

### DIFF
--- a/chromadb/test/distributed/test_repair_collection_log_offset.py
+++ b/chromadb/test/distributed/test_repair_collection_log_offset.py
@@ -1,17 +1,21 @@
 # Add some records, wait for compaction, then roll back the log offset.
-# Poll the log for up to 30s to see if the offset gets repaired.
+# Poll the log for up to 240s to see if the offset gets repaired.
 
 import grpc
 import random
 import time
-from typing import cast, List, Any, Dict
+from typing import cast
 
 import numpy as np
 
 from chromadb.api import ClientAPI
-from chromadb.proto.logservice_pb2 import InspectLogStateRequest, UpdateCollectionLogOffsetRequest
+from chromadb.proto.logservice_pb2 import (
+    InspectLogStateRequest,
+    UpdateCollectionLogOffsetRequest,
+)
 from chromadb.proto.logservice_pb2_grpc import LogServiceStub
 from chromadb.test.conftest import (
+    multi_region_test,
     reset,
     skip_if_not_cluster,
 )
@@ -19,8 +23,50 @@ from chromadb.test.utils.wait_for_version_increase import wait_for_version_incre
 
 RECORDS = 1000
 BATCH_SIZE = 100
+EXPECTED_REPAIRED_LOG_OFFSET = RECORDS + 1
+COMPACTION_ADDITIONAL_TIME_SECONDS = 120
+LOG_REPAIR_TIMEOUT_SECONDS = 240
+LOG_POLL_INTERVAL_SECONDS = 1
+
+
+def _inspect_collection_log_start(
+    log_service_stub: LogServiceStub,
+    database_name: str,
+    collection_id: str,
+) -> int:
+    request = InspectLogStateRequest(
+        database_name=database_name,
+        collection_id=collection_id,
+    )
+    response = log_service_stub.InspectLogState(request, timeout=60)
+    return int(response.start)
+
+
+def _wait_for_collection_log_start(
+    log_service_stub: LogServiceStub,
+    database_name: str,
+    collection_id: str,
+    expected_start: int,
+) -> None:
+    deadline = time.time() + LOG_REPAIR_TIMEOUT_SECONDS
+    last_start = None
+    while time.time() < deadline:
+        last_start = _inspect_collection_log_start(
+            log_service_stub, database_name, collection_id
+        )
+        if last_start == expected_start:
+            return
+        time.sleep(LOG_POLL_INTERVAL_SECONDS)
+
+    raise TimeoutError(
+        "Timed out waiting for collection log start "
+        f"database={database_name} collection_id={collection_id} "
+        f"expected={expected_start} last_seen={last_start}"
+    )
+
 
 @skip_if_not_cluster()
+@multi_region_test
 def test_repair_collection_log_offset(
     client: ClientAPI,
 ) -> None:
@@ -29,8 +75,9 @@ def test_repair_collection_log_offset(
     print("Generating data with seed ", seed)
     reset(client)
 
-    channel = grpc.insecure_channel('localhost:50054')
+    channel = grpc.insecure_channel("localhost:50054")
     log_service_stub = LogServiceStub(channel)
+    database_name = str(client.database)
 
     collection = client.create_collection(
         name="test_repair_collection_log_offset",
@@ -40,7 +87,8 @@ def test_repair_collection_log_offset(
 
     initial_version = cast(int, collection.get_model()["version"])
 
-    # Add RECORDS records, where each embedding has 3 dimensions randomly generated between 0 and 1
+    # Add RECORDS records, where each embedding has 3 dimensions randomly generated
+    # between 0 and 1.
     for i in range(0, RECORDS, BATCH_SIZE):
         ids = []
         embeddings = []
@@ -48,26 +96,31 @@ def test_repair_collection_log_offset(
         embeddings.extend([np.random.rand(1, 3)[0] for x in range(i, i + BATCH_SIZE)])
         collection.add(ids=ids, embeddings=embeddings)
 
-    wait_for_version_increase(client, collection.name, initial_version)
+    wait_for_version_increase(
+        client,
+        collection.name,
+        initial_version,
+        COMPACTION_ADDITIONAL_TIME_SECONDS,
+    )
 
-    found = False
-    now = time.time()
-    while time.time() - now < 240:
-        request = InspectLogStateRequest(database_name=str(client.database), collection_id=str(collection.id))
-        response = log_service_stub.InspectLogState(request, timeout=60)
-        if '''LogPosition { offset: 1001 }''' in response.debug:
-            found = True
-            break
-    assert found
+    collection_id = str(collection.id)
+    _wait_for_collection_log_start(
+        log_service_stub,
+        database_name,
+        collection_id,
+        EXPECTED_REPAIRED_LOG_OFFSET,
+    )
 
-    request = UpdateCollectionLogOffsetRequest(database_name=str(client.database), collection_id=str(collection.id), log_offset=1)
-    response = log_service_stub.RollbackCollectionLogOffset(request, timeout=60)
+    request = UpdateCollectionLogOffsetRequest(
+        database_name=database_name,
+        collection_id=collection_id,
+        log_offset=1,
+    )
+    log_service_stub.RollbackCollectionLogOffset(request, timeout=60)
 
-    now = time.time()
-    while time.time() - now < 240:
-        request = InspectLogStateRequest(database_name=str(client.database), collection_id=str(collection.id))
-        response = log_service_stub.InspectLogState(request, timeout=60)
-        if '''LogPosition { offset: 1001 }''' in response.debug:
-            return
-        time.sleep(1)
-    raise RuntimeError("Test timed out without repair")
+    _wait_for_collection_log_start(
+        log_service_stub,
+        database_name,
+        collection_id,
+        EXPECTED_REPAIRED_LOG_OFFSET,
+    )


### PR DESCRIPTION
## Description of changes

Extract helper functions and named constants to improve readability:
- Add _inspect_collection_log_start and _wait_for_collection_log_start
  helpers to eliminate duplicated polling logic
- Replace string matching on debug output with structured start field
- Define constants for timeouts, poll intervals, and expected offsets
- Add @multi_region_test decorator
- Remove unused imports (List, Any, Dict)

## Test plan

Tests improved.  Checked that both sides run locally.  CI for rest.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
