### PR TITLE
fix: cache ONNXMiniLM_L6_V2 instance in DefaultEmbeddingFunction

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -955,6 +955,7 @@ class DefaultEmbeddingFunction(EmbeddingFunction[Documents]):
     def __init__(self) -> None:
         if is_thin_client:
             return
+        self._ef: Optional["ONNXMiniLM_L6_V2"] = None
 
     def __call__(self, input: Documents) -> Embeddings:
         # Import here to avoid circular imports
@@ -962,7 +963,9 @@ class DefaultEmbeddingFunction(EmbeddingFunction[Documents]):
             ONNXMiniLM_L6_V2,
         )
 
-        return ONNXMiniLM_L6_V2()(input)
+        if self._ef is None:
+            self._ef = ONNXMiniLM_L6_V2()
+        return self._ef(input)
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "DefaultEmbeddingFunction":


### PR DESCRIPTION
DefaultEmbeddingFunction.__call__ was constructing a fresh ONNXMiniLM_L6_V2 on every call, triggering cold lazy-init of the tokenizer (~5ms) and ONNX session each time. This caused a ~10x slowdown on repeated embed calls.

Fix: create the ONNXMiniLM_L6_V2 instance once in __call__ and cache it on self._ef for subsequent calls.

Fixes chroma-core#6941

Signed-off-by: Jah-yee <jydu_seven@outlook.com>

---

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof