### PR TITLE
[ENH](garbage_collector): remove wal3 hack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7866,6 +7866,7 @@ dependencies = [
  "chroma-error",
  "chroma-segment",
  "chroma-storage",
+ "chroma-system",
  "chroma-tracing",
  "chroma-types",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3885,6 +3885,8 @@ dependencies = [
  "clap",
  "figment",
  "futures",
+ "gcloud-gax",
+ "gcloud-spanner",
  "humantime",
  "indicatif",
  "itertools 0.13.0",

--- a/chromadb/test/property/test_add_gc.py
+++ b/chromadb/test/property/test_add_gc.py
@@ -1,0 +1,435 @@
+import datetime
+import hashlib
+import hmac
+import selectors
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+import uuid
+from typing import Dict, List, Optional, Tuple, cast
+
+import pytest
+
+from chromadb.api import ClientAPI
+from chromadb.api.models.Collection import Collection
+from chromadb.api.types import Embeddings, Metadatas
+from chromadb.test.conftest import MULTI_REGION_ENABLED
+from chromadb.test.property.test_add_mcmr import (
+    _create_isolated_database_mcmr,
+    _create_mcmr_clients,
+)
+from chromadb.test.utils.wait_for_version_increase import wait_for_version_increase
+from chromadb.utils.batch_utils import create_batches
+
+
+GC_NAMESPACES = ("chroma", "chroma2")
+GC_POD_NAME = "garbage-collector-0"
+MINIO_S3_ENDPOINT = "http://localhost:9001"
+MINIO_BUCKETS = ("chroma-storage", "chroma-storage2")
+MINIO_ACCESS_KEY = "minio"
+MINIO_SECRET_KEY = "minio123"
+MINIO_REGION = "us-east-1"
+COMPACTION_ROUNDS = 3
+RECORDS_PER_ROUND = 25
+GC_HARD_DELETE_TIMEOUT_SECONDS = 240
+MINIO_OBJECT_APPEAR_TIMEOUT_SECONDS = 60
+MINIO_OBJECT_DELETE_TIMEOUT_SECONDS = 60
+MINIO_OBJECT_LIST_TIMEOUT_SECONDS = 30.0
+
+
+def _records_for_round(
+    round_index: int,
+) -> Tuple[List[str], Embeddings, Metadatas, List[str]]:
+    ids = [
+        f"round-{round_index}-record-{record_index}-{uuid.uuid4()}"
+        for record_index in range(RECORDS_PER_ROUND)
+    ]
+    embeddings = [
+        [float(round_index), float(record_index), 1.0]
+        for record_index in range(RECORDS_PER_ROUND)
+    ]
+    metadatas = [
+        {"round": round_index, "record": record_index}
+        for record_index in range(RECORDS_PER_ROUND)
+    ]
+    documents = [
+        f"round {round_index} record {record_index}"
+        for record_index in range(RECORDS_PER_ROUND)
+    ]
+    return ids, cast(Embeddings, embeddings), cast(Metadatas, metadatas), documents
+
+
+def _add_round(client: ClientAPI, collection: Collection, round_index: int) -> None:
+    ids, embeddings, metadatas, documents = _records_for_round(round_index)
+    for batch in create_batches(
+        api=client,
+        ids=ids,
+        embeddings=embeddings,
+        metadatas=metadatas,
+        documents=documents,
+    ):
+        collection.add(*batch)
+
+
+def _start_gc_log_watchers() -> List[Tuple[str, subprocess.Popen]]:
+    watchers = []
+    for namespace in GC_NAMESPACES:
+        try:
+            proc = subprocess.Popen(
+                [
+                    "kubectl",
+                    "logs",
+                    "-n",
+                    namespace,
+                    GC_POD_NAME,
+                    "--tail=0",
+                    "--follow",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+        except FileNotFoundError:
+            pytest.skip("kubectl is required to watch garbage collector logs")
+        watchers.append((namespace, proc))
+    return watchers
+
+
+def _hard_delete_log_found(output: str, collection_uuid: str) -> bool:
+    offset = 0
+    while True:
+        hard_delete_index = output.find("Hard deleting collections", offset)
+        if hard_delete_index == -1:
+            return False
+        if collection_uuid in output[hard_delete_index : hard_delete_index + 4096]:
+            return True
+        offset = hard_delete_index + len("Hard deleting collections")
+
+
+def _wait_for_gc_hard_delete_log(
+    watchers: List[Tuple[str, subprocess.Popen]],
+    captured_stdout: Dict[str, List[str]],
+    collection_uuid: str,
+) -> None:
+    selector = selectors.DefaultSelector()
+    try:
+        for namespace, proc in watchers:
+            if proc.stdout is None:
+                continue
+            selector.register(proc.stdout, selectors.EVENT_READ, namespace)
+
+        deadline = time.monotonic() + GC_HARD_DELETE_TIMEOUT_SECONDS
+        while time.monotonic() < deadline and selector.get_map():
+            timeout = min(1.0, max(0.0, deadline - time.monotonic()))
+            for key, _ in selector.select(timeout=timeout):
+                namespace = cast(str, key.data)
+                line = key.fileobj.readline()
+                if line == "":
+                    selector.unregister(key.fileobj)
+                    continue
+                captured_stdout[namespace].append(line)
+                if _hard_delete_log_found(
+                    "".join(captured_stdout[namespace]), collection_uuid
+                ):
+                    return
+    finally:
+        selector.close()
+
+
+def _stop_gc_log_watchers(
+    watchers: List[Tuple[str, subprocess.Popen]],
+    captured_stdout: Dict[str, List[str]],
+) -> Dict[str, str]:
+    captured_stderr = {}
+    for _, proc in watchers:
+        proc.terminate()
+
+    for namespace, proc in watchers:
+        try:
+            stdout, stderr = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+        if stdout:
+            captured_stdout[namespace].append(stdout)
+        captured_stderr[namespace] = stderr
+    return captured_stderr
+
+
+def _aws_quote(value: str) -> str:
+    return urllib.parse.quote(value, safe="-_.~")
+
+
+def _signing_key(date_stamp: str) -> bytes:
+    date_key = hmac.new(
+        f"AWS4{MINIO_SECRET_KEY}".encode("utf-8"),
+        date_stamp.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    region_key = hmac.new(
+        date_key, MINIO_REGION.encode("utf-8"), hashlib.sha256
+    ).digest()
+    service_key = hmac.new(region_key, b"s3", hashlib.sha256).digest()
+    return hmac.new(service_key, b"aws4_request", hashlib.sha256).digest()
+
+
+def _minio_signed_get(bucket: str, query: Dict[str, str]) -> bytes:
+    endpoint = urllib.parse.urlparse(MINIO_S3_ENDPOINT)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    date_stamp = now.strftime("%Y%m%d")
+    payload_hash = hashlib.sha256(b"").hexdigest()
+
+    path = f"/{bucket}"
+    canonical_uri = urllib.parse.quote(path, safe="/-_.~")
+    canonical_query = "&".join(
+        f"{_aws_quote(key)}={_aws_quote(value)}" for key, value in sorted(query.items())
+    )
+    canonical_headers = (
+        f"host:{endpoint.netloc}\n"
+        f"x-amz-content-sha256:{payload_hash}\n"
+        f"x-amz-date:{amz_date}\n"
+    )
+    signed_headers = "host;x-amz-content-sha256;x-amz-date"
+    canonical_request = "\n".join(
+        [
+            "GET",
+            canonical_uri,
+            canonical_query,
+            canonical_headers,
+            signed_headers,
+            payload_hash,
+        ]
+    )
+
+    credential_scope = f"{date_stamp}/{MINIO_REGION}/s3/aws4_request"
+    string_to_sign = "\n".join(
+        [
+            "AWS4-HMAC-SHA256",
+            amz_date,
+            credential_scope,
+            hashlib.sha256(canonical_request.encode("utf-8")).hexdigest(),
+        ]
+    )
+    signature = hmac.new(
+        _signing_key(date_stamp),
+        string_to_sign.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    authorization = (
+        "AWS4-HMAC-SHA256 "
+        f"Credential={MINIO_ACCESS_KEY}/{credential_scope}, "
+        f"SignedHeaders={signed_headers}, Signature={signature}"
+    )
+
+    url = urllib.parse.urlunparse(
+        (
+            endpoint.scheme,
+            endpoint.netloc,
+            path,
+            "",
+            canonical_query,
+            "",
+        )
+    )
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": authorization,
+            "x-amz-content-sha256": payload_hash,
+            "x-amz-date": amz_date,
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(
+            request, timeout=MINIO_OBJECT_LIST_TIMEOUT_SECONDS
+        ) as response:
+            return response.read()
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        pytest.fail(
+            "Failed to list MinIO objects from S3 API "
+            f"{MINIO_S3_ENDPOINT}/{bucket}: HTTP {e.code} {e.reason}; body={body!r}"
+        )
+    except urllib.error.URLError as e:
+        pytest.fail(
+            "Failed to connect to MinIO S3 API "
+            f"{MINIO_S3_ENDPOINT}/{bucket}: {e}"
+        )
+
+
+def _xml_local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _child_text(element: ET.Element, name: str) -> Optional[str]:
+    for child in element:
+        if _xml_local_name(child.tag) == name:
+            return child.text
+    return None
+
+
+def _list_minio_files_for_collection(bucket: str, collection_uuid: str) -> List[str]:
+    keys: List[str] = []
+    continuation_token: Optional[str] = None
+    while True:
+        query = {"list-type": "2", "max-keys": "1000"}
+        if continuation_token is not None:
+            query["continuation-token"] = continuation_token
+
+        body = _minio_signed_get(bucket, query)
+        root = ET.fromstring(body)
+
+        for element in root.iter():
+            if _xml_local_name(element.tag) != "Contents":
+                continue
+            key = _child_text(element, "Key")
+            if key is not None and collection_uuid in key:
+                keys.append(key)
+
+        is_truncated = _child_text(root, "IsTruncated") == "true"
+        if not is_truncated:
+            break
+        continuation_token = _child_text(root, "NextContinuationToken")
+        if continuation_token is None:
+            pytest.fail(
+                "MinIO returned a truncated object listing without a continuation token"
+            )
+
+    return sorted(keys)
+
+
+def _format_minio_file_sample(paths: List[str]) -> str:
+    sample_size = 50
+    sample = paths[:sample_size]
+    suffix = (
+        "" if len(paths) <= sample_size else f" ... and {len(paths) - sample_size} more"
+    )
+    return f"{sample}{suffix}"
+
+
+def _wait_for_minio_files_for_collection(collection_uuid: str) -> Dict[str, List[str]]:
+    deadline = time.monotonic() + MINIO_OBJECT_APPEAR_TIMEOUT_SECONDS
+    paths_by_bucket: Dict[str, List[str]] = {}
+    while True:
+        paths_by_bucket = {
+            bucket: _list_minio_files_for_collection(bucket, collection_uuid)
+            for bucket in MINIO_BUCKETS
+        }
+        if all(paths_by_bucket.values()):
+            return paths_by_bucket
+        if time.monotonic() >= deadline:
+            missing_buckets = [
+                bucket for bucket, paths in paths_by_bucket.items() if not paths
+            ]
+            pytest.fail(
+                "Expected MinIO to contain files for collection "
+                f"{collection_uuid} in every test bucket before deletion, "
+                f"but these buckets had none: {missing_buckets}. "
+                f"Found counts: "
+                f"{ {bucket: len(paths) for bucket, paths in paths_by_bucket.items()} }"
+            )
+        time.sleep(1)
+
+
+def _wait_for_minio_files_deleted(collection_uuid: str) -> None:
+    deadline = time.monotonic() + MINIO_OBJECT_DELETE_TIMEOUT_SECONDS
+    paths_by_bucket: Dict[str, List[str]] = {}
+    while True:
+        paths_by_bucket = {
+            bucket: _list_minio_files_for_collection(bucket, collection_uuid)
+            for bucket in MINIO_BUCKETS
+        }
+        if not any(paths_by_bucket.values()):
+            return
+        if time.monotonic() >= deadline:
+            remaining = {
+                bucket: paths for bucket, paths in paths_by_bucket.items() if paths
+            }
+            samples = {
+                bucket: _format_minio_file_sample(paths)
+                for bucket, paths in remaining.items()
+            }
+            pytest.fail(
+                "Expected MinIO files for collection "
+                f"{collection_uuid} to be deleted from every test bucket, "
+                f"but found files in these buckets: "
+                f"{ {bucket: len(paths) for bucket, paths in remaining.items()} }. "
+                f"Samples: {samples}"
+            )
+        time.sleep(1)
+
+
+@pytest.mark.skipif(
+    not MULTI_REGION_ENABLED,
+    reason="MCMR GC coverage requires a multi-region Kubernetes cluster",
+)
+def test_add_gc_hard_deletes_mcmr_collection() -> None:
+    client1, client2 = _create_mcmr_clients()
+    _create_isolated_database_mcmr(client1, client2, "tilt-spanning")
+
+    collection_name = f"test_add_gc_{uuid.uuid4().hex}"
+    coll1 = client1.create_collection(name=collection_name)
+    coll2 = client2.get_collection(name=collection_name)
+    collection_uuid = str(coll1.id)
+
+    current_version1 = cast(int, coll1.get_model()["version"])
+    current_version2 = cast(int, coll2.get_model()["version"])
+
+    for round_index in range(COMPACTION_ROUNDS):
+        writer_client = client1 if round_index % 2 == 0 else client2
+        writer_collection = coll1 if round_index % 2 == 0 else coll2
+        _add_round(writer_client, writer_collection, round_index)
+
+        current_version1 = wait_for_version_increase(
+            client1, collection_name, current_version1
+        )
+        current_version2 = wait_for_version_increase(
+            client2, collection_name, current_version2
+        )
+
+    minio_files_before_delete_by_bucket = _wait_for_minio_files_for_collection(
+        collection_uuid
+    )
+    for bucket, paths in minio_files_before_delete_by_bucket.items():
+        print(
+            f"MinIO bucket {bucket} contained {len(paths)} files for collection "
+            f"{collection_uuid} before deletion"
+        )
+
+    watchers = _start_gc_log_watchers()
+    captured_stdout = {namespace: [] for namespace in GC_NAMESPACES}
+    captured_stderr: Dict[str, str] = {}
+    try:
+        time.sleep(1)
+        client1.delete_collection(collection_name)
+        _wait_for_gc_hard_delete_log(watchers, captured_stdout, collection_uuid)
+    finally:
+        captured_stderr = _stop_gc_log_watchers(watchers, captured_stdout)
+
+    stdout_by_namespace = {
+        namespace: "".join(lines) for namespace, lines in captured_stdout.items()
+    }
+    matching_namespaces = [
+        namespace
+        for namespace, stdout in stdout_by_namespace.items()
+        if _hard_delete_log_found(stdout, collection_uuid)
+    ]
+
+    for namespace, stdout in stdout_by_namespace.items():
+        print(f"{namespace} GC stdout captured {len(stdout)} bytes")
+    for namespace, stderr in captured_stderr.items():
+        if stderr:
+            print(f"{namespace} GC stderr: {stderr[-1000:]}")
+
+    assert matching_namespaces, (
+        "Expected garbage collector logs to hard delete collection "
+        f"{collection_uuid}. Captured stdout tails: "
+        f"{ {namespace: stdout[-2000:] for namespace, stdout in stdout_by_namespace.items()} }"
+    )
+    _wait_for_minio_files_deleted(collection_uuid)

--- a/rust/frontend/src/bin/frontend_service.rs
+++ b/rust/frontend/src/bin/frontend_service.rs
@@ -1,7 +1,17 @@
 use chroma_frontend::frontend_service_entrypoint;
+use chroma_system::thread_stack_size_bytes;
 use std::sync::Arc;
 
-#[tokio::main]
-async fn main() {
-    frontend_service_entrypoint(Arc::new(()) as _, Arc::new(()) as _, true).await;
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-frontend")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(frontend_service_entrypoint(
+            Arc::new(()) as _,
+            Arc::new(()) as _,
+            true,
+        ));
 }

--- a/rust/garbage_collector/Cargo.toml
+++ b/rust/garbage_collector/Cargo.toml
@@ -40,6 +40,8 @@ tracing-subscriber = { workspace = true }
 indicatif = { workspace = true }
 sqlx = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+google-cloud-gax = { workspace = true }
+google-cloud-spanner = { workspace = true }
 
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }

--- a/rust/garbage_collector/src/bin/garbage_collector_service.rs
+++ b/rust/garbage_collector/src/bin/garbage_collector_service.rs
@@ -1,3 +1,4 @@
+use chroma_system::thread_stack_size_bytes;
 use garbage_collector_library::garbage_collector_service_entrypoint;
 use tracing::{error, info};
 
@@ -8,15 +9,22 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[tokio::main]
-async fn main() {
-    info!("Starting garbage collector service");
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-gc")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(async {
+            info!("Starting garbage collector service");
 
-    match garbage_collector_service_entrypoint().await {
-        Ok(_) => info!("Garbage collector service completed successfully"),
-        Err(e) => {
-            error!("Garbage collector service failed: {:?}", e);
-            panic!("Garbage collector service failed: {:?}", e);
-        }
-    }
+            match garbage_collector_service_entrypoint().await {
+                Ok(_) => info!("Garbage collector service completed successfully"),
+                Err(e) => {
+                    error!("Garbage collector service failed: {:?}", e);
+                    panic!("Garbage collector service failed: {:?}", e);
+                }
+            }
+        });
 }

--- a/rust/garbage_collector/src/bin/garbage_collector_tool.rs
+++ b/rust/garbage_collector/src/bin/garbage_collector_tool.rs
@@ -15,7 +15,8 @@ use clap::Parser;
 use futures::StreamExt;
 use garbage_collector_library::{
     config::GarbageCollectorConfig,
-    garbage_collector_orchestrator_v2::GarbageCollectorOrchestrator, types::CleanupMode,
+    garbage_collector_orchestrator_v2::GarbageCollectorOrchestrator,
+    mcmr::instantiate_regions_and_topologies, types::CleanupMode,
 };
 use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
@@ -189,7 +190,7 @@ async fn main() {
             let registry = chroma_config::registry::Registry::new();
             let config = GarbageCollectorConfig::load_from_path(&config_path);
 
-            let log_client = Log::try_from_config(&(config.log, system.clone()), &registry)
+            let log_client = Log::try_from_config(&(config.log.clone(), system.clone()), &registry)
                 .await
                 .unwrap();
 
@@ -199,7 +200,8 @@ async fn main() {
 
             let dispatcher_handle = system.start_component(dispatcher);
 
-            let storage_client = Storage::try_from_config(&config.storage_config, &registry)
+            let storage_client = config
+                .instantiate_storage(&registry)
                 .await
                 .expect("Failed to create storage client");
 
@@ -218,6 +220,12 @@ async fn main() {
                     .await
                     .unwrap();
             let root_manager = RootManager::new(storage_client.clone(), root_manager_cache);
+            let regions_and_topologies = instantiate_regions_and_topologies(
+                config.regions_and_topologies.clone(),
+                &registry,
+            )
+            .await
+            .expect("Failed to create regions_and_topologies");
 
             let mut collections = sysdb_client
                 .get_collections(GetCollectionsOptions {
@@ -254,6 +262,7 @@ async fn main() {
                 system.clone(),
                 storage_client,
                 log_client,
+                regions_and_topologies,
                 root_manager,
                 cleanup_mode.into(),
                 config.min_versions_to_keep,
@@ -287,7 +296,8 @@ async fn main() {
             let registry = chroma_config::registry::Registry::new();
             let config = GarbageCollectorConfig::load_from_path(&config_path);
 
-            let storage_client = Storage::try_from_config(&config.storage_config, &registry)
+            let storage_client = config
+                .instantiate_storage(&registry)
                 .await
                 .expect("Failed to create storage client");
 

--- a/rust/garbage_collector/src/bin/garbage_collector_tool.rs
+++ b/rust/garbage_collector/src/bin/garbage_collector_tool.rs
@@ -63,8 +63,6 @@ enum GarbageCollectorCommand {
         collection_id: String,
         #[arg(long, default_value = "true")]
         enable_log_gc: bool,
-        #[arg(long, default_value = "false")]
-        enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
         #[arg(long)]
         cleanup_mode: CliCleanupMode,
         #[arg(long)]
@@ -178,7 +176,6 @@ async fn main() {
         GarbageCollectorCommand::GarbageCollect {
             collection_id,
             enable_log_gc,
-            enable_dangerous_option_to_ignore_min_versions_for_wal3,
             cleanup_mode,
             version_absolute_cutoff_time,
             collection_soft_delete_absolute_cutoff_time,
@@ -267,7 +264,6 @@ async fn main() {
                 cleanup_mode.into(),
                 config.min_versions_to_keep,
                 enable_log_gc,
-                enable_dangerous_option_to_ignore_min_versions_for_wal3,
                 10,
             );
 

--- a/rust/garbage_collector/src/config.rs
+++ b/rust/garbage_collector/src/config.rs
@@ -1,7 +1,10 @@
 use chroma_cache::CacheConfig;
 use chroma_config::helpers::deserialize_duration_from_seconds;
+use chroma_config::{registry::Registry, Configurable};
+use chroma_error::{ChromaError, ErrorCodes};
 use chroma_log::config::LogConfig;
 use chroma_storage::config::StorageConfig;
+use chroma_storage::Storage;
 use chroma_system::DispatcherConfig;
 use chroma_tracing::{OtelFilter, OtelFilterLevel};
 use chroma_types::CollectionUuid;
@@ -11,7 +14,9 @@ use std::{
     time::Duration,
 };
 
+use crate::mcmr::RegionsAndTopologiesConfig;
 use crate::types::CleanupMode;
+use thiserror::Error;
 
 const DEFAULT_CONFIG_PATH: &str = "./garbage_collector_config.yaml";
 
@@ -54,8 +59,11 @@ pub struct GarbageCollectorConfig {
     pub sysdb_config: chroma_sysdb::GrpcSysDbConfig,
     #[serde(default)]
     pub mcmr_sysdb_config: Option<chroma_sysdb::GrpcSysDbConfig>,
+    #[serde(default)]
+    pub regions_and_topologies: Option<RegionsAndTopologiesConfig>,
     pub dispatcher_config: DispatcherConfig,
-    pub storage_config: StorageConfig,
+    #[serde(default)]
+    pub storage_config: Option<StorageConfig>,
     #[serde(default)]
     pub(super) default_mode: CleanupMode,
     #[serde(default)]
@@ -83,6 +91,24 @@ pub struct GarbageCollectorConfig {
     pub max_attached_functions_to_gc_per_run: i32,
 }
 
+#[derive(Debug, Error)]
+pub enum GarbageCollectorConfigError {
+    #[error(
+        "storage_config and regions_and_topologies are mutually exclusive; exactly one must be set"
+    )]
+    StorageAndRegionsMutuallyExclusive,
+    #[error("exactly one of storage_config or regions_and_topologies must be set")]
+    MissingStorageAndRegions,
+    #[error("preferred region {preferred_region} not found in regions_and_topologies")]
+    MissingPreferredRegion { preferred_region: String },
+}
+
+impl ChromaError for GarbageCollectorConfigError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::InvalidArgument
+    }
+}
+
 impl GarbageCollectorConfig {
     fn default_min_versions_to_keep() -> u32 {
         2
@@ -101,6 +127,16 @@ impl GarbageCollectorConfig {
     }
 
     pub fn load_from_path(path: &str) -> Self {
+        println!("loading config from {path}");
+        println!(
+            r#"Full config is:
+================================================================================
+{}
+================================================================================
+"#,
+            std::fs::read_to_string(path)
+                .expect("should be able to open and read config to string")
+        );
         // Unfortunately, figment doesn't support environment variables with underscores. So we have to map and replace them.
         // Excluding our own environment variables, which are prefixed with CHROMA_.
         let mut f = figment::Figment::from(Env::prefixed("CHROMA_GC_").map(|k| match k {
@@ -152,13 +188,76 @@ impl GarbageCollectorConfig {
     fn enable_log_gc_for_tenant_threshold() -> String {
         "00000000-0000-0000-0000-000000000000".to_string()
     }
+
+    pub fn validate_storage_xor(&self) -> Result<(), Box<dyn ChromaError>> {
+        let storage_set = self.storage_config.is_some();
+        let regions_set = self.regions_and_topologies.is_some();
+
+        match (storage_set, regions_set) {
+            (true, true) => Err(Box::new(
+                GarbageCollectorConfigError::StorageAndRegionsMutuallyExclusive,
+            )),
+            (false, false) => Err(Box::new(
+                GarbageCollectorConfigError::MissingStorageAndRegions,
+            )),
+            (true, false) | (false, true) => Ok(()),
+        }
+    }
+
+    pub async fn instantiate_storage(
+        &self,
+        registry: &Registry,
+    ) -> Result<Storage, Box<dyn ChromaError>> {
+        self.validate_storage_xor()?;
+        if let Some(storage_config) = &self.storage_config {
+            return Storage::try_from_config(storage_config, registry).await;
+        }
+
+        let regions_and_topologies =
+            self.regions_and_topologies
+                .as_ref()
+                .ok_or_else(|| -> Box<dyn ChromaError> {
+                    Box::new(GarbageCollectorConfigError::MissingStorageAndRegions)
+                })?;
+        let preferred_region = regions_and_topologies
+            .preferred_region_config()
+            .ok_or_else(|| -> Box<dyn ChromaError> {
+                Box::new(GarbageCollectorConfigError::MissingPreferredRegion {
+                    preferred_region: regions_and_topologies.preferred.to_string(),
+                })
+            })?;
+
+        Storage::try_from_config(&preferred_region.storage, registry).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use chroma_storage::config::S3CredentialsConfig;
+    use chroma_storage::config::{LocalStorageConfig, S3CredentialsConfig};
+    use chroma_types::{MultiCloudMultiRegionConfiguration, ProviderRegion, RegionName};
+
+    use crate::mcmr::RegionalStorageConfig;
 
     use super::*;
+
+    fn local_storage_config(root: String) -> StorageConfig {
+        StorageConfig::Local(LocalStorageConfig { root })
+    }
+
+    fn regions_and_topologies(storage: StorageConfig) -> RegionsAndTopologiesConfig {
+        let region_name = RegionName::new("test-region").unwrap();
+        MultiCloudMultiRegionConfiguration::new(
+            region_name.clone(),
+            vec![ProviderRegion::new(
+                region_name,
+                "test-provider",
+                "test-location",
+                RegionalStorageConfig { storage },
+            )],
+            vec![],
+        )
+        .unwrap()
+    }
 
     #[test]
     fn test_load_config() {
@@ -180,7 +279,7 @@ mod tests {
         assert_eq!(config.dispatcher_config.num_worker_threads, 4);
         assert_eq!(config.dispatcher_config.dispatcher_queue_size, 100);
         assert_eq!(config.dispatcher_config.worker_queue_size, 100);
-        match config.storage_config {
+        match config.storage_config.expect("storage_config should be set") {
             StorageConfig::S3(storage_config) => {
                 assert_eq!(storage_config.bucket, "chroma-storage");
                 if let S3CredentialsConfig::Minio = storage_config.credentials {
@@ -196,5 +295,90 @@ mod tests {
             }
             _ => panic!("Expected S3 storage config"),
         }
+    }
+
+    #[test]
+    fn validate_storage_xor_allows_storage_only() {
+        let config = GarbageCollectorConfig {
+            storage_config: Some(StorageConfig::default()),
+            regions_and_topologies: None,
+            ..Default::default()
+        };
+
+        config
+            .validate_storage_xor()
+            .expect("storage-only config should pass");
+    }
+
+    #[test]
+    fn validate_storage_xor_allows_regions_only() {
+        let config = GarbageCollectorConfig {
+            storage_config: None,
+            regions_and_topologies: Some(regions_and_topologies(StorageConfig::default())),
+            ..Default::default()
+        };
+
+        config
+            .validate_storage_xor()
+            .expect("regions-only config should pass");
+    }
+
+    #[test]
+    fn validate_storage_xor_rejects_both_sources() {
+        let config = GarbageCollectorConfig {
+            storage_config: Some(StorageConfig::default()),
+            regions_and_topologies: Some(regions_and_topologies(StorageConfig::default())),
+            ..Default::default()
+        };
+
+        let err = config
+            .validate_storage_xor()
+            .expect_err("both storage config sources should fail");
+        assert!(
+            err.to_string()
+                .contains("storage_config and regions_and_topologies are mutually exclusive"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_storage_xor_rejects_neither_source() {
+        let config = GarbageCollectorConfig {
+            storage_config: None,
+            regions_and_topologies: None,
+            ..Default::default()
+        };
+
+        let err = config
+            .validate_storage_xor()
+            .expect_err("missing storage config sources should fail");
+        assert!(
+            err.to_string()
+                .contains("exactly one of storage_config or regions_and_topologies must be set"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn instantiate_storage_uses_preferred_region_when_storage_config_is_absent() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config = GarbageCollectorConfig {
+            storage_config: None,
+            regions_and_topologies: Some(regions_and_topologies(local_storage_config(
+                temp_dir.path().to_str().unwrap().to_string(),
+            ))),
+            ..Default::default()
+        };
+        let registry = Registry::new();
+
+        let storage = config
+            .instantiate_storage(&registry)
+            .await
+            .expect("preferred region local storage should instantiate");
+
+        assert!(
+            matches!(storage, Storage::Local(_)),
+            "expected preferred region local storage, got {storage:?}"
+        );
     }
 }

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -244,7 +244,6 @@ impl GarbageCollector {
         collection_soft_delete_absolute_cutoff_time: DateTime<Utc>,
         collection: CollectionToGcInfo,
         cleanup_mode: CleanupMode,
-        enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
     ) -> Result<GarbageCollectorResponse, GarbageCollectCollectionError> {
         let dispatcher = self
             .dispatcher
@@ -279,7 +278,6 @@ impl GarbageCollector {
                 cleanup_mode,
                 self.config.min_versions_to_keep,
                 enable_log_gc,
-                enable_dangerous_option_to_ignore_min_versions_for_wal3,
                 self.config
                     .max_concurrent_list_files_operations_per_collection,
             );
@@ -627,8 +625,6 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
                     collection_soft_delete_absolute_cutoff_time,
                     collection,
                     cleanup_mode,
-                    self.config
-                        .enable_dangerous_option_to_ignore_min_versions_for_wal3,
                 )
                 .instrument(instrumented_span)) as std::pin::Pin<Box<dyn std::future::Future<Output = Result<GarbageCollectorResponse, GarbageCollectCollectionError>> + Send + '_>>
             });

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::operators::truncate_dirty_log::{
     TruncateDirtyLogError, TruncateDirtyLogOperator, TruncateDirtyLogOutput,
@@ -35,12 +36,15 @@ use thiserror::Error;
 use tracing::{span, Instrument, Level, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+use crate::mcmr::{instantiate_regions_and_topologies, RegionsAndTopologies};
+
 #[allow(dead_code)]
 pub(crate) struct GarbageCollector {
     config: GarbageCollectorConfig,
     sysdb_client: SysDb,
     storage: Storage,
     logs: Log,
+    regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
     dispatcher: Option<ComponentHandle<Dispatcher>>,
     system: Option<System>,
     assignment_policy: Box<dyn AssignmentPolicy>,
@@ -78,6 +82,7 @@ impl GarbageCollector {
         sysdb_client: SysDb,
         storage: Storage,
         logs: Log,
+        regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
         assignment_policy: Box<dyn AssignmentPolicy>,
         root_manager: RootManager,
     ) -> Self {
@@ -88,6 +93,7 @@ impl GarbageCollector {
             sysdb_client,
             storage,
             logs,
+            regions_and_topologies,
             dispatcher: None,
             system: None,
             assignment_policy,
@@ -141,6 +147,7 @@ impl GarbageCollector {
                 dispatcher.clone(),
                 self.storage.clone(),
                 self.logs.clone(),
+                self.regions_and_topologies.clone(),
                 collection_id,
                 database_name,
             );
@@ -267,6 +274,7 @@ impl GarbageCollector {
                 system.clone(),
                 self.storage.clone(),
                 self.logs.clone(),
+                self.regions_and_topologies.clone(),
                 self.root_manager.clone(),
                 cleanup_mode,
                 self.config.min_versions_to_keep,
@@ -746,13 +754,16 @@ impl Configurable<(GarbageCollectorConfig, System)> for GarbageCollector {
             config.mcmr_sysdb_config.clone(),
         );
         let sysdb_client = SysDb::try_from_config(&sysdb_config, registry).await?;
-        let storage = Storage::try_from_config(&config.storage_config, registry).await?;
+        let storage = config.instantiate_storage(registry).await?;
 
         let assignment_policy =
             Box::<dyn AssignmentPolicy>::try_from_config(&config.assignment_policy, registry)
                 .await?;
 
         let logs = Log::try_from_config(&(config.log.clone(), system.clone()), registry).await?;
+        let regions_and_topologies =
+            instantiate_regions_and_topologies(config.regions_and_topologies.clone(), registry)
+                .await?;
 
         let root_manager_cache =
             chroma_cache::from_config_persistent(&config.root_cache_config).await?;
@@ -763,6 +774,7 @@ impl Configurable<(GarbageCollectorConfig, System)> for GarbageCollector {
             sysdb_client,
             storage,
             logs,
+            regions_and_topologies,
             assignment_policy,
             root_manager,
         ))
@@ -988,8 +1000,9 @@ mod tests {
                 num_channels: 1,
             },
             mcmr_sysdb_config: None,
+            regions_and_topologies: None,
             dispatcher_config: DispatcherConfig::default(),
-            storage_config: s3_config_for_localhost_with_bucket_name("chroma-storage").await,
+            storage_config: Some(s3_config_for_localhost_with_bucket_name("chroma-storage").await),
             default_mode: CleanupMode::DryRunV2,
             tenant_mode_overrides: Some(tenant_mode_overrides),
             assignment_policy: chroma_config::assignment::config::AssignmentPolicyConfig::default(),
@@ -1212,7 +1225,7 @@ mod tests {
                 num_channels: 1,
             },
             dispatcher_config: DispatcherConfig::default(),
-            storage_config: s3_config_for_localhost_with_bucket_name("chroma-storage").await,
+            storage_config: Some(s3_config_for_localhost_with_bucket_name("chroma-storage").await),
             default_mode: CleanupMode::DeleteV2,
             tenant_mode_overrides: None,
             assignment_policy: chroma_config::assignment::config::AssignmentPolicyConfig::default(),

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -49,6 +49,8 @@ use tokio::sync::oneshot::{error::RecvError, Sender};
 use tracing::Span;
 use wal3::LogPosition;
 
+use crate::mcmr::RegionsAndTopologies;
+
 #[derive(Debug)]
 pub struct GarbageCollectorOrchestrator {
     collection_id: CollectionUuid,
@@ -61,6 +63,7 @@ pub struct GarbageCollectorOrchestrator {
     system: System,
     storage: Storage,
     logs: Log,
+    regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
     root_manager: RootManager,
     result_channel: Option<Sender<Result<GarbageCollectorResponse, GarbageCollectorError>>>,
     cleanup_mode: CleanupMode,
@@ -98,6 +101,7 @@ impl GarbageCollectorOrchestrator {
         system: System,
         storage: Storage,
         logs: Log,
+        regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
         root_manager: RootManager,
         cleanup_mode: CleanupMode,
         min_versions_to_keep: u32,
@@ -116,6 +120,7 @@ impl GarbageCollectorOrchestrator {
             system,
             storage,
             logs,
+            regions_and_topologies,
             root_manager,
             cleanup_mode,
             result_channel: None,
@@ -564,6 +569,7 @@ impl GarbageCollectorOrchestrator {
                 mode: self.cleanup_mode,
                 storage: self.storage.clone(),
                 logs: self.logs.clone(),
+                regions_and_topologies: self.regions_and_topologies.clone(),
                 enable_dangerous_option_to_ignore_min_versions_for_wal3: self
                     .enable_dangerous_option_to_ignore_min_versions_for_wal3,
             }),
@@ -1394,6 +1400,7 @@ mod tests {
             system.clone(),
             storage,
             logs,
+            None,
             root_manager,
             crate::types::CleanupMode::DeleteV2,
             1,

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -205,6 +205,73 @@ where
     }
 }
 
+/// After mark_version_for_deletion succeeds in sysdb, update the cached version
+/// files so that marked_for_deletion is true for the affected versions. Without
+/// this refresh, DeleteVersionsAtSysDbOperator receives a stale pre-mark
+/// snapshot and skips physical file deletion, orphaning per-version files in
+/// storage.
+///
+/// NOTE: Old root/current version-file snapshots (_flush, _gc_mark, _gc_delete)
+/// created by sysdb during mark/delete operations are a separate cleanup concern.
+/// See rust/rust-sysdb/src/server.rs for the existing CAS-failure orphan TODO.
+fn refresh_version_files_after_mark(
+    version_files: &mut HashMap<CollectionUuid, Arc<CollectionVersionFile>>,
+    versions_marked: &[VersionListForCollection],
+) -> Result<(), GarbageCollectorError> {
+    for version_list in versions_marked {
+        let collection_id: CollectionUuid = version_list
+            .collection_id
+            .parse()
+            .map_err(GarbageCollectorError::UnparsableUuid)?;
+        if let Some(version_file_arc) = version_files.get_mut(&collection_id) {
+            let mut version_file = (**version_file_arc).clone();
+            let history =
+                version_file
+                    .version_history
+                    .as_mut()
+                    .ok_or(GarbageCollectorError::InvariantViolation(format!(
+                        "Expected version_history to be set for collection {} when refreshing marked versions",
+                        collection_id
+                    )))?;
+
+            for version_info in history.versions.iter_mut() {
+                if version_list.versions.contains(&version_info.version) {
+                    version_info.marked_for_deletion = true;
+                }
+            }
+            *version_file_arc = Arc::new(version_file);
+        } else {
+            return Err(GarbageCollectorError::MissingVersionFile(collection_id));
+        }
+    }
+    Ok(())
+}
+
+fn validate_mark_version_results(
+    versions_marked: &[VersionListForCollection],
+    mark_results: &HashMap<String, bool>,
+) -> Result<(), GarbageCollectorError> {
+    for version_list in versions_marked {
+        match mark_results.get(&version_list.collection_id) {
+            Some(true) => {}
+            Some(false) => {
+                return Err(GarbageCollectorError::SysDbMethodFailed(format!(
+                    "mark_version_for_deletion reported failure for collection {}",
+                    version_list.collection_id
+                )));
+            }
+            None => {
+                return Err(GarbageCollectorError::SysDbMethodFailed(format!(
+                    "mark_version_for_deletion did not return a result for collection {}",
+                    version_list.collection_id
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn build_versions_to_mark(
     versions_by_collection: &HashMap<CollectionUuid, HashMap<i64, CollectionVersionAction>>,
     version_files: &HashMap<CollectionUuid, Arc<CollectionVersionFile>>,
@@ -424,11 +491,15 @@ impl GarbageCollectorOrchestrator {
         let versions_to_mark = build_versions_to_mark(&output.versions, &self.version_files)?;
 
         if !versions_to_mark.is_empty() {
-            self.sysdb_client
+            let versions_marked = versions_to_mark.clone();
+            let mark_results = self
+                .sysdb_client
                 .mark_version_for_deletion(0, versions_to_mark, self.database_name.clone())
                 .await
                 .map_err(|err| GarbageCollectorError::SysDbMethodFailed(err.to_string()))?;
 
+            validate_mark_version_results(&versions_marked, &mark_results)?;
+            refresh_version_files_after_mark(&mut self.version_files, &versions_marked)?;
             tracing::debug!("Marked versions as deleted in SysDb.");
         } else {
             tracing::debug!("No versions to mark for deletion in SysDb.");
@@ -1139,6 +1210,8 @@ impl Handler<TaskResult<DeleteVersionsAtSysDbOutput, DeleteVersionsAtSysDbError>
 #[cfg(test)]
 mod tests {
     use super::build_versions_to_mark;
+    use super::refresh_version_files_after_mark;
+    use super::validate_mark_version_results;
     use super::GarbageCollectorError;
     use super::GarbageCollectorOrchestrator;
     use crate::operators::compute_versions_to_delete_from_graph::CollectionVersionAction;
@@ -1148,9 +1221,12 @@ mod tests {
     use chroma_storage::test_storage;
     use chroma_sysdb::{GetCollectionsOptions, TestSysDb};
     use chroma_system::{Dispatcher, Orchestrator, System};
+    use chroma_types::chroma_proto::{
+        CollectionInfoImmutable, CollectionVersionFile, CollectionVersionHistory,
+        CollectionVersionInfo, VersionListForCollection,
+    };
     use chroma_types::{
-        chroma_proto::CollectionInfoImmutable, chroma_proto::CollectionVersionFile, CollectionUuid,
-        Segment, SegmentFlushInfo, SegmentScope, SegmentType, SegmentUuid,
+        CollectionUuid, Segment, SegmentFlushInfo, SegmentScope, SegmentType, SegmentUuid,
     };
     use chrono::DateTime;
     use std::{collections::HashMap, sync::Arc, time::SystemTime};
@@ -1264,6 +1340,219 @@ mod tests {
                 );
             }
             other => panic!("expected InvariantViolation, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn refresh_version_files_marks_correct_versions() {
+        let collection_id = CollectionUuid::new();
+        let mut version_files = HashMap::from([(
+            collection_id,
+            Arc::new(CollectionVersionFile {
+                collection_info_immutable: Some(CollectionInfoImmutable {
+                    tenant_id: "t".to_string(),
+                    database_id: "d".to_string(),
+                    collection_id: collection_id.to_string(),
+                    dimension: 0,
+                    ..Default::default()
+                }),
+                version_history: Some(CollectionVersionHistory {
+                    versions: vec![
+                        CollectionVersionInfo {
+                            version: 1,
+                            marked_for_deletion: false,
+                            version_file_name: "v1_file".to_string(),
+                            ..Default::default()
+                        },
+                        CollectionVersionInfo {
+                            version: 2,
+                            marked_for_deletion: false,
+                            version_file_name: "v2_file".to_string(),
+                            ..Default::default()
+                        },
+                        CollectionVersionInfo {
+                            version: 3,
+                            marked_for_deletion: false,
+                            version_file_name: "v3_file".to_string(),
+                            ..Default::default()
+                        },
+                    ],
+                }),
+            }),
+        )]);
+
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: collection_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1, 3],
+        }];
+
+        refresh_version_files_after_mark(&mut version_files, &versions_marked)
+            .expect("refresh should succeed");
+
+        let vf = version_files.get(&collection_id).unwrap();
+        let history = vf.version_history.as_ref().unwrap();
+
+        // Version 1 should now be marked.
+        assert!(
+            history.versions[0].marked_for_deletion,
+            "version 1 should be marked_for_deletion"
+        );
+        // Version 2 was not in the mark list and should remain unmarked.
+        assert!(
+            !history.versions[1].marked_for_deletion,
+            "version 2 should NOT be marked_for_deletion"
+        );
+        // Version 3 should now be marked.
+        assert!(
+            history.versions[2].marked_for_deletion,
+            "version 3 should be marked_for_deletion"
+        );
+        println!("refresh_version_files_marks_correct_versions: passed");
+    }
+
+    #[test]
+    fn refresh_version_files_errors_on_missing_collection() {
+        let present_id = CollectionUuid::new();
+        let absent_id = CollectionUuid::new();
+
+        let mut version_files = HashMap::from([(
+            present_id,
+            Arc::new(CollectionVersionFile {
+                collection_info_immutable: Some(CollectionInfoImmutable {
+                    tenant_id: "t".to_string(),
+                    database_id: "d".to_string(),
+                    collection_id: present_id.to_string(),
+                    dimension: 0,
+                    ..Default::default()
+                }),
+                version_history: Some(CollectionVersionHistory {
+                    versions: vec![CollectionVersionInfo {
+                        version: 1,
+                        marked_for_deletion: false,
+                        version_file_name: "v1_file".to_string(),
+                        ..Default::default()
+                    }],
+                }),
+            }),
+        )]);
+
+        // Mark a collection that is NOT in the cache.
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: absent_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1],
+        }];
+
+        let err = refresh_version_files_after_mark(&mut version_files, &versions_marked)
+            .expect_err("refresh should fail when a collection is missing from the cache");
+        match err {
+            GarbageCollectorError::MissingVersionFile(id) => {
+                assert_eq!(id, absent_id);
+            }
+            other => panic!("expected MissingVersionFile, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn refresh_version_files_errors_on_missing_version_history() {
+        let collection_id = CollectionUuid::new();
+        let mut version_files = HashMap::from([(
+            collection_id,
+            Arc::new(CollectionVersionFile {
+                collection_info_immutable: Some(CollectionInfoImmutable {
+                    tenant_id: "t".to_string(),
+                    database_id: "d".to_string(),
+                    collection_id: collection_id.to_string(),
+                    dimension: 0,
+                    ..Default::default()
+                }),
+                version_history: None, // No history
+            }),
+        )]);
+
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: collection_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1],
+        }];
+
+        let err = refresh_version_files_after_mark(&mut version_files, &versions_marked)
+            .expect_err("refresh should fail when version_history is missing");
+        match err {
+            GarbageCollectorError::InvariantViolation(msg) => {
+                assert!(
+                    msg.contains("Expected version_history to be set"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected InvariantViolation, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_mark_version_results_accepts_successful_results() {
+        let collection_id = CollectionUuid::new();
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: collection_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1, 2],
+        }];
+        let mark_results = HashMap::from([(collection_id.to_string(), true)]);
+
+        validate_mark_version_results(&versions_marked, &mark_results)
+            .expect("all successful mark results should validate");
+    }
+
+    #[test]
+    fn validate_mark_version_results_errors_on_failed_collection() {
+        let collection_id = CollectionUuid::new();
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: collection_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1],
+        }];
+        let mark_results = HashMap::from([(collection_id.to_string(), false)]);
+
+        let err = validate_mark_version_results(&versions_marked, &mark_results)
+            .expect_err("failed mark results should return an error");
+        match err {
+            GarbageCollectorError::SysDbMethodFailed(msg) => {
+                assert!(
+                    msg.contains("reported failure"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected SysDbMethodFailed, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_mark_version_results_errors_on_missing_collection_result() {
+        let collection_id = CollectionUuid::new();
+        let versions_marked = vec![VersionListForCollection {
+            collection_id: collection_id.to_string(),
+            tenant_id: "t".to_string(),
+            database_id: "d".to_string(),
+            versions: vec![1],
+        }];
+        let mark_results = HashMap::new();
+
+        let err = validate_mark_version_results(&versions_marked, &mark_results)
+            .expect_err("missing mark results should return an error");
+        match err {
+            GarbageCollectorError::SysDbMethodFailed(msg) => {
+                assert!(
+                    msg.contains("did not return a result"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected SysDbMethodFailed, got: {other:?}"),
         }
     }
 

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -83,8 +83,6 @@ pub struct GarbageCollectorOrchestrator {
 
     num_files_deleted: u32,
     num_versions_deleted: u32,
-
-    enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -106,7 +104,6 @@ impl GarbageCollectorOrchestrator {
         cleanup_mode: CleanupMode,
         min_versions_to_keep: u32,
         enable_log_gc: bool,
-        enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
         max_concurrent_list_files_operations_per_collection: usize,
     ) -> Self {
         Self {
@@ -140,7 +137,6 @@ impl GarbageCollectorOrchestrator {
             num_files_deleted: 0,
             num_versions_deleted: 0,
 
-            enable_dangerous_option_to_ignore_min_versions_for_wal3,
             max_concurrent_list_files_operations_per_collection,
         }
     }
@@ -641,8 +637,6 @@ impl GarbageCollectorOrchestrator {
                 storage: self.storage.clone(),
                 logs: self.logs.clone(),
                 regions_and_topologies: self.regions_and_topologies.clone(),
-                enable_dangerous_option_to_ignore_min_versions_for_wal3: self
-                    .enable_dangerous_option_to_ignore_min_versions_for_wal3,
             }),
             DeleteUnusedLogsInput {
                 collections_to_destroy,
@@ -1694,7 +1688,6 @@ mod tests {
             crate::types::CleanupMode::DeleteV2,
             1,
             true,
-            false,
             10,
         );
         let result = orchestrator.run(system).await;

--- a/rust/garbage_collector/src/lib.rs
+++ b/rust/garbage_collector/src/lib.rs
@@ -26,6 +26,7 @@ mod construct_version_graph_orchestrator;
 mod garbage_collector_component;
 pub mod garbage_collector_orchestrator_v2;
 mod log_only_orchestrator;
+pub mod mcmr;
 
 #[cfg(test)]
 pub(crate) mod helper;

--- a/rust/garbage_collector/src/log_only_orchestrator.rs
+++ b/rust/garbage_collector/src/log_only_orchestrator.rs
@@ -1,4 +1,5 @@
 use crate::garbage_collector_orchestrator_v2::GarbageCollectorError;
+use crate::mcmr::RegionsAndTopologies;
 use crate::operators::delete_unused_logs::{
     DeleteUnusedLogsError, DeleteUnusedLogsInput, DeleteUnusedLogsOperator, DeleteUnusedLogsOutput,
 };
@@ -12,6 +13,7 @@ use chroma_system::{
 };
 use chroma_types::{CollectionUuid, DatabaseName};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use tokio::sync::oneshot::Sender;
 use tracing::{Level, Span};
 
@@ -20,6 +22,7 @@ pub struct HardDeleteLogOnlyGarbageCollectorOrchestrator {
     context: OrchestratorContext,
     storage: Storage,
     logs: Log,
+    regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
     result_channel: Option<Sender<Result<GarbageCollectorResponse, GarbageCollectorError>>>,
     collection_to_destroy: CollectionUuid,
     database_name: Option<DatabaseName>,
@@ -31,6 +34,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
         dispatcher: ComponentHandle<Dispatcher>,
         storage: Storage,
         logs: Log,
+        regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
         collection_to_destroy: CollectionUuid,
         database_name: Option<DatabaseName>,
     ) -> Self {
@@ -38,6 +42,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
             context: OrchestratorContext::new(dispatcher),
             storage,
             logs,
+            regions_and_topologies,
             result_channel: None,
             collection_to_destroy,
             database_name,
@@ -98,6 +103,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
                 mode: CleanupMode::DeleteV2,
                 storage: self.storage.clone(),
                 logs: self.logs.clone(),
+                regions_and_topologies: self.regions_and_topologies.clone(),
                 enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
             }),
             DeleteUnusedLogsInput {
@@ -202,6 +208,7 @@ mod tests {
             dispatcher_handle.clone(),
             storage.clone(),
             logs.clone(),
+            None,
             collection_to_destroy,
             None,
         );
@@ -245,6 +252,7 @@ mod tests {
             dispatcher_handle,
             storage.clone(),
             logs.clone(),
+            None,
             collection_to_destroy,
             None,
         );

--- a/rust/garbage_collector/src/log_only_orchestrator.rs
+++ b/rust/garbage_collector/src/log_only_orchestrator.rs
@@ -104,7 +104,6 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
                 storage: self.storage.clone(),
                 logs: self.logs.clone(),
                 regions_and_topologies: self.regions_and_topologies.clone(),
-                enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
             }),
             DeleteUnusedLogsInput {
                 collections_to_destroy,
@@ -230,7 +229,6 @@ mod tests {
     /// it uses the following hardcoded configuration:
     /// - `enabled`: true (operator is active)
     /// - `mode`: `CleanupMode::DeleteV2` (performs hard deletion)
-    /// - `enable_dangerous_option_to_ignore_min_versions_for_wal3`: false (safety check enabled)
     ///
     /// The collection UUID stored in `collection_to_destroy` is placed in the
     /// `collections_to_destroy` set, while `collections_to_garbage_collect` remains empty

--- a/rust/garbage_collector/src/mcmr.rs
+++ b/rust/garbage_collector/src/mcmr.rs
@@ -1,0 +1,141 @@
+use std::{fmt::Debug, sync::Arc, time::Duration};
+
+use chroma_config::{
+    registry::Registry,
+    spanner::{SpannerChannelConfig, SpannerConfig, SpannerSessionPoolConfig},
+    Configurable,
+};
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_storage::{config::StorageConfig, Storage};
+use chroma_types::MultiCloudMultiRegionConfiguration;
+use google_cloud_gax::conn::Environment;
+use google_cloud_spanner::client::{
+    ChannelConfig, Client as SpannerClient, ClientConfig as SpannerClientConfig,
+};
+use google_cloud_spanner::session::SessionConfig;
+use thiserror::Error;
+use tracing::Level;
+use wal3::ReplicatedFragmentOptions;
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
+pub struct RegionalStorageConfig {
+    pub storage: StorageConfig,
+}
+
+#[derive(Clone, Debug)]
+pub struct RegionalStorage {
+    pub storage: Storage,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
+pub struct TopologicalStorageConfig {
+    pub spanner: SpannerConfig,
+    pub repl: ReplicatedFragmentOptions,
+}
+
+#[derive(Clone)]
+pub struct TopologicalStorage {
+    pub spanner: SpannerClient,
+    pub repl: ReplicatedFragmentOptions,
+}
+
+impl std::fmt::Debug for TopologicalStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TopologicalStorage")
+            .field("spanner", &"SpannerClient { ... }")
+            .field("repl", &self.repl)
+            .finish()
+    }
+}
+
+pub type RegionsAndTopologiesConfig =
+    MultiCloudMultiRegionConfiguration<RegionalStorageConfig, TopologicalStorageConfig>;
+pub type RegionsAndTopologies =
+    MultiCloudMultiRegionConfiguration<RegionalStorage, TopologicalStorage>;
+
+#[derive(Debug, Error)]
+pub enum RegionsAndTopologiesError {
+    #[error("spanner error: {0}")]
+    Spanner(#[from] google_cloud_spanner::client::Error),
+    #[error("spanner auth error")]
+    SpannerAuth(#[from] google_cloud_spanner::admin::google_cloud_auth::error::Error),
+}
+
+impl ChromaError for RegionsAndTopologiesError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
+}
+
+fn to_session_config(cfg: &SpannerSessionPoolConfig) -> SessionConfig {
+    let mut config = SessionConfig::default();
+    config.session_get_timeout = Duration::from_secs(cfg.session_get_timeout_secs);
+    config.max_opened = cfg.max_opened;
+    config.min_opened = cfg.min_opened;
+    config
+}
+
+fn to_channel_config(cfg: &SpannerChannelConfig) -> ChannelConfig {
+    ChannelConfig {
+        num_channels: cfg.num_channels,
+        connect_timeout: Duration::from_secs(cfg.connect_timeout_secs),
+        timeout: Duration::from_secs(cfg.timeout_secs),
+        http2_keep_alive_interval: Some(Duration::from_secs(cfg.http2_keep_alive_interval_secs)),
+        keep_alive_timeout: Some(Duration::from_secs(cfg.keep_alive_timeout_secs)),
+        keep_alive_while_idle: Some(cfg.keep_alive_while_idle),
+    }
+}
+
+pub async fn instantiate_regions_and_topologies(
+    config: Option<RegionsAndTopologiesConfig>,
+    registry: &Registry,
+) -> Result<Option<Arc<RegionsAndTopologies>>, Box<dyn ChromaError>> {
+    let Some(config) = config else {
+        return Ok(None);
+    };
+
+    let runtime = config
+        .try_cast_async(
+            |region| async move {
+                Ok::<RegionalStorage, Box<dyn ChromaError>>(RegionalStorage {
+                    storage: Storage::try_from_config(&region.storage, registry).await?,
+                })
+            },
+            |topology| async move {
+                let database_path = topology.spanner.database_path().clone();
+                let session_config = to_session_config(topology.spanner.session_pool());
+                let channel_config = to_channel_config(topology.spanner.channel());
+                let config = match &topology.spanner {
+                    SpannerConfig::Emulator(emulator) => SpannerClientConfig {
+                        environment: Environment::Emulator(emulator.grpc_endpoint()),
+                        session_config,
+                        channel_config,
+                        ..Default::default()
+                    },
+                    SpannerConfig::Gcp(_) => {
+                        let mut config = SpannerClientConfig::default().with_auth().await.map_err(
+                            |err| -> Box<dyn ChromaError> {
+                                tracing::event!(Level::ERROR, name = "auth error", error = ?err);
+                                Box::new(RegionsAndTopologiesError::from(err)) as _
+                            },
+                        )?;
+                        config.session_config = session_config;
+                        config.channel_config = channel_config;
+                        config
+                    }
+                };
+                let repl = topology.repl.clone();
+                Ok::<TopologicalStorage, Box<dyn ChromaError>>(TopologicalStorage {
+                    spanner: SpannerClient::new(database_path, config).await.map_err(
+                        |err| -> Box<dyn ChromaError> {
+                            Box::new(RegionsAndTopologiesError::from(err)) as _
+                        },
+                    )?,
+                    repl,
+                })
+            },
+        )
+        .await?;
+
+    Ok(Some(Arc::new(runtime)))
+}

--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -8,16 +8,19 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_log::Log;
 use chroma_storage::Storage;
 use chroma_system::{Operator, OperatorType};
-use chroma_types::{CollectionUuid, DatabaseName};
+use chroma_types::{CollectionUuid, DatabaseName, TopologyName};
 use futures::future::try_join_all;
 use thiserror::Error;
 use tracing::Level;
 use wal3::{
-    create_s3_factories, FragmentSeqNo, GarbageCollectionOptions, GarbageCollector, LogPosition,
-    LogReaderOptions, LogWriterOptions, ManifestManager, S3FragmentManagerFactory,
-    S3ManifestManagerFactory, SnapshotOptions, ThrottleOptions,
+    create_repl_factories, create_s3_factories, FragmentSeqNo, FragmentUuid,
+    GarbageCollectionOptions, GarbageCollectionState, GarbageCollector, LogPosition,
+    LogReaderOptions, LogWriterOptions, ManifestManager, ManifestManagerFactory,
+    ReplicatedFragmentManagerFactory, ReplicatedManifestManagerFactory, S3FragmentManagerFactory,
+    S3ManifestManagerFactory, SnapshotOptions, StorageWrapper, ThrottleOptions,
 };
 
+use crate::mcmr::RegionsAndTopologies;
 use crate::types::CleanupMode;
 
 #[derive(Clone, Debug)]
@@ -26,6 +29,7 @@ pub struct DeleteUnusedLogsOperator {
     pub mode: CleanupMode,
     pub storage: Storage,
     pub logs: Log,
+    pub regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
     pub enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
 }
 
@@ -45,6 +49,20 @@ pub enum DeleteUnusedLogsError {
         collection_id: CollectionUuid,
         err: wal3::Error,
     },
+    #[error("missing MCMR regions_and_topologies config for database {database_name}")]
+    MissingRegionsAndTopologies { database_name: String },
+    #[error("invalid topology {topology} for database {database_name}")]
+    InvalidTopology {
+        database_name: String,
+        topology: String,
+    },
+    #[error("topology {topology} not found in regions_and_topologies config")]
+    MissingTopology { topology: String },
+    #[error("preferred region {preferred_region} is not present in topology {topology}")]
+    PreferredRegionNotInTopology {
+        preferred_region: String,
+        topology: String,
+    },
     #[error(transparent)]
     Gc(#[from] chroma_log::GarbageCollectError),
 }
@@ -52,6 +70,208 @@ pub enum DeleteUnusedLogsError {
 impl ChromaError for DeleteUnusedLogsError {
     fn code(&self) -> ErrorCodes {
         ErrorCodes::Internal
+    }
+}
+
+struct ReplTopologyContext {
+    storage_wrappers: Arc<Vec<StorageWrapper>>,
+    region_names: Vec<String>,
+    preferred_index: usize,
+    spanner: Arc<google_cloud_spanner::client::Client>,
+    repl_options: wal3::ReplicatedFragmentOptions,
+}
+
+#[async_trait]
+trait CollectionGarbageCollector: Send {
+    async fn garbage_collect_phase1_compute_garbage(
+        &self,
+        options: &GarbageCollectionOptions,
+        keep_at_least: Option<LogPosition>,
+    ) -> Result<Option<GarbageCollectionState>, wal3::Error>;
+
+    async fn garbage_collect_phase3_delete_garbage(
+        &self,
+        options: &GarbageCollectionOptions,
+        gc_state: &GarbageCollectionState,
+    ) -> Result<(), wal3::Error>;
+}
+
+#[async_trait]
+impl<P, FP, MP> CollectionGarbageCollector for GarbageCollector<P, FP, MP>
+where
+    P: wal3::FragmentPointer + Send + Sync + 'static,
+    FP: wal3::FragmentManagerFactory<FragmentPointer = P> + Send + Sync + 'static,
+    MP: wal3::ManifestManagerFactory<FragmentPointer = P> + Send + Sync + 'static,
+{
+    async fn garbage_collect_phase1_compute_garbage(
+        &self,
+        options: &GarbageCollectionOptions,
+        keep_at_least: Option<LogPosition>,
+    ) -> Result<Option<GarbageCollectionState>, wal3::Error> {
+        GarbageCollector::garbage_collect_phase1_compute_garbage(self, options, keep_at_least).await
+    }
+
+    async fn garbage_collect_phase3_delete_garbage(
+        &self,
+        options: &GarbageCollectionOptions,
+        gc_state: &GarbageCollectionState,
+    ) -> Result<(), wal3::Error> {
+        GarbageCollector::garbage_collect_phase3_delete_garbage(self, options, gc_state).await
+    }
+}
+
+impl DeleteUnusedLogsOperator {
+    fn repl_topology_context(
+        &self,
+        database_name: Option<&DatabaseName>,
+        collection_id: CollectionUuid,
+    ) -> Result<Option<ReplTopologyContext>, DeleteUnusedLogsError> {
+        let Some(database_name) = database_name else {
+            return Ok(None);
+        };
+        let Some(topology) = database_name.topology() else {
+            return Ok(None);
+        };
+        let Some(regions_and_topologies) = &self.regions_and_topologies else {
+            return Err(DeleteUnusedLogsError::MissingRegionsAndTopologies {
+                database_name: database_name.as_ref().to_string(),
+            });
+        };
+
+        let topology_name = TopologyName::new(topology.clone()).map_err(|_| {
+            DeleteUnusedLogsError::InvalidTopology {
+                database_name: database_name.as_ref().to_string(),
+                topology: topology.clone(),
+            }
+        })?;
+        let Some((regions, topology_config)) =
+            regions_and_topologies.lookup_topology(&topology_name)
+        else {
+            return Err(DeleteUnusedLogsError::MissingTopology {
+                topology: topology_name.to_string(),
+            });
+        };
+
+        let prefix = collection_id.storage_prefix_for_log();
+        let mut storage_wrappers = Vec::with_capacity(regions.len());
+        let mut region_names = Vec::with_capacity(regions.len());
+        for region in regions {
+            region_names.push(region.name().to_string());
+            storage_wrappers.push(StorageWrapper::new(
+                region.name().to_string(),
+                region.config.storage.clone(),
+                prefix.clone(),
+            ));
+        }
+
+        let preferred_index = storage_wrappers
+            .iter()
+            .position(|region| region.region.as_str() == regions_and_topologies.preferred.as_str())
+            .ok_or_else(|| DeleteUnusedLogsError::PreferredRegionNotInTopology {
+                preferred_region: regions_and_topologies.preferred.to_string(),
+                topology: topology_name.to_string(),
+            })?;
+
+        Ok(Some(ReplTopologyContext {
+            storage_wrappers: Arc::new(storage_wrappers),
+            region_names,
+            preferred_index,
+            spanner: Arc::new(topology_config.config.spanner.clone()),
+            repl_options: topology_config.config.repl.clone(),
+        }))
+    }
+
+    async fn open_collection_garbage_collector(
+        &self,
+        database_name: Option<&DatabaseName>,
+        collection_id: CollectionUuid,
+        storage: Arc<Storage>,
+    ) -> Result<Box<dyn CollectionGarbageCollector>, DeleteUnusedLogsError> {
+        let prefix = collection_id.storage_prefix_for_log();
+        let options = LogWriterOptions::default();
+
+        if let Some(repl) = self.repl_topology_context(database_name, collection_id)? {
+            let (fragment_manager_factory, manifest_manager_factory) = create_repl_factories(
+                options.clone(),
+                repl.repl_options,
+                repl.preferred_index,
+                repl.storage_wrappers,
+                repl.spanner,
+                repl.region_names,
+                collection_id.0,
+            );
+            let writer =
+                GarbageCollector::<
+                    FragmentUuid,
+                    ReplicatedFragmentManagerFactory,
+                    ReplicatedManifestManagerFactory,
+                >::open(options, fragment_manager_factory, manifest_manager_factory)
+                .await
+                .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })?;
+            Ok(Box::new(writer))
+        } else {
+            let (fragment_manager_factory, manifest_manager_factory) = create_s3_factories(
+                options.clone(),
+                LogReaderOptions::default(),
+                storage,
+                prefix,
+                "garbage collection service".to_string(),
+                Arc::new(()),
+                Arc::new(()),
+            );
+            let writer =
+                GarbageCollector::<
+                    (FragmentSeqNo, LogPosition),
+                    S3FragmentManagerFactory,
+                    S3ManifestManagerFactory,
+                >::open(options, fragment_manager_factory, manifest_manager_factory)
+                .await
+                .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })?;
+            Ok(Box::new(writer))
+        }
+    }
+
+    async fn destroy_collection_log(
+        &self,
+        database_name: Option<&DatabaseName>,
+        collection_id: CollectionUuid,
+        storage: Arc<Storage>,
+    ) -> Result<(), DeleteUnusedLogsError> {
+        let prefix = collection_id.storage_prefix_for_log();
+
+        if let Some(repl) = self.repl_topology_context(database_name, collection_id)? {
+            let local_region = repl.region_names[repl.preferred_index].clone();
+            let preferred_storage =
+                Arc::new(repl.storage_wrappers[repl.preferred_index].storage.clone());
+            let manifest_manager_factory = ReplicatedManifestManagerFactory::new(
+                repl.spanner,
+                repl.region_names,
+                local_region,
+                collection_id.0,
+            );
+            let manifest_manager = manifest_manager_factory
+                .open_publisher()
+                .await
+                .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })?;
+            wal3::destroy(preferred_storage, &prefix, &manifest_manager)
+                .await
+                .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })
+        } else {
+            let manifest_manager = ManifestManager::new(
+                ThrottleOptions::default(),
+                SnapshotOptions::default(),
+                storage.clone(),
+                prefix.clone(),
+                "destroy service".to_string(),
+                Arc::new(()),
+                Arc::new(()),
+            )
+            .await
+            .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })?;
+            wal3::destroy(storage, &prefix, &manifest_manager)
+                .await
+                .map_err(|err| DeleteUnusedLogsError::Wal3 { collection_id, err })
+        }
     }
 }
 
@@ -80,35 +300,27 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
             {
                 let collection_id = *collection_id;
                 let storage_clone = storage_arc.clone();
+                let database_name = input.database_name.clone();
                 let mut logs = self.logs.clone();
                 log_gc_futures.push(async move {
-                    let prefix = collection_id.storage_prefix_for_log();
-                    let options = LogWriterOptions::default();
-                    let (fragment_manager_factory, manifest_manager_factory) = create_s3_factories(
-                        options.clone(),
-                        LogReaderOptions::default(),
-                        storage_clone.clone(),
-                        prefix.clone(),
-                        "garbage collection service".to_string(),
-                        Arc::new(()),
-                        Arc::new(()),
-                    );
-                    let writer = match GarbageCollector::<
-                        (FragmentSeqNo, LogPosition),
-                        S3FragmentManagerFactory,
-                        S3ManifestManagerFactory,
-                    >::open(
-                        options,
-                        fragment_manager_factory,
-                        manifest_manager_factory,
-                    )
-                    .await
+                    let writer = match self
+                        .open_collection_garbage_collector(
+                            database_name.as_ref(),
+                            collection_id,
+                            storage_clone.clone(),
+                        )
+                        .await
                     {
                         Ok(log_writer) => log_writer,
-                        Err(wal3::Error::UninitializedLog) => return Ok(()),
+                        Err(DeleteUnusedLogsError::Wal3 {
+                            collection_id: _,
+                            err: wal3::Error::UninitializedLog,
+                        }) => return Ok(()),
                         Err(err) => {
-                            tracing::error!("Unable to initialize log writer for collection [{collection_id}]: {err}");
-                            return Err(DeleteUnusedLogsError::Wal3{ collection_id, err})
+                            tracing::error!(
+                                "Unable to initialize log writer for collection [{collection_id}]: {err}"
+                            );
+                            return Err(err);
                         }
                     };
                     // NOTE(rescrv):  Once upon a time, we had a bug where we would not pass the
@@ -127,32 +339,61 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                     // times.
                     let mut min_log_offset = Some(*minimum_log_offset_to_keep);
                     let mut gc_state = wal3::GarbageCollectionState::empty();
-                    for _ in 0..if self.enable_dangerous_option_to_ignore_min_versions_for_wal3 { 2 } else { 1 } {
+                    for _ in 0..if self.enable_dangerous_option_to_ignore_min_versions_for_wal3 {
+                        2
+                    } else {
+                        1
+                    } {
                         // See README.md in wal3 for a description of why this happens in three phases.
-                        match writer.garbage_collect_phase1_compute_garbage(&GarbageCollectionOptions::default(), min_log_offset).await {
-                            Ok(Some(state)) => { gc_state = state; },
+                        match writer
+                            .garbage_collect_phase1_compute_garbage(
+                                &GarbageCollectionOptions::default(),
+                                min_log_offset,
+                            )
+                            .await
+                        {
+                            Ok(Some(state)) => {
+                                gc_state = state;
+                            }
                             Ok(None) => return Ok(()),
-                            Err(wal3::Error::CorruptGarbage(c)) if c.starts_with("First to keep does not overlap manifest") => {
+                            Err(wal3::Error::CorruptGarbage(c))
+                                if c.starts_with("First to keep does not overlap manifest") =>
+                            {
                                 if self.enable_dangerous_option_to_ignore_min_versions_for_wal3 {
                                     tracing::event!(Level::WARN, name = "encountered enable_dangerous_option_to_ignore_min_versions_for_wal3 path", collection_id =? collection_id);
                                     min_log_offset.take();
                                 }
                             }
                             Err(err) => {
-                                tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
-                                return Err(DeleteUnusedLogsError::Wal3{ collection_id, err});
+                                tracing::error!(
+                                    "Unable to garbage collect log for collection [{collection_id}]: {err}"
+                                );
+                                return Err(DeleteUnusedLogsError::Wal3 { collection_id, err });
                             }
                         };
                     }
-                    if let Err(err) = logs.garbage_collect_phase2(input.database_name.clone(), collection_id).await {
-                        tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
+                    if let Err(err) = logs
+                        .garbage_collect_phase2(database_name.clone(), collection_id)
+                        .await
+                    {
+                        tracing::error!(
+                            "Unable to garbage collect log for collection [{collection_id}]: {err}"
+                        );
                         return Err(DeleteUnusedLogsError::Gc(err));
                     };
                     match self.mode {
                         CleanupMode::DeleteV2 => {
-                            if let Err(err) = writer.garbage_collect_phase3_delete_garbage(&GarbageCollectionOptions::default(), &gc_state).await {
-                                tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
-                                return Err(DeleteUnusedLogsError::Wal3{ collection_id, err});
+                            if let Err(err) = writer
+                                .garbage_collect_phase3_delete_garbage(
+                                    &GarbageCollectionOptions::default(),
+                                    &gc_state,
+                                )
+                                .await
+                            {
+                                tracing::error!(
+                                    "Unable to garbage collect log for collection [{collection_id}]: {err}"
+                                );
+                                return Err(DeleteUnusedLogsError::Wal3 { collection_id, err });
                             };
                         }
                         mode => {
@@ -176,38 +417,26 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                     for collection_id in &input.collections_to_destroy {
                         let collection_id = *collection_id;
                         let storage_clone = storage_arc.clone();
+                        let database_name = input.database_name.clone();
                         log_destroy_futures.push(async move {
-                            let prefix = collection_id.storage_prefix_for_log();
-                            let manifest_manager = match ManifestManager::new(
-                                ThrottleOptions::default(),
-                                SnapshotOptions::default(),
-                                storage_clone.clone(),
-                                prefix.clone(),
-                                "destroy service".to_string(),
-                                Arc::new(()),
-                                Arc::new(()),
-                            )
-                            .await
+                            match self
+                                .destroy_collection_log(
+                                    database_name.as_ref(),
+                                    collection_id,
+                                    storage_clone.clone(),
+                                )
+                                .await
                             {
-                                Ok(mm) => mm,
-                                Err(wal3::Error::UninitializedLog) => return Ok(()),
-                                Err(err) => {
-                                    tracing::error!(
-                                        "Unable to create manifest manager for collection [{collection_id}]: {err:?}"
-                                    );
-                                    return Err(DeleteUnusedLogsError::Wal3 {
-                                        collection_id,
-                                        err,
-                                    });
-                                }
-                            };
-                            match wal3::destroy(storage_clone, &prefix, &manifest_manager).await {
                                 Ok(()) => Ok(()),
+                                Err(DeleteUnusedLogsError::Wal3 {
+                                    collection_id: _,
+                                    err: wal3::Error::UninitializedLog,
+                                }) => Ok(()),
                                 Err(err) => {
                                     tracing::error!(
                                         "Unable to destroy log for collection [{collection_id}]: {err:?}"
                                     );
-                                    Err(DeleteUnusedLogsError::Wal3 { collection_id, err })
+                                    Err(err)
                                 }
                             }
                         })

--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -11,7 +11,6 @@ use chroma_system::{Operator, OperatorType};
 use chroma_types::{CollectionUuid, DatabaseName, TopologyName};
 use futures::future::try_join_all;
 use thiserror::Error;
-use tracing::Level;
 use wal3::{
     create_repl_factories, create_s3_factories, FragmentSeqNo, FragmentUuid,
     GarbageCollectionOptions, GarbageCollectionState, GarbageCollector, LogPosition,
@@ -30,7 +29,6 @@ pub struct DeleteUnusedLogsOperator {
     pub storage: Storage,
     pub logs: Log,
     pub regions_and_topologies: Option<Arc<RegionsAndTopologies>>,
-    pub enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -323,55 +321,26 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                             return Err(err);
                         }
                     };
-                    // NOTE(rescrv):  Once upon a time, we had a bug where we would not pass the
-                    // min log offset into the wal3 garbage collect process.  For disaster
-                    // recovery, we need to keep N versions per the config, but the collections
-                    // (staging only) were collected up to the most recent version.  The fix is
-                    // this hack to allow a corrupt garbage error to be masked iff the appropriate
-                    // configuration value is set.
-                    //
-                    // The configuration is
-                    // enable_dangerous_option_to_ignore_min_versions_for_wal3.  Its default is
-                    // false.  Setting it to true enables this loop to skip the min_log_offset.
-                    //
-                    // To remove this hack, search for the warning below, and then make every
-                    // collection that appears with that warning compact min-versions-to-keep
-                    // times.
-                    let mut min_log_offset = Some(*minimum_log_offset_to_keep);
-                    let mut gc_state = wal3::GarbageCollectionState::empty();
-                    for _ in 0..if self.enable_dangerous_option_to_ignore_min_versions_for_wal3 {
-                        2
-                    } else {
-                        1
-                    } {
-                        // See README.md in wal3 for a description of why this happens in three phases.
-                        match writer
-                            .garbage_collect_phase1_compute_garbage(
-                                &GarbageCollectionOptions::default(),
-                                min_log_offset,
-                            )
-                            .await
-                        {
-                            Ok(Some(state)) => {
-                                gc_state = state;
-                            }
-                            Ok(None) => return Ok(()),
-                            Err(wal3::Error::CorruptGarbage(c))
-                                if c.starts_with("First to keep does not overlap manifest") =>
-                            {
-                                if self.enable_dangerous_option_to_ignore_min_versions_for_wal3 {
-                                    tracing::event!(Level::WARN, name = "encountered enable_dangerous_option_to_ignore_min_versions_for_wal3 path", collection_id =? collection_id);
-                                    min_log_offset.take();
-                                }
-                            }
-                            Err(err) => {
-                                tracing::error!(
-                                    "Unable to garbage collect log for collection [{collection_id}]: {err}"
-                                );
-                                return Err(DeleteUnusedLogsError::Wal3 { collection_id, err });
-                            }
-                        };
-                    }
+                    let min_log_offset = Some(*minimum_log_offset_to_keep);
+                    // See README.md in wal3 for a description of why this happens in three phases.
+                    let gc_state = match writer
+                        .garbage_collect_phase1_compute_garbage(
+                            &GarbageCollectionOptions::default(),
+                            min_log_offset,
+                        )
+                        .await
+                    {
+                        Ok(Some(state)) => {
+                            state
+                        }
+                        Ok(None) => return Ok(()),
+                        Err(err) => {
+                            tracing::error!(
+                                "Unable to garbage collect log for collection [{collection_id}]: {err}"
+                            );
+                            return Err(DeleteUnusedLogsError::Wal3 { collection_id, err });
+                        }
+                    };
                     if let Err(err) = logs
                         .garbage_collect_phase2(database_name.clone(), collection_id)
                         .await

--- a/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
@@ -422,6 +422,161 @@ mod tests {
         assert_eq!(output.versions_to_delete, versions_to_delete);
     }
 
+    /// Confirms the stale-cache bug: when the operator receives a version file
+    /// cached BEFORE mark_version_for_deletion (so marked_for_deletion is false),
+    /// physical files are NOT deleted even though they appear in versions_to_delete.
+    ///
+    /// This proves that if the GC orchestrator does not refresh its cached version
+    /// files after calling mark_version_for_deletion, per-version files will be
+    /// orphaned in storage.
+    #[tokio::test]
+    async fn stale_cache_skips_physical_file_deletion() {
+        let tmp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let sysdb = SysDb::Test(TestSysDb::new());
+
+        // Create physical files in storage that should be deleted.
+        let test_files = vec!["stale_version_1", "stale_version_2"];
+        for file in &test_files {
+            std::fs::write(tmp_dir.path().join(file), "test content").unwrap();
+        }
+
+        // Simulate a PRE-MARK cached version file: marked_for_deletion is false
+        // because this snapshot was captured before mark_version_for_deletion was
+        // called on sysdb.
+        let stale_version_file = Arc::new(CollectionVersionFile {
+            version_history: Some(chroma_proto::CollectionVersionHistory {
+                versions: vec![
+                    chroma_proto::CollectionVersionInfo {
+                        version: 1,
+                        version_file_name: "stale_version_1".to_string(),
+                        marked_for_deletion: false, // Stale: not yet marked
+                        ..Default::default()
+                    },
+                    chroma_proto::CollectionVersionInfo {
+                        version: 2,
+                        version_file_name: "stale_version_2".to_string(),
+                        marked_for_deletion: false, // Stale: not yet marked
+                        ..Default::default()
+                    },
+                ],
+            }),
+            ..Default::default()
+        });
+
+        let versions_to_delete = VersionListForCollection {
+            collection_id: "test_collection".to_string(),
+            database_id: "default".to_string(),
+            tenant_id: "default".to_string(),
+            versions: vec![1, 2],
+        };
+
+        let input = DeleteVersionsAtSysDbInput {
+            version_file: stale_version_file,
+            versions_to_delete,
+            sysdb_client: sysdb,
+            epoch_id: 123,
+            database_name: DatabaseName::new("test_db").expect("valid db name"),
+        };
+
+        let operator = DeleteVersionsAtSysDbOperator {
+            storage: storage.clone(),
+        };
+        let result = operator.run(&input).await;
+
+        // The operator reports success (sysdb logical deletion works via TestSysDb).
+        assert!(result.is_ok());
+
+        // Physical files REMAIN because the stale version file has
+        // marked_for_deletion = false, so delete_version_files skips them.
+        //
+        // This is part of the contract for the operator and is handled at a
+        // higher level by the orchestration code.
+        for file in &test_files {
+            assert!(
+                tmp_dir.path().join(file).exists(),
+                "File {} was deleted despite stale (unmarked) version file; \
+                 the stale-cache bug is not present at the operator level",
+                file
+            );
+        }
+    }
+
+    /// Control test: when the operator receives a version file refreshed AFTER
+    /// mark_version_for_deletion (so marked_for_deletion is true), physical
+    /// files are correctly deleted.
+    ///
+    /// Together with stale_cache_skips_physical_file_deletion, this pair proves
+    /// that the only difference between "files orphaned" and "files cleaned up"
+    /// is whether the version file passed to the operator reflects the post-mark
+    /// state.
+    #[tokio::test]
+    async fn refreshed_cache_enables_physical_file_deletion() {
+        let tmp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let sysdb = SysDb::Test(TestSysDb::new());
+
+        // Create physical files in storage that should be deleted.
+        let test_files = vec!["refreshed_version_1", "refreshed_version_2"];
+        for file in &test_files {
+            std::fs::write(tmp_dir.path().join(file), "test content").unwrap();
+        }
+
+        // Simulate a POST-MARK refreshed version file: marked_for_deletion is
+        // true because the orchestrator refreshed the cache after
+        // mark_version_for_deletion succeeded.
+        let refreshed_version_file = Arc::new(CollectionVersionFile {
+            version_history: Some(chroma_proto::CollectionVersionHistory {
+                versions: vec![
+                    chroma_proto::CollectionVersionInfo {
+                        version: 1,
+                        version_file_name: "refreshed_version_1".to_string(),
+                        marked_for_deletion: true, // Refreshed: marked after sysdb call
+                        ..Default::default()
+                    },
+                    chroma_proto::CollectionVersionInfo {
+                        version: 2,
+                        version_file_name: "refreshed_version_2".to_string(),
+                        marked_for_deletion: true, // Refreshed: marked after sysdb call
+                        ..Default::default()
+                    },
+                ],
+            }),
+            ..Default::default()
+        });
+
+        let versions_to_delete = VersionListForCollection {
+            collection_id: "test_collection".to_string(),
+            database_id: "default".to_string(),
+            tenant_id: "default".to_string(),
+            versions: vec![1, 2],
+        };
+
+        let input = DeleteVersionsAtSysDbInput {
+            version_file: refreshed_version_file,
+            versions_to_delete,
+            sysdb_client: sysdb,
+            epoch_id: 123,
+            database_name: DatabaseName::new("test_db").expect("valid db name"),
+        };
+
+        let operator = DeleteVersionsAtSysDbOperator {
+            storage: storage.clone(),
+        };
+        let result = operator.run(&input).await;
+        assert!(result.is_ok());
+
+        // Physical files are correctly deleted because the refreshed version
+        // file has marked_for_deletion = true.
+        for file in &test_files {
+            assert!(
+                !tmp_dir.path().join(file).exists(),
+                "File {} should have been deleted with a refreshed (marked) version file",
+                file
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_only_deletes_files_marked_for_deletion() {
         let tmp_dir = TempDir::new().unwrap();

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -335,6 +335,7 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                                 system.clone(),
                                 state.storage.clone(),
                                 state.logs.clone(),
+                                None,
                                 state.root_manager.clone(),
                                 CleanupMode::DeleteV2,
                                 min_versions_to_keep as u32,

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -340,7 +340,6 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                                 CleanupMode::DeleteV2,
                                 min_versions_to_keep as u32,
                                 true,
-                                false,
                                 10,
                             );
                             let result = orchestrator.run(system.clone()).await;

--- a/rust/rust-sysdb/Cargo.toml
+++ b/rust/rust-sysdb/Cargo.toml
@@ -16,6 +16,7 @@ tonic-health = { workspace = true }
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }
 chroma-storage = { workspace = true }
+chroma-system = { workspace = true }
 chroma-types = { workspace = true }
 chroma-tracing = { workspace = true, features = ["grpc"]}
 serde = { workspace = true }

--- a/rust/rust-sysdb/src/bin/sysdb_service.rs
+++ b/rust/rust-sysdb/src/bin/sysdb_service.rs
@@ -1,6 +1,14 @@
+use chroma_system::thread_stack_size_bytes;
 use rust_sysdb::sysdb_service_entrypoint;
 
-#[tokio::main]
-async fn main() {
-    Box::pin(sysdb_service_entrypoint()).await;
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-rust-sysdb")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(async {
+            Box::pin(sysdb_service_entrypoint()).await;
+        });
 }

--- a/rust/s3heap-service/src/bin/heap_tender_service.rs
+++ b/rust/s3heap-service/src/bin/heap_tender_service.rs
@@ -1,6 +1,10 @@
+use chroma_system::thread_stack_size_bytes;
+
 fn main() {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
+        .thread_name("chroma-heap-tender")
+        .thread_stack_size(thread_stack_size_bytes())
         .build()
         .unwrap()
         .block_on(s3heap_service::entrypoint());

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -138,6 +138,10 @@ impl S3Storage {
                     }
                     _ => match inner.code() {
                         Some("SlowDown") => StorageError::Backoff,
+                        Some("NoSuchKey") => StorageError::NotFound {
+                            path: key.to_string(),
+                            source: Arc::new(inner),
+                        },
                         Some("AccessDenied") => {
                             tracing::error!(
                                 bucket = %self.bucket,
@@ -179,9 +183,16 @@ impl S3Storage {
             Err(e) => match e {
                 SdkError::ServiceError(err) => {
                     let inner = err.into_err();
-                    Err(StorageError::Generic {
-                        source: Arc::new(inner),
-                    })
+                    if inner.is_not_found() || inner.code() == Some("NoSuchKey") {
+                        Err(StorageError::NotFound {
+                            path: key.to_string(),
+                            source: Arc::new(inner),
+                        })
+                    } else {
+                        Err(StorageError::Generic {
+                            source: Arc::new(inner),
+                        })
+                    }
                 }
                 _ => Err(StorageError::Generic {
                     source: Arc::new(e),
@@ -396,6 +407,10 @@ impl S3Storage {
                         let code = inner.code().map(|code| code.to_string());
                         match code.as_deref() {
                             Some("SlowDown") => Err(StorageError::Backoff),
+                            Some("NoSuchKey") => Err(StorageError::NotFound {
+                                path: key.to_string(),
+                                source: Arc::new(inner),
+                            }),
                             Some("AccessDenied") => Err(StorageError::PermissionDenied {
                                 path: key.to_string(),
                                 source: Arc::new(inner),
@@ -801,6 +816,11 @@ impl S3Storage {
                     path: key.to_string(),
                     source: Arc::new(err),
                 }
+            } else if err.meta().code() == Some("NoSuchKey") {
+                StorageError::NotFound {
+                    path: key.to_string(),
+                    source: Arc::new(err),
+                }
             } else if err.meta().code() == Some("SlowDown") {
                 StorageError::Backoff
             } else {
@@ -989,7 +1009,7 @@ impl S3Storage {
                 SdkError::ServiceError(err) => {
                     let inner = err.into_err();
                     match inner.code() {
-                        Some("NotFound") => Err(StorageError::NotFound {
+                        Some("NotFound") | Some("NoSuchKey") => Err(StorageError::NotFound {
                             path: key.to_string(),
                             source: Arc::new(inner),
                         }),
@@ -1068,6 +1088,11 @@ impl S3Storage {
             Err(e) => {
                 if e.code() == Some("SlowDown") {
                     Err(StorageError::Backoff)
+                } else if e.code() == Some("NoSuchKey") {
+                    Err(StorageError::NotFound {
+                        path: String::new(),
+                        source: Arc::new(e),
+                    })
                 } else {
                     Err(StorageError::Generic {
                         source: Arc::new(e),
@@ -1120,10 +1145,18 @@ impl S3Storage {
         {
             Ok(_) => Ok(()),
             Err(e) => {
-                tracing::error!(error = %e, src = %src_key, dst = %dst_key, "Failed to copy object");
-                Err(StorageError::Generic {
-                    source: Arc::new(e.into_service_error()),
-                })
+                let inner = e.into_service_error();
+                tracing::error!(error = %inner, src = %src_key, dst = %dst_key, "Failed to copy object");
+                if inner.meta().code() == Some("NoSuchKey") {
+                    Err(StorageError::NotFound {
+                        path: src_key.to_string(),
+                        source: Arc::new(inner),
+                    })
+                } else {
+                    Err(StorageError::Generic {
+                        source: Arc::new(inner),
+                    })
+                }
             }
         }
     }

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -50,6 +50,20 @@ pub struct DeletedObjects {
     pub errors: Vec<StorageError>,
 }
 
+fn not_found_deleted_objects(
+    keys: Vec<String>,
+    source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+) -> DeletedObjects {
+    let mut out = DeletedObjects::default();
+    for key in keys {
+        out.errors.push(StorageError::NotFound {
+            path: key,
+            source: Arc::clone(&source),
+        });
+    }
+    out
+}
+
 #[derive(Clone)]
 pub struct S3Storage {
     pub(crate) bucket: String,
@@ -1036,11 +1050,16 @@ impl S3Storage {
     ) -> Result<DeletedObjects, StorageError> {
         self.metrics.s3_delete_many_count.add(1, &[]);
 
-        let mut objects = vec![];
-        for key in keys {
+        let keys = keys
+            .into_iter()
+            .map(|key| key.as_ref().to_string())
+            .collect::<Vec<_>>();
+
+        let mut objects = Vec::with_capacity(keys.len());
+        for key in &keys {
             objects.push(
                 ObjectIdentifier::builder()
-                    .key(key.as_ref())
+                    .key(key.as_str())
                     .build()
                     .map_err(|err| StorageError::Generic {
                         source: Arc::new(err),
@@ -1071,7 +1090,7 @@ impl S3Storage {
                 for error in resp.errors() {
                     out.errors.push(if Some("NoSuchKey") == error.code() {
                         StorageError::NotFound {
-                            path: error.key.clone().unwrap_or(String::new()),
+                            path: error.key.clone().unwrap_or_else(|| keys.join(",")),
                             source: Arc::new(StorageError::Message {
                                 message: format!("{error:#?}"),
                             }),
@@ -1089,10 +1108,8 @@ impl S3Storage {
                 if e.code() == Some("SlowDown") {
                     Err(StorageError::Backoff)
                 } else if e.code() == Some("NoSuchKey") {
-                    Err(StorageError::NotFound {
-                        path: String::new(),
-                        source: Arc::new(e),
-                    })
+                    let source: Arc<dyn std::error::Error + Send + Sync + 'static> = Arc::new(e);
+                    Ok(not_found_deleted_objects(keys, source))
                 } else {
                     Err(StorageError::Generic {
                         source: Arc::new(e),
@@ -1396,6 +1413,29 @@ mod tests {
     use rand::{distributions::Alphanumeric, Rng, SeedableRng};
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_not_found_deleted_objects_preserves_requested_keys() {
+        let source: Arc<dyn std::error::Error + Send + Sync + 'static> =
+            Arc::new(StorageError::Message {
+                message: "NoSuchKey".to_string(),
+            });
+        let deleted_objects =
+            not_found_deleted_objects(vec!["first".to_string(), "second".to_string()], source);
+
+        assert!(deleted_objects.deleted.is_empty());
+        assert_eq!(deleted_objects.errors.len(), 2);
+
+        let paths = deleted_objects
+            .errors
+            .iter()
+            .map(|err| match err {
+                StorageError::NotFound { path, .. } => path.as_str(),
+                other => panic!("expected NotFound error, got {other:?}"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(paths, vec!["first", "second"]);
+    }
 
     fn get_s3_client() -> aws_sdk_s3::Client {
         // Set up credentials assuming minio is running locally

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -1967,10 +1967,10 @@ mod tests {
             "confirm_same should return error for nonexistent file"
         );
         match result.unwrap_err() {
-            StorageError::Generic { source: _ } => {
-                // This is expected - the head operation will fail on nonexistent file
+            StorageError::NotFound { path, .. } => {
+                assert_eq!(path, "nonexistent-file");
             }
-            other => panic!("Expected Generic error, got: {:?}", other),
+            other => panic!("Expected NotFound error, got: {:?}", other),
         }
     }
 

--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -2,7 +2,7 @@ use super::operator::OperatorType;
 use super::{operator::TaskMessage, worker_thread::WorkerThread};
 use crate::execution::affinity::{io_core_for_task, pin_current_thread};
 use crate::execution::config::DispatcherConfig;
-use crate::utils::duration_ms;
+use crate::utils::{duration_ms, thread_stack_size_bytes};
 use crate::{
     Component, ComponentContext, ComponentHandle, ConsumeJoinHandleError, Handler,
     ReceiverForMessage, System,
@@ -194,6 +194,7 @@ impl Dispatcher {
         let mut builder = tokio::runtime::Builder::new_multi_thread();
         builder.enable_all();
         builder.thread_name("chroma-io");
+        builder.thread_stack_size(thread_stack_size_bytes());
         if let Some(affinity_count) = config.io_affinity_num_cores {
             let total_cores = std::thread::available_parallelism()
                 .map(|n| n.get())

--- a/rust/system/src/system.rs
+++ b/rust/system/src/system.rs
@@ -5,6 +5,7 @@ use super::ComponentSender;
 use super::ConsumableJoinHandle;
 use super::Message;
 use super::{executor::ComponentExecutor, Component, ComponentHandle, Handler, StreamHandler};
+use crate::utils::thread_stack_size_bytes;
 use futures::Stream;
 use futures::StreamExt;
 use std::fmt::Debug;
@@ -67,9 +68,24 @@ impl System {
                 tracing::debug!("Spawning on dedicated thread");
                 // Spawn on a dedicated thread
                 let rt = Builder::new_current_thread().enable_all().build().unwrap();
-                let join_handle = std::thread::spawn(move || {
-                    rt.block_on(async move { executor.run(rx).await });
-                });
+                let thread_name = format!(
+                    "chroma-dedicated-{}",
+                    C::get_name().to_ascii_lowercase().replace(' ', "-")
+                );
+                let thread_stack_size = thread_stack_size_bytes();
+                let log_thread_name = thread_name.clone();
+                let join_handle = std::thread::Builder::new()
+                    .name(thread_name)
+                    .stack_size(thread_stack_size)
+                    .spawn(move || {
+                        tracing::debug!(
+                            thread_name = %log_thread_name,
+                            stack_size_bytes = thread_stack_size,
+                            "Running component on dedicated thread"
+                        );
+                        rt.block_on(async move { executor.run(rx).await });
+                    })
+                    .expect("dedicated component thread should spawn");
                 ComponentHandle::new(
                     cancel_token,
                     Some(ConsumableJoinHandle::from_thread_handle(join_handle)),

--- a/rust/system/src/utils/mod.rs
+++ b/rust/system/src/utils/mod.rs
@@ -12,3 +12,48 @@ use std::time::Duration;
 pub fn duration_ms(d: Duration) -> f64 {
     d.as_secs_f64() * 1000.0
 }
+
+const DEFAULT_THREAD_STACK_SIZE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Returns the configured stack size for Rust worker threads.
+///
+/// `CHROMA_THREAD_STACK_SIZE_BYTES` takes precedence. If it is unset, `RUST_MIN_STACK`
+/// is used. Invalid values fall back to 16MiB.
+pub fn thread_stack_size_bytes() -> usize {
+    std::env::var("CHROMA_THREAD_STACK_SIZE_BYTES")
+        .ok()
+        .or_else(|| std::env::var("RUST_MIN_STACK").ok())
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_THREAD_STACK_SIZE_BYTES)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::thread_stack_size_bytes;
+
+    #[test]
+    fn chroma_thread_stack_size_overrides_rust_min_stack() {
+        unsafe {
+            std::env::set_var("RUST_MIN_STACK", "8388608");
+            std::env::set_var("CHROMA_THREAD_STACK_SIZE_BYTES", "16777216");
+        }
+        assert_eq!(thread_stack_size_bytes(), 16 * 1024 * 1024);
+        unsafe {
+            std::env::remove_var("CHROMA_THREAD_STACK_SIZE_BYTES");
+            std::env::remove_var("RUST_MIN_STACK");
+        }
+    }
+
+    #[test]
+    fn falls_back_to_rust_min_stack() {
+        unsafe {
+            std::env::remove_var("CHROMA_THREAD_STACK_SIZE_BYTES");
+            std::env::set_var("RUST_MIN_STACK", "4194304");
+        }
+        assert_eq!(thread_stack_size_bytes(), 4 * 1024 * 1024);
+        unsafe {
+            std::env::remove_var("RUST_MIN_STACK");
+        }
+    }
+}

--- a/rust/wal3/src/destroy.rs
+++ b/rust/wal3/src/destroy.rs
@@ -101,6 +101,7 @@ async fn destroy_dangling_fragments(storage: &Arc<Storage>, prefix: &str) -> Res
             Ok(possible_fragments) => possible_fragments,
             Err(err) => return Err(Error::StorageError(err)),
         };
+        tracing::info!(possible_fragments = ?possible_fragments, "possible fragments");
         if possible_fragments.is_empty() {
             return Ok(());
         }

--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -276,11 +276,16 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
     }
 
     async fn read_json_file(&self, path: &str) -> Result<(Arc<Vec<u8>>, Option<ETag>), Error> {
-        Ok(
-            crate::interfaces::read_raw_bytes(path, self.fragment_uploader.storages().await)
-                .await
-                .map_err(Arc::new)?,
-        )
+        let preferred = self.fragment_uploader.preferred_storage_wrapper().await;
+        let path = crate::fragment_path(&preferred.prefix, path);
+        Ok(preferred
+            .storage
+            .get_with_e_tag(
+                &path,
+                chroma_storage::GetOptions::new(StorageRequestPriority::P0),
+            )
+            .await
+            .map_err(Arc::new)?)
     }
 
     async fn preferred_storage(&self) -> Storage {
@@ -343,8 +348,16 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
                 .await
             {
                 Ok(e_tag) => return Ok(e_tag),
-                Err(StorageError::AlreadyExists { path: _, source: _ })
-                | Err(StorageError::Precondition { path: _, source: _ }) => {
+                Err(StorageError::AlreadyExists { path: _, source: _ }) => {
+                    return Err(Error::LogContentionFailure);
+                }
+                Err(StorageError::Precondition { path: _, source: _ }) => {
+                    return Err(Error::LogContentionFailure);
+                }
+                Err(StorageError::NotFound { path: _, source: _ }) => {
+                    // NotFound means another process deleted gc/GARBAGE between our
+                    // load (which obtained the ETag) and this conditional put.  Treat
+                    // it as contention so callers retry with a fresh load.
                     return Err(Error::LogContentionFailure);
                 }
                 Err(e) => {
@@ -366,8 +379,22 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
         e_tag: &ETag,
     ) -> Result<(), Error> {
         let empty = crate::Garbage::empty();
-        self.write_garbage(options, Some(e_tag), &empty).await?;
-        Ok(())
+        match self.write_garbage(options, Some(e_tag), &empty).await {
+            Ok(_) => Ok(()),
+            Err(Error::LogContentionFailure) => {
+                // The GARBAGE file was modified or deleted by another process between
+                // our load and this reset.  Either the file was deleted (nothing to
+                // reset) or overwritten with new content from a concurrent GC cycle
+                // (the new content will be processed in a future cycle).  Both cases
+                // are safe to treat as success.
+                tracing::info!("garbage reset skipped: file was concurrently modified or deleted");
+                Ok(())
+            }
+            Err(err) => {
+                tracing::error!(error =% err, "could not write garbage");
+                Err(err)
+            }
+        }
     }
 }
 
@@ -444,12 +471,15 @@ pub async fn upload_parquet(
 mod tests {
     use std::sync::Arc;
 
-    use chroma_storage::s3_client_for_test_with_new_bucket;
+    use chroma_storage::{s3_client_for_test_with_new_bucket, test_storage, PutOptions};
 
     use super::*;
     use crate::interfaces::s3::manifest_manager::ManifestManager;
     use crate::interfaces::s3::S3FragmentUploader;
-    use crate::{FragmentSeqNo, LogWriterOptions, SnapshotOptions, ThrottleOptions};
+    use crate::{
+        FragmentSeqNo, FragmentUuid, LogWriterOptions, SnapshotOptions, StorageWrapper,
+        ThrottleOptions,
+    };
 
     #[tokio::test]
     async fn test_k8s_integration_upload_parquet_returns_retry_on_already_exists() {
@@ -551,5 +581,80 @@ mod tests {
         assert_eq!(vec![vec![1]], work[0].0);
         // Check batch 2
         assert_eq!(vec![vec![2, 3]], work[1].0);
+    }
+
+    struct DualStorageUploader {
+        preferred: usize,
+        storages: Arc<Vec<StorageWrapper>>,
+    }
+
+    #[async_trait::async_trait]
+    impl FragmentUploader<FragmentUuid> for DualStorageUploader {
+        async fn upload_parquet(
+            &self,
+            _pointer: &FragmentUuid,
+            _messages: Vec<Vec<u8>>,
+            _cmek: Option<Cmek>,
+            _epoch_micros: u64,
+        ) -> Result<UploadResult, Error> {
+            unreachable!("upload_parquet is not used in this test")
+        }
+
+        async fn preferred_storage(&self) -> Storage {
+            self.storages[self.preferred].storage.clone()
+        }
+
+        async fn preferred_prefix(&self) -> String {
+            self.storages[self.preferred].prefix.clone()
+        }
+
+        async fn preferred_storage_wrapper(&self) -> &StorageWrapper {
+            &self.storages[self.preferred]
+        }
+
+        async fn storages(&self) -> &[StorageWrapper] {
+            &self.storages
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_json_file_uses_only_preferred_storage() {
+        let (_preferred_dir, preferred_storage) = test_storage();
+        let (_replica_dir, replica_storage) = test_storage();
+        let prefix = "test-read-json-file-preferred".to_string();
+        let path = format!("{prefix}/gc/GARBAGE");
+
+        replica_storage
+            .put_bytes(
+                &path,
+                br#"{"first_to_keep":1}"#.to_vec(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("write to replica storage");
+
+        let fragment_uploader = DualStorageUploader {
+            preferred: 0,
+            storages: Arc::new(vec![
+                StorageWrapper::new(
+                    "preferred".to_string(),
+                    preferred_storage.clone(),
+                    prefix.clone(),
+                ),
+                StorageWrapper::new("replica".to_string(), replica_storage, prefix),
+            ]),
+        };
+        let batch_manager = BatchManager::new(LogWriterOptions::default(), fragment_uploader)
+            .expect("batch manager");
+
+        let err = batch_manager
+            .read_json_file("gc/GARBAGE")
+            .await
+            .expect_err("preferred storage miss should not fall back to replicas");
+
+        assert!(
+            matches!(&err, Error::StorageError(storage_err) if matches!(&**storage_err, StorageError::NotFound { .. })),
+            "expected preferred-storage NotFound, got {err:?}"
+        );
     }
 }

--- a/rust/wal3/src/interfaces/mod.rs
+++ b/rust/wal3/src/interfaces/mod.rs
@@ -6,9 +6,9 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use setsum::Setsum;
 use tracing::Span;
 
-use chroma_storage::{
-    admissioncontrolleds3::StorageRequestPriority, ETag, GetOptions, Storage, StorageError,
-};
+#[cfg(test)]
+use chroma_storage::{admissioncontrolleds3::StorageRequestPriority, GetOptions, StorageError};
+use chroma_storage::{ETag, Storage};
 use chroma_types::Cmek;
 
 use crate::{
@@ -909,43 +909,13 @@ pub fn checksum_parquet(
     }
 }
 
-async fn read_raw_bytes(
-    path: &str,
-    storages: &[repl::StorageWrapper],
-) -> Result<(Arc<Vec<u8>>, Option<ETag>), StorageError> {
-    let mut err: Option<StorageError> = None;
-    for storage in storages.iter() {
-        let path = crate::fragment_path(&storage.prefix, path);
-        match storage
-            .storage
-            .get_with_e_tag(&path, GetOptions::new(StorageRequestPriority::P0))
-            .await
-        {
-            Ok((parquet, e_tag)) => return Ok((parquet, e_tag)),
-            Err(e @ StorageError::NotFound { .. }) => err = Some(e),
-            Err(e) => {
-                tracing::error!("reading from region {} failed", storage.region);
-                err = Some(e);
-            }
-        }
-    }
-    if let Some(err) = err {
-        Err(err)
-    } else {
-        Err(StorageError::NotFound {
-            path: path.into(),
-            source: Arc::new(std::io::Error::other("replicas exhausted")),
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
     use crate::{FragmentSeqNo, LogPosition};
-    use chroma_storage::Storage;
+    use chroma_storage::{test_storage, PutOptions, Storage};
 
     const TEST_EPOCH_MICROS: u64 = 1234567890123456;
 

--- a/rust/wal3/src/interfaces/mod.rs
+++ b/rust/wal3/src/interfaces/mod.rs
@@ -6,8 +6,6 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use setsum::Setsum;
 use tracing::Span;
 
-#[cfg(test)]
-use chroma_storage::{admissioncontrolleds3::StorageRequestPriority, GetOptions, StorageError};
 use chroma_storage::{ETag, Storage};
 use chroma_types::Cmek;
 
@@ -915,7 +913,7 @@ mod tests {
 
     use super::*;
     use crate::{FragmentSeqNo, LogPosition};
-    use chroma_storage::{test_storage, PutOptions, Storage};
+    use chroma_storage::Storage;
 
     const TEST_EPOCH_MICROS: u64 = 1234567890123456;
 

--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -1372,6 +1372,7 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
 
     async fn destroy(&self) -> Result<(), Error> {
         let log_id = self.log_id.to_string();
+        tracing::info!(log_id = %log_id, "destroying");
         let exp_backoff = ExponentialBackoff::new(2_000.0, 1_500.0);
         let mut last_err: Option<String> = None;
         for _ in 0..3 {

--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -1405,7 +1405,7 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                         );
                         stmt2.add_param("log_id", &log_id);
                         let mut iter = tx.query(stmt2).await?;
-                        let mut preserve_the_shared_pieces = false;
+                        let mut preserve_shared_pieces = false;
                         while let Some(row) = iter.next().await? {
                             let region = row.column_by_name::<String>("region")?;
                             if region == local_region {
@@ -1414,11 +1414,11 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                                 Key::composite(&[&log_id, &region]),
                             ));
                             } else {
-                                preserve_the_shared_pieces = true;
+                                preserve_shared_pieces = true;
                             }
                         }
 
-                        if !preserve_the_shared_pieces {
+                        if !preserve_shared_pieces {
                             // Query all fragment idents to delete from fragments.
                             let mut stmt3 =
                                 Statement::new("SELECT ident FROM fragments WHERE log_id = @log_id");

--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -1380,12 +1380,14 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                 .spanner
                 .read_write_transaction(|tx| {
                     let log_id = log_id.clone();
+                    let local_region = self.local_region.clone();
                     Box::pin(async move {
                         // First, query all fragment idents and regions to delete from fragment_regions.
                         let mut stmt1 = Statement::new(
-                            "SELECT ident, region FROM fragment_regions WHERE log_id = @log_id",
+                            "SELECT ident, region FROM fragment_regions WHERE log_id = @log_id AND region = @local_region",
                         );
                         stmt1.add_param("log_id", &log_id);
+                        stmt1.add_param("local_region", &local_region);
                         let mut iter = tx.query(stmt1).await?;
                         let mut mutations = vec![];
                         while let Some(row) = iter.next().await? {
@@ -1397,32 +1399,38 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                             ));
                         }
 
-                        // Query all fragment idents to delete from fragments.
-                        let mut stmt2 =
-                            Statement::new("SELECT ident FROM fragments WHERE log_id = @log_id");
-                        stmt2.add_param("log_id", &log_id);
-                        let mut iter = tx.query(stmt2).await?;
-                        while let Some(row) = iter.next().await? {
-                            let ident = row.column_by_name::<String>("ident")?;
-                            mutations.push(delete("fragments", Key::composite(&[&log_id, &ident])));
-                        }
-
                         // Query all regions to delete from manifest_regions.
-                        let mut stmt3 = Statement::new(
+                        let mut stmt2 = Statement::new(
                             "SELECT region FROM manifest_regions WHERE log_id = @log_id",
                         );
-                        stmt3.add_param("log_id", &log_id);
-                        let mut iter = tx.query(stmt3).await?;
+                        stmt2.add_param("log_id", &log_id);
+                        let mut iter = tx.query(stmt2).await?;
+                        let mut preserve_the_shared_pieces = false;
                         while let Some(row) = iter.next().await? {
                             let region = row.column_by_name::<String>("region")?;
+                            if region == local_region {
                             mutations.push(delete(
                                 "manifest_regions",
                                 Key::composite(&[&log_id, &region]),
                             ));
+                            } else {
+                                preserve_the_shared_pieces = true;
+                            }
                         }
 
-                        // Delete from manifests.
-                        mutations.push(delete("manifests", Key::new(&log_id)));
+                        if !preserve_the_shared_pieces {
+                            // Query all fragment idents to delete from fragments.
+                            let mut stmt3 =
+                                Statement::new("SELECT ident FROM fragments WHERE log_id = @log_id");
+                            stmt3.add_param("log_id", &log_id);
+                            let mut iter = tx.query(stmt3).await?;
+                            while let Some(row) = iter.next().await? {
+                                let ident = row.column_by_name::<String>("ident")?;
+                                mutations.push(delete("fragments", Key::composite(&[&log_id, &ident])));
+                            }
+                            // Delete from manifests.
+                            mutations.push(delete("manifests", Key::new(&log_id)));
+                        }
 
                         tx.buffer_write(mutations);
                         Ok::<_, google_cloud_spanner::client::Error>(())

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -819,6 +819,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 }
                 Ok(None) => None,
                 Err(err) => {
+                    tracing::error!(error =% err, "could not install garbage");
                     return Err(err);
                 }
             };
@@ -856,6 +857,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 | Err(Error::LogContentionRetry)
                 | Err(Error::LogContentionDurable) => {}
                 Err(err) => {
+                    tracing::error!(error =% err, "could not install garbage");
                     return Err(err);
                 }
             };

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -310,7 +310,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
-  collection_soft_delete_grace_period_seconds: 60
+  collection_soft_delete_grace_period_seconds: 60 # GC any soft deleted collection older than this.
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]
@@ -330,11 +330,60 @@ garbage_collector:
     num_worker_threads: 4
     dispatcher_queue_size: 10000
     worker_queue_size: 10000
-  storage_config:
-    s3:
-      bucket: "chroma-storage"
-      connect_timeout_ms: 60000
-      request_timeout_ms: 60000 # 1 minute
+  regions_and_topologies:
+    preferred: tilt-config-1
+    regions:
+    - name: tilt-config-1
+      provider: tilt
+      region: config-1
+      config:
+        storage:
+          admission_controlled_s3:
+            s3_config:
+              bucket: "chroma-storage"
+              credentials: "Minio"
+              connect_timeout_ms: 5000
+              request_timeout_ms: 60000 # 1 minute
+              upload_part_size_bytes: 536870912 # 512MiB
+              download_part_size_bytes: 8388608 # 8MiB
+            rate_limiting_policy:
+              count_based_policy:
+                max_concurrent_requests: 500
+                bandwidth_allocation: [1.0]
+    - name: tilt-config-2
+      provider: tilt
+      region: config-2
+      config:
+        storage:
+          admission_controlled_s3:
+            s3_config:
+              bucket: "chroma-storage2"
+              credentials: "Minio"
+              connect_timeout_ms: 5000
+              request_timeout_ms: 30000 # 1 minute
+              upload_part_size_bytes: 536870912 # 512MiB
+              download_part_size_bytes: 8388608 # 8MiB
+            rate_limiting_policy:
+              count_based_policy:
+                max_concurrent_requests: 30
+                bandwidth_allocation: [0.7, 0.3]
+    topologies:
+    - name: tilt-spanning
+      regions:
+      - tilt-config-1
+      - tilt-config-2
+      config:
+        repl:
+          minimum_allowed_replication_factor: 1
+          minimum_failures_to_exclude_replica: 100
+        spanner:
+          emulator:
+            host: "spanner.chroma.svc.cluster.local"
+            grpc_port: 9010
+            rest_port: 9020
+            project: "local-project"
+            instance: "test-instance"
+            database: "local-logdb-database"
   assignment_policy:
     rendezvous_hashing:
       hasher: Murmur3

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -175,7 +175,7 @@ compaction_service:
     active_io_tasks: 10000
   compactor:
     compaction_manager_queue_size: 1000
-    max_concurrent_jobs: 2
+    max_concurrent_jobs: 10
     compaction_interval_sec: 10
     min_compaction_size: 10
     max_compaction_size: 10000

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -310,7 +310,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
-  collection_soft_delete_grace_period: 60
+  collection_soft_delete_grace_period_seconds: 60
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -70,7 +70,7 @@ query_service:
             admission_rate_limit: 256 # 256MiB/s
             shards: 64
             eviction: lru
-        num_concurrent_block_flushes: 40
+        num_concurrent_block_flushes: 1
       sparse_index_manager_config:
         sparse_index_cache_config:
           lru:
@@ -175,7 +175,7 @@ compaction_service:
     active_io_tasks: 10000
   compactor:
     compaction_manager_queue_size: 1000
-    max_concurrent_jobs: 50
+    max_concurrent_jobs: 2
     compaction_interval_sec: 10
     min_compaction_size: 10
     max_compaction_size: 10000
@@ -310,6 +310,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
+  collection_soft_delete_grace_period: 60
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -311,7 +311,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
-  collection_soft_delete_grace_period_seconds: 60
+  collection_soft_delete_grace_period_seconds: 60 # GC any soft deleted collection older than this.
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]
@@ -331,11 +331,60 @@ garbage_collector:
     num_worker_threads: 4
     dispatcher_queue_size: 10000
     worker_queue_size: 10000
-  storage_config:
-    s3:
-      bucket: "chroma-storage2"
-      connect_timeout_ms: 60000
-      request_timeout_ms: 60000 # 1 minute
+  regions_and_topologies:
+    preferred: tilt-config-2
+    regions:
+    - name: tilt-config-1
+      provider: tilt
+      region: config-1
+      config:
+        storage:
+          admission_controlled_s3:
+            s3_config:
+              bucket: "chroma-storage"
+              credentials: "Minio"
+              connect_timeout_ms: 5000
+              request_timeout_ms: 60000 # 1 minute
+              upload_part_size_bytes: 536870912 # 512MiB
+              download_part_size_bytes: 8388608 # 8MiB
+            rate_limiting_policy:
+              count_based_policy:
+                max_concurrent_requests: 500
+                bandwidth_allocation: [1.0]
+    - name: tilt-config-2
+      provider: tilt
+      region: config-2
+      config:
+        storage:
+          admission_controlled_s3:
+            s3_config:
+              bucket: "chroma-storage2"
+              credentials: "Minio"
+              connect_timeout_ms: 5000
+              request_timeout_ms: 30000 # 1 minute
+              upload_part_size_bytes: 536870912 # 512MiB
+              download_part_size_bytes: 8388608 # 8MiB
+            rate_limiting_policy:
+              count_based_policy:
+                max_concurrent_requests: 30
+                bandwidth_allocation: [0.7, 0.3]
+    topologies:
+    - name: tilt-spanning
+      regions:
+      - tilt-config-1
+      - tilt-config-2
+      config:
+        repl:
+          minimum_allowed_replication_factor: 1
+          minimum_failures_to_exclude_replica: 100
+        spanner:
+          emulator:
+            host: "spanner.chroma.svc.cluster.local"
+            grpc_port: 9010
+            rest_port: 9020
+            project: "local-project"
+            instance: "test-instance"
+            database: "local-logdb-database"
   assignment_policy:
     rendezvous_hashing:
       hasher: Murmur3

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -175,7 +175,7 @@ compaction_service:
     active_io_tasks: 10000
   compactor:
     compaction_manager_queue_size: 1000
-    max_concurrent_jobs: 50
+    max_concurrent_jobs: 2
     compaction_interval_sec: 10
     min_compaction_size: 10
     max_compaction_size: 10000
@@ -192,7 +192,7 @@ compaction_service:
           lru:
             name: "block_cache"
             capacity: 1000
-        num_concurrent_block_flushes: 40
+        num_concurrent_block_flushes: 1
       sparse_index_manager_config:
         sparse_index_cache_config:
           lru:
@@ -311,6 +311,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
+  collection_soft_delete_grace_period: 60
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -175,7 +175,7 @@ compaction_service:
     active_io_tasks: 10000
   compactor:
     compaction_manager_queue_size: 1000
-    max_concurrent_jobs: 2
+    max_concurrent_jobs: 10
     compaction_interval_sec: 10
     min_compaction_size: 10
     max_compaction_size: 10000

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -311,7 +311,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
-  collection_soft_delete_grace_period: 60
+  collection_soft_delete_grace_period_seconds: 60
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]

--- a/rust/worker/src/bin/compaction_client.rs
+++ b/rust/worker/src/bin/compaction_client.rs
@@ -1,4 +1,11 @@
-#[tokio::main]
-async fn main() {
-    worker::compaction_client_entrypoint().await;
+use chroma_system::thread_stack_size_bytes;
+
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-compaction-client")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(worker::compaction_client_entrypoint());
 }

--- a/rust/worker/src/bin/compaction_service.rs
+++ b/rust/worker/src/bin/compaction_service.rs
@@ -1,3 +1,4 @@
+use chroma_system::thread_stack_size_bytes;
 use worker::compaction_service_entrypoint;
 
 #[cfg(not(target_env = "msvc"))]
@@ -7,7 +8,12 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[tokio::main]
-async fn main() {
-    compaction_service_entrypoint().await;
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-compaction")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(compaction_service_entrypoint());
 }

--- a/rust/worker/src/bin/query_service.rs
+++ b/rust/worker/src/bin/query_service.rs
@@ -1,3 +1,4 @@
+use chroma_system::thread_stack_size_bytes;
 use worker::query_service_entrypoint;
 
 #[cfg(not(target_env = "msvc"))]
@@ -7,7 +8,12 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[tokio::main]
-async fn main() {
-    query_service_entrypoint().await;
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-query")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(query_service_entrypoint());
 }

--- a/rust/worker/src/execution/operators/commit_segment_writer.rs
+++ b/rust/worker/src/execution/operators/commit_segment_writer.rs
@@ -9,7 +9,7 @@ use tracing::Instrument;
 
 #[derive(Error, Debug)]
 pub enum CommitSegmentWriterOperatorError {
-    #[error("Finishing segment writer failed {0}")]
+    #[error("Finishing segment writer failed {0:?}")]
     FinishSegmentWriterFailed(#[from] Box<dyn ChromaError>),
 }
 

--- a/rust/worker/src/execution/operators/flush_segment_writer.rs
+++ b/rust/worker/src/execution/operators/flush_segment_writer.rs
@@ -11,7 +11,7 @@ use tracing::Instrument;
 
 #[derive(Error, Debug)]
 pub enum FlushSegmentWriterOperatorError {
-    #[error("Finishing segment writer failed {0}")]
+    #[error("Finishing segment writer failed {0:?}")]
     FinishSegmentWriterFailed(#[from] Box<dyn ChromaError>),
     #[error("Segment flusher is missing")]
     SegmentFlusherMissing,


### PR DESCRIPTION
## Description of changes

Remove the enable_dangerous_option_to_ignore_min_versions_for_wal3
configuration option and its associated retry logic. This workaround
masked CorruptGarbage errors by retrying wal3 garbage collection
without min_log_offset when the error indicated the first-to-keep
fragment did not overlap the manifest.

The underlying bug has been fixed, so the workaround is no longer
needed. Garbage collection now calls phase1 once with the
min_log_offset and propagates any errors directly.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
