### PR TITLE
[BUG] propagate schema in multi-region collection ops

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -121,7 +121,6 @@ jobs:
         shell: bash
         env:
           CHROMA_THIN_CLIENT: "1"
-          MULTI_REGION: "true"
           ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -340,7 +340,12 @@ class RustBindingsAPI(ServerAPI):
         else:
             new_configuration_json_str = None
         self.bindings.update_collection(
-            str(id), new_name, new_metadata, new_configuration_json_str
+            str(id),
+            new_name,
+            new_metadata,
+            new_configuration_json_str,
+            tenant,
+            database,
         )
 
     @override

--- a/chromadb/chromadb_rust_bindings.pyi
+++ b/chromadb/chromadb_rust_bindings.pyi
@@ -119,6 +119,8 @@ class Bindings:
         new_name: Optional[str] = None,
         new_metadata: Optional[CollectionMetadata] = None,
         new_configuration_json_str: Optional[str] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
     ) -> None: ...
     def delete_collection(
         self,

--- a/chromadb/db/impl/grpc/client.py
+++ b/chromadb/db/impl/grpc/client.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional, Sequence, Tuple, Union, cast
 from uuid import UUID
 from overrides import overrides
@@ -339,6 +340,8 @@ class GrpcSysDB(SysDB):
                 database=database,
                 segments=[to_proto_segment(segment) for segment in segments],
             )
+            if schema is not None:
+                request.schema_str = json.dumps(schema.serialize_to_json())
             response = self._sys_db_stub.CreateCollection(
                 request, timeout=self._request_timeout_seconds
             )

--- a/chromadb/db/impl/grpc/server.py
+++ b/chromadb/db/impl/grpc/server.py
@@ -4,6 +4,12 @@ from uuid import UUID
 from overrides import overrides
 import json
 
+from chromadb.api.collection_configuration import (
+    load_update_collection_configuration_from_json_str,
+    overwrite_collection_configuration,
+    update_schema_from_collection_configuration,
+)
+from chromadb.api.types import Schema
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Component, System
 from chromadb.proto.convert import (
     from_proto_metadata,
@@ -292,7 +298,9 @@ class GrpcMockSysDB(SysDBServicer, Component):
             id=id,
             name=request.name,
             configuration_json=configuration_json,
-            serialized_schema=None,
+            serialized_schema=json.loads(request.schema_str)
+            if request.HasField("schema_str") and request.schema_str
+            else None,
             metadata=from_proto_metadata(request.metadata),
             dimension=request.dimension,
             database=database,
@@ -477,6 +485,26 @@ class GrpcMockSysDB(SysDBServicer, Component):
             elif request.HasField("reset_metadata"):
                 if request.reset_metadata:
                     collection["metadata"] = {}
+            # NOTE(rescrv):  Unsure of the invariants between the json string and the other schema,
+            # but from what I can gather, the configuration_json_str is the old way and this retains
+            # compatiblity.  It was necessary to get parity between sysdb and rust sysdb.
+            if request.HasField("configuration_json_str"):
+                update_configuration = load_update_collection_configuration_from_json_str(
+                    request.configuration_json_str
+                )
+                collection.set_configuration(
+                    overwrite_collection_configuration(
+                        collection.get_configuration(), update_configuration
+                    )
+                )
+
+                serialized_schema = collection.get_serialized_schema()
+                if serialized_schema is not None:
+                    schema = update_schema_from_collection_configuration(
+                        Schema.deserialize_from_json(serialized_schema),
+                        update_configuration,
+                    )
+                    collection.set_serialized_schema(schema.serialize_to_json())
 
             return UpdateCollectionResponse()
 

--- a/chromadb/proto/convert.py
+++ b/chromadb/proto/convert.py
@@ -240,6 +240,9 @@ def from_proto_collection(collection: chroma_pb.Collection) -> Collection:
         id=UUID(hex=collection.id),
         name=collection.name,
         configuration_json=json.loads(collection.configuration_json_str),
+        serialized_schema=json.loads(collection.schema_str)
+        if collection.HasField("schema_str") and collection.schema_str
+        else None,
         metadata=from_proto_metadata(collection.metadata)
         if collection.HasField("metadata")
         else None,
@@ -254,7 +257,7 @@ def from_proto_collection(collection: chroma_pb.Collection) -> Collection:
 
 
 def to_proto_collection(collection: Collection) -> chroma_pb.Collection:
-    return chroma_pb.Collection(
+    collection_proto = chroma_pb.Collection(
         id=collection["id"].hex,
         name=collection["name"],
         configuration_json_str=collection_configuration_to_json_str(
@@ -269,6 +272,9 @@ def to_proto_collection(collection: Collection) -> chroma_pb.Collection:
         log_position=collection["log_position"],
         version=collection["version"],
     )
+    if collection["serialized_schema"] is not None:
+        collection_proto.schema_str = json.dumps(collection["serialized_schema"])
+    return collection_proto
 
 
 def to_proto_operation(operation: Operation) -> chroma_pb.Operation:

--- a/chromadb/test/api/test_schema_e2e.py
+++ b/chromadb/test/api/test_schema_e2e.py
@@ -17,6 +17,7 @@ from chromadb.api.types import (
 from chromadb.execution.expression.operator import Key
 from chromadb.test.conftest import (
     ClientFactories,
+    multi_region_test,
     is_spann_disabled_mode,
     skip_if_not_cluster,
     skip_reason_spann_disabled,
@@ -98,12 +99,14 @@ class RecordingSearchEmbeddingFunction(EmbeddingFunction[List[str]]):
         return RecordingSearchEmbeddingFunction(config.get("label", "default"))
 
 
+@multi_region_test
 def test_schema_vector_config_persistence(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Ensure schema-provided SPANN settings persist across client restarts."""
 
-    client = client_factories.create_client_from_system()
+    client = client_factories.create_client(database=database_name)
     client.reset()
 
     collection_name = f"schema_spann_{uuid4().hex}"
@@ -140,7 +143,7 @@ def test_schema_vector_config_persistence(
     assert vector_index.config.space is not None
     assert vector_index.config.space == "cosine"
 
-    client_reloaded = client_factories.create_client_from_system()
+    client_reloaded = client_factories.create_client(database=database_name)
     reloaded_collection = client_reloaded.get_collection(
         name=collection_name,
     )
@@ -156,12 +159,14 @@ def test_schema_vector_config_persistence(
     assert reloaded_vector_index.config.space == "cosine"
 
 
+@multi_region_test
 def test_schema_vector_config_persistence_with_ef(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Ensure schema-provided SPANN settings persist across client restarts."""
 
-    client = client_factories.create_client_from_system()
+    client = client_factories.create_client(database=database_name)
     client.reset()
 
     collection_name = f"schema_spann_{uuid4().hex}"
@@ -236,7 +241,7 @@ def test_schema_vector_config_persistence_with_ef(
         assert hnsw_json["ef_search"] == 100
         assert hnsw_json["max_neighbors"] == 16
 
-    client_reloaded = client_factories.create_client_from_system()
+    client_reloaded = client_factories.create_client(database=database_name)
     reloaded_collection = client_reloaded.get_collection(
         name=collection_name,
     )
@@ -298,11 +303,12 @@ class DeterministicSparseEmbeddingFunction(SparseEmbeddingFunction[List[str]]):
 
 def _create_isolated_collection(
     client_factories: "ClientFactories",
+    database_name: str,
     schema: Optional[Schema] = None,
     embedding_function: Optional[EmbeddingFunction[Any]] = None,
 ) -> Tuple[Collection, ClientAPI]:
     """Provision a new temporary collection and return it with the backing client."""
-    client = client_factories.create_client_from_system()
+    client = client_factories.create_client(database=database_name)
     client.reset()
 
     collection_name = f"schema_e2e_{uuid4().hex}"
@@ -354,11 +360,13 @@ def _collect_knn_queries(rank: Any) -> List[Any]:
     return queries
 
 
+@multi_region_test
 def test_schema_defaults_enable_indexed_operations(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Validate default schema indexes support filtering, updates, and embeddings."""
-    collection, client = _create_isolated_collection(client_factories)
+    collection, client = _create_isolated_collection(client_factories, database_name)
 
     schema = collection.schema
     assert schema is not None
@@ -432,8 +440,10 @@ def test_schema_defaults_enable_indexed_operations(
         assert reloaded.schema.serialize_to_json() == schema.serialize_to_json()
 
 
+@multi_region_test
 def test_get_or_create_and_get_collection_preserve_schema(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Ensure repeated collection lookups reuse the persisted schema definition."""
     base_schema = Schema()
@@ -448,6 +458,7 @@ def test_get_or_create_and_get_collection_preserve_schema(
 
     collection, client = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=base_schema,
     )
 
@@ -474,8 +485,10 @@ def test_get_or_create_and_get_collection_preserve_schema(
     assert set(stored["ids"]) == {"schema-preserve"}
 
 
+@multi_region_test
 def test_delete_collection_resets_schema_configuration(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Deleting and recreating a collection should drop prior schema overrides."""
     schema = Schema()
@@ -486,6 +499,7 @@ def test_delete_collection_resets_schema_configuration(
 
     collection, client = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=schema,
     )
 
@@ -503,8 +517,10 @@ def test_delete_collection_resets_schema_configuration(
 
 
 @pytest.mark.skipif(not is_spann_disabled_mode, reason=skip_reason_spann_enabled)
+@multi_region_test
 def test_sparse_vector_not_allowed_locally(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Sparse vector configs are not allowed to be created locally."""
     schema = Schema()
@@ -512,12 +528,14 @@ def test_sparse_vector_not_allowed_locally(
     with pytest.raises(
         InvalidArgumentError, match="Sparse vector indexing is not enabled in local"
     ):
-        _create_isolated_collection(client_factories, schema=schema)
+        _create_isolated_collection(client_factories, database_name, schema=schema)
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_vector_source_key_and_index_constraints(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Sparse vector configs honor source key embedding and single-index enforcement."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="source-test")
@@ -533,7 +551,11 @@ def test_sparse_vector_source_key_and_index_constraints(
     schema.create_index(key="tag_a", config=StringInvertedIndexConfig())
     schema.create_index(key="tag_b", config=StringInvertedIndexConfig())
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     assert collection.schema is not None
     assert "sparse_metadata" in collection.schema.keys
@@ -573,8 +595,10 @@ def test_sparse_vector_source_key_and_index_constraints(
     assert set(string_filter["ids"]) == {"sparse-1"}
 
 
+@multi_region_test
 def test_schema_persistence_with_custom_overrides(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Custom schema overrides persist across new client instances."""
     schema = Schema()
@@ -585,6 +609,7 @@ def test_schema_persistence_with_custom_overrides(
 
     collection, client = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=schema,
     )
 
@@ -604,7 +629,7 @@ def test_schema_persistence_with_custom_overrides(
     assert collection.schema is not None
     expected_schema_json = collection.schema.serialize_to_json()
 
-    reloaded_client = client_factories.create_client_from_system()
+    reloaded_client = client_factories.create_client(database=database_name)
     reloaded_collection = reloaded_client.get_collection(name=collection.name)
     assert reloaded_collection.schema is not None
     if not is_spann_disabled_mode:
@@ -614,8 +639,10 @@ def test_schema_persistence_with_custom_overrides(
     assert set(fetched["ids"]) == {"persist-1"}
 
 
+@multi_region_test
 def test_collection_embed_uses_schema_or_collection_embedding_function(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """_embed should respect schema-provided and direct embedding functions."""
 
@@ -625,6 +652,7 @@ def test_collection_embed_uses_schema_or_collection_embedding_function(
     )
     schema_collection, _ = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=schema,
     )
 
@@ -635,6 +663,7 @@ def test_collection_embed_uses_schema_or_collection_embedding_function(
     direct_emb_fn = SimpleEmbeddingFunction(dim=3)
     direct_collection, _ = _create_isolated_collection(
         client_factories,
+        database_name,
         embedding_function=direct_emb_fn,
     )
 
@@ -644,14 +673,18 @@ def test_collection_embed_uses_schema_or_collection_embedding_function(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_search_embeds_string_knn_queries(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """_embed_search_string_queries should embed string KNN queries using collection EF."""
 
     embedding_fn = RecordingSearchEmbeddingFunction(label="primary")
     collection, _ = _create_isolated_collection(
-        client_factories, embedding_function=embedding_fn
+        client_factories,
+        database_name,
+        embedding_function=embedding_fn,
     )
 
     search = Search().rank(Knn(query="hello world"))
@@ -672,8 +705,10 @@ def test_search_embeds_string_knn_queries(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_search_embeds_string_knn_queries_with_sparse_embedding_function(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """_embed_search_string_queries should embed string KNN queries using collection EF."""
 
@@ -684,7 +719,11 @@ def test_search_embeds_string_knn_queries_with_sparse_embedding_function(
             source_key="raw_text", embedding_function=sparse_ef
         ),
     )
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     search = Search().rank(Knn(key="sparse_metadata", query="hello world"))
 
@@ -702,14 +741,18 @@ def test_search_embeds_string_knn_queries_with_sparse_embedding_function(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_search_embeds_string_queries_in_nested_ranks(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """String queries in composite rank trees should all be embedded."""
 
     embedding_fn = RecordingSearchEmbeddingFunction(label="nested")
     collection, _ = _create_isolated_collection(
-        client_factories, embedding_function=embedding_fn
+        client_factories,
+        database_name,
+        embedding_function=embedding_fn,
     )
 
     rank_one = (Knn(query="alpha") + Knn(query="beta")).max(Knn(query="gamma"))
@@ -730,13 +773,16 @@ def test_search_embeds_string_queries_in_nested_ranks(
     assert all(isinstance(query, list) for query in all_queries)
 
 
+@multi_region_test
 def test_schema_delete_index_and_restore(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Toggling inverted index enablement reflects in query behavior."""
     disabled_defaults = Schema().delete_index(config=StringInvertedIndexConfig())
     collection, client = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=disabled_defaults,
     )
 
@@ -786,14 +832,20 @@ def test_schema_delete_index_and_restore(
     assert set(search["ids"]) == {"key-enabled"}
 
 
+@multi_region_test
 def test_disabled_metadata_index_filters_raise_invalid_argument_all_modes(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Disabled metadata inverted index should block filter-based operations in get, query, and delete for local, single node, and distributed."""
     schema = Schema().delete_index(
         key="restricted_tag", config=StringInvertedIndexConfig()
     )
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     collection.add(
         ids=["restricted-doc"],
@@ -833,14 +885,20 @@ def test_disabled_metadata_index_filters_raise_invalid_argument_all_modes(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_disabled_metadata_index_filters_raise_invalid_argument(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Disabled metadata inverted index should block filter-based operations."""
     schema = Schema().delete_index(
         key="restricted_tag", config=StringInvertedIndexConfig()
     )
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     collection.add(
         ids=["restricted-doc"],
@@ -881,11 +939,13 @@ def test_disabled_metadata_index_filters_raise_invalid_argument(
         _expect_disabled_error(operation)
 
 
+@multi_region_test
 def test_schema_discovers_new_keys_after_compaction(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Compaction promotes unseen metadata keys into discoverable schema entries."""
-    collection, client = _create_isolated_collection(client_factories)
+    collection, client = _create_isolated_collection(client_factories, database_name)
 
     initial_version = get_collection_version(client, collection.name)
 
@@ -943,18 +1003,20 @@ def test_schema_discovers_new_keys_after_compaction(
     result_upsert = collection.get(where={"discover_upsert": "topic_42"})
     assert set(result_upsert["ids"]) == {"discover-upsert-42"}
 
-    reload_client = client_factories.create_client_from_system()
+    reload_client = client_factories.create_client(database=database_name)
     persisted = reload_client.get_collection(collection.name)
     assert persisted.schema is not None
     assert "discover_add" in persisted.schema.keys
     assert "discover_upsert" in persisted.schema.keys
 
 
+@multi_region_test
 def test_schema_rejects_conflicting_discoverable_key_types(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Conflicting value types should not corrupt discoverable schema entries."""
-    collection, client = _create_isolated_collection(client_factories)
+    collection, client = _create_isolated_collection(client_factories, database_name)
 
     initial_version = get_collection_version(client, collection.name)
 
@@ -1003,6 +1065,7 @@ def test_schema_rejects_conflicting_discoverable_key_types(
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
 def test_collection_fork_inherits_and_isolates_schema(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Assert forked collections inherit schema and evolve independently of the parent."""
     schema = Schema()
@@ -1010,6 +1073,7 @@ def test_collection_fork_inherits_and_isolates_schema(
 
     collection, client = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=schema,
     )
 
@@ -1073,8 +1137,10 @@ def test_collection_fork_inherits_and_isolates_schema(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_schema_embedding_configuration_enforced(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Schema-provided embedding functions drive both dense and sparse embeddings."""
     vector_schema = Schema().create_index(
@@ -1082,6 +1148,7 @@ def test_schema_embedding_configuration_enforced(
     )
     vector_collection, _ = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=vector_schema,
         embedding_function=SimpleEmbeddingFunction(dim=5),
     )
@@ -1105,6 +1172,7 @@ def test_schema_embedding_configuration_enforced(
     )
     sparse_collection, _ = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=sparse_schema,
     )
 
@@ -1141,8 +1209,10 @@ def test_schema_embedding_configuration_enforced(
     assert "sparse_auto" not in numeric_metadata
 
 
+@multi_region_test
 def test_schema_precedence_for_overrides_discoverables_and_defaults(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Explicit overrides take precedence over disabled defaults and discoverables."""
     schema = (
@@ -1153,6 +1223,7 @@ def test_schema_precedence_for_overrides_discoverables_and_defaults(
 
     collection, client = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=schema,
     )
 
@@ -1193,8 +1264,10 @@ def test_schema_precedence_for_overrides_discoverables_and_defaults(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_with_document_source_no_metadata(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test sparse embedding auto-generation using #document as source with no metadata."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="doc_no_meta")
@@ -1207,7 +1280,11 @@ def test_sparse_auto_embedding_with_document_source_no_metadata(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Add documents without metadata
     collection.add(
@@ -1234,8 +1311,10 @@ def test_sparse_auto_embedding_with_document_source_no_metadata(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_with_document_source_and_metadata(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test sparse embedding with #document source when metadata is also provided."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="doc_with_meta")
@@ -1248,7 +1327,11 @@ def test_sparse_auto_embedding_with_document_source_and_metadata(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Add documents with metadata
     collection.add(
@@ -1280,8 +1363,10 @@ def test_sparse_auto_embedding_with_document_source_and_metadata(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_with_metadata_source_key(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test sparse embedding using a metadata field as source."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="meta_source")
@@ -1294,7 +1379,11 @@ def test_sparse_auto_embedding_with_metadata_source_key(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Add with source field in metadata
     collection.add(
@@ -1330,8 +1419,10 @@ def test_sparse_auto_embedding_with_metadata_source_key(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_with_mixed_metadata_none_and_filled(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test sparse embedding with mixed metadata (None, empty, filled)."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="mixed_meta")
@@ -1344,7 +1435,11 @@ def test_sparse_auto_embedding_with_mixed_metadata_none_and_filled(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Add with None metadata items mixed in
     collection.add(
@@ -1378,8 +1473,10 @@ def test_sparse_auto_embedding_with_mixed_metadata_none_and_filled(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_skips_existing_values(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test that sparse auto-embedding doesn't overwrite existing values."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="preserve")
@@ -1392,7 +1489,11 @@ def test_sparse_auto_embedding_skips_existing_values(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Pre-create a sparse vector
     existing_sparse = SparseVector(indices=[999], values=[123.456])
@@ -1426,8 +1527,10 @@ def test_sparse_auto_embedding_skips_existing_values(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_with_missing_source_field(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test sparse embedding when source metadata field is missing or wrong type."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="missing_field")
@@ -1440,7 +1543,11 @@ def test_sparse_auto_embedding_with_missing_source_field(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     collection.add(
         ids=["f1", "f2", "f3", "f4"],
@@ -1469,8 +1576,10 @@ def test_sparse_auto_embedding_with_missing_source_field(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_with_string_inverted_index(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test sparse auto-embedding works alongside string inverted indexes."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="with_string_index")
@@ -1488,7 +1597,11 @@ def test_sparse_auto_embedding_with_string_inverted_index(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     collection.add(
         ids=["multi1", "multi2"],
@@ -1524,8 +1637,10 @@ def test_sparse_auto_embedding_with_string_inverted_index(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_dense_and_sparse_auto_embeddings_together(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test that dense and sparse auto-embeddings work together."""
     dense_ef = SimpleEmbeddingFunction(dim=4)
@@ -1543,6 +1658,7 @@ def test_dense_and_sparse_auto_embeddings_together(
 
     collection, _ = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=schema,
         embedding_function=dense_ef,
     )
@@ -1570,8 +1686,10 @@ def test_dense_and_sparse_auto_embeddings_together(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_with_update_and_upsert(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test sparse auto-embedding with update and upsert operations."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="update_upsert")
@@ -1584,7 +1702,11 @@ def test_sparse_auto_embedding_with_update_and_upsert(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Initial add
     collection.add(
@@ -1626,8 +1748,10 @@ def test_sparse_auto_embedding_with_update_and_upsert(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_persistence_across_client_reload(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test that sparse auto-embedding config persists across client reloads."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="persist_test")
@@ -1640,7 +1764,11 @@ def test_sparse_auto_embedding_persistence_across_client_reload(
         ),
     )
 
-    collection, client = _create_isolated_collection(client_factories, schema=schema)
+    collection, client = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
     collection_name = collection.name
 
     collection.add(
@@ -1649,7 +1777,7 @@ def test_sparse_auto_embedding_persistence_across_client_reload(
     )
 
     # Reload client
-    reloaded_client = client_factories.create_client_from_system()
+    reloaded_client = client_factories.create_client(database=database_name)
     reloaded_collection = reloaded_client.get_collection(
         name=collection_name,
     )
@@ -1675,8 +1803,10 @@ def test_sparse_auto_embedding_persistence_across_client_reload(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_with_batch_operations(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test sparse auto-embedding with large batch of documents."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="batch_test")
@@ -1689,7 +1819,11 @@ def test_sparse_auto_embedding_with_batch_operations(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Add large batch
     batch_size = 100
@@ -1714,8 +1848,10 @@ def test_sparse_auto_embedding_with_batch_operations(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_auto_embedding_with_empty_documents(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test sparse auto-embedding handles empty/None documents gracefully."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="empty_test")
@@ -1728,7 +1864,11 @@ def test_sparse_auto_embedding_with_empty_documents(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Add with empty string document
     collection.add(
@@ -1745,12 +1885,14 @@ def test_sparse_auto_embedding_with_empty_documents(
     assert "empty_sparse" in metadata
 
 
+@multi_region_test
 def test_default_embedding_function_when_no_schema_provided(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Verify that when no schema is provided, the collection uses DefaultEmbeddingFunction (not legacy)."""
     # Create collection without providing any schema
-    collection, client = _create_isolated_collection(client_factories)
+    collection, client = _create_isolated_collection(client_factories, database_name)
 
     # Get the schema from the collection
     schema = collection.schema
@@ -1802,11 +1944,13 @@ def test_default_embedding_function_when_no_schema_provided(
     assert sparse_ef_config["type"] == "unknown"
 
 
+@multi_region_test
 def test_custom_embedding_function_without_schema(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Verify that custom embedding function is reflected in schema when no schema is provided."""
-    client = client_factories.create_client_from_system()
+    client = client_factories.create_client(database=database_name)
     client.reset()
 
     collection_name = f"custom_ef_no_schema_{uuid4().hex}"
@@ -1878,11 +2022,13 @@ def test_custom_embedding_function_without_schema(
     assert len(result["embeddings"][0]) == 8
 
 
+@multi_region_test
 def test_custom_embedding_function_with_default_schema(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Verify that custom embedding function is reflected in schema when default Schema() is provided."""
-    client = client_factories.create_client_from_system()
+    client = client_factories.create_client(database=database_name)
     client.reset()
 
     collection_name = f"custom_ef_default_schema_{uuid4().hex}"
@@ -1955,11 +2101,13 @@ def test_custom_embedding_function_with_default_schema(
     assert len(result["embeddings"][0]) == 8
 
 
+@multi_region_test
 def test_conflicting_embedding_functions_in_schema_and_config_fails(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Verify that setting different custom embedding functions in schema and config fails."""
-    client = client_factories.create_client_from_system()
+    client = client_factories.create_client(database=database_name)
     client.reset()
 
     collection_name = f"conflict_ef_{uuid4().hex}"
@@ -1988,8 +2136,10 @@ def test_conflicting_embedding_functions_in_schema_and_config_fails(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_create_index_with_key_type(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test that create_index accepts both str and Key types."""
     # Create schema using both str and Key types
@@ -1997,7 +2147,11 @@ def test_create_index_with_key_type(
     schema.create_index(config=StringInvertedIndexConfig(), key="field_str")
     schema.create_index(config=IntInvertedIndexConfig(), key=Key("field_key"))
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Verify both fields are in the schema
     assert collection.schema is not None
@@ -2021,8 +2175,10 @@ def test_create_index_with_key_type(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_delete_index_with_key_type(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test that delete_index accepts both str and Key types."""
     # Disable indexes using both str and Key types
@@ -2030,7 +2186,11 @@ def test_delete_index_with_key_type(
     schema.delete_index(config=StringInvertedIndexConfig(), key="disabled_str")
     schema.delete_index(config=IntInvertedIndexConfig(), key=Key("disabled_key"))
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Verify both fields have disabled indexes
     assert collection.schema is not None
@@ -2053,8 +2213,10 @@ def test_delete_index_with_key_type(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_vector_index_config_with_key_document_source(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test that VectorIndexConfig source_key accepts Key.DOCUMENT."""
     schema = Schema()
@@ -2067,6 +2229,7 @@ def test_vector_index_config_with_key_document_source(
 
     collection, _ = _create_isolated_collection(
         client_factories,
+        database_name,
         schema=schema,
         embedding_function=SimpleEmbeddingFunction(dim=5),
     )
@@ -2100,8 +2263,10 @@ def test_vector_index_config_with_key_document_source(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_sparse_vector_index_config_with_key_types(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test that SparseVectorIndexConfig source_key accepts both str and Key types."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="key_types")
@@ -2115,7 +2280,11 @@ def test_sparse_vector_index_config_with_key_types(
         ),
     )
 
-    collection1, _ = _create_isolated_collection(client_factories, schema=schema1)
+    collection1, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema1,
+    )
     assert collection1.schema is not None
     sparse1_config = collection1.schema.keys["sparse1"].sparse_vector
     assert sparse1_config is not None
@@ -2150,7 +2319,11 @@ def test_sparse_vector_index_config_with_key_types(
         ),
     )
 
-    collection2, _ = _create_isolated_collection(client_factories, schema=schema2)
+    collection2, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema2,
+    )
     assert collection2.schema is not None
     sparse2_config = collection2.schema.keys["sparse2"].sparse_vector
     assert sparse2_config is not None
@@ -2232,11 +2405,13 @@ def test_schema_rejects_invalid_source_key_in_configs() -> None:
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_server_validates_schema_with_special_keys(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test that server-side validation rejects schemas with invalid special keys."""
-    client = client_factories.create_client_from_system()
+    client = client_factories.create_client(database=database_name)
     client.reset()
 
     collection_name = f"server_validate_{uuid4().hex}"
@@ -2273,11 +2448,13 @@ def test_server_validates_schema_with_special_keys(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_server_validates_invalid_source_key_in_sparse_vector_config(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Test that server-side validation rejects invalid source_key in SparseVectorIndexConfig."""
-    client = client_factories.create_client_from_system()
+    client = client_factories.create_client(database=database_name)
     client.reset()
 
     collection_name = f"server_source_key_{uuid4().hex}"
@@ -2321,6 +2498,7 @@ def test_server_validates_invalid_source_key_in_sparse_vector_config(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_modify_collection_no_initial_config_creates_default_schema(
     client: ClientAPI,
 ) -> None:
@@ -2355,6 +2533,7 @@ def test_modify_collection_no_initial_config_creates_default_schema(
 
 
 @pytest.mark.skipif(not is_spann_disabled_mode, reason="SPANN is disabled")
+@multi_region_test
 def test_modify_collection_no_initial_config_creates_default_schema_local(
     client: ClientAPI,
 ) -> None:
@@ -2389,6 +2568,7 @@ def test_modify_collection_no_initial_config_creates_default_schema_local(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_modify_collection_with_initial_spann_schema(client: ClientAPI) -> None:
     """Test creating collection with SPANN schema within server limits and modifying it."""
     collection_name = f"test_modify_with_schema_{uuid4()}"
@@ -2434,6 +2614,7 @@ def test_modify_collection_with_initial_spann_schema(client: ClientAPI) -> None:
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_modify_collection_updates_schema_spann_multiple_fields(
     client: ClientAPI,
 ) -> None:
@@ -2479,6 +2660,7 @@ def test_modify_collection_updates_schema_spann_multiple_fields(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_modify_collection_preserves_other_schema_fields(client: ClientAPI) -> None:
     """Test that modifying configuration doesn't affect other schema value types."""
     collection_name = f"test_modify_schema_preserve_{uuid4()}"
@@ -2617,8 +2799,10 @@ class TestSparseEmbeddingFunction(SparseEmbeddingFunction[List[str]]):
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_search_api_uses_embedded_searches_with_sparse_embeddings(
     client_factories: ClientFactories,
+    database_name: str,
 ) -> None:
     """Test that search API uses embedded_searches when string queries are embedded."""
 
@@ -2631,7 +2815,11 @@ def test_search_api_uses_embedded_searches_with_sparse_embeddings(
         ),
     )
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     collection.add(
         ids=["doc1", "doc2"],
@@ -2658,14 +2846,20 @@ def test_search_api_uses_embedded_searches_with_sparse_embeddings(
 # ============================================================================
 
 
+@multi_region_test
 def test_fts_disabled_blocks_where_document_queries(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Disabling FTS via schema should block where_document queries on get, query, and delete."""
     schema = Schema()
     schema.delete_index(config=FtsIndexConfig(), key="#document")
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     # Verify FTS is disabled in the schema
     assert collection.schema is not None
@@ -2707,11 +2901,13 @@ def test_fts_disabled_blocks_where_document_queries(
     assert set(filtered["ids"]) == {"fts-off-1", "fts-off-3"}
 
 
+@multi_region_test
 def test_fts_enabled_by_default_where_document_works(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Default schema should have FTS enabled and where_document queries should work."""
-    collection, _ = _create_isolated_collection(client_factories)
+    collection, _ = _create_isolated_collection(client_factories, database_name)
 
     # Verify FTS is enabled in the default schema
     assert collection.schema is not None
@@ -2732,14 +2928,20 @@ def test_fts_enabled_by_default_where_document_works(
     assert set(items["ids"]) == {"fts-on-2"}
 
 
+@multi_region_test
 def test_fts_disabled_schema_persistence(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """FTS-disabled schema should persist across client reloads."""
     schema = Schema()
     schema.delete_index(config=FtsIndexConfig(), key="#document")
 
-    collection, client = _create_isolated_collection(client_factories, schema=schema)
+    collection, client = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
     collection_name = collection.name
 
     collection.add(
@@ -2748,7 +2950,7 @@ def test_fts_disabled_schema_persistence(
     )
 
     # Reload client
-    reloaded_client = client_factories.create_client_from_system()
+    reloaded_client = client_factories.create_client(database=database_name)
     reloaded_collection = reloaded_client.get_collection(name=collection_name)
 
     # Verify FTS is still disabled after reload
@@ -2763,14 +2965,20 @@ def test_fts_disabled_schema_persistence(
         reloaded_collection.get(where_document={"$contains": "persistent"})
 
 
+@multi_region_test
 def test_fts_disabled_documents_still_stored(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Documents should still be stored and retrievable when FTS is disabled."""
     schema = Schema()
     schema.delete_index(config=FtsIndexConfig(), key="#document")
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     collection.add(
         ids=["stored-1", "stored-2"],
@@ -2787,8 +2995,10 @@ def test_fts_disabled_documents_still_stored(
     assert collection.count() == 2
 
 
+@multi_region_test
 def test_fts_disabled_then_new_collection_with_fts_enabled(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Deleting a FTS-disabled collection and recreating with FTS enabled should restore FTS."""
     # Create with FTS disabled
@@ -2796,7 +3006,9 @@ def test_fts_disabled_then_new_collection_with_fts_enabled(
     schema_disabled.delete_index(config=FtsIndexConfig(), key="#document")
 
     collection, client = _create_isolated_collection(
-        client_factories, schema=schema_disabled
+        client_factories,
+        database_name,
+        schema=schema_disabled,
     )
     col_name = collection.name
 
@@ -2822,14 +3034,20 @@ def test_fts_disabled_then_new_collection_with_fts_enabled(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+@multi_region_test
 def test_fts_disabled_search_api_blocks_document_filter(
     client_factories: "ClientFactories",
+    database_name: str,
 ) -> None:
     """Search API should also reject document filters when FTS is disabled."""
     schema = Schema()
     schema.delete_index(config=FtsIndexConfig(), key="#document")
 
-    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        database_name,
+        schema=schema,
+    )
 
     collection.add(
         ids=["search-fts-1", "search-fts-2"],

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -559,9 +559,9 @@ users:
                 yield item
 
 
-def fastapi_fixture_admin_and_singleton_tenant_db_user() -> Generator[
-    System, None, None
-]:
+def fastapi_fixture_admin_and_singleton_tenant_db_user(
+    singleton_database: str = "singleton_database",
+) -> Generator[System, None, None]:
     # Check if we should connect to existing server instead of spawning a new one
     if os.getenv("CHROMA_SERVER_HOST") and not NOT_CLUSTER_ONLY:
         # Connect to existing Tilt instance using the same pattern as basic_http_client
@@ -587,7 +587,7 @@ def fastapi_fixture_admin_and_singleton_tenant_db_user() -> Generator[
     # Original behavior: spawn isolated server
     with tempfile.NamedTemporaryFile("w", suffix=".authn", delete=False) as f:
         f.write(
-            """
+            f"""
 users:
   - id: admin
     tokens:
@@ -595,7 +595,7 @@ users:
   - id: singleton_user
     tenant: singleton_tenant
     databases:
-      - singleton_database
+      - {singleton_database}
     tokens:
       - singleton-token
 """

--- a/chromadb/test/distributed/test_repair_collection_log_offset.py
+++ b/chromadb/test/distributed/test_repair_collection_log_offset.py
@@ -1,17 +1,21 @@
 # Add some records, wait for compaction, then roll back the log offset.
-# Poll the log for up to 30s to see if the offset gets repaired.
+# Poll the log for up to 240s to see if the offset gets repaired.
 
 import grpc
 import random
 import time
-from typing import cast, List, Any, Dict
+from typing import cast
 
 import numpy as np
 
 from chromadb.api import ClientAPI
-from chromadb.proto.logservice_pb2 import InspectLogStateRequest, UpdateCollectionLogOffsetRequest
+from chromadb.proto.logservice_pb2 import (
+    InspectLogStateRequest,
+    UpdateCollectionLogOffsetRequest,
+)
 from chromadb.proto.logservice_pb2_grpc import LogServiceStub
 from chromadb.test.conftest import (
+    multi_region_test,
     reset,
     skip_if_not_cluster,
 )
@@ -19,8 +23,50 @@ from chromadb.test.utils.wait_for_version_increase import wait_for_version_incre
 
 RECORDS = 1000
 BATCH_SIZE = 100
+EXPECTED_REPAIRED_LOG_OFFSET = RECORDS + 1
+COMPACTION_ADDITIONAL_TIME_SECONDS = 120
+LOG_REPAIR_TIMEOUT_SECONDS = 240
+LOG_POLL_INTERVAL_SECONDS = 1
+
+
+def _inspect_collection_log_start(
+    log_service_stub: LogServiceStub,
+    database_name: str,
+    collection_id: str,
+) -> int:
+    request = InspectLogStateRequest(
+        database_name=database_name,
+        collection_id=collection_id,
+    )
+    response = log_service_stub.InspectLogState(request, timeout=60)
+    return int(response.start)
+
+
+def _wait_for_collection_log_start(
+    log_service_stub: LogServiceStub,
+    database_name: str,
+    collection_id: str,
+    expected_start: int,
+) -> None:
+    deadline = time.time() + LOG_REPAIR_TIMEOUT_SECONDS
+    last_start = None
+    while time.time() < deadline:
+        last_start = _inspect_collection_log_start(
+            log_service_stub, database_name, collection_id
+        )
+        if last_start == expected_start:
+            return
+        time.sleep(LOG_POLL_INTERVAL_SECONDS)
+
+    raise TimeoutError(
+        "Timed out waiting for collection log start "
+        f"database={database_name} collection_id={collection_id} "
+        f"expected={expected_start} last_seen={last_start}"
+    )
+
 
 @skip_if_not_cluster()
+@multi_region_test
 def test_repair_collection_log_offset(
     client: ClientAPI,
 ) -> None:
@@ -29,8 +75,9 @@ def test_repair_collection_log_offset(
     print("Generating data with seed ", seed)
     reset(client)
 
-    channel = grpc.insecure_channel('localhost:50054')
+    channel = grpc.insecure_channel("localhost:50054")
     log_service_stub = LogServiceStub(channel)
+    database_name = str(client.database)
 
     collection = client.create_collection(
         name="test_repair_collection_log_offset",
@@ -40,7 +87,8 @@ def test_repair_collection_log_offset(
 
     initial_version = cast(int, collection.get_model()["version"])
 
-    # Add RECORDS records, where each embedding has 3 dimensions randomly generated between 0 and 1
+    # Add RECORDS records, where each embedding has 3 dimensions randomly generated
+    # between 0 and 1.
     for i in range(0, RECORDS, BATCH_SIZE):
         ids = []
         embeddings = []
@@ -48,26 +96,31 @@ def test_repair_collection_log_offset(
         embeddings.extend([np.random.rand(1, 3)[0] for x in range(i, i + BATCH_SIZE)])
         collection.add(ids=ids, embeddings=embeddings)
 
-    wait_for_version_increase(client, collection.name, initial_version)
+    wait_for_version_increase(
+        client,
+        collection.name,
+        initial_version,
+        COMPACTION_ADDITIONAL_TIME_SECONDS,
+    )
 
-    found = False
-    now = time.time()
-    while time.time() - now < 240:
-        request = InspectLogStateRequest(database_name=str(client.database), collection_id=str(collection.id))
-        response = log_service_stub.InspectLogState(request, timeout=60)
-        if '''LogPosition { offset: 1001 }''' in response.debug:
-            found = True
-            break
-    assert found
+    collection_id = str(collection.id)
+    _wait_for_collection_log_start(
+        log_service_stub,
+        database_name,
+        collection_id,
+        EXPECTED_REPAIRED_LOG_OFFSET,
+    )
 
-    request = UpdateCollectionLogOffsetRequest(database_name=str(client.database), collection_id=str(collection.id), log_offset=1)
-    response = log_service_stub.RollbackCollectionLogOffset(request, timeout=60)
+    request = UpdateCollectionLogOffsetRequest(
+        database_name=database_name,
+        collection_id=collection_id,
+        log_offset=1,
+    )
+    log_service_stub.RollbackCollectionLogOffset(request, timeout=60)
 
-    now = time.time()
-    while time.time() - now < 240:
-        request = InspectLogStateRequest(database_name=str(client.database), collection_id=str(collection.id))
-        response = log_service_stub.InspectLogState(request, timeout=60)
-        if '''LogPosition { offset: 1001 }''' in response.debug:
-            return
-        time.sleep(1)
-    raise RuntimeError("Test timed out without repair")
+    _wait_for_collection_log_start(
+        log_service_stub,
+        database_name,
+        collection_id,
+        EXPECTED_REPAIRED_LOG_OFFSET,
+    )

--- a/chromadb/test/distributed/test_sanity.py
+++ b/chromadb/test/distributed/test_sanity.py
@@ -5,6 +5,7 @@ import random
 import time
 from chromadb.api import ClientAPI
 from chromadb.test.conftest import (
+    multi_region_test,
     reset,
     skip_if_not_cluster,
 )
@@ -17,6 +18,7 @@ import numpy as np
 
 
 @skip_if_not_cluster()
+@multi_region_test
 def test_add(
     client: ClientAPI,
 ) -> None:
@@ -58,6 +60,7 @@ def test_add(
 
 
 @skip_if_not_cluster()
+@multi_region_test
 def test_add_include_all_with_compaction_delay(client: ClientAPI) -> None:
     seed = time.time()
     random.seed(seed)

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -15,6 +15,7 @@ from hypothesis.stateful import (
     run_state_machine_as_test,
     MultipleResults,
 )
+from chromadb.test.conftest import multi_region_test
 import chromadb.test.property.invariants as invariants
 from typing import Any, Dict, Mapping, Optional
 import numpy
@@ -241,6 +242,7 @@ class CollectionStateMachine(RuleBasedStateMachine):
         return self._model
 
 
+@multi_region_test
 def test_collections(caplog: pytest.LogCaptureFixture, client: ClientAPI) -> None:
     caplog.set_level(logging.ERROR)
     run_state_machine_as_test(lambda: CollectionStateMachine(client))  # type: ignore

--- a/chromadb/test/property/test_collections_with_database_tenant.py
+++ b/chromadb/test/property/test_collections_with_database_tenant.py
@@ -3,12 +3,12 @@ from typing import Dict, Optional, Tuple
 import pytest
 from chromadb.api import AdminAPI
 import chromadb.api.types as types
-from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT
+from chromadb.config import DEFAULT_TENANT
 from chromadb.test.conftest import (
     ClientFactories,
-    MULTI_REGION_ENABLED,
     DEFAULT_MCMR_DATABASE,
     MULTI_REGION_TOPOLOGY,
+    multi_region_test,
 )
 
 from chromadb.test.property.test_collections import CollectionStateMachine
@@ -22,11 +22,6 @@ from hypothesis.stateful import (
 )
 import chromadb.test.property.strategies as strategies
 
-EFFECTIVE_DEFAULT_DATABASE = (
-    DEFAULT_MCMR_DATABASE if MULTI_REGION_ENABLED else DEFAULT_DATABASE
-)
-
-
 class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
     """A collection state machine test that includes tenant and database information,
     and switches between them."""
@@ -39,12 +34,20 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
     admin_client: AdminAPI
     curr_tenant: str
     curr_database: str
+    effective_default_database: str
+    uses_multi_region_database: bool
 
     tenants = Bundle("tenants")
     databases = Bundle("databases")
 
-    def __init__(self, client_factories: ClientFactories):
-        client = client_factories.create_client()
+    def __init__(
+        self,
+        client_factories: ClientFactories,
+        database_name: str,
+    ) -> None:
+        self.effective_default_database = database_name
+        self.uses_multi_region_database = database_name == DEFAULT_MCMR_DATABASE
+        client = client_factories.create_client(database=database_name)
         super().__init__(client)
         self.client = client
         self.admin_client = client_factories.create_admin_client_from_system()
@@ -54,8 +57,8 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
         self.client.reset()
         self.tenant_to_database_to_model = {}
         self.curr_tenant = DEFAULT_TENANT
-        self.curr_database = EFFECTIVE_DEFAULT_DATABASE
-        self.client.set_tenant(DEFAULT_TENANT, EFFECTIVE_DEFAULT_DATABASE)
+        self.curr_database = self.effective_default_database
+        self.client.set_tenant(DEFAULT_TENANT, self.effective_default_database)
         self.set_tenant_model(self.curr_tenant, {})
         self.set_database_model_for_tenant(self.curr_tenant, self.curr_database, {})
 
@@ -72,14 +75,18 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
         # When we create a tenant, create a default database for it just for testing
         # since the state machine could call collection operations before creating a
         # database
-        self.admin_client.create_database(EFFECTIVE_DEFAULT_DATABASE, tenant=tenant)
+        self.admin_client.create_database(
+            self.effective_default_database, tenant=tenant
+        )
         self.set_tenant_model(tenant, {})
-        self.set_database_model_for_tenant(tenant, EFFECTIVE_DEFAULT_DATABASE, {})
+        self.set_database_model_for_tenant(
+            tenant, self.effective_default_database, {}
+        )
         return multiple(tenant)
 
     @rule(target=databases, name=strategies.tenant_database_name)
     def create_database(self, name: str) -> MultipleResults:  # [Tuple[str, str]]:
-        if MULTI_REGION_ENABLED:
+        if self.uses_multi_region_database:
             name = f"{MULTI_REGION_TOPOLOGY}+{name}"
         database = self.overwrite_database(name)
         tenant = self.overwrite_tenant(self.curr_tenant)
@@ -106,9 +113,9 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
 
     @rule(tenant=tenants)
     def set_tenant(self, tenant: str) -> None:
-        self.set_api_tenant_database(tenant, EFFECTIVE_DEFAULT_DATABASE)
+        self.set_api_tenant_database(tenant, self.effective_default_database)
         self.curr_tenant = tenant
-        self.curr_database = EFFECTIVE_DEFAULT_DATABASE
+        self.curr_database = self.effective_default_database
 
     # These methods allow other tests, namely
     # test_collections_with_database_tenant_override.py, to swap out the model
@@ -157,8 +164,15 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
         return self.tenant_to_database_to_model[self.curr_tenant][self.curr_database]
 
 
+@multi_region_test
 def test_collections(
-    caplog: pytest.LogCaptureFixture, client_factories: ClientFactories
+    caplog: pytest.LogCaptureFixture,
+    client_factories: ClientFactories,
+    database_name: str,
 ) -> None:
     caplog.set_level(logging.ERROR)
-    run_state_machine_as_test(lambda: TenantDatabaseCollectionStateMachine(client_factories))  # type: ignore
+    run_state_machine_as_test(
+        lambda: TenantDatabaseCollectionStateMachine(
+            client_factories, database_name=database_name
+        )
+    )  # type: ignore

--- a/chromadb/test/property/test_collections_with_database_tenant_overwrite.py
+++ b/chromadb/test/property/test_collections_with_database_tenant_overwrite.py
@@ -11,14 +11,15 @@ import uuid
 import logging
 import os
 import pytest
-from chromadb.api import AdminAPI
+from chromadb.api import AdminAPI, ServerAPI
 from chromadb.api.client import AdminClient, Client
 from chromadb.config import Settings, System
 from chromadb.test.conftest import (
     ClientFactories,
+    DEFAULT_MCMR_DATABASE,
     fastapi_fixture_admin_and_singleton_tenant_db_user,
-    MULTI_REGION_ENABLED,
     MULTI_REGION_TOPOLOGY,
+    multi_region_test,
     NOT_CLUSTER_ONLY,
 )
 from chromadb.test.property.test_collections_with_database_tenant import (
@@ -30,9 +31,13 @@ import chromadb.api.types as types
 
 # See conftest.py
 SINGLETON_TENANT = "singleton_tenant"
-SINGLETON_DATABASE = "singleton_database"
-if MULTI_REGION_ENABLED:
-    SINGLETON_DATABASE = f"{MULTI_REGION_TOPOLOGY}+singleton_database"
+SINGLETON_DATABASE_NAME = "singleton_database"
+
+
+def singleton_database_name(database_name: str) -> str:
+    if database_name == DEFAULT_MCMR_DATABASE:
+        return f"{MULTI_REGION_TOPOLOGY}+{SINGLETON_DATABASE_NAME}"
+    return SINGLETON_DATABASE_NAME
 
 
 class SingletonTenantDatabaseCollectionStateMachine(
@@ -42,17 +47,20 @@ class SingletonTenantDatabaseCollectionStateMachine(
     singleton_admin_client: AdminAPI
     root_client: Client
     root_admin_client: AdminAPI
+    singleton_database: str
 
     def __init__(
         self,
         singleton_client: Client,
         root_client: Client,
         client_factories: ClientFactories,
+        database_name: str,
     ) -> None:
-        super().__init__(client_factories)
+        super().__init__(client_factories, database_name=database_name)
         self.root_client = root_client
         self.root_admin_client = self.admin_client
 
+        self.singleton_database = singleton_database_name(database_name)
         self.singleton_client = singleton_client
         self.singleton_admin_client = AdminClient.from_system(singleton_client._system)
 
@@ -66,10 +74,14 @@ class SingletonTenantDatabaseCollectionStateMachine(
         super().initialize()
 
         self.root_admin_client.create_tenant(SINGLETON_TENANT)
-        self.root_admin_client.create_database(SINGLETON_DATABASE, SINGLETON_TENANT)
+        self.root_admin_client.create_database(
+            self.singleton_database, SINGLETON_TENANT
+        )
 
         self.set_tenant_model(SINGLETON_TENANT, {})
-        self.set_database_model_for_tenant(SINGLETON_TENANT, SINGLETON_DATABASE, {})
+        self.set_database_model_for_tenant(
+            SINGLETON_TENANT, self.singleton_database, {}
+        )
 
     @invariant()
     def check_api_and_admin_client_are_in_sync(self) -> None:
@@ -84,22 +96,18 @@ class SingletonTenantDatabaseCollectionStateMachine(
             self.client = self.root_client
             self.admin_client = self.root_admin_client
             # When switching back to root, restore the previous tenant/database context
-            # Use EFFECTIVE_DEFAULT_DATABASE for consistency with base class
-            from chromadb.test.property.test_collections_with_database_tenant import (
-                EFFECTIVE_DEFAULT_DATABASE,
-            )
             from chromadb.config import DEFAULT_TENANT
 
-            self.client.set_tenant(DEFAULT_TENANT, EFFECTIVE_DEFAULT_DATABASE)
+            self.client.set_tenant(DEFAULT_TENANT, self.effective_default_database)
             self.curr_tenant = DEFAULT_TENANT
-            self.curr_database = EFFECTIVE_DEFAULT_DATABASE
+            self.curr_database = self.effective_default_database
         else:
             self.client = self.singleton_client
             self.admin_client = self.singleton_admin_client
             # Set to singleton tenant/database context and update state
-            self.client.set_tenant(SINGLETON_TENANT, SINGLETON_DATABASE)
+            self.client.set_tenant(SINGLETON_TENANT, self.singleton_database)
             self.curr_tenant = SINGLETON_TENANT
-            self.curr_database = SINGLETON_DATABASE
+            self.curr_database = self.singleton_database
 
     @overrides
     def set_api_tenant_database(self, tenant: str, database: str) -> None:
@@ -147,7 +155,7 @@ class SingletonTenantDatabaseCollectionStateMachine(
     @overrides
     def overwrite_database(self, database: str) -> str:
         if self.client == self.singleton_client:
-            return SINGLETON_DATABASE
+            return self.singleton_database
         return database
 
     @overrides
@@ -162,18 +170,22 @@ class SingletonTenantDatabaseCollectionStateMachine(
         return self.tenant_to_database_to_model[self.curr_tenant][self.curr_database]
 
 
-def _singleton_and_root_clients() -> Tuple[Client, Client, ClientFactories]:
-    api_fixture = fastapi_fixture_admin_and_singleton_tenant_db_user()
+def _singleton_and_root_clients(
+    database_name: str,
+) -> Tuple[Client, Client, ClientFactories]:
+    singleton_database = singleton_database_name(database_name)
+    api_fixture = fastapi_fixture_admin_and_singleton_tenant_db_user(
+        singleton_database=singleton_database
+    )
     sys: System = next(api_fixture)
     sys.reset_state()
 
     # When connecting to external Tilt, also reset the server
     if os.getenv("CHROMA_SERVER_HOST") and not NOT_CLUSTER_ONLY:
-        root_client_for_reset = ClientFactories(sys).create_client()
-        root_client_for_reset.reset()
+        sys.instance(ServerAPI).reset()
 
     client_factories = ClientFactories(sys)
-    root_client = client_factories.create_client()
+    root_client = client_factories.create_client(database=database_name)
     root_client.reset()
     _root_admin_client = client_factories.create_admin_client_from_system()
 
@@ -181,39 +193,49 @@ def _singleton_and_root_clients() -> Tuple[Client, Client, ClientFactories]:
     # before we can instantiate a Client which connects to them. This also
     # means we need to manually populate state in the state machine.
     _root_admin_client.create_tenant(SINGLETON_TENANT)
-    _root_admin_client.create_database(SINGLETON_DATABASE, SINGLETON_TENANT)
+    _root_admin_client.create_database(singleton_database, SINGLETON_TENANT)
 
     singleton_settings = Settings(**dict(sys.settings))
     singleton_settings.chroma_client_auth_credentials = "singleton-token"
     singleton_system = System(singleton_settings)
     singleton_system.start()
-    singleton_client = Client.from_system(singleton_system)
+    singleton_client = Client.from_system(
+        singleton_system, tenant=SINGLETON_TENANT, database=singleton_database
+    )
 
     return singleton_client, root_client, client_factories
 
 
+@multi_region_test
 def test_collections_with_tenant_database_overwrite(
     caplog: pytest.LogCaptureFixture,
+    database_name: str,
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    singleton_client, root_client, client_factories = _singleton_and_root_clients()
+    singleton_client, root_client, client_factories = _singleton_and_root_clients(
+        database_name
+    )
     run_state_machine_as_test(
         lambda: SingletonTenantDatabaseCollectionStateMachine(
-            singleton_client, root_client, client_factories
+            singleton_client, root_client, client_factories, database_name
         )
     )  # type: ignore
 
 
+@multi_region_test
 def test_repeat_failure(
     caplog: pytest.LogCaptureFixture,
+    database_name: str,
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    singleton_client, root_client, client_factories = _singleton_and_root_clients()
+    singleton_client, root_client, client_factories = _singleton_and_root_clients(
+        database_name
+    )
 
     state = SingletonTenantDatabaseCollectionStateMachine(
-        singleton_client, root_client, client_factories
+        singleton_client, root_client, client_factories, database_name
     )
     state.initialize()
     state.check_api_and_admin_client_are_in_sync()

--- a/chromadb/test/property/test_schema.py
+++ b/chromadb/test/property/test_schema.py
@@ -13,8 +13,9 @@ from chromadb.api.types import (
 from chromadb.test.property import strategies
 from chromadb.test.property.invariants import check_metadata
 from chromadb.test.conftest import (
-    reset,
     is_spann_disabled_mode,
+    multi_region_test,
+    reset,
 )
 
 
@@ -647,6 +648,7 @@ def _assert_schema_indexes(
             ), f"Key '{key}' vector_index enabled mismatch: expected {expected_enabled}, got {actual_float_list.vector_index.enabled}"
 
 
+@multi_region_test
 @given(
     name=strategies.collection_name(),
     optional_fields=strategies.metadata_configuration_schema_strategy(),
@@ -750,6 +752,7 @@ def test_vector_index_configuration_create_collection(
                 )
 
 
+@multi_region_test
 @given(
     name=strategies.collection_name(),
     schema=strategies.schema_strategy(),

--- a/chromadb/test/stress/test_many_collections.py
+++ b/chromadb/test/stress/test_many_collections.py
@@ -3,8 +3,10 @@ import numpy as np
 
 from chromadb.api import ServerAPI
 from chromadb.api.models.Collection import Collection
+from chromadb.test.conftest import multi_region_test
 
 
+@multi_region_test
 def test_many_collections(client: ServerAPI) -> None:
     """Test that we can create a large number of collections and that the system
     # remains responsive."""

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -366,7 +366,7 @@ impl Bindings {
     }
 
     #[pyo3(
-        signature = (collection_id, new_name = None, new_metadata = None, new_configuration_json_str = None)
+        signature = (collection_id, new_name = None, new_metadata = None, new_configuration_json_str = None, tenant = DEFAULT_TENANT.to_string(), database = DEFAULT_DATABASE.to_string())
     )]
     fn update_collection(
         &self,
@@ -374,10 +374,15 @@ impl Bindings {
         new_name: Option<String>,
         new_metadata: Option<UpdateMetadata>,
         new_configuration_json_str: Option<String>,
+        tenant: String,
+        database: String,
     ) -> ChromaPyResult<()> {
+        let _ = tenant;
         let collection_id = chroma_types::CollectionUuid(
             uuid::Uuid::parse_str(&collection_id).map_err(WrappedUuidError)?,
         );
+        let database_name =
+            DatabaseName::new(database.clone()).ok_or(InvalidDatabaseNameError(database))?;
 
         let configuration_json = match new_configuration_json_str {
             Some(new_configuration_json_str) => {
@@ -397,7 +402,7 @@ impl Bindings {
         };
 
         let request = UpdateCollectionRequest::try_new(
-            None,
+            Some(database_name),
             collection_id,
             new_name,
             new_metadata.map(CollectionMetadataUpdate::UpdateMetadata),

--- a/rust/rust-sysdb/src/types.rs
+++ b/rust/rust-sysdb/src/types.rs
@@ -238,17 +238,12 @@ impl TryFrom<chroma_proto::CreateCollectionRequest> for CreateCollectionRequest 
             return Err(SysDbError::InvalidSegmentsCount);
         }
 
-        // Convert metadata if provided, filtering out legacy "hnsw:" keys
+        // Convert metadata if provided. Legacy "hnsw:" keys are still
+        // user-visible collection metadata and must round-trip.
         let metadata = req
             .metadata
             .map(|proto_metadata| -> Result<Metadata, SysDbError> {
-                let mut metadata =
-                    Metadata::try_from(proto_metadata).map_err(SysDbError::InvalidMetadata)?;
-
-                // Filter out legacy metadata keys starting with "hnsw:"
-                metadata.retain(|key, _| !key.starts_with("hnsw:"));
-
-                Ok(metadata)
+                Metadata::try_from(proto_metadata).map_err(SysDbError::InvalidMetadata)
             })
             .transpose()?;
 
@@ -1414,9 +1409,53 @@ impl TryAs<GrpcStatus> for SysDbError {
 
 #[cfg(test)]
 mod tests {
-    use super::SysDbError;
+    use super::*;
     use chroma_error::{ChromaError, ErrorCodes};
     use google_cloud_gax::grpc::Status as GrpcStatus;
+
+    #[test]
+    fn create_collection_request_preserves_legacy_hnsw_metadata() {
+        let collection_id = CollectionUuid(Uuid::new_v4());
+        let mut metadata = chroma_proto::UpdateMetadata {
+            metadata: HashMap::new(),
+        };
+        metadata.metadata.insert(
+            "hnsw:space".to_string(),
+            chroma_proto::UpdateMetadataValue {
+                value: Some(chroma_proto::update_metadata_value::Value::StringValue(
+                    "cosine".to_string(),
+                )),
+            },
+        );
+
+        let proto_req = chroma_proto::CreateCollectionRequest {
+            id: collection_id.0.to_string(),
+            name: "test_collection".to_string(),
+            dimension: None,
+            segments: [
+                SegmentScope::METADATA,
+                SegmentScope::RECORD,
+                SegmentScope::VECTOR,
+            ]
+            .into_iter()
+            .map(|scope| chroma_types::test_segment(collection_id, scope).into())
+            .collect(),
+            configuration_json_str: "{}".to_string(),
+            metadata: Some(metadata),
+            get_or_create: Some(false),
+            tenant: "test_tenant".to_string(),
+            database: "test_database".to_string(),
+            schema_str: Some(serde_json::to_string(&Schema::default()).unwrap()),
+        };
+
+        let req = CreateCollectionRequest::try_from(proto_req).unwrap();
+        let got = req.metadata.unwrap();
+
+        assert_eq!(
+            got.get("hnsw:space"),
+            Some(&MetadataValue::Str("cosine".to_string()))
+        );
+    }
 
     #[test]
     fn sysdb_error_recognizes_spanner_aborted_as_retryable() {

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -913,6 +913,12 @@ impl TryFrom<chroma_proto::CollectionToGcInfo> for CollectionToGcInfo {
 }
 
 impl GrpcSysDb {
+    fn routes_to_mcmr(database_name: &DatabaseName) -> bool {
+        database_name
+            .topology()
+            .is_some_and(|topo_str| TopologyName::new(topo_str).is_ok())
+    }
+
     fn client(
         &self,
         database_name: &DatabaseName,
@@ -923,13 +929,11 @@ impl GrpcSysDb {
         // Route to MCMR client if database has a valid topology prefix (before '+').
         // TopologyName::new() validates the topology is non-empty and well-formed.
         // Otherwise use single region client.
-        if let Some(topo_str) = database_name.topology() {
-            if TopologyName::new(topo_str).is_ok() {
-                if let Some(mcmr_client) = &self._mcmr_client {
-                    return Ok(mcmr_client.clone());
-                } else {
-                    return Err(ClientResolutionError::McmrNotSupported);
-                }
+        if Self::routes_to_mcmr(database_name) {
+            if let Some(mcmr_client) = &self._mcmr_client {
+                return Ok(mcmr_client.clone());
+            } else {
+                return Err(ClientResolutionError::McmrNotSupported);
             }
         }
         Ok(self.client.clone())
@@ -1445,9 +1449,16 @@ impl GrpcSysDb {
                 .map_err(|e| UpdateCollectionError::Internal(Box::new(e)))?,
             None => self.client.clone(),
         };
+        let routes_to_mcmr = database.as_ref().map(Self::routes_to_mcmr).unwrap_or(false);
         let mut configuration_json_str = None;
         if let Some(configuration) = configuration {
-            configuration_json_str = Some(serde_json::to_string(&configuration).unwrap());
+            configuration_json_str = Some(if routes_to_mcmr {
+                let configuration =
+                    chroma_types::UpdateCollectionConfiguration::from(configuration);
+                serde_json::to_string(&configuration).unwrap()
+            } else {
+                serde_json::to_string(&configuration).unwrap()
+            });
         }
         let req = chroma_proto::UpdateCollectionRequest {
             id: collection_id.0.to_string(),

--- a/rust/types/src/collection_configuration.rs
+++ b/rust/types/src/collection_configuration.rs
@@ -585,6 +585,22 @@ impl TryFrom<UpdateCollectionConfiguration> for InternalUpdateCollectionConfigur
     }
 }
 
+impl From<InternalUpdateCollectionConfiguration> for UpdateCollectionConfiguration {
+    fn from(value: InternalUpdateCollectionConfiguration) -> Self {
+        let (hnsw, spann) = match value.vector_index {
+            Some(UpdateVectorIndexConfiguration::Hnsw(hnsw)) => (hnsw, None),
+            Some(UpdateVectorIndexConfiguration::Spann(spann)) => (None, spann),
+            None => (None, None),
+        };
+
+        Self {
+            hnsw,
+            spann,
+            embedding_function: value.embedding_function,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -1078,6 +1094,36 @@ mod tests {
                 },
             ))
         );
+    }
+
+    #[test]
+    fn test_internal_update_collection_configuration_to_public_spann() {
+        let embedding_function =
+            EmbeddingFunctionConfiguration::Known(EmbeddingFunctionNewConfiguration {
+                name: "test".to_string(),
+                config: serde_json::Value::Null,
+            });
+        let internal = InternalUpdateCollectionConfiguration {
+            vector_index: Some(UpdateVectorIndexConfiguration::Spann(Some(
+                UpdateSpannConfiguration {
+                    search_nprobe: Some(128),
+                    ef_search: Some(200),
+                },
+            ))),
+            embedding_function: Some(embedding_function.clone()),
+        };
+
+        let public = UpdateCollectionConfiguration::from(internal);
+
+        assert_eq!(public.hnsw, None);
+        assert_eq!(
+            public.spann,
+            Some(UpdateSpannConfiguration {
+                search_nprobe: Some(128),
+                ef_search: Some(200),
+            })
+        );
+        assert_eq!(public.embedding_function, Some(embedding_function));
     }
 
     #[cfg(feature = "testing")]


### PR DESCRIPTION
## Description of changes

Ensure schema data flows through gRPC create/update collection
paths for multi-region (MCMR) routing:

- Add From<InternalUpdateCollectionConfiguration> for the public
  UpdateCollectionConfiguration to serialize the correct format
  when routing to MCMR endpoints
- Extract routes_to_mcmr() helper in GrpcSysDb and use it to
  conditionally serialize update configuration format
- Pass tenant/database through Python bindings update_collection
  so Rust can resolve the correct gRPC client
- Wire schema_str through gRPC proto in create and update flows
  in the mock sysdb server
- Convert all schema e2e tests to multi-region via
  @multi_region_test decorator and database_name fixture

## Test plan

CI + local pass of the test_schema_e2e.py.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
