### PR TITLE
[BUG](garbage_collector): refresh cache after mark

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -205,6 +205,73 @@ where
     }
 }
 
+/// After mark_version_for_deletion succeeds in sysdb, update the cached version
+/// files so that marked_for_deletion is true for the affected versions. Without
+/// this refresh, DeleteVersionsAtSysDbOperator receives a stale pre-mark
+/// snapshot and skips physical file deletion, orphaning per-version files in
+/// storage.
+///
+/// NOTE: Old root/current version-file snapshots (_flush, _gc_mark, _gc_delete)
+/// created by sysdb during mark/delete operations are a separate cleanup concern.
+/// See rust/rust-sysdb/src/server.rs for the existing CAS-failure orphan TODO.
+fn refresh_version_files_after_mark(
+    version_files: &mut HashMap<CollectionUuid, Arc<CollectionVersionFile>>,
+    versions_marked: &[VersionListForCollection],
+) -> Result<(), GarbageCollectorError> {
+    for version_list in versions_marked {
+        let collection_id: CollectionUuid = version_list
+            .collection_id
+            .parse()
+            .map_err(GarbageCollectorError::UnparsableUuid)?;
+        if let Some(version_file_arc) = version_files.get_mut(&collection_id) {
+            let mut version_file = (**version_file_arc).clone();
+            let history =
+                version_file
+                    .version_history
+                    .as_mut()
+                    .ok_or(GarbageCollectorError::InvariantViolation(format!(
+                        "Expected version_history to be set for collection {} when refreshing marked versions",
+                        collection_id
+                    )))?;
+
+            for version_info in history.versions.iter_mut() {
+                if version_list.versions.contains(&version_info.version) {
+                    version_info.marked_for_deletion = true;
+                }
+            }
+            *version_file_arc = Arc::new(version_file);
+        } else {
+            return Err(GarbageCollectorError::MissingVersionFile(collection_id));
+        }
+    }
+    Ok(())
+}
+
+fn validate_mark_version_results(
+    versions_marked: &[VersionListForCollection],
+    mark_results: &HashMap<String, bool>,
+) -> Result<(), GarbageCollectorError> {
+    for version_list in versions_marked {
+        match mark_results.get(&version_list.collection_id) {
+            Some(true) => {}
+            Some(false) => {
+                return Err(GarbageCollectorError::SysDbMethodFailed(format!(
+                    "mark_version_for_deletion reported failure for collection {}",
+                    version_list.collection_id
+                )));
+            }
+            None => {
+                return Err(GarbageCollectorError::SysDbMethodFailed(format!(
+                    "mark_version_for_deletion did not return a result for collection {}",
+                    version_list.collection_id
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn build_versions_to_mark(
     versions_by_collection: &HashMap<CollectionUuid, HashMap<i64, CollectionVersionAction>>,
     version_files: &HashMap<CollectionUuid, Arc<CollectionVersionFile>>,
@@ -424,11 +491,15 @@ impl GarbageCollectorOrchestrator {
         let versions_to_mark = build_versions_to_mark(&output.versions, &self.version_files)?;
 
         if !versions_to_mark.is_empty() {
-            self.sysdb_client
+            let versions_marked = versions_to_mark.clone();
+            let mark_results = self
+                .sysdb_client
                 .mark_version_for_deletion(0, versions_to_mark, self.database_name.clone())
                 .await
                 .map_err(|err| GarbageCollectorError::SysDbMethodFailed(err.to_string()))?;
 
+            validate_mark_version_results(&versions_marked, &mark_results)?;
+            refresh_version_files_after_mark(&mut self.version_files, &versions_marked)?;
             tracing::debug!("Marked versions as deleted in SysDb.");
         } else {
             tracing::debug!("No versions to mark for deletion in SysDb.");
@@ -1138,6 +1209,8 @@ impl Handler<TaskResult<DeleteVersionsAtSysDbOutput, DeleteVersionsAtSysDbError>
 #[cfg(test)]
 mod tests {
     use super::build_versions_to_mark;
+    use super::refresh_version_files_after_mark;
+    use super::validate_mark_version_results;
     use super::GarbageCollectorError;
     use super::GarbageCollectorOrchestrator;
     use crate::operators::compute_versions_to_delete_from_graph::CollectionVersionAction;
@@ -1154,6 +1227,7 @@ mod tests {
         chroma_proto::{
             CollectionInfoImmutable, CollectionSegmentInfo, CollectionVersionFile,
             CollectionVersionHistory, CollectionVersionInfo, FilePaths, FlushSegmentCompactionInfo,
+            VersionListForCollection,
         },
         CollectionUuid, Segment, SegmentFlushInfo, SegmentScope, SegmentType, SegmentUuid,
     };
@@ -1269,6 +1343,219 @@ mod tests {
                 );
             }
             other => panic!("expected InvariantViolation, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn refresh_version_files_marks_correct_versions() {
+        let collection_id = CollectionUuid::new();
+        let mut version_files = HashMap::from([(
+            collection_id,
+            Arc::new(CollectionVersionFile {
+                collection_info_immutable: Some(CollectionInfoImmutable {
+                    tenant_id: "t".to_string(),
+                    database_id: "d".to_string(),
+                    collection_id: collection_id.to_string(),
+                    dimension: 0,
+                    ..Default::default()
+                }),
+                version_history: Some(CollectionVersionHistory {
+                    versions: vec![
+                        CollectionVersionInfo {
+                            version: 1,
+                            marked_for_deletion: false,
+                            version_file_name: "v1_file".to_string(),
+                            ..Default::default()
+                        },
+                        CollectionVersionInfo {
+                            version: 2,
+                            marked_for_deletion: false,
+                            version_file_name: "v2_file".to_string(),
+                            ..Default::default()
+                        },
+                        CollectionVersionInfo {
+                            version: 3,
+                            marked_for_deletion: false,
+                            version_file_name: "v3_file".to_string(),
+                            ..Default::default()
+                        },
+                    ],
+                }),
+            }),
+        )]);
+
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: collection_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1, 3],
+        }];
+
+        refresh_version_files_after_mark(&mut version_files, &versions_marked)
+            .expect("refresh should succeed");
+
+        let vf = version_files.get(&collection_id).unwrap();
+        let history = vf.version_history.as_ref().unwrap();
+
+        // Version 1 should now be marked.
+        assert!(
+            history.versions[0].marked_for_deletion,
+            "version 1 should be marked_for_deletion"
+        );
+        // Version 2 was not in the mark list and should remain unmarked.
+        assert!(
+            !history.versions[1].marked_for_deletion,
+            "version 2 should NOT be marked_for_deletion"
+        );
+        // Version 3 should now be marked.
+        assert!(
+            history.versions[2].marked_for_deletion,
+            "version 3 should be marked_for_deletion"
+        );
+        println!("refresh_version_files_marks_correct_versions: passed");
+    }
+
+    #[test]
+    fn refresh_version_files_errors_on_missing_collection() {
+        let present_id = CollectionUuid::new();
+        let absent_id = CollectionUuid::new();
+
+        let mut version_files = HashMap::from([(
+            present_id,
+            Arc::new(CollectionVersionFile {
+                collection_info_immutable: Some(CollectionInfoImmutable {
+                    tenant_id: "t".to_string(),
+                    database_id: "d".to_string(),
+                    collection_id: present_id.to_string(),
+                    dimension: 0,
+                    ..Default::default()
+                }),
+                version_history: Some(CollectionVersionHistory {
+                    versions: vec![CollectionVersionInfo {
+                        version: 1,
+                        marked_for_deletion: false,
+                        version_file_name: "v1_file".to_string(),
+                        ..Default::default()
+                    }],
+                }),
+            }),
+        )]);
+
+        // Mark a collection that is NOT in the cache.
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: absent_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1],
+        }];
+
+        let err = refresh_version_files_after_mark(&mut version_files, &versions_marked)
+            .expect_err("refresh should fail when a collection is missing from the cache");
+        match err {
+            GarbageCollectorError::MissingVersionFile(id) => {
+                assert_eq!(id, absent_id);
+            }
+            other => panic!("expected MissingVersionFile, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn refresh_version_files_errors_on_missing_version_history() {
+        let collection_id = CollectionUuid::new();
+        let mut version_files = HashMap::from([(
+            collection_id,
+            Arc::new(CollectionVersionFile {
+                collection_info_immutable: Some(CollectionInfoImmutable {
+                    tenant_id: "t".to_string(),
+                    database_id: "d".to_string(),
+                    collection_id: collection_id.to_string(),
+                    dimension: 0,
+                    ..Default::default()
+                }),
+                version_history: None, // No history
+            }),
+        )]);
+
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: collection_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1],
+        }];
+
+        let err = refresh_version_files_after_mark(&mut version_files, &versions_marked)
+            .expect_err("refresh should fail when version_history is missing");
+        match err {
+            GarbageCollectorError::InvariantViolation(msg) => {
+                assert!(
+                    msg.contains("Expected version_history to be set"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected InvariantViolation, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_mark_version_results_accepts_successful_results() {
+        let collection_id = CollectionUuid::new();
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: collection_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1, 2],
+        }];
+        let mark_results = HashMap::from([(collection_id.to_string(), true)]);
+
+        validate_mark_version_results(&versions_marked, &mark_results)
+            .expect("all successful mark results should validate");
+    }
+
+    #[test]
+    fn validate_mark_version_results_errors_on_failed_collection() {
+        let collection_id = CollectionUuid::new();
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: collection_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1],
+        }];
+        let mark_results = HashMap::from([(collection_id.to_string(), false)]);
+
+        let err = validate_mark_version_results(&versions_marked, &mark_results)
+            .expect_err("failed mark results should return an error");
+        match err {
+            GarbageCollectorError::SysDbMethodFailed(msg) => {
+                assert!(
+                    msg.contains("reported failure"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected SysDbMethodFailed, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_mark_version_results_errors_on_missing_collection_result() {
+        let collection_id = CollectionUuid::new();
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: collection_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1],
+        }];
+        let mark_results = HashMap::new();
+
+        let err = validate_mark_version_results(&versions_marked, &mark_results)
+            .expect_err("missing mark results should return an error");
+        match err {
+            GarbageCollectorError::SysDbMethodFailed(msg) => {
+                assert!(
+                    msg.contains("did not return a result"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected SysDbMethodFailed, got: {other:?}"),
         }
     }
 

--- a/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
@@ -422,6 +422,161 @@ mod tests {
         assert_eq!(output.versions_to_delete, versions_to_delete);
     }
 
+    /// Confirms the stale-cache bug: when the operator receives a version file
+    /// cached BEFORE mark_version_for_deletion (so marked_for_deletion is false),
+    /// physical files are NOT deleted even though they appear in versions_to_delete.
+    ///
+    /// This proves that if the GC orchestrator does not refresh its cached version
+    /// files after calling mark_version_for_deletion, per-version files will be
+    /// orphaned in storage.
+    #[tokio::test]
+    async fn stale_cache_skips_physical_file_deletion() {
+        let tmp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let sysdb = SysDb::Test(TestSysDb::new());
+
+        // Create physical files in storage that should be deleted.
+        let test_files = vec!["stale_version_1", "stale_version_2"];
+        for file in &test_files {
+            std::fs::write(tmp_dir.path().join(file), "test content").unwrap();
+        }
+
+        // Simulate a PRE-MARK cached version file: marked_for_deletion is false
+        // because this snapshot was captured before mark_version_for_deletion was
+        // called on sysdb.
+        let stale_version_file = Arc::new(CollectionVersionFile {
+            version_history: Some(chroma_proto::CollectionVersionHistory {
+                versions: vec![
+                    chroma_proto::CollectionVersionInfo {
+                        version: 1,
+                        version_file_name: "stale_version_1".to_string(),
+                        marked_for_deletion: false, // Stale: not yet marked
+                        ..Default::default()
+                    },
+                    chroma_proto::CollectionVersionInfo {
+                        version: 2,
+                        version_file_name: "stale_version_2".to_string(),
+                        marked_for_deletion: false, // Stale: not yet marked
+                        ..Default::default()
+                    },
+                ],
+            }),
+            ..Default::default()
+        });
+
+        let versions_to_delete = VersionListForCollection {
+            collection_id: "test_collection".to_string(),
+            database_id: "default".to_string(),
+            tenant_id: "default".to_string(),
+            versions: vec![1, 2],
+        };
+
+        let input = DeleteVersionsAtSysDbInput {
+            version_file: stale_version_file,
+            versions_to_delete,
+            sysdb_client: sysdb,
+            epoch_id: 123,
+            database_name: DatabaseName::new("test_db").expect("valid db name"),
+        };
+
+        let operator = DeleteVersionsAtSysDbOperator {
+            storage: storage.clone(),
+        };
+        let result = operator.run(&input).await;
+
+        // The operator reports success (sysdb logical deletion works via TestSysDb).
+        assert!(result.is_ok());
+
+        // Physical files REMAIN because the stale version file has
+        // marked_for_deletion = false, so delete_version_files skips them.
+        //
+        // This is part of the contract for the operator and is handled at a
+        // higher level by the orchestration code.
+        for file in &test_files {
+            assert!(
+                tmp_dir.path().join(file).exists(),
+                "File {} was deleted despite stale (unmarked) version file; \
+                 the stale-cache bug is not present at the operator level",
+                file
+            );
+        }
+    }
+
+    /// Control test: when the operator receives a version file refreshed AFTER
+    /// mark_version_for_deletion (so marked_for_deletion is true), physical
+    /// files are correctly deleted.
+    ///
+    /// Together with stale_cache_skips_physical_file_deletion, this pair proves
+    /// that the only difference between "files orphaned" and "files cleaned up"
+    /// is whether the version file passed to the operator reflects the post-mark
+    /// state.
+    #[tokio::test]
+    async fn refreshed_cache_enables_physical_file_deletion() {
+        let tmp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let sysdb = SysDb::Test(TestSysDb::new());
+
+        // Create physical files in storage that should be deleted.
+        let test_files = vec!["refreshed_version_1", "refreshed_version_2"];
+        for file in &test_files {
+            std::fs::write(tmp_dir.path().join(file), "test content").unwrap();
+        }
+
+        // Simulate a POST-MARK refreshed version file: marked_for_deletion is
+        // true because the orchestrator refreshed the cache after
+        // mark_version_for_deletion succeeded.
+        let refreshed_version_file = Arc::new(CollectionVersionFile {
+            version_history: Some(chroma_proto::CollectionVersionHistory {
+                versions: vec![
+                    chroma_proto::CollectionVersionInfo {
+                        version: 1,
+                        version_file_name: "refreshed_version_1".to_string(),
+                        marked_for_deletion: true, // Refreshed: marked after sysdb call
+                        ..Default::default()
+                    },
+                    chroma_proto::CollectionVersionInfo {
+                        version: 2,
+                        version_file_name: "refreshed_version_2".to_string(),
+                        marked_for_deletion: true, // Refreshed: marked after sysdb call
+                        ..Default::default()
+                    },
+                ],
+            }),
+            ..Default::default()
+        });
+
+        let versions_to_delete = VersionListForCollection {
+            collection_id: "test_collection".to_string(),
+            database_id: "default".to_string(),
+            tenant_id: "default".to_string(),
+            versions: vec![1, 2],
+        };
+
+        let input = DeleteVersionsAtSysDbInput {
+            version_file: refreshed_version_file,
+            versions_to_delete,
+            sysdb_client: sysdb,
+            epoch_id: 123,
+            database_name: DatabaseName::new("test_db").expect("valid db name"),
+        };
+
+        let operator = DeleteVersionsAtSysDbOperator {
+            storage: storage.clone(),
+        };
+        let result = operator.run(&input).await;
+        assert!(result.is_ok());
+
+        // Physical files are correctly deleted because the refreshed version
+        // file has marked_for_deletion = true.
+        for file in &test_files {
+            assert!(
+                !tmp_dir.path().join(file).exists(),
+                "File {} should have been deleted with a refreshed (marked) version file",
+                file
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_only_deletes_files_marked_for_deletion() {
         let tmp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Description of changes

After mark_version_for_deletion succeeds in sysdb, the orchestrator's
cached version files still had marked_for_deletion = false. When
DeleteVersionsAtSysDbOperator later received these stale snapshots, it
skipped physical file deletion, orphaning per-version files in storage.

- Add refresh_version_files_after_mark to update the cached version
  files with post-mark state before passing them to the delete operator
- Add validate_mark_version_results to verify sysdb reported success
  for all collections in the mark batch
- Add unit and integration tests proving stale vs refreshed cache
  behavior at both orchestrator and operator levels

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
