### PR TITLE
[BUG] Switch to storing DOCKERHUB_USERNAME as var

### DIFF
--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.GITHUB_TOKEN }}
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Compute arch-specific tags
@@ -129,7 +129,7 @@ jobs:
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.GITHUB_TOKEN }}
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create and push manifest

--- a/.github/workflows/_build_release_service_images.yml
+++ b/.github/workflows/_build_release_service_images.yml
@@ -102,7 +102,7 @@ jobs:
           GCP_ARTIFACT_REGISTRY_REGION: ${{ vars.GCP_ARTIFACT_REGISTRY_REGION }}
           GCP_ARTIFACT_REGISTRY_PROJECT_ID: ${{ vars.GCP_ARTIFACT_REGISTRY_PROJECT_ID }}
           GCP_ARTIFACT_REGISTRY_NAME: ${{ vars.GCP_ARTIFACT_REGISTRY_NAME }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           ADDRESS_SANITIZER: ${{ inputs.address_sanitizer }}
           ENABLE_AVX512: ${{ inputs.enable_avx512 }}

--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Docker
         uses: ./.github/actions/docker
         with:
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Start Tilt services
         uses: ./.github/actions/tilt

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Setup Docker
         uses: ./.github/actions/docker
         with:
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Start Tilt services
         uses: ./.github/actions/tilt

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Set up Docker
         uses: ./.github/actions/docker
         with:
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Start services in Tilt
         uses: ./.github/actions/tilt
@@ -162,7 +162,7 @@ jobs:
       - name: Set up Docker
         uses: ./.github/actions/docker
         with:
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Tilt Setup & Pre-Build
         uses: ./.github/actions/tilt-setup-prebuild


### PR DESCRIPTION
## Description of changes

Previously, when we used a secret, we would fail to export values that contain the (already public) string `chromadb`:

```
Warning: Skip output 'dockerhub_tag_arm64' since it may contain secret.
```

This broke our CI.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
