### PR TITLE
[BUG](garbage_collector): use correct version file per collection in ancestor walk

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -778,15 +778,84 @@ mod tests {
 
     use super::*;
     use crate::helper::ChromaGrpcClients;
+    use chroma_blockstore::RootManager;
+    use chroma_cache::nop::NopCache;
+    use chroma_config::assignment::{
+        assignment_policy::AssignmentPolicy, rendezvous_hash::AssignmentError,
+    };
     use chroma_log::config::{GrpcLogConfig, LogConfig};
+    use chroma_log::in_memory_log::InMemoryLog;
     use chroma_memberlist::memberlist_provider::Member;
     use chroma_storage::s3_config_for_localhost_with_bucket_name;
-    use chroma_sysdb::{GetCollectionsOptions, GrpcSysDb, GrpcSysDbConfig};
+    use chroma_storage::test_storage;
+    use chroma_sysdb::{GetCollectionsOptions, GrpcSysDb, GrpcSysDbConfig, SysDb, TestSysDb};
     use chroma_system::{DispatcherConfig, System};
     use chroma_tracing::{OtelFilter, OtelFilterLevel};
-    use chroma_types::CollectionUuid;
+    use chroma_types::{CollectionUuid, DatabaseName};
     use tracing_test::traced_test;
     use uuid::Uuid;
+
+    #[derive(Clone, Debug, Default)]
+    struct TestAssignmentPolicy {
+        members: Vec<String>,
+        assignments: HashMap<String, String>,
+        fail_keys: HashSet<String>,
+    }
+
+    impl AssignmentPolicy for TestAssignmentPolicy {
+        fn assign_one(&self, key: &str) -> Result<String, AssignmentError> {
+            if self.fail_keys.contains(key) {
+                return Err(AssignmentError::HashError);
+            }
+            if let Some(member) = self.assignments.get(key) {
+                return Ok(member.clone());
+            }
+            self.members
+                .first()
+                .cloned()
+                .ok_or(AssignmentError::InsufficientMember(1, 0))
+        }
+
+        fn assign(&self, key: &str, k: usize) -> Result<Vec<String>, AssignmentError> {
+            let member = self.assign_one(key)?;
+            if k == 1 {
+                Ok(vec![member])
+            } else {
+                Err(AssignmentError::InsufficientMember(k, 1))
+            }
+        }
+
+        fn get_members(&self) -> Vec<String> {
+            self.members.clone()
+        }
+
+        fn set_members(&mut self, members: Vec<String>) {
+            self.members = members;
+        }
+    }
+
+    fn test_gc_config(my_member_id: &str) -> GarbageCollectorConfig {
+        GarbageCollectorConfig {
+            my_member_id: my_member_id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn new_test_garbage_collector(
+        config: GarbageCollectorConfig,
+        sysdb_client: SysDb,
+        storage: Storage,
+        assignment_policy: Box<dyn AssignmentPolicy>,
+    ) -> GarbageCollector {
+        GarbageCollector::new(
+            config,
+            sysdb_client,
+            storage.clone(),
+            Log::InMemory(InMemoryLog::new()),
+            assignment_policy,
+            RootManager::new(storage, Box::new(NopCache)),
+        )
+    }
 
     #[test]
     fn test_runtime_drop_join_error_detection() {
@@ -795,6 +864,151 @@ mod tests {
         ));
         assert!(!is_known_runtime_drop_join_error(
             "panic: dispatcher task failed"
+        ));
+    }
+
+    #[test]
+    fn test_filter_collections_respects_assignment_disallow_list_and_assignment_failures() {
+        let (_storage_dir, storage) = test_storage();
+        let assigned_collection_id = CollectionUuid::new();
+        let other_member_collection_id = CollectionUuid::new();
+        let disallowed_collection_id = CollectionUuid::new();
+        let failed_collection_id = CollectionUuid::new();
+        let database = DatabaseName::new("test_db").expect("valid database name");
+
+        let mut garbage_collector = new_test_garbage_collector(
+            GarbageCollectorConfig {
+                disallow_collections: HashSet::from([disallowed_collection_id]),
+                ..test_gc_config("gc-a")
+            },
+            SysDb::Test(TestSysDb::new()),
+            storage,
+            Box::new(TestAssignmentPolicy {
+                assignments: HashMap::from([
+                    (assigned_collection_id.0.to_string(), "gc-a".to_string()),
+                    (other_member_collection_id.0.to_string(), "gc-b".to_string()),
+                    (disallowed_collection_id.0.to_string(), "gc-a".to_string()),
+                ]),
+                fail_keys: HashSet::from([failed_collection_id.0.to_string()]),
+                ..Default::default()
+            }),
+        );
+        garbage_collector.memberlist = vec![
+            Member {
+                member_id: "gc-a".to_string(),
+                member_ip: "127.0.0.1".to_string(),
+                member_node_name: "gc-a-node".to_string(),
+            },
+            Member {
+                member_id: "gc-b".to_string(),
+                member_ip: "127.0.0.2".to_string(),
+                member_node_name: "gc-b-node".to_string(),
+            },
+        ];
+
+        let filtered = garbage_collector.filter_collections(vec![
+            CollectionToGcInfo {
+                id: assigned_collection_id,
+                tenant: "tenant-a".to_string(),
+                database: database.clone(),
+                name: "assigned".to_string(),
+                version_file_path: "assigned/version.bin".to_string(),
+                lineage_file_path: None,
+            },
+            CollectionToGcInfo {
+                id: other_member_collection_id,
+                tenant: "tenant-a".to_string(),
+                database: database.clone(),
+                name: "other-member".to_string(),
+                version_file_path: "other/version.bin".to_string(),
+                lineage_file_path: None,
+            },
+            CollectionToGcInfo {
+                id: disallowed_collection_id,
+                tenant: "tenant-a".to_string(),
+                database: database.clone(),
+                name: "disallowed".to_string(),
+                version_file_path: "disallowed/version.bin".to_string(),
+                lineage_file_path: None,
+            },
+            CollectionToGcInfo {
+                id: failed_collection_id,
+                tenant: "tenant-a".to_string(),
+                database,
+                name: "failed".to_string(),
+                version_file_path: "failed/version.bin".to_string(),
+                lineage_file_path: None,
+            },
+        ]);
+
+        assert_eq!(
+            filtered
+                .into_iter()
+                .map(|collection| collection.id)
+                .collect::<Vec<_>>(),
+            vec![assigned_collection_id]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_manual_garbage_collection_request_records_existing_collection() {
+        let (_storage_dir, storage) = test_storage();
+        let mut sysdb = SysDb::Test(TestSysDb::new());
+        let collection_id = CollectionUuid::new();
+        let database_name = DatabaseName::new("test_db").expect("valid database name");
+
+        sysdb
+            .create_collection(
+                "test-tenant".to_string(),
+                database_name.clone(),
+                collection_id,
+                "test-collection".to_string(),
+                vec![],
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .await
+            .expect("collection should be created");
+
+        let mut garbage_collector = new_test_garbage_collector(
+            test_gc_config("gc-a"),
+            sysdb,
+            storage,
+            Box::new(TestAssignmentPolicy::default()),
+        );
+
+        garbage_collector
+            .manual_garbage_collection_request(collection_id)
+            .await
+            .expect("manual collection request should succeed");
+
+        assert_eq!(
+            garbage_collector.manual_collections.lock().clone(),
+            HashMap::from([(collection_id, database_name)])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_manual_garbage_collection_request_missing_collection() {
+        let (_storage_dir, storage) = test_storage();
+        let mut garbage_collector = new_test_garbage_collector(
+            test_gc_config("gc-a"),
+            SysDb::Test(TestSysDb::new()),
+            storage,
+            Box::new(TestAssignmentPolicy::default()),
+        );
+
+        let err = garbage_collector
+            .manual_garbage_collection_request(CollectionUuid::new())
+            .await
+            .expect_err("missing collection should fail");
+
+        assert!(matches!(
+            err,
+            GarbageCollectCollectionError::NoSuchCollection
         ));
     }
 

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -1454,19 +1454,18 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn errors_on_cross_collection_version_collisions_in_empty_path_invariant_check() {
-        let (_storage_dir, storage) = test_storage();
+    fn test_orchestrator(
+        storage: chroma_storage::Storage,
+        collection_id: CollectionUuid,
+    ) -> GarbageCollectorOrchestrator {
         let system = System::new();
         let dispatcher = Dispatcher::new(Default::default());
         let dispatcher_handle = system.start_component(dispatcher);
         let root_manager = RootManager::new(storage.clone(), Box::new(NopCache));
         let database_name = chroma_types::DatabaseName::new("test_db").expect("valid db name");
-        let root_collection_id = CollectionUuid::new();
-        let child_collection_id = CollectionUuid::new();
 
-        let mut orchestrator = GarbageCollectorOrchestrator::new(
-            child_collection_id,
+        GarbageCollectorOrchestrator::new(
+            collection_id,
             database_name,
             "version_file".to_string(),
             None,
@@ -1483,7 +1482,179 @@ mod tests {
             false,
             false,
             10,
-        );
+        )
+    }
+
+    fn fork_tree_graph(
+        root_collection_id: CollectionUuid,
+        root_versions: &[i64],
+        child_collection_id: CollectionUuid,
+        child_versions: &[i64],
+    ) -> VersionGraph {
+        let mut graph = VersionGraph::new();
+
+        let mut previous_root = None;
+        for version in root_versions {
+            let node = graph.add_node(VersionGraphNode {
+                collection_id: root_collection_id,
+                version: *version,
+                status: crate::types::VersionStatus::Deleted,
+            });
+            if let Some(previous) = previous_root {
+                graph.add_edge(previous, node, ());
+            }
+            previous_root = Some(node);
+        }
+
+        let root_tail = previous_root.expect("root_versions should not be empty");
+        let mut previous_child = None;
+        for version in child_versions {
+            let node = graph.add_node(VersionGraphNode {
+                collection_id: child_collection_id,
+                version: *version,
+                status: crate::types::VersionStatus::Deleted,
+            });
+            if let Some(previous) = previous_child {
+                graph.add_edge(previous, node, ());
+            } else {
+                graph.add_edge(root_tail, node, ());
+            }
+            previous_child = Some(node);
+        }
+
+        graph
+    }
+
+    fn file_path_set(paths: &[&str]) -> crate::types::FilePathSet {
+        let mut file_paths = crate::types::FilePathSet::new();
+        for path in paths {
+            file_paths.insert_path((*path).to_string());
+        }
+        file_paths
+    }
+
+    fn sorted_paths(file_paths: crate::types::FilePathSet) -> Vec<String> {
+        let mut paths = file_paths.iter().collect::<Vec<_>>();
+        paths.sort();
+        paths
+    }
+
+    #[tokio::test]
+    async fn allows_empty_file_paths_before_any_ancestor_has_paths_in_fork_tree() {
+        let (_storage_dir, storage) = test_storage();
+        let root_collection_id = CollectionUuid::new();
+        let child_collection_id = CollectionUuid::new();
+
+        let mut orchestrator = test_orchestrator(storage, child_collection_id);
+        orchestrator.version_files = HashMap::from([
+            (
+                root_collection_id,
+                test_version_file(
+                    root_collection_id,
+                    vec![version_info(0, false), version_info(1, false)],
+                ),
+            ),
+            (
+                child_collection_id,
+                test_version_file(
+                    child_collection_id,
+                    vec![version_info(0, false), version_info(1, false)],
+                ),
+            ),
+        ]);
+        orchestrator.versions_to_delete_output = Some(ComputeVersionsToDeleteOutput {
+            versions: HashMap::from([(
+                child_collection_id,
+                HashMap::from([(1, CollectionVersionAction::Keep)]),
+            )]),
+        });
+        orchestrator.graph = Some(fork_tree_graph(
+            root_collection_id,
+            &[0, 1],
+            child_collection_id,
+            &[0, 1],
+        ));
+
+        orchestrator
+            .handle_list_files_at_version_output(ListFilesAtVersionOutput {
+                collection_id: child_collection_id,
+                version: 1,
+                file_paths: crate::types::FilePathSet::new(),
+            })
+            .await
+            .expect("empty paths should be allowed until some ancestor first has paths");
+
+        assert!(orchestrator.file_ref_counts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn errors_on_cross_collection_missing_ancestor_versions_in_empty_path_invariant_check() {
+        let (_storage_dir, storage) = test_storage();
+        let root_collection_id = CollectionUuid::new();
+        let child_collection_id = CollectionUuid::new();
+
+        let mut orchestrator = test_orchestrator(storage, child_collection_id);
+        orchestrator.version_files = HashMap::from([
+            (
+                root_collection_id,
+                test_version_file(
+                    root_collection_id,
+                    vec![
+                        version_info(0, false),
+                        version_info(1, false),
+                        version_info(3, true),
+                    ],
+                ),
+            ),
+            (
+                child_collection_id,
+                test_version_file(
+                    child_collection_id,
+                    vec![
+                        version_info(0, false),
+                        version_info(1, false),
+                        version_info(2, false),
+                    ],
+                ),
+            ),
+        ]);
+        orchestrator.versions_to_delete_output = Some(ComputeVersionsToDeleteOutput {
+            versions: HashMap::from([(
+                child_collection_id,
+                HashMap::from([(2, CollectionVersionAction::Keep)]),
+            )]),
+        });
+        orchestrator.graph = Some(fork_tree_graph(
+            root_collection_id,
+            &[0, 1, 3],
+            child_collection_id,
+            &[0, 1, 2],
+        ));
+
+        let err = orchestrator
+            .handle_list_files_at_version_output(ListFilesAtVersionOutput {
+                collection_id: child_collection_id,
+                version: 2,
+                file_paths: crate::types::FilePathSet::new(),
+            })
+            .await
+            .expect_err("ancestor versions from another collection should resolve via that collection's version file");
+
+        match err {
+            GarbageCollectorError::InvariantViolation(message) => {
+                assert!(message.contains("has no file paths, but has ancestors with file paths"));
+            }
+            other => panic!("expected InvariantViolation, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn errors_on_cross_collection_version_collisions_in_empty_path_invariant_check() {
+        let (_storage_dir, storage) = test_storage();
+        let root_collection_id = CollectionUuid::new();
+        let child_collection_id = CollectionUuid::new();
+
+        let mut orchestrator = test_orchestrator(storage, child_collection_id);
 
         orchestrator.version_files = HashMap::from([
             (
@@ -1515,44 +1686,12 @@ mod tests {
                 HashMap::from([(2, CollectionVersionAction::Keep)]),
             )]),
         });
-
-        let mut graph = VersionGraph::new();
-        let root_v0 = graph.add_node(VersionGraphNode {
-            collection_id: root_collection_id,
-            version: 0,
-            status: crate::types::VersionStatus::Deleted,
-        });
-        let root_v1 = graph.add_node(VersionGraphNode {
-            collection_id: root_collection_id,
-            version: 1,
-            status: crate::types::VersionStatus::Deleted,
-        });
-        let root_v2 = graph.add_node(VersionGraphNode {
-            collection_id: root_collection_id,
-            version: 2,
-            status: crate::types::VersionStatus::Deleted,
-        });
-        let child_v0 = graph.add_node(VersionGraphNode {
-            collection_id: child_collection_id,
-            version: 0,
-            status: crate::types::VersionStatus::Deleted,
-        });
-        let child_v1 = graph.add_node(VersionGraphNode {
-            collection_id: child_collection_id,
-            version: 1,
-            status: crate::types::VersionStatus::Deleted,
-        });
-        let child_v2 = graph.add_node(VersionGraphNode {
-            collection_id: child_collection_id,
-            version: 2,
-            status: crate::types::VersionStatus::Deleted,
-        });
-        graph.add_edge(root_v0, root_v1, ());
-        graph.add_edge(root_v1, root_v2, ());
-        graph.add_edge(root_v2, child_v0, ());
-        graph.add_edge(child_v0, child_v1, ());
-        graph.add_edge(child_v1, child_v2, ());
-        orchestrator.graph = Some(graph);
+        orchestrator.graph = Some(fork_tree_graph(
+            root_collection_id,
+            &[0, 1, 2],
+            child_collection_id,
+            &[0, 1, 2],
+        ));
 
         let err = orchestrator
             .handle_list_files_at_version_output(ListFilesAtVersionOutput {
@@ -1569,5 +1708,93 @@ mod tests {
             }
             other => panic!("expected invariant violation, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn cross_collection_empty_path_invariant_stops_before_unprotected_delete_candidates_can_proceed(
+    ) {
+        let (_storage_dir, storage) = test_storage();
+        let root_collection_id = CollectionUuid::new();
+        let child_collection_id = CollectionUuid::new();
+
+        let mut orchestrator = test_orchestrator(storage, child_collection_id);
+        orchestrator.version_files = HashMap::from([
+            (
+                root_collection_id,
+                test_version_file(
+                    root_collection_id,
+                    vec![
+                        version_info(0, false),
+                        version_info(1, false),
+                        version_info(2, true),
+                    ],
+                ),
+            ),
+            (
+                child_collection_id,
+                test_version_file(
+                    child_collection_id,
+                    vec![
+                        version_info(0, false),
+                        version_info(1, false),
+                        version_info(2, false),
+                    ],
+                ),
+            ),
+        ]);
+        orchestrator.versions_to_delete_output = Some(ComputeVersionsToDeleteOutput {
+            versions: HashMap::from([
+                (
+                    root_collection_id,
+                    HashMap::from([(2, CollectionVersionAction::Delete)]),
+                ),
+                (
+                    child_collection_id,
+                    HashMap::from([(2, CollectionVersionAction::Keep)]),
+                ),
+            ]),
+        });
+        orchestrator.graph = Some(fork_tree_graph(
+            root_collection_id,
+            &[0, 1, 2],
+            child_collection_id,
+            &[0, 1, 2],
+        ));
+
+        orchestrator
+            .handle_list_files_at_version_output(ListFilesAtVersionOutput {
+                collection_id: root_collection_id,
+                version: 2,
+                file_paths: file_path_set(&["data/path"]),
+            })
+            .await
+            .expect("delete candidates should be tracked for deleted ancestor versions");
+        assert_eq!(
+            sorted_paths(orchestrator.file_ref_counts.as_set(0)),
+            vec!["data/path".to_string()]
+        );
+
+        let err = orchestrator
+            .handle_list_files_at_version_output(ListFilesAtVersionOutput {
+                collection_id: child_collection_id,
+                version: 2,
+                file_paths: crate::types::FilePathSet::new(),
+            })
+            .await
+            .expect_err(
+                "kept child versions with empty paths must fail closed when ancestors have data",
+            );
+
+        match err {
+            GarbageCollectorError::InvariantViolation(message) => {
+                assert!(message.contains("has no file paths, but has ancestors with file paths"));
+            }
+            other => panic!("expected InvariantViolation, got {other:?}"),
+        }
+
+        assert_eq!(
+            sorted_paths(orchestrator.file_ref_counts.as_set(0)),
+            vec!["data/path".to_string()]
+        );
     }
 }

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -586,12 +586,6 @@ impl GarbageCollectorOrchestrator {
         &mut self,
         output: ListFilesAtVersionOutput,
     ) -> Result<(), GarbageCollectorError> {
-        let version_file = self.version_files.get(&output.collection_id).ok_or(
-            GarbageCollectorError::InvariantViolation(format!(
-                "Expected version file to be set for collection {}",
-                output.collection_id
-            )),
-        )?;
         let version_action = self
             .versions_to_delete_output
             .as_ref()
@@ -709,13 +703,18 @@ impl GarbageCollectorOrchestrator {
                 }
                 Ok(false)
             }
-            let extracted_paths = nodes_from_root_to_this_node
-                .iter()
-                .map(|node| extract_paths(version_file, node, &output).map(|x| (node.version, x)))
-                .collect::<Vec<_>>();
-            let mut have_paths = Vec::with_capacity(extracted_paths.len());
-            for res in extracted_paths.into_iter() {
-                have_paths.push(res?);
+            let mut have_paths = Vec::with_capacity(nodes_from_root_to_this_node.len());
+            for node in nodes_from_root_to_this_node.iter() {
+                let node_version_file = self.version_files.get(&node.collection_id).ok_or(
+                    GarbageCollectorError::InvariantViolation(format!(
+                        "Expected version file to be set for collection {}",
+                        node.collection_id
+                    )),
+                )?;
+                have_paths.push((
+                    node.version,
+                    extract_paths(node_version_file, node, &output)?,
+                ));
             }
             let has_no_paths_at_version = have_paths
                 .into_iter()
@@ -1136,15 +1135,21 @@ mod tests {
     use super::GarbageCollectorError;
     use super::GarbageCollectorOrchestrator;
     use crate::operators::compute_versions_to_delete_from_graph::CollectionVersionAction;
+    use crate::operators::compute_versions_to_delete_from_graph::ComputeVersionsToDeleteOutput;
+    use crate::operators::list_files_at_version::ListFilesAtVersionOutput;
+    use crate::types::{VersionGraph, VersionGraphNode};
     use chroma_blockstore::RootManager;
     use chroma_cache::nop::NopCache;
-    use chroma_log::Log;
+    use chroma_log::{in_memory_log::InMemoryLog, Log};
     use chroma_storage::test_storage;
     use chroma_sysdb::{GetCollectionsOptions, TestSysDb};
     use chroma_system::{Dispatcher, Orchestrator, System};
     use chroma_types::{
-        chroma_proto::CollectionInfoImmutable, chroma_proto::CollectionVersionFile, CollectionUuid,
-        Segment, SegmentFlushInfo, SegmentScope, SegmentType, SegmentUuid,
+        chroma_proto::{
+            CollectionInfoImmutable, CollectionSegmentInfo, CollectionVersionFile,
+            CollectionVersionHistory, CollectionVersionInfo, FilePaths, FlushSegmentCompactionInfo,
+        },
+        CollectionUuid, Segment, SegmentFlushInfo, SegmentScope, SegmentType, SegmentUuid,
     };
     use chrono::DateTime;
     use std::{collections::HashMap, sync::Arc, time::SystemTime};
@@ -1405,5 +1410,164 @@ mod tests {
         assert!(result.is_err());
         println!("{:?}", result);
         assert!(format!("{:?}", result).contains("no file paths"));
+    }
+
+    fn test_version_file(
+        collection_id: CollectionUuid,
+        versions: Vec<CollectionVersionInfo>,
+    ) -> Arc<CollectionVersionFile> {
+        Arc::new(CollectionVersionFile {
+            collection_info_immutable: Some(CollectionInfoImmutable {
+                tenant_id: "test-tenant".to_string(),
+                database_id: "test-db".to_string(),
+                collection_id: collection_id.to_string(),
+                dimension: 0,
+                ..Default::default()
+            }),
+            version_history: Some(CollectionVersionHistory { versions }),
+        })
+    }
+
+    fn version_info(version: i64, has_paths: bool) -> CollectionVersionInfo {
+        CollectionVersionInfo {
+            version,
+            segment_info: Some(CollectionSegmentInfo {
+                segment_compaction_info: if has_paths {
+                    vec![FlushSegmentCompactionInfo {
+                        segment_id: "segment-1".to_string(),
+                        file_paths: HashMap::from([(
+                            "data".to_string(),
+                            FilePaths {
+                                paths: vec!["data/path".to_string()],
+                            },
+                        )]),
+                    }]
+                } else {
+                    vec![]
+                },
+            }),
+            collection_info_mutable: None,
+            created_at_secs: 0,
+            version_change_reason: 0,
+            version_file_name: String::new(),
+            marked_for_deletion: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn errors_on_cross_collection_version_collisions_in_empty_path_invariant_check() {
+        let (_storage_dir, storage) = test_storage();
+        let system = System::new();
+        let dispatcher = Dispatcher::new(Default::default());
+        let dispatcher_handle = system.start_component(dispatcher);
+        let root_manager = RootManager::new(storage.clone(), Box::new(NopCache));
+        let database_name = chroma_types::DatabaseName::new("test_db").expect("valid db name");
+        let root_collection_id = CollectionUuid::new();
+        let child_collection_id = CollectionUuid::new();
+
+        let mut orchestrator = GarbageCollectorOrchestrator::new(
+            child_collection_id,
+            database_name,
+            "version_file".to_string(),
+            None,
+            chrono::Utc::now(),
+            chrono::Utc::now(),
+            chroma_sysdb::SysDb::Test(TestSysDb::new()),
+            dispatcher_handle,
+            system,
+            storage,
+            Log::InMemory(InMemoryLog::new()),
+            root_manager,
+            crate::types::CleanupMode::DeleteV2,
+            1,
+            false,
+            false,
+            10,
+        );
+
+        orchestrator.version_files = HashMap::from([
+            (
+                root_collection_id,
+                test_version_file(
+                    root_collection_id,
+                    vec![
+                        version_info(0, false),
+                        version_info(1, false),
+                        version_info(2, true),
+                    ],
+                ),
+            ),
+            (
+                child_collection_id,
+                test_version_file(
+                    child_collection_id,
+                    vec![
+                        version_info(0, false),
+                        version_info(1, false),
+                        version_info(2, false),
+                    ],
+                ),
+            ),
+        ]);
+        orchestrator.versions_to_delete_output = Some(ComputeVersionsToDeleteOutput {
+            versions: HashMap::from([(
+                child_collection_id,
+                HashMap::from([(2, CollectionVersionAction::Keep)]),
+            )]),
+        });
+
+        let mut graph = VersionGraph::new();
+        let root_v0 = graph.add_node(VersionGraphNode {
+            collection_id: root_collection_id,
+            version: 0,
+            status: crate::types::VersionStatus::Deleted,
+        });
+        let root_v1 = graph.add_node(VersionGraphNode {
+            collection_id: root_collection_id,
+            version: 1,
+            status: crate::types::VersionStatus::Deleted,
+        });
+        let root_v2 = graph.add_node(VersionGraphNode {
+            collection_id: root_collection_id,
+            version: 2,
+            status: crate::types::VersionStatus::Deleted,
+        });
+        let child_v0 = graph.add_node(VersionGraphNode {
+            collection_id: child_collection_id,
+            version: 0,
+            status: crate::types::VersionStatus::Deleted,
+        });
+        let child_v1 = graph.add_node(VersionGraphNode {
+            collection_id: child_collection_id,
+            version: 1,
+            status: crate::types::VersionStatus::Deleted,
+        });
+        let child_v2 = graph.add_node(VersionGraphNode {
+            collection_id: child_collection_id,
+            version: 2,
+            status: crate::types::VersionStatus::Deleted,
+        });
+        graph.add_edge(root_v0, root_v1, ());
+        graph.add_edge(root_v1, root_v2, ());
+        graph.add_edge(root_v2, child_v0, ());
+        graph.add_edge(child_v0, child_v1, ());
+        graph.add_edge(child_v1, child_v2, ());
+        orchestrator.graph = Some(graph);
+
+        let err = orchestrator
+            .handle_list_files_at_version_output(ListFilesAtVersionOutput {
+                collection_id: child_collection_id,
+                version: 2,
+                file_paths: crate::types::FilePathSet::new(),
+            })
+            .await
+            .expect_err("cross-collection version collisions should not bypass the invariant");
+
+        match err {
+            GarbageCollectorError::InvariantViolation(message) => {
+                assert!(message.contains("has no file paths, but has ancestors with file paths"));
+            }
+            other => panic!("expected invariant violation, got {other:?}"),
+        }
     }
 }

--- a/rust/garbage_collector/src/lib.rs
+++ b/rust/garbage_collector/src/lib.rs
@@ -209,3 +209,111 @@ pub async fn garbage_collector_service_entrypoint() -> Result<(), Box<dyn std::e
     info!("Shutting down garbage collector service");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_blockstore::RootManager;
+    use chroma_cache::nop::NopCache;
+    use chroma_config::assignment::assignment_policy::RendezvousHashingAssignmentPolicy;
+    use chroma_log::{in_memory_log::InMemoryLog, Log};
+    use chroma_storage::test_storage;
+    use chroma_sysdb::{SysDb, TestSysDb};
+    use chroma_system::System;
+    use chroma_types::chroma_proto::garbage_collector_server::GarbageCollector as GarbageCollectorApi;
+    use tonic::Code;
+
+    fn new_test_service(handle: ComponentHandle<GarbageCollector>) -> GarbageCollectorService {
+        GarbageCollectorService { handle }
+    }
+
+    #[tokio::test]
+    async fn kickoff_garbage_collection_rejects_invalid_collection_id() {
+        let system = System::new();
+        let (_storage_dir, storage) = test_storage();
+        let garbage_collector = GarbageCollector::new(
+            GarbageCollectorConfig {
+                my_member_id: "test-gc".to_string(),
+                ..Default::default()
+            },
+            SysDb::Test(TestSysDb::new()),
+            storage.clone(),
+            Log::InMemory(InMemoryLog::new()),
+            Box::new(RendezvousHashingAssignmentPolicy::default()),
+            RootManager::new(storage, Box::new(NopCache)),
+        );
+        let mut handle = system.start_component(garbage_collector);
+        let service = new_test_service(handle.clone());
+
+        let err = GarbageCollectorApi::kickoff_garbage_collection(
+            &service,
+            Request::new(KickoffGarbageCollectionRequest {
+                collection_id: "not-a-uuid".to_string(),
+            }),
+        )
+        .await
+        .expect_err("invalid collection IDs should be rejected");
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+
+        handle.stop();
+        handle.join().await.expect("component should stop cleanly");
+        system.stop().await;
+        system.join().await;
+    }
+
+    #[tokio::test]
+    async fn kickoff_garbage_collection_accepts_valid_collection_id() {
+        let system = System::new();
+        let (_storage_dir, storage) = test_storage();
+        let mut sysdb = SysDb::Test(TestSysDb::new());
+        let database_name = chroma_types::DatabaseName::new("test_db").expect("valid db name");
+        let collection_id = CollectionUuid::new();
+
+        sysdb
+            .create_collection(
+                "test-tenant".to_string(),
+                database_name,
+                collection_id,
+                "test-collection".to_string(),
+                vec![],
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .await
+            .expect("collection should be created");
+
+        let garbage_collector = GarbageCollector::new(
+            GarbageCollectorConfig {
+                my_member_id: "test-gc".to_string(),
+                ..Default::default()
+            },
+            sysdb,
+            storage.clone(),
+            Log::InMemory(InMemoryLog::new()),
+            Box::new(RendezvousHashingAssignmentPolicy::default()),
+            RootManager::new(storage, Box::new(NopCache)),
+        );
+        let mut handle = system.start_component(garbage_collector);
+        let service = new_test_service(handle.clone());
+
+        let response = GarbageCollectorApi::kickoff_garbage_collection(
+            &service,
+            Request::new(KickoffGarbageCollectionRequest {
+                collection_id: collection_id.to_string(),
+            }),
+        )
+        .await
+        .expect("valid collection IDs should be accepted");
+
+        let _response = response.into_inner();
+
+        handle.stop();
+        handle.join().await.expect("component should stop cleanly");
+        system.stop().await;
+        system.join().await;
+    }
+}

--- a/rust/garbage_collector/src/log_only_orchestrator.rs
+++ b/rust/garbage_collector/src/log_only_orchestrator.rs
@@ -185,7 +185,7 @@ mod tests {
     /// - Collection UUID must match the one provided during construction
     /// - Result channel must be `None` initially (set later by the system)
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_k8s_integration_orchestrator_initialization() {
+    async fn test_orchestrator_initialization() {
         let (_storage_dir, storage) = test_storage();
         let system = System::new();
         let dispatcher = Dispatcher::new(Default::default());
@@ -229,7 +229,7 @@ mod tests {
     /// `collections_to_destroy` set, while `collections_to_garbage_collect` remains empty
     /// since this orchestrator only handles hard deletion, not soft garbage collection.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_k8s_integration_delete_operator_params() {
+    async fn test_delete_operator_params() {
         let (_storage_dir, storage) = test_storage();
         let system = System::new();
         let dispatcher = Dispatcher::new(Default::default());

--- a/rust/garbage_collector/src/log_only_orchestrator.rs
+++ b/rust/garbage_collector/src/log_only_orchestrator.rs
@@ -229,7 +229,7 @@ mod tests {
     /// `collections_to_destroy` set, while `collections_to_garbage_collect` remains empty
     /// since this orchestrator only handles hard deletion, not soft garbage collection.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_delete_operator_params() {
+    async fn test_k8s_integration_delete_operator_params() {
         let (_storage_dir, storage) = test_storage();
         let system = System::new();
         let dispatcher = Dispatcher::new(Default::default());

--- a/rust/garbage_collector/src/log_only_orchestrator.rs
+++ b/rust/garbage_collector/src/log_only_orchestrator.rs
@@ -185,7 +185,7 @@ mod tests {
     /// - Collection UUID must match the one provided during construction
     /// - Result channel must be `None` initially (set later by the system)
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_orchestrator_initialization() {
+    async fn test_k8s_integration_orchestrator_initialization() {
         let (_storage_dir, storage) = test_storage();
         let system = System::new();
         let dispatcher = Dispatcher::new(Default::default());

--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -227,3 +227,185 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_log::{in_memory_log::InMemoryLog, Log};
+    use chroma_storage::{s3_client_for_test_with_new_bucket, GetOptions};
+    use chroma_system::Operator;
+    use wal3::{Cursor, CursorName, CursorStore, CursorStoreOptions, LogWriter, SnapshotOptions};
+
+    async fn seed_collection_log(storage: Storage, collection_id: CollectionUuid) -> LogPosition {
+        let prefix = collection_id.storage_prefix_for_log();
+        let options = LogWriterOptions {
+            snapshot_manifest: SnapshotOptions {
+                snapshot_rollover_threshold: 2,
+                fragment_rollover_threshold: 2,
+            },
+            ..LogWriterOptions::default()
+        };
+        let storage = Arc::new(storage);
+        let (fragment_factory, manifest_factory) = create_s3_factories(
+            options.clone(),
+            LogReaderOptions::default(),
+            storage.clone(),
+            prefix.clone(),
+            "test-writer".to_string(),
+            Arc::new(()),
+            Arc::new(()),
+        );
+        let log = LogWriter::open_or_initialize(
+            options,
+            "test-writer",
+            fragment_factory,
+            manifest_factory,
+            None,
+        )
+        .await
+        .expect("log should initialize");
+
+        let mut keep_position = LogPosition::default();
+        for i in 0..40 {
+            let position = log
+                .append_many(
+                    (0..5)
+                        .map(|j| format!("collection:{i}:{j}").into_bytes())
+                        .collect(),
+                )
+                .await
+                .expect("append should succeed");
+            if i == 20 {
+                keep_position = position;
+            }
+        }
+
+        let cursors = CursorStore::new(
+            CursorStoreOptions::default(),
+            storage,
+            prefix,
+            "cursor-writer".to_string(),
+        );
+        cursors
+            .init(
+                &CursorName::new("so_you_may_gc").expect("cursor name should be valid"),
+                Cursor {
+                    position: keep_position,
+                    epoch_us: keep_position.offset(),
+                    writer: "test-writer".to_string(),
+                },
+            )
+            .await
+            .expect("cursor should initialize");
+
+        keep_position
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_delete_unused_logs_delete_mode_removes_garbage() {
+        let storage = s3_client_for_test_with_new_bucket().await;
+        let collection_id = CollectionUuid::new();
+        let keep_position = seed_collection_log(storage.clone(), collection_id).await;
+        let prefix = collection_id.storage_prefix_for_log();
+        let before = storage
+            .list_prefix(&prefix, GetOptions::default())
+            .await
+            .expect("list should succeed");
+
+        DeleteUnusedLogsOperator {
+            enabled: true,
+            mode: CleanupMode::DeleteV2,
+            storage: storage.clone(),
+            logs: Log::InMemory(InMemoryLog::new()),
+            enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
+        }
+        .run(&DeleteUnusedLogsInput {
+            collections_to_destroy: HashSet::new(),
+            collections_to_garbage_collect: HashMap::from([(collection_id, keep_position)]),
+            database_name: None,
+        })
+        .await
+        .expect("delete-mode GC should succeed");
+
+        let after = storage
+            .list_prefix(&prefix, GetOptions::default())
+            .await
+            .expect("list should succeed");
+
+        assert!(
+            after.len() < before.len(),
+            "expected GC to delete at least one log artifact, before={} after={}",
+            before.len(),
+            after.len()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore] // TODO(rescrv, gc week):  Unignore this test.
+    async fn test_k8s_integration_delete_unused_logs_dry_run_keeps_files() {
+        let storage = s3_client_for_test_with_new_bucket().await;
+        let collection_id = CollectionUuid::new();
+        let keep_position = seed_collection_log(storage.clone(), collection_id).await;
+        let prefix = collection_id.storage_prefix_for_log();
+        let before = storage
+            .list_prefix(&prefix, GetOptions::default())
+            .await
+            .expect("list should succeed")
+            .into_iter()
+            .collect::<HashSet<_>>();
+
+        DeleteUnusedLogsOperator {
+            enabled: true,
+            mode: CleanupMode::DryRunV2,
+            storage: storage.clone(),
+            logs: Log::InMemory(InMemoryLog::new()),
+            enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
+        }
+        .run(&DeleteUnusedLogsInput {
+            collections_to_destroy: HashSet::new(),
+            collections_to_garbage_collect: HashMap::from([(collection_id, keep_position)]),
+            database_name: None,
+        })
+        .await
+        .expect("dry-run GC should succeed");
+
+        let after = storage
+            .list_prefix(&prefix, GetOptions::default())
+            .await
+            .expect("list should succeed")
+            .into_iter()
+            .collect::<HashSet<_>>();
+
+        assert_eq!(after, before);
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_delete_unused_logs_hard_delete_destroys_collection_prefix() {
+        let storage = s3_client_for_test_with_new_bucket().await;
+        let collection_id = CollectionUuid::new();
+        seed_collection_log(storage.clone(), collection_id).await;
+        let prefix = collection_id.storage_prefix_for_log();
+
+        DeleteUnusedLogsOperator {
+            enabled: true,
+            mode: CleanupMode::DeleteV2,
+            storage: storage.clone(),
+            logs: Log::InMemory(InMemoryLog::new()),
+            enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
+        }
+        .run(&DeleteUnusedLogsInput {
+            collections_to_destroy: HashSet::from([collection_id]),
+            collections_to_garbage_collect: HashMap::new(),
+            database_name: None,
+        })
+        .await
+        .expect("hard-delete should succeed");
+
+        let remaining = storage
+            .list_prefix(&prefix, GetOptions::default())
+            .await
+            .expect("list should succeed");
+
+        assert!(remaining.is_empty(), "expected log prefix to be destroyed");
+    }
+}

--- a/rust/garbage_collector/src/operators/fetch_lineage_file.rs
+++ b/rust/garbage_collector/src/operators/fetch_lineage_file.rs
@@ -78,3 +78,80 @@ impl Operator<FetchLineageFileInput, FetchLineageFileOutput> for FetchLineageFil
         Ok(FetchLineageFileOutput(lineage))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_storage::{test_storage, PutOptions};
+    use chroma_system::Operator;
+    use chroma_types::chroma_proto::CollectionVersionDependency;
+
+    #[tokio::test]
+    async fn test_fetch_lineage_file_success() {
+        let (_storage_dir, storage) = test_storage();
+        let lineage_file = CollectionLineageFile {
+            dependencies: vec![CollectionVersionDependency {
+                source_collection_id: "source".to_string(),
+                source_collection_version: 7,
+                target_collection_id: "target".to_string(),
+            }],
+        };
+        let lineage_file_path = "lineage/test.bin".to_string();
+
+        storage
+            .put_bytes(
+                &lineage_file_path,
+                lineage_file.encode_to_vec(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("lineage file should be written");
+
+        let output = FetchLineageFileOperator::new()
+            .run(&FetchLineageFileInput::new(
+                storage,
+                lineage_file_path.to_string(),
+            ))
+            .await
+            .expect("lineage file should be fetched");
+
+        assert_eq!(output.0, lineage_file);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_lineage_file_missing_object() {
+        let (_storage_dir, storage) = test_storage();
+
+        let err = FetchLineageFileOperator::new()
+            .run(&FetchLineageFileInput::new(
+                storage,
+                "lineage/missing.bin".to_string(),
+            ))
+            .await
+            .expect_err("missing lineage file should fail");
+
+        assert!(matches!(err, FetchLineageFileError::Storage(_)));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_lineage_file_decode_error() {
+        let (_storage_dir, storage) = test_storage();
+        let lineage_file_path = "lineage/invalid.bin".to_string();
+
+        storage
+            .put_bytes(
+                &lineage_file_path,
+                b"not a protobuf".to_vec(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("invalid lineage file should be written");
+
+        let err = FetchLineageFileOperator::new()
+            .run(&FetchLineageFileInput::new(storage, lineage_file_path))
+            .await
+            .expect_err("invalid lineage file should fail to decode");
+
+        assert!(matches!(err, FetchLineageFileError::Decode(_)));
+    }
+}

--- a/rust/garbage_collector/src/operators/fetch_version_file.rs
+++ b/rust/garbage_collector/src/operators/fetch_version_file.rs
@@ -138,32 +138,15 @@ impl Operator<FetchVersionFileInput, FetchVersionFileOutput> for FetchVersionFil
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chroma_config::registry;
-    use chroma_config::Configurable;
-    use chroma_storage::s3_config_for_localhost_with_bucket_name;
-    use chroma_storage::PutOptions;
+    use chroma_storage::{test_storage, PutOptions};
     use chroma_types::chroma_proto::CollectionInfoImmutable;
     use chroma_types::chroma_proto::CollectionVersionHistory;
-    use tracing_test::traced_test;
     use uuid::Uuid;
 
-    async fn setup_test_storage() -> Storage {
-        // Create storage config for Minio
-        let storage_config = s3_config_for_localhost_with_bucket_name("chroma-storage").await;
-
-        // Add more detailed logging
-        tracing::info!("Setting up test storage with config: {:?}", storage_config);
-
-        let registry = registry::Registry::new();
-        Storage::try_from_config(&storage_config, &registry)
-            .await
-            .expect("Failed to create storage")
-    }
-
     #[tokio::test]
-    #[traced_test]
-    async fn test_k8s_integration_fetch_version_file() {
-        let storage = setup_test_storage().await;
+    async fn test_fetch_version_file() {
+        let (_storage_dir, storage) = test_storage();
+        let collection_id = Uuid::new_v4();
         let test_file = CollectionVersionFile {
             collection_info_immutable: Some(CollectionInfoImmutable {
                 tenant_id: Uuid::new_v4().to_string(),
@@ -171,7 +154,7 @@ mod tests {
                 database_name: "test".to_string(),
                 is_deleted: false,
                 dimension: 3,
-                collection_id: Uuid::new_v4().to_string(),
+                collection_id: collection_id.to_string(),
                 collection_name: "test".to_string(),
                 collection_creation_secs: 0,
             }),
@@ -185,45 +168,104 @@ mod tests {
             .put_bytes(test_file_path, test_content.clone(), PutOptions::default())
             .await
         {
-            Ok(_) => tracing::info!("Successfully wrote test file"),
+            Ok(_) => {}
             Err(e) => {
-                tracing::error!("Failed to write test file: {:?}", e);
                 panic!("Failed to write test file: {:?}", e);
             }
         }
 
-        // Create operator and input
         let operator = FetchVersionFileOperator {};
         let input = FetchVersionFileInput {
             version_file_path: test_file_path.to_string(),
             storage: storage.clone(),
         };
 
-        // Run the operator
         let result = operator.run(&input).await.expect("Failed to run operator");
 
-        // Verify the content
-        assert_eq!(result.file, test_file.into());
-
-        // Cleanup - Note: object_store doesn't have a delete method,
-        // but the test bucket should be cleaned up between test runs
+        assert_eq!(*result.file, test_file);
+        assert_eq!(result.collection_id, CollectionUuid(collection_id));
     }
 
     #[tokio::test]
-    #[traced_test]
-    async fn test_k8s_integration_fetch_nonexistent_file() {
-        let storage = setup_test_storage().await;
+    async fn test_fetch_nonexistent_file() {
+        let (_storage_dir, storage) = test_storage();
         let operator = FetchVersionFileOperator {};
         let input = FetchVersionFileInput {
             version_file_path: "nonexistent_file.txt".to_string(),
             storage,
         };
 
-        // Run the operator and expect an error
         let result = operator.run(&input).await;
         assert!(matches!(
             result,
             Err(FetchVersionFileError::StorageError(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_version_file_missing_collection_info() {
+        let (_storage_dir, storage) = test_storage();
+        let test_file = CollectionVersionFile {
+            collection_info_immutable: None,
+            version_history: Some(CollectionVersionHistory { versions: vec![] }),
+        };
+        let test_file_path = "missing_collection_info.bin";
+
+        storage
+            .put_bytes(
+                test_file_path,
+                test_file.encode_to_vec(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("version file should be written");
+
+        let err = FetchVersionFileOperator::new()
+            .run(&FetchVersionFileInput::new(
+                test_file_path.to_string(),
+                storage,
+            ))
+            .await
+            .expect_err("missing collection info should fail");
+
+        assert!(matches!(err, FetchVersionFileError::MissingCollectionId));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_version_file_invalid_collection_uuid() {
+        let (_storage_dir, storage) = test_storage();
+        let test_file = CollectionVersionFile {
+            collection_info_immutable: Some(CollectionInfoImmutable {
+                tenant_id: Uuid::new_v4().to_string(),
+                database_id: Uuid::new_v4().to_string(),
+                database_name: "test".to_string(),
+                is_deleted: false,
+                dimension: 3,
+                collection_id: "not-a-uuid".to_string(),
+                collection_name: "test".to_string(),
+                collection_creation_secs: 0,
+            }),
+            version_history: Some(CollectionVersionHistory { versions: vec![] }),
+        };
+        let test_file_path = "invalid_collection_uuid.bin";
+
+        storage
+            .put_bytes(
+                test_file_path,
+                test_file.encode_to_vec(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("version file should be written");
+
+        let err = FetchVersionFileOperator::new()
+            .run(&FetchVersionFileInput::new(
+                test_file_path.to_string(),
+                storage,
+            ))
+            .await
+            .expect_err("invalid collection UUID should fail");
+
+        assert!(matches!(err, FetchVersionFileError::InvalidUuid(_)));
     }
 }

--- a/rust/garbage_collector/src/operators/get_version_file_paths.rs
+++ b/rust/garbage_collector/src/operators/get_version_file_paths.rs
@@ -77,3 +77,91 @@ impl Operator<GetVersionFilePathsInput, GetVersionFilePathsOutput> for GetVersio
         Ok(GetVersionFilePathsOutput(paths))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_sysdb::TestSysDb;
+    use chroma_system::Operator;
+
+    #[tokio::test]
+    async fn test_get_version_file_paths_success() {
+        let mut sysdb = SysDb::Test(TestSysDb::new());
+        let database_name = DatabaseName::new("test_db").expect("valid database name");
+        let collection_id = CollectionUuid::new();
+
+        sysdb
+            .create_collection(
+                "test-tenant".to_string(),
+                database_name.clone(),
+                collection_id,
+                "test-collection".to_string(),
+                vec![],
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .await
+            .expect("collection should be created");
+
+        match &mut sysdb {
+            SysDb::Test(test_sysdb) => {
+                test_sysdb.set_collection_version_file_path(
+                    collection_id,
+                    "version-files/test.bin".to_string(),
+                );
+            }
+            _ => panic!("expected test sysdb"),
+        }
+
+        let output = GetVersionFilePathsOperator::new()
+            .run(&GetVersionFilePathsInput::new(
+                vec![collection_id],
+                sysdb,
+                database_name,
+            ))
+            .await
+            .expect("version file path lookup should succeed");
+
+        assert_eq!(
+            output.0,
+            HashMap::from([(collection_id, "version-files/test.bin".to_string())])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_version_file_paths_missing_path() {
+        let mut sysdb = SysDb::Test(TestSysDb::new());
+        let database_name = DatabaseName::new("test_db").expect("valid database name");
+        let collection_id = CollectionUuid::new();
+
+        sysdb
+            .create_collection(
+                "test-tenant".to_string(),
+                database_name.clone(),
+                collection_id,
+                "test-collection".to_string(),
+                vec![],
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .await
+            .expect("collection should be created");
+
+        let err = GetVersionFilePathsOperator::new()
+            .run(&GetVersionFilePathsInput::new(
+                vec![collection_id],
+                sysdb,
+                database_name,
+            ))
+            .await
+            .expect_err("lookup should fail when the version file path is missing");
+
+        assert!(matches!(err, GetVersionFilePathsError::SysDb(_)));
+    }
+}

--- a/rust/garbage_collector/src/operators/list_files_at_version.rs
+++ b/rust/garbage_collector/src/operators/list_files_at_version.rs
@@ -345,4 +345,236 @@ mod tests {
         assert_eq!(all_paths.len(), 1);
         assert!(all_paths.contains(&bf_path));
     }
+
+    #[tokio::test]
+    async fn test_hnsw_index_paths_are_expanded() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
+        let root_manager = RootManager::new(storage, Box::new(NopCache));
+
+        let index_id = Uuid::new_v4();
+        let prefix = "hnsw-index";
+        let collection_id = Uuid::new_v4().to_string();
+        let version_file = create_version_file(
+            &collection_id,
+            vec![CollectionVersionInfo {
+                version: 1,
+                segment_info: Some(create_segment_info(vec![(
+                    HNSW_PATH.to_string(),
+                    vec![format!("{prefix}/{index_id}")],
+                )])),
+                collection_info_mutable: None,
+                created_at_secs: 0,
+                version_change_reason: 0,
+                version_file_name: String::new(),
+                marked_for_deletion: false,
+            }],
+        );
+
+        let output = ListFilesAtVersionsOperator {}
+            .run(&ListFilesAtVersionInput::new(root_manager, version_file, 1))
+            .await
+            .unwrap();
+
+        let all_paths: std::collections::HashSet<String> = output.file_paths.iter().collect();
+        let expected_paths: std::collections::HashSet<String> = FILES
+            .iter()
+            .map(|file| HnswIndexProvider::format_key(prefix, &IndexUuid(index_id), file))
+            .collect();
+
+        assert_eq!(all_paths, expected_paths);
+    }
+
+    #[tokio::test]
+    async fn test_quantized_spann_paths_are_expanded() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
+        let root_manager = RootManager::new(storage, Box::new(NopCache));
+
+        let raw_id = Uuid::new_v4();
+        let quantized_id = Uuid::new_v4();
+        let collection_id = Uuid::new_v4().to_string();
+        let version_file = create_version_file(
+            &collection_id,
+            vec![CollectionVersionInfo {
+                version: 1,
+                segment_info: Some(create_segment_info(vec![
+                    (
+                        QUANTIZED_SPANN_RAW_CENTROID.to_string(),
+                        vec![format!("spann-raw/{raw_id}")],
+                    ),
+                    (
+                        QUANTIZED_SPANN_QUANTIZED_CENTROID.to_string(),
+                        vec![format!("spann-quantized/{quantized_id}")],
+                    ),
+                ])),
+                collection_info_mutable: None,
+                created_at_secs: 0,
+                version_change_reason: 0,
+                version_file_name: String::new(),
+                marked_for_deletion: false,
+            }],
+        );
+
+        let output = ListFilesAtVersionsOperator {}
+            .run(&ListFilesAtVersionInput::new(root_manager, version_file, 1))
+            .await
+            .unwrap();
+
+        let all_paths: std::collections::HashSet<String> = output.file_paths.iter().collect();
+        let expected_paths = std::collections::HashSet::from([
+            USearchIndex::format_storage_key("spann-raw", IndexUuid(raw_id), false),
+            USearchIndex::format_storage_key("spann-quantized", IndexUuid(quantized_id), true),
+        ]);
+
+        assert_eq!(all_paths, expected_paths);
+    }
+
+    #[tokio::test]
+    async fn test_sparse_index_not_found_keeps_root_path_only() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
+        let root_manager = RootManager::new(storage.clone(), Box::new(NopCache));
+
+        let sparse_index_id = Uuid::new_v4();
+        let prefix = "sparse-index";
+        let collection_id = Uuid::new_v4().to_string();
+        let version_file = create_version_file(
+            &collection_id,
+            vec![CollectionVersionInfo {
+                version: 1,
+                segment_info: Some(create_segment_info(vec![(
+                    "data".to_string(),
+                    vec![format!("{prefix}/{sparse_index_id}")],
+                )])),
+                collection_info_mutable: None,
+                created_at_secs: 0,
+                version_change_reason: 0,
+                version_file_name: String::new(),
+                marked_for_deletion: false,
+            }],
+        );
+
+        let output = ListFilesAtVersionsOperator {}
+            .run(&ListFilesAtVersionInput::new(root_manager, version_file, 1))
+            .await
+            .unwrap();
+
+        let all_paths: std::collections::HashSet<String> = output.file_paths.iter().collect();
+        assert_eq!(
+            all_paths,
+            std::collections::HashSet::from([RootManager::get_storage_key(
+                prefix,
+                &sparse_index_id
+            )])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_version_history_returns_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
+        let root_manager = RootManager::new(storage, Box::new(NopCache));
+        let version_file = Arc::new(CollectionVersionFile {
+            collection_info_immutable: Some(CollectionInfoImmutable {
+                collection_id: Uuid::new_v4().to_string(),
+                tenant_id: "test_tenant".to_string(),
+                database_id: "test_db".to_string(),
+                dimension: 0,
+                ..Default::default()
+            }),
+            version_history: None,
+        });
+
+        let err = ListFilesAtVersionsOperator {}
+            .run(&ListFilesAtVersionInput::new(root_manager, version_file, 1))
+            .await
+            .expect_err("missing version history should fail");
+
+        assert!(matches!(
+            err,
+            ListFilesAtVersionError::VersionHistoryMissing
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_missing_collection_id_returns_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
+        let root_manager = RootManager::new(storage, Box::new(NopCache));
+        let version_file = Arc::new(CollectionVersionFile {
+            collection_info_immutable: None,
+            version_history: Some(CollectionVersionHistory { versions: vec![] }),
+        });
+
+        let err = ListFilesAtVersionsOperator {}
+            .run(&ListFilesAtVersionInput::new(root_manager, version_file, 1))
+            .await
+            .expect_err("missing collection id should fail");
+
+        assert!(matches!(
+            err,
+            ListFilesAtVersionError::VersionFileMissingCollectionId
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_invalid_collection_uuid_returns_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
+        let root_manager = RootManager::new(storage, Box::new(NopCache));
+        let version_file = Arc::new(CollectionVersionFile {
+            collection_info_immutable: Some(CollectionInfoImmutable {
+                collection_id: "not-a-uuid".to_string(),
+                tenant_id: "test_tenant".to_string(),
+                database_id: "test_db".to_string(),
+                dimension: 0,
+                ..Default::default()
+            }),
+            version_history: Some(CollectionVersionHistory {
+                versions: vec![CollectionVersionInfo {
+                    version: 1,
+                    segment_info: None,
+                    collection_info_mutable: None,
+                    created_at_secs: 0,
+                    version_change_reason: 0,
+                    version_file_name: String::new(),
+                    marked_for_deletion: false,
+                }],
+            }),
+        });
+
+        let err = ListFilesAtVersionsOperator {}
+            .run(&ListFilesAtVersionInput::new(root_manager, version_file, 1))
+            .await
+            .expect_err("invalid collection id should fail");
+
+        assert!(matches!(err, ListFilesAtVersionError::InvalidUuid(_)));
+    }
+
+    #[tokio::test]
+    async fn test_missing_requested_version_returns_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
+        let root_manager = RootManager::new(storage, Box::new(NopCache));
+        let version_file = create_version_file(
+            &Uuid::new_v4().to_string(),
+            vec![CollectionVersionInfo {
+                version: 1,
+                segment_info: None,
+                collection_info_mutable: None,
+                created_at_secs: 0,
+                version_change_reason: 0,
+                version_file_name: String::new(),
+                marked_for_deletion: false,
+            }],
+        );
+
+        let err = ListFilesAtVersionsOperator {}
+            .run(&ListFilesAtVersionInput::new(root_manager, version_file, 2))
+            .await
+            .expect_err("missing version should fail");
+
+        assert!(matches!(err, ListFilesAtVersionError::VersionNotFound(2)));
+    }
 }

--- a/rust/garbage_collector/src/operators/truncate_dirty_log.rs
+++ b/rust/garbage_collector/src/operators/truncate_dirty_log.rs
@@ -140,3 +140,138 @@ impl Operator<TruncateDirtyLogInput, TruncateDirtyLogOutput> for TruncateDirtyLo
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_log::{in_memory_log::InMemoryLog, Log};
+    use chroma_storage::{s3_client_for_test_with_new_bucket, GetOptions};
+    use chroma_system::Operator;
+    use wal3::{Cursor, CursorName, CursorStore, CursorStoreOptions, LogWriter, SnapshotOptions};
+
+    async fn seed_dirty_log(storage: Storage, replica_id: u64) -> String {
+        let prefix = format!("dirty-rust-log-service-{replica_id}");
+        let options = LogWriterOptions {
+            snapshot_manifest: SnapshotOptions {
+                snapshot_rollover_threshold: 2,
+                fragment_rollover_threshold: 2,
+            },
+            ..LogWriterOptions::default()
+        };
+        let storage = Arc::new(storage);
+        let (fragment_factory, manifest_factory) = create_s3_factories(
+            options.clone(),
+            LogReaderOptions::default(),
+            storage.clone(),
+            prefix.clone(),
+            "dirty-log-writer".to_string(),
+            Arc::new(()),
+            Arc::new(()),
+        );
+        let log = LogWriter::open_or_initialize(
+            options,
+            "dirty-log-writer",
+            fragment_factory,
+            manifest_factory,
+            None,
+        )
+        .await
+        .expect("dirty log should initialize");
+
+        let mut keep_position = LogPosition::default();
+        for i in 0..40 {
+            let position = log
+                .append_many(
+                    (0..5)
+                        .map(|j| format!("dirty:{replica_id}:{i}:{j}").into_bytes())
+                        .collect(),
+                )
+                .await
+                .expect("append should succeed");
+            if i == 20 {
+                keep_position = position;
+            }
+        }
+
+        let cursors = CursorStore::new(
+            CursorStoreOptions::default(),
+            storage,
+            prefix.clone(),
+            "cursor-writer".to_string(),
+        );
+        cursors
+            .init(
+                &CursorName::new("so_you_may_gc").expect("cursor name should be valid"),
+                Cursor {
+                    position: keep_position,
+                    epoch_us: keep_position.offset(),
+                    writer: "dirty-log-writer".to_string(),
+                },
+            )
+            .await
+            .expect("cursor should initialize");
+
+        prefix
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_truncate_dirty_log_returns_no_log_service_found_when_uninitialized(
+    ) {
+        let storage = s3_client_for_test_with_new_bucket().await;
+
+        let err = TruncateDirtyLogOperator {
+            storage,
+            logs: Log::InMemory(InMemoryLog::new()),
+        }
+        .run(&())
+        .await
+        .expect_err("missing dirty logs should fail");
+
+        assert!(matches!(err, TruncateDirtyLogError::NoLogServiceFound));
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_truncate_dirty_log_truncates_multiple_prefixes() {
+        let storage = s3_client_for_test_with_new_bucket().await;
+        let prefix0 = seed_dirty_log(storage.clone(), 0).await;
+        let prefix1 = seed_dirty_log(storage.clone(), 1).await;
+        let before0 = storage
+            .list_prefix(&prefix0, GetOptions::default())
+            .await
+            .expect("list should succeed");
+        let before1 = storage
+            .list_prefix(&prefix1, GetOptions::default())
+            .await
+            .expect("list should succeed");
+
+        TruncateDirtyLogOperator {
+            storage: storage.clone(),
+            logs: Log::InMemory(InMemoryLog::new()),
+        }
+        .run(&())
+        .await
+        .expect("dirty log truncation should succeed");
+
+        let after0 = storage
+            .list_prefix(&prefix0, GetOptions::default())
+            .await
+            .expect("list should succeed");
+        let after1 = storage
+            .list_prefix(&prefix1, GetOptions::default())
+            .await
+            .expect("list should succeed");
+
+        assert!(
+            after0.len() < before0.len(),
+            "expected replica 0 dirty log to shrink, before={} after={}",
+            before0.len(),
+            after0.len()
+        );
+        assert!(
+            after1.len() < before1.len(),
+            "expected replica 1 dirty log to shrink, before={} after={}",
+            before1.len(),
+            after1.len()
+        );
+    }
+}

--- a/rust/garbage_collector/src/types.rs
+++ b/rust/garbage_collector/src/types.rs
@@ -214,6 +214,7 @@ impl FilePathRefCountSet {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
 
     #[test]
     fn test_file_path_set_basics() {
@@ -354,5 +355,99 @@ mod tests {
                 "path/one".to_string()
             ])
         );
+    }
+
+    #[test]
+    fn test_version_graph_to_collection_dependency_graph_ignores_intra_collection_edges() {
+        let collection_a = CollectionUuid::new();
+        let collection_b = CollectionUuid::new();
+        let collection_c = CollectionUuid::new();
+        let mut version_graph = VersionGraph::new();
+
+        let a_v0 = version_graph.add_node(VersionGraphNode {
+            collection_id: collection_a,
+            version: 0,
+            status: VersionStatus::Alive {
+                created_at: Utc::now(),
+            },
+        });
+        let a_v1 = version_graph.add_node(VersionGraphNode {
+            collection_id: collection_a,
+            version: 1,
+            status: VersionStatus::Alive {
+                created_at: Utc::now(),
+            },
+        });
+        let b_v0 = version_graph.add_node(VersionGraphNode {
+            collection_id: collection_b,
+            version: 0,
+            status: VersionStatus::Alive {
+                created_at: Utc::now(),
+            },
+        });
+        let c_v0 = version_graph.add_node(VersionGraphNode {
+            collection_id: collection_c,
+            version: 0,
+            status: VersionStatus::Alive {
+                created_at: Utc::now(),
+            },
+        });
+
+        version_graph.add_edge(a_v0, a_v1, ());
+        version_graph.add_edge(a_v1, b_v0, ());
+        version_graph.add_edge(b_v0, c_v0, ());
+
+        let dependency_graph = version_graph_to_collection_dependency_graph(&version_graph);
+
+        assert!(dependency_graph.contains_node(collection_a));
+        assert!(dependency_graph.contains_node(collection_b));
+        assert!(dependency_graph.contains_node(collection_c));
+        assert!(dependency_graph.contains_edge(collection_a, collection_b));
+        assert!(dependency_graph.contains_edge(collection_b, collection_c));
+        assert!(!dependency_graph.contains_edge(collection_a, collection_a));
+    }
+
+    #[test]
+    fn test_version_graph_to_collection_dependency_graph_deduplicates_collection_edges() {
+        let collection_a = CollectionUuid::new();
+        let collection_b = CollectionUuid::new();
+        let mut version_graph = VersionGraph::new();
+
+        let a_v0 = version_graph.add_node(VersionGraphNode {
+            collection_id: collection_a,
+            version: 0,
+            status: VersionStatus::Alive {
+                created_at: Utc::now(),
+            },
+        });
+        let a_v1 = version_graph.add_node(VersionGraphNode {
+            collection_id: collection_a,
+            version: 1,
+            status: VersionStatus::Alive {
+                created_at: Utc::now(),
+            },
+        });
+        let b_v0 = version_graph.add_node(VersionGraphNode {
+            collection_id: collection_b,
+            version: 0,
+            status: VersionStatus::Alive {
+                created_at: Utc::now(),
+            },
+        });
+        let b_v1 = version_graph.add_node(VersionGraphNode {
+            collection_id: collection_b,
+            version: 1,
+            status: VersionStatus::Alive {
+                created_at: Utc::now(),
+            },
+        });
+
+        version_graph.add_edge(a_v0, b_v0, ());
+        version_graph.add_edge(a_v1, b_v1, ());
+
+        let dependency_graph = version_graph_to_collection_dependency_graph(&version_graph);
+
+        assert_eq!(dependency_graph.edge_count(), 1);
+        assert!(dependency_graph.contains_edge(collection_a, collection_b));
     }
 }


### PR DESCRIPTION
## Description of changes

The empty-path invariant check in handle_list_files_at_version_output
looked up the version file once using the output collection ID, then
reused it for every ancestor node in the graph walk.  When the version
graph spans multiple collections, ancestor nodes from a different
collection were checked against the wrong version file, allowing
cross-collection version collisions to bypass the invariant.

Move the version file lookup inside the per-node loop so each ancestor
resolves against its own collection version file.

Also add comprehensive test coverage across the garbage collector
crate:

- garbage_collector_component: collection filtering by assignment
  policy, disallow list, and manual GC request handling
- garbage_collector_orchestrator_v2: cross-collection version
  collision detection in the empty-path invariant check
- lib: GarbageCollectorService kickoff request validation
- operators/delete_unused_logs: delete mode, dry run, and hard delete
- operators/fetch_lineage_file: success, missing object, and decode
  error paths
- operators/fetch_version_file: missing collection info and invalid
  UUID; refactor to use test_storage()
- operators/get_version_file_paths: success and missing path
- operators/list_files_at_version: HNSW index path expansion,
  quantized SPANN paths, sparse index fallback, and error conditions
- operators/truncate_dirty_log: uninitialized state and multi-prefix
  truncation
- types: version_graph_to_collection_dependency_graph edge filtering
  and deduplication

## Test plan

CI

## Migration plan

Backwards-compatible.

## Observability plan

Watch staging + tests.

## Documentation Changes

N/A

Co-authored-by: AI
