### PR TITLE
[BUG] remove @chroma-core/ollama runtime dependency on testcontainers

### DIFF
--- a/clients/new-js/packages/ai-embeddings/ollama/package-manifest.test.ts
+++ b/clients/new-js/packages/ai-embeddings/ollama/package-manifest.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+test("does not ship testcontainers as a runtime dependency", () => {
+  const packageJsonPath = path.resolve(__dirname, "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+  expect(packageJson.dependencies?.testcontainers).toBeUndefined();
+});

--- a/clients/new-js/packages/ai-embeddings/ollama/package.json
+++ b/clients/new-js/packages/ai-embeddings/ollama/package.json
@@ -35,6 +35,7 @@
     "dotenv": "^16.3.1",
     "jest": "^29.7.0",
     "rimraf": "^5.0.0",
+    "testcontainers": "^10.9.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "tsup": "^8.3.5"
@@ -44,8 +45,7 @@
   },
   "dependencies": {
     "@chroma-core/ai-embeddings-common": "workspace:^",
-    "ollama": "^0.5.15",
-    "testcontainers": "^10.9.0"
+    "ollama": "^0.5.15"
   },
   "engines": {
     "node": ">=20"

--- a/clients/new-js/pnpm-lock.yaml
+++ b/clients/new-js/pnpm-lock.yaml
@@ -468,9 +468,6 @@ importers:
       ollama:
         specifier: ^0.5.15
         version: 0.5.15
-      testcontainers:
-        specifier: ^10.9.0
-        version: 10.25.0
     devDependencies:
       '@jest/globals':
         specifier: ^29.7.0
@@ -484,6 +481,9 @@ importers:
       rimraf:
         specifier: ^5.0.0
         version: 5.0.10
+      testcontainers:
+        specifier: ^10.9.0
+        version: 10.25.0
       ts-jest:
         specifier: ^29.1.2
         version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3)


### PR DESCRIPTION
## Description of changes

`@chroma-core/ollama` listed `testcontainers` as a runtime dependency even though it is only used by the local `start-ollama.ts` helper. This moves `testcontainers` to `devDependencies` so consumers do not install an extra copy just by depending on the package.

- Improvements & Bug fixes
  - move `testcontainers` from runtime deps to devDependencies in `packages/ai-embeddings/ollama/package.json`
  - update the pnpm lockfile importer entry for `@chroma-core/ollama`
  - add a regression test that guards against shipping `testcontainers` as a runtime dependency again
- New functionality
  - none

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
- `pnpm --filter "@chroma-core/ollama" test`
- `pnpm --filter "@chroma-core/ollama" build`

## Migration plan

No migration is needed. Package consumers just stop pulling in an unused runtime dependency.

## Observability plan

No runtime behavior changes, so no new observability is needed.

## Documentation Changes

No documentation changes needed.

Fixes #6972