### PR TITLE
[ENH](gc): GC empty MCMR collections

### DIFF
--- a/chromadb/test/property/test_add_gc.py
+++ b/chromadb/test/property/test_add_gc.py
@@ -274,6 +274,10 @@ def _child_text(element: ET.Element, name: str) -> Optional[str]:
     return None
 
 
+def _is_collection_version_file_key(key: str, collection_uuid: str) -> bool:
+    return f"/collection/{collection_uuid}/versionfiles/" in key
+
+
 def _list_minio_files_for_collection(bucket: str, collection_uuid: str) -> List[str]:
     keys: List[str] = []
     continuation_token: Optional[str] = None
@@ -292,7 +296,7 @@ def _list_minio_files_for_collection(bucket: str, collection_uuid: str) -> List[
             if (
                 key is not None
                 and collection_uuid in key
-                and "/versionfiles/" not in key
+                and not _is_collection_version_file_key(key, collection_uuid)
             ):
                 keys.append(key)
 
@@ -332,7 +336,7 @@ def _wait_for_minio_files_for_collection(collection_uuid: str) -> Dict[str, List
                 bucket for bucket, paths in paths_by_bucket.items() if not paths
             ]
             pytest.fail(
-                "Expected MinIO to contain files for collection "
+                "Expected MinIO to contain non-version files for collection "
                 f"{collection_uuid} in every test bucket before deletion, "
                 f"but these buckets had none: {missing_buckets}. "
                 f"Found counts: "
@@ -360,7 +364,7 @@ def _wait_for_minio_files_deleted(collection_uuid: str) -> None:
                 for bucket, paths in remaining.items()
             }
             pytest.fail(
-                "Expected MinIO files for collection "
+                "Expected non-version MinIO files for collection "
                 f"{collection_uuid} to be deleted from every test bucket, "
                 f"but found files in these buckets: "
                 f"{ {bucket: len(paths) for bucket, paths in remaining.items()} }. "
@@ -371,6 +375,58 @@ def _wait_for_minio_files_deleted(collection_uuid: str) -> None:
 
 def round_robin(round_index, round_around):
     return round_around[round_index % len(round_around)]
+
+
+def _delete_collection_and_assert_gc_hard_delete(
+    client: ClientAPI, collection_name: str, collection_uuid: str
+) -> None:
+    watchers = _start_gc_log_watchers()
+    captured_stdout = {namespace: [] for namespace in GC_NAMESPACES}
+    captured_stderr: Dict[str, str] = {}
+    try:
+        time.sleep(1)
+        client.delete_collection(collection_name)
+        _wait_for_gc_hard_delete_log(watchers, captured_stdout, collection_uuid)
+    finally:
+        captured_stderr = _stop_gc_log_watchers(watchers, captured_stdout)
+
+    stdout_by_namespace = {
+        namespace: "".join(lines) for namespace, lines in captured_stdout.items()
+    }
+    matching_namespaces = [
+        namespace
+        for namespace, stdout in stdout_by_namespace.items()
+        if _hard_delete_log_found(stdout, collection_uuid)
+    ]
+
+    for namespace, stdout in stdout_by_namespace.items():
+        print(f"{namespace} GC stdout captured {len(stdout)} bytes")
+    for namespace, stderr in captured_stderr.items():
+        if stderr:
+            print(f"{namespace} GC stderr: {stderr[-1000:]}")
+
+    assert matching_namespaces, (
+        "Expected garbage collector logs to hard delete collection "
+        f"{collection_uuid}. Captured stdout tails: "
+        f"{ {namespace: stdout[-2000:] for namespace, stdout in stdout_by_namespace.items()} }"
+    )
+
+
+@pytest.mark.skipif(
+    not MULTI_REGION_ENABLED,
+    reason="MCMR GC coverage requires a multi-region Kubernetes cluster",
+)
+def test_add_gc_hard_deletes_empty_mcmr_collection() -> None:
+    client1, client2 = _create_mcmr_clients()
+    _create_isolated_database_mcmr(client1, client2, "tilt-spanning")
+
+    collection_name = f"test_add_gc_empty_{uuid.uuid4().hex}"
+    collection = client1.create_collection(name=collection_name)
+    client2.get_collection(name=collection_name)
+
+    _delete_collection_and_assert_gc_hard_delete(
+        client1, collection_name, str(collection.id)
+    )
 
 
 @pytest.mark.skipif(
@@ -413,34 +469,7 @@ def test_add_gc_hard_deletes_mcmr_collection() -> None:
             f"{collection_uuid} before deletion"
         )
 
-    watchers = _start_gc_log_watchers()
-    captured_stdout = {namespace: [] for namespace in GC_NAMESPACES}
-    captured_stderr: Dict[str, str] = {}
-    try:
-        time.sleep(1)
-        client1.delete_collection(collection_name)
-        _wait_for_gc_hard_delete_log(watchers, captured_stdout, collection_uuid)
-    finally:
-        captured_stderr = _stop_gc_log_watchers(watchers, captured_stdout)
-
-    stdout_by_namespace = {
-        namespace: "".join(lines) for namespace, lines in captured_stdout.items()
-    }
-    matching_namespaces = [
-        namespace
-        for namespace, stdout in stdout_by_namespace.items()
-        if _hard_delete_log_found(stdout, collection_uuid)
-    ]
-
-    for namespace, stdout in stdout_by_namespace.items():
-        print(f"{namespace} GC stdout captured {len(stdout)} bytes")
-    for namespace, stderr in captured_stderr.items():
-        if stderr:
-            print(f"{namespace} GC stderr: {stderr[-1000:]}")
-
-    assert matching_namespaces, (
-        "Expected garbage collector logs to hard delete collection "
-        f"{collection_uuid}. Captured stdout tails: "
-        f"{ {namespace: stdout[-2000:] for namespace, stdout in stdout_by_namespace.items()} }"
+    _delete_collection_and_assert_gc_hard_delete(
+        client1, collection_name, collection_uuid
     )
     _wait_for_minio_files_deleted(collection_uuid)

--- a/chromadb/test/property/test_add_gc.py
+++ b/chromadb/test/property/test_add_gc.py
@@ -384,7 +384,6 @@ def _delete_collection_and_assert_gc_hard_delete(
     captured_stdout = {namespace: [] for namespace in GC_NAMESPACES}
     captured_stderr: Dict[str, str] = {}
     try:
-        time.sleep(1)
         client.delete_collection(collection_name)
         _wait_for_gc_hard_delete_log(watchers, captured_stdout, collection_uuid)
     finally:

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -16,13 +16,14 @@ use chroma_log::Log;
 use chroma_memberlist::memberlist_provider::Memberlist;
 use chroma_storage::Storage;
 use chroma_sysdb::{
-    CollectionToGcInfo, GetCollectionsOptions, GetCollectionsToGcError, SysDb, SysDbConfig,
+    CollectionToGcInfo, DatabaseOrTopology, GetCollectionsOptions, GetCollectionsToGcError, SysDb,
+    SysDbConfig,
 };
 use chroma_system::{
     wrap, Component, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator, System,
     TaskResult,
 };
-use chroma_types::{CollectionUuid, DatabaseName, GetCollectionsError};
+use chroma_types::{CollectionUuid, DatabaseName, DeleteCollectionError, GetCollectionsError};
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use opentelemetry::metrics::{Counter, Histogram};
@@ -73,6 +74,14 @@ enum GarbageCollectCollectionError {
     NoSuchCollection,
     #[error("Failed to get collections: {0}")]
     GetCollectionsError(#[from] GetCollectionsError),
+    #[error("Collection deletion failed: {0}")]
+    CollectionDeletionFailed(#[from] DeleteCollectionError),
+    #[error("SysDb method failed: {0}")]
+    SysDbMethodFailed(String),
+}
+
+fn should_use_no_version_file_fallback(collection: &CollectionToGcInfo) -> bool {
+    collection.version_file_path.is_empty() && collection.database.as_ref().contains('+')
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -255,6 +264,37 @@ impl GarbageCollector {
             .as_ref()
             .ok_or(GarbageCollectCollectionError::Uninitialized)?;
 
+        let started_at = SystemTime::now();
+
+        if should_use_no_version_file_fallback(&collection) {
+            let result = self
+                .garbage_collect_collection_without_version_file(
+                    collection_soft_delete_absolute_cutoff_time,
+                    collection,
+                )
+                .await?;
+            let duration_ms = started_at
+                .elapsed()
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+            self.job_duration_ms_metric.record(duration_ms, &[]);
+            self.total_files_deleted_metric.add(
+                result.num_files_deleted as u64,
+                &[opentelemetry::KeyValue::new(
+                    "cleanup_mode",
+                    format!("{:?}", cleanup_mode),
+                )],
+            );
+            self.total_versions_deleted_metric.add(
+                result.num_versions_deleted as u64,
+                &[opentelemetry::KeyValue::new(
+                    "cleanup_mode",
+                    format!("{:?}", cleanup_mode),
+                )],
+            );
+            return Ok(result);
+        }
+
         let enable_log_gc = collection.tenant <= self.config.enable_log_gc_for_tenant_threshold
             || self
                 .config
@@ -284,7 +324,6 @@ impl GarbageCollector {
                     .max_concurrent_list_files_operations_per_collection,
             );
 
-        let started_at = SystemTime::now();
         let result = match orchestrator.run(system.clone()).await {
             Ok(res) => res,
             Err(e) => {
@@ -313,6 +352,99 @@ impl GarbageCollector {
         );
 
         Ok(result)
+    }
+
+    async fn garbage_collect_collection_without_version_file(
+        &self,
+        collection_soft_delete_absolute_cutoff_time: DateTime<Utc>,
+        collection: CollectionToGcInfo,
+    ) -> Result<GarbageCollectorResponse, GarbageCollectCollectionError> {
+        if !self
+            .should_hard_delete_collection_without_version_file(
+                collection_soft_delete_absolute_cutoff_time,
+                &collection,
+            )
+            .await?
+        {
+            return Ok(GarbageCollectorResponse {
+                collection_id: collection.id,
+                ..Default::default()
+            });
+        }
+
+        let result = self
+            .garbage_collect_hard_delete_log(collection.id, Some(collection.database.clone()))
+            .await?;
+
+        tracing::debug!("Hard deleting collections {:#?}", vec![collection.id]);
+
+        self.sysdb_client
+            .clone()
+            .finish_collection_deletion(
+                collection.tenant,
+                collection.database.into_string(),
+                collection.id,
+            )
+            .await?;
+
+        Ok(result)
+    }
+
+    async fn should_hard_delete_collection_without_version_file(
+        &self,
+        collection_soft_delete_absolute_cutoff_time: DateTime<Utc>,
+        collection: &CollectionToGcInfo,
+    ) -> Result<bool, GarbageCollectCollectionError> {
+        let is_soft_deleted = self
+            .sysdb_client
+            .clone()
+            .batch_get_collection_soft_delete_status(
+                Some(collection.database.clone()),
+                vec![collection.id],
+            )
+            .await
+            .map_err(|err| GarbageCollectCollectionError::SysDbMethodFailed(err.to_string()))?
+            .get(&collection.id)
+            .copied()
+            .unwrap_or(false);
+
+        if !is_soft_deleted {
+            tracing::debug!(
+                collection_id = %collection.id,
+                database_name = %collection.database.as_ref(),
+                "Skipping no-version-file GC fallback because collection is not soft deleted"
+            );
+            return Ok(false);
+        }
+
+        let mut sysdb = self.sysdb_client.clone();
+        let mut collections = sysdb
+            .get_collections(GetCollectionsOptions {
+                collection_ids: Some(vec![collection.id]),
+                database_or_topology: Some(DatabaseOrTopology::Database(
+                    collection.database.clone(),
+                )),
+                include_soft_deleted: true,
+                ..Default::default()
+            })
+            .await?;
+        let stored_collection = collections
+            .pop()
+            .ok_or(GarbageCollectCollectionError::NoSuchCollection)?;
+
+        let cutoff_time: SystemTime = collection_soft_delete_absolute_cutoff_time.into();
+        if stored_collection.updated_at >= cutoff_time {
+            tracing::debug!(
+                collection_id = %collection.id,
+                database_name = %collection.database.as_ref(),
+                updated_at = ?stored_collection.updated_at,
+                cutoff_time = ?cutoff_time,
+                "Skipping no-version-file GC fallback because collection is still inside the soft delete grace period"
+            );
+            return Ok(false);
+        }
+
+        Ok(true)
     }
 
     async fn truncate_dirty_log(&self, ctx: &ComponentContext<Self>) {
@@ -792,6 +924,7 @@ mod tests {
     use crate::helper::ChromaGrpcClients;
     use chroma_blockstore::RootManager;
     use chroma_cache::nop::NopCache;
+    use chroma_config::assignment::assignment_policy::RendezvousHashingAssignmentPolicy;
     use chroma_config::assignment::{
         assignment_policy::AssignmentPolicy, rendezvous_hash::AssignmentError,
     };
@@ -961,6 +1094,86 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![assigned_collection_id]
         );
+    }
+
+    #[test]
+    fn no_version_file_fallback_is_mcmr_only() {
+        let make_collection = |database_name: &str, version_file_path: &str| CollectionToGcInfo {
+            id: CollectionUuid::new(),
+            tenant: "tenant".to_string(),
+            database: DatabaseName::new(database_name).expect("database name should be valid"),
+            name: "collection".to_string(),
+            version_file_path: version_file_path.to_string(),
+            lineage_file_path: None,
+        };
+
+        assert!(should_use_no_version_file_fallback(&make_collection(
+            "tilt-spanning+test-db",
+            ""
+        )));
+        assert!(!should_use_no_version_file_fallback(&make_collection(
+            "test-db", ""
+        )));
+        assert!(!should_use_no_version_file_fallback(&make_collection(
+            "tilt-spanning+test-db",
+            "tenant/default/versionfiles/000001_flush"
+        )));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recognizes_soft_deleted_mcmr_collection_without_version_file() {
+        let (_storage_dir, storage) = test_storage();
+        let mut test_sysdb = TestSysDb::new();
+        let database_name =
+            DatabaseName::new(format!("tilt-spanning+test-db-{}", Uuid::new_v4())).unwrap();
+        let collection_id = CollectionUuid::new();
+
+        SysDb::Test(test_sysdb.clone())
+            .create_collection(
+                "tenant".to_string(),
+                database_name.clone(),
+                collection_id,
+                "collection".to_string(),
+                vec![],
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .await
+            .expect("should create collection");
+        test_sysdb.soft_delete_collection(collection_id);
+        test_sysdb.set_collection_updated_at(
+            collection_id,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1),
+        );
+
+        let gc = GarbageCollector::new(
+            GarbageCollectorConfig::default(),
+            SysDb::Test(test_sysdb.clone()),
+            storage.clone(),
+            Log::InMemory(InMemoryLog::default()),
+            None,
+            Box::new(RendezvousHashingAssignmentPolicy::default()),
+            RootManager::new(storage, Box::new(NopCache)),
+        );
+        let should_hard_delete = gc
+            .should_hard_delete_collection_without_version_file(
+                Utc::now(),
+                &CollectionToGcInfo {
+                    id: collection_id,
+                    tenant: "tenant".to_string(),
+                    database: database_name,
+                    name: "collection".to_string(),
+                    version_file_path: String::new(),
+                    lineage_file_path: None,
+                },
+            )
+            .await
+            .expect("should evaluate no-version-file fallback");
+
+        assert!(should_hard_delete);
     }
 
     #[tokio::test]

--- a/rust/rust-sysdb/src/spanner.rs
+++ b/rust/rust-sysdb/src/spanner.rs
@@ -1772,12 +1772,11 @@ impl SpannerBackend {
     ) -> Result<ListCollectionsToGcResponse, SysDbError> {
         let region = self.local_region();
 
-        // TODO(tanujnay112): This is due to the garbage collector being unable
-        // to handle collections with no version files. Until that is fixed, we
-        // must have this filter.
+        // GC typically starts from the latest version file. Empty MCMR
+        // collections never write one, so allow soft-deleted '+' databases to
+        // flow through to the dedicated no-version-file fallback path.
         let mut where_clauses: Vec<String> = vec![
-            "ccc.version_file_name IS NOT NULL".to_string(),
-            "ccc.version_file_name != ''".to_string(),
+            "((ccc.version_file_name IS NOT NULL AND ccc.version_file_name != '') OR c.is_deleted = TRUE)".to_string(),
         ];
 
         if req.tenant_id.is_some() {
@@ -1858,7 +1857,7 @@ impl SpannerBackend {
             let name: String = row
                 .column_by_name("name")
                 .map_err(SysDbError::FailedToReadColumn)?;
-            let version_file_name: String = row
+            let version_file_name: Option<String> = row
                 .column_by_name("version_file_name")
                 .map_err(SysDbError::FailedToReadColumn)?;
             let tenant_id: String = row
@@ -1871,7 +1870,7 @@ impl SpannerBackend {
             collections.push(chroma_proto::CollectionToGcInfo {
                 id: collection_id,
                 name,
-                version_file_path: version_file_name,
+                version_file_path: version_file_name.unwrap_or_default(),
                 tenant_id,
                 lineage_file_path: None, // Not available in Spanner schema
                 database_name,
@@ -9287,8 +9286,8 @@ pub mod tests {
             result.err()
         );
 
-        // Manually insert a compaction cursor to make the collection eligible for GC
-        // (list_collections_to_gc only returns collections with version_file_name set)
+        // Manually insert a compaction cursor to make this non-soft-deleted collection eligible
+        // for GC. Soft-deleted empty MCMR collections are covered separately below.
         let version_file_name = format!("test_version_{}.bin", collection_id);
         let region = backend.local_region().to_string();
         backend
@@ -9344,6 +9343,95 @@ pub mod tests {
         assert_eq!(gc_collection.version_file_path, version_file_name);
         assert_eq!(gc_collection.database_name, Some(db_name.into_string()));
         assert_eq!(gc_collection.lineage_file_path, None); // Not set in Spanner schema
+    }
+
+    #[tokio::test]
+    async fn test_k8s_mcmr_integration_list_collections_to_gc_includes_soft_deleted_empty_mcmr_collection(
+    ) {
+        let Some(backend) = setup_test_backend().await else {
+            eprintln!("Skipping test: Spanner emulator not reachable. Is Tilt running?");
+            return;
+        };
+
+        let tenant_id = Uuid::new_v4().to_string();
+        backend
+            .create_tenant(CreateTenantRequest {
+                id: tenant_id.clone(),
+            })
+            .await
+            .expect("Failed to create tenant");
+
+        let db_name = chroma_types::DatabaseName::new(format!(
+            "tilt-spanning+test_db_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+        .expect("test db name should be valid");
+        backend
+            .create_database(CreateDatabaseRequest {
+                id: Uuid::new_v4(),
+                name: db_name.clone(),
+                tenant_id: tenant_id.clone(),
+            })
+            .await
+            .expect("Failed to create database");
+
+        let collection_name = format!("test_gc_empty_collection_{}", Uuid::new_v4());
+        let collection_id = create_collection_for_update(
+            &backend,
+            &tenant_id,
+            &db_name,
+            &collection_name,
+            Some(128),
+            None,
+        )
+        .await;
+
+        backend
+            .update_collection(UpdateCollectionRequest {
+                database_name: db_name.clone(),
+                id: collection_id,
+                name: Some(format!("deleted_{}", collection_name)),
+                dimension: None,
+                metadata: None,
+                reset_metadata: false,
+                new_configuration: None,
+                cursor_updates: None,
+                is_deleted: Some(true),
+            })
+            .await
+            .expect("Failed to soft-delete collection");
+
+        let response = backend
+            .list_collections_to_gc(ListCollectionsToGcRequest {
+                cutoff_time: None,
+                limit: None,
+                tenant_id: Some(tenant_id.clone()),
+                min_versions_if_alive: None,
+            })
+            .await
+            .expect("Failed to list collections to GC");
+
+        assert_eq!(
+            response.collections.len(),
+            1,
+            "Expected exactly one collection eligible for GC"
+        );
+
+        let gc_collection = &response.collections[0];
+        assert_eq!(gc_collection.id, collection_id.to_string());
+        assert_eq!(gc_collection.name, format!("deleted_{}", collection_name));
+        assert_eq!(gc_collection.tenant_id, tenant_id);
+        assert_eq!(
+            gc_collection.version_file_path, "",
+            "Soft-deleted empty MCMR collections should surface an empty version file path"
+        );
+        assert_eq!(
+            gc_collection.database_name,
+            Some(db_name.as_ref().to_string())
+        );
     }
 
     #[tokio::test]

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -433,8 +433,10 @@ impl SysDb {
                     .await
             }
             SysDb::Sqlite(_) => unimplemented!(),
-            SysDb::Test(_) => {
-                todo!()
+            SysDb::Test(test) => {
+                let _ = tenant;
+                let _ = database;
+                test.finish_collection_deletion(collection_id).await
             }
         }
     }

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -1,11 +1,12 @@
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::{
     BatchGetCollectionSoftDeleteStatusError, BatchGetCollectionVersionFilePathsError, Collection,
-    CollectionAndSegments, CollectionUuid, CountForksError, Database, FlushCompactionResponse,
-    GetCollectionByCrnError, GetCollectionSizeError, GetCollectionWithSegmentsError,
-    GetCollectionsError, GetSegmentsError, ListAttachedFunctionsError, ListDatabasesError,
-    ListDatabasesResponse, Segment, SegmentFlushInfo, SegmentScope, SegmentType, SegmentUuid,
-    Tenant, UpdateTenantError, UpdateTenantResponse,
+    CollectionAndSegments, CollectionUuid, CountForksError, Database, DeleteCollectionError,
+    FlushCompactionResponse, GetCollectionByCrnError, GetCollectionSizeError,
+    GetCollectionWithSegmentsError, GetCollectionsError, GetSegmentsError,
+    ListAttachedFunctionsError, ListDatabasesError, ListDatabasesResponse, Segment,
+    SegmentFlushInfo, SegmentScope, SegmentType, SegmentUuid, Tenant, UpdateTenantError,
+    UpdateTenantResponse,
 };
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
@@ -137,6 +138,21 @@ impl TestSysDb {
 
         let collection = inner.collections.get_mut(&collection_id).unwrap();
         collection.version_file_path = Some(version_file_path);
+    }
+
+    pub fn set_collection_updated_at(
+        &mut self,
+        collection_id: CollectionUuid,
+        updated_at: SystemTime,
+    ) {
+        let mut inner = self.inner.lock();
+        let collection = inner.collections.get_mut(&collection_id).unwrap();
+        collection.updated_at = updated_at;
+    }
+
+    pub fn soft_delete_collection(&mut self, collection_id: CollectionUuid) {
+        let mut inner = self.inner.lock();
+        inner.soft_deleted_collections.insert(collection_id);
     }
 
     fn filter_collections(
@@ -736,6 +752,24 @@ impl TestSysDb {
             }
         }
         Ok(statuses)
+    }
+
+    pub(crate) async fn finish_collection_deletion(
+        &mut self,
+        collection_id: CollectionUuid,
+    ) -> Result<(), DeleteCollectionError> {
+        let mut inner = self.inner.lock();
+        if !inner.soft_deleted_collections.remove(&collection_id) {
+            return Err(DeleteCollectionError::NotFound(collection_id.to_string()));
+        }
+        if inner.collections.remove(&collection_id).is_none() {
+            return Err(DeleteCollectionError::NotFound(collection_id.to_string()));
+        }
+        inner.collection_to_version_file.remove(&collection_id);
+        inner
+            .segments
+            .retain(|_, segment| segment.collection != collection_id);
+        Ok(())
     }
 
     pub(crate) async fn update_tenant(


### PR DESCRIPTION
## Description of changes

Empty MCMR collections never write a version file, so the
previous list_collections_to_gc query filtered them out. Add a
fallback path for soft-deleted MCMR collections without version
files:

- Update Spanner query to surface soft-deleted collections even
  when version_file_name is NULL
- Detect empty MCMR collections via database name containing +
  and missing version file
- Check soft-delete status and grace period before hard deleting
- Implement finish_collection_deletion in TestSysDb
- Filter version file keys from MinIO file listings in tests
- Add end-to-end and unit tests for the new path

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
