### PR TITLE
[ENH](spanner): add spanner-cli wrapper binary

### DIFF
--- a/rust/spanner-migrations/src/bin/spanner-cli.rs
+++ b/rust/spanner-migrations/src/bin/spanner-cli.rs
@@ -2,22 +2,25 @@ use std::path::Path;
 
 const KNOWN_PATH: &str = "/opt/homebrew/share/google-cloud-sdk/bin/spanner-cli";
 
-
 fn main() {
     if Path::new(KNOWN_PATH).exists() {
         let mut pid = std::process::Command::new(KNOWN_PATH)
             .args(std::env::args_os().skip(1))
             .spawn()
             .expect("failed to spawn spanner-cli");
-        let exit = pid.wait().expect("could not wait for spanner-cli; zombies?");
+        let exit = pid
+            .wait()
+            .expect("could not wait for spanner-cli; zombies?");
         std::process::exit(exit.code().unwrap_or(if exit.success() { 0 } else { 1 }));
     }
-    eprintln!("spanner-cli not found at its known location.
+    eprintln!(
+        "spanner-cli not found at its known location.
 if you haven't run this tool before, the following should help; it's on you to have gcloud:
 
 ```console
 gcloud components install spanner-cli
 ```
-");
+"
+    );
     std::process::exit(127);
 }

--- a/rust/spanner-migrations/src/bin/spanner-cli.rs
+++ b/rust/spanner-migrations/src/bin/spanner-cli.rs
@@ -7,10 +7,16 @@ fn main() {
         let mut pid = std::process::Command::new(KNOWN_PATH)
             .args(std::env::args_os().skip(1))
             .spawn()
-            .expect("failed to spawn spanner-cli");
+            .unwrap_or_else(|err| {
+                eprintln!("failed to spawn spanner-cli: {}", err);
+                std::process::exit(1);
+            });
         let exit = pid
             .wait()
-            .expect("could not wait for spanner-cli; zombies?");
+            .unwrap_or_else(|err| {
+                eprintln!("failed while waiting for spanner-cli: {}", err);
+                std::process::exit(1);
+            });
         std::process::exit(exit.code().unwrap_or(if exit.success() { 0 } else { 1 }));
     }
     eprintln!(

--- a/rust/spanner-migrations/src/bin/spanner-cli.rs
+++ b/rust/spanner-migrations/src/bin/spanner-cli.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+
+const KNOWN_PATH: &str = "/opt/homebrew/share/google-cloud-sdk/bin/spanner-cli";
+
+
+fn main() {
+    if Path::new(KNOWN_PATH).exists() {
+        let mut pid = std::process::Command::new(KNOWN_PATH)
+            .args(std::env::args_os().skip(1))
+            .spawn()
+            .expect("failed to spawn spanner-cli");
+        let exit = pid.wait().expect("could not wait for spanner-cli; zombies?");
+        std::process::exit(exit.code().unwrap_or(if exit.success() { 0 } else { 1 }));
+    }
+    eprintln!("spanner-cli not found at its known location.
+if you haven't run this tool before, the following should help; it's on you to have gcloud:
+
+```console
+gcloud components install spanner-cli
+```
+");
+    std::process::exit(127);
+}

--- a/rust/spanner-migrations/src/bin/spanner-cli.rs
+++ b/rust/spanner-migrations/src/bin/spanner-cli.rs
@@ -1,6 +1,20 @@
 use std::path::Path;
 
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
+
 const KNOWN_PATH: &str = "/opt/homebrew/share/google-cloud-sdk/bin/spanner-cli";
+
+#[cfg(unix)]
+fn exit_code(exit: std::process::ExitStatus) -> i32 {
+    exit.code()
+        .unwrap_or_else(|| exit.signal().map_or(1, |signal| 128 + signal))
+}
+
+#[cfg(not(unix))]
+fn exit_code(exit: std::process::ExitStatus) -> i32 {
+    exit.code().unwrap_or(1)
+}
 
 fn main() {
     if Path::new(KNOWN_PATH).exists() {
@@ -17,7 +31,7 @@ fn main() {
                 eprintln!("failed while waiting for spanner-cli: {}", err);
                 std::process::exit(1);
             });
-        std::process::exit(exit.code().unwrap_or(if exit.success() { 0 } else { 1 }));
+        std::process::exit(exit_code(exit));
     }
     eprintln!(
         "spanner-cli not found at its known location.

--- a/rust/spanner-migrations/src/bin/spanner-cli.rs
+++ b/rust/spanner-migrations/src/bin/spanner-cli.rs
@@ -25,12 +25,10 @@ fn main() {
                 eprintln!("failed to spawn spanner-cli: {}", err);
                 std::process::exit(1);
             });
-        let exit = pid
-            .wait()
-            .unwrap_or_else(|err| {
-                eprintln!("failed while waiting for spanner-cli: {}", err);
-                std::process::exit(1);
-            });
+        let exit = pid.wait().unwrap_or_else(|err| {
+            eprintln!("failed while waiting for spanner-cli: {}", err);
+            std::process::exit(1);
+        });
         std::process::exit(exit_code(exit));
     }
     eprintln!(


### PR DESCRIPTION
## Description of changes

Provide a convenience wrapper that locates spanner-cli at its
known homebrew installation path and delegates to it, forwarding
all arguments and the exit code. When the tool is not installed,
print actionable installation instructions using gcloud.

## Test plan

I ran the tool by hand in both cases.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
