### PR TITLE
[TST] add multi_region_test to more tests

### DIFF
--- a/chromadb/test/distributed/test_sanity.py
+++ b/chromadb/test/distributed/test_sanity.py
@@ -5,6 +5,7 @@ import random
 import time
 from chromadb.api import ClientAPI
 from chromadb.test.conftest import (
+    multi_region_test,
     reset,
     skip_if_not_cluster,
 )
@@ -17,6 +18,7 @@ import numpy as np
 
 
 @skip_if_not_cluster()
+@multi_region_test
 def test_add(
     client: ClientAPI,
 ) -> None:
@@ -58,6 +60,7 @@ def test_add(
 
 
 @skip_if_not_cluster()
+@multi_region_test
 def test_add_include_all_with_compaction_delay(client: ClientAPI) -> None:
     seed = time.time()
     random.seed(seed)

--- a/chromadb/test/stress/test_many_collections.py
+++ b/chromadb/test/stress/test_many_collections.py
@@ -3,8 +3,10 @@ import numpy as np
 
 from chromadb.api import ServerAPI
 from chromadb.api.models.Collection import Collection
+from chromadb.test.conftest import multi_region_test
 
 
+@multi_region_test
 def test_many_collections(client: ServerAPI) -> None:
     """Test that we can create a large number of collections and that the system
     # remains responsive."""


### PR DESCRIPTION
## Description of changes

Extend multi-region test coverage by decorating additional tests
with @multi_region_test:
- test_add in distributed/test_sanity.py
- test_add_include_all_with_compaction_delay in
  distributed/test_sanity.py
- test_many_collections in stress/test_many_collections.py

## Test plan

CI + local for the named tests.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
