### PR TITLE
[DOC]: Document file-upload sync API, AWS credential reuse, and EU region

### DIFF
--- a/docs/mintlify/cloud/getting-started.mdx
+++ b/docs/mintlify/cloud/getting-started.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Getting Started"
 
 Our fully managed hosted service, **Chroma Cloud** is here. [Sign up for free](https://trychroma.com/signup?utm_source=docs-getting-started).
 
-**Chroma Cloud** is a managed offering of [Distributed Chroma](/reference/architecture/distributed), operated by the same database engineers who build Chroma. Chroma Cloud implements the same APIs as open-source Chroma, but runs on a distributed vector indexing system to support much larger scale than a single instance of open-source Chroma. Chroma Cloud runs in various regions across AWS and GCP and supports multi-region replication. Chroma Cloud is serverless - you don't have to provision servers or think about operations, and is billed [based on usage](/cloud/pricing)
+**Chroma Cloud** is a managed offering of [Distributed Chroma](/reference/architecture/distributed), operated by the same database engineers who build Chroma. Chroma Cloud implements the same APIs as open-source Chroma, but runs on a distributed vector indexing system to support much larger scale than a single instance of open-source Chroma. Chroma Cloud runs in [multiple regions](#regions) across AWS and GCP — each database stays entirely within the region you choose. Chroma Cloud is serverless - you don't have to provision servers or think about operations, and is billed [based on usage](/cloud/pricing)
 
 ### Easy to use and operate
 
@@ -17,7 +17,29 @@ Reliability and accuracy are core to the design. Chroma Cloud is thoroughly test
 
 ### Security and Deployment
 
-Chroma Cloud is SOC 2 Type II certified, and offers deployment flexibility to match your needs. You can sign up for our fully-managed multi-tenant cluster currently running in AWS us-east-1 or contact us for single-tenant deployment managed by Chroma or hosted in your own VPC (BYOC). If you ever want to self-host open source Chroma, we will help you transition your data from Cloud to your self-managed deployment.
+Chroma Cloud is SOC 2 Type II certified, and offers deployment flexibility to match your needs. You can sign up for our fully-managed multi-tenant cluster running in AWS `us-east-1` or GCP `europe-west1`, or contact us for single-tenant deployment managed by Chroma or hosted in your own VPC (BYOC). If you ever want to self-host open source Chroma, we will help you transition your data from Cloud to your self-managed deployment.
+
+### Regions
+
+Chroma Cloud's multi-tenant offering currently runs in two regions:
+
+| Region | Slug | Endpoint |
+|--------|------|----------|
+| AWS US East (N. Virginia) | `aws-us-east-1` | `api.trychroma.com` (default) |
+| GCP Europe West 1 (Belgium) | `gcp-europe-west1` | `europe-west1.gcp.trychroma.com` |
+
+Each database is created in a single region and stays there — your data is stored and processed entirely within the region you select. Pick the region when creating a database in the dashboard, or pass it when creating a database via the API. Existing US databases are unaffected; to move data to the EU, create a new database in `gcp-europe-west1` and reindex.
+
+Connecting to a non-default region only requires pointing the client at the right host. See [Connecting to a non-default region](/docs/run-chroma/clients#connecting-to-a-non-default-region) for SDK examples.
+
+#### Feature availability by region
+
+| Feature | `aws-us-east-1` | `gcp-europe-west1` |
+|---------|----------------|--------------------|
+| Core API (collections, search, forking) | ✓ | ✓ |
+| Chroma Sync (S3, GitHub, Web, file upload) | ✓ | — |
+| Chroma CLI (`chroma db`, `chroma browse`) | ✓ | — |
+| Chroma Search Agent | ✓ | — |
 
 ### Dashboard
 

--- a/docs/mintlify/cloud/sync/file-upload.mdx
+++ b/docs/mintlify/cloud/sync/file-upload.mdx
@@ -3,9 +3,9 @@ title: File Upload
 description: Upload individual files directly to Chroma Cloud.
 ---
 
-The file upload API lets you upload a single file directly to sync. You send a multipart `POST` to `https://sync.trychroma.com/api/v1/add-file` with the file and a target collection; Chroma chunks, embeds, and indexes it just like any other Sync source.
+The file upload API lets you upload a single file directly to sync. You send a `POST` to `https://sync.trychroma.com/api/v1/add-file` with the file and a target collection; Chroma chunks, embeds, and indexes it just like any other Sync source.
 
-Each upload specifies a `collection_name`. If a collection with that name already exists in the database, the new content is added to it. Otherwise the collection is created on the first upload.
+Every upload names a target collection. If a collection with that name already exists in the database, the new content is added to it. Otherwise the collection is created on the first upload.
 
 ## Walkthrough
 

--- a/docs/mintlify/cloud/sync/file-upload.mdx
+++ b/docs/mintlify/cloud/sync/file-upload.mdx
@@ -1,21 +1,22 @@
 ---
 title: File Upload
-description: Push individual files directly into Chroma Cloud over HTTP.
+description: Upload individual files directly to Chroma Cloud.
 ---
 
-The file upload API lets you index a single file in Chroma without first staging it in S3 or GitHub. You send a multipart `POST` to `https://sync.trychroma.com/api/v1/add-file` with the file and target collection; Chroma chunks, embeds, and indexes it just like any other Sync source.
+The file upload API lets you upload a single file directly to sync. You send a multipart `POST` to `https://sync.trychroma.com/api/v1/add-file` with the file and a target collection; Chroma chunks, embeds, and indexes it just like any other Sync source.
 
-The first time you upload to a database, Chroma creates a `file_upload` source for that database automatically. Every subsequent upload to the same database reuses that source. You don't need to (and can't) create file-upload sources via `POST /api/v1/sources`.
+Each upload specifies a `collection_name`. If a collection with that name already exists in the database, the new content is added to it. Otherwise the collection is created on the first upload.
 
 ## Walkthrough
 
 ### Uploading via the Dashboard
 
-1. Open a collection in Chroma Cloud and click **Add data**.
-2. Choose **Upload file** and drag a file or pick one from your computer.
-3. Optionally set a custom document ID and metadata, then submit.
+There are two ways to upload files from the dashboard:
 
-The dashboard creates an invocation and shows progress on the collection's Sync page. The file is processed using the [same pipeline](/cloud/sync/s3#supported-file-types) as S3 sources — documents are converted to markdown, code is chunked with tree-sitter, and everything else is split line-by-line.
+- **From the Add data page.** Open a database, choose **Add data**, and select **File upload**. Drop or pick one or more files; Chroma chunks and embeds them into a collection named `file_upload` (created on the first upload).
+- **From a collection page.** Open any collection and click **Upload files**. Files are uploaded into that collection.
+
+Both flows accept the same file types: PDFs, Office documents, spreadsheets, presentations, HTML, ebooks, images, and any UTF-8 text or markdown file. The 200 MB-per-file limit is enforced in the browser before the upload starts.
 
 ### Uploading via the API
 
@@ -24,8 +25,7 @@ The endpoint is multipart `POST /api/v1/add-file`. Two rules to be aware of:
 - The header `x-upload-content-length` (file size in bytes) is required.
 - `database_name` and `collection_name` **must appear before** the `file` part. Chroma authorizes the request and acquires an upload slot before streaming any bytes — so these fields have to arrive first.
 
-<CodeGroup>
-```bash curl
+```bash
 curl -X POST https://sync.trychroma.com/api/v1/add-file \
   -H "x-chroma-token: $CHROMA_API_KEY" \
   -H "x-upload-content-length: $(stat -f%z report.pdf)" \
@@ -35,65 +35,6 @@ curl -X POST https://sync.trychroma.com/api/v1/add-file \
   -F 'metadata={"author":"Jane Doe","year":2024}' \
   -F "file=@report.pdf"
 ```
-
-```python Python
-import os
-import requests
-
-path = "report.pdf"
-
-with open(path, "rb") as f:
-    response = requests.post(
-        "https://sync.trychroma.com/api/v1/add-file",
-        headers={
-            "x-chroma-token": os.environ["CHROMA_API_KEY"],
-            "x-upload-content-length": str(os.path.getsize(path)),
-        },
-        # Order matters: database_name and collection_name must come before file.
-        files=[
-            ("database_name", (None, "my-db")),
-            ("collection_name", (None, "my-collection")),
-            ("custom_id", (None, "report-2024-q4")),
-            ("metadata", (None, '{"author":"Jane Doe","year":2024}')),
-            ("file", ("report.pdf", f, "application/pdf")),
-        ],
-    )
-
-response.raise_for_status()
-print(response.json())  # {"invocation_id": "..."}
-```
-
-```typescript TypeScript
-import { readFileSync, statSync } from "node:fs";
-
-const path = "report.pdf";
-const data = readFileSync(path);
-
-const form = new FormData();
-// Order matters: database_name and collection_name must come before file.
-form.append("database_name", "my-db");
-form.append("collection_name", "my-collection");
-form.append("custom_id", "report-2024-q4");
-form.append("metadata", JSON.stringify({ author: "Jane Doe", year: 2024 }));
-form.append("file", new Blob([data], { type: "application/pdf" }), "report.pdf");
-
-const response = await fetch("https://sync.trychroma.com/api/v1/add-file", {
-  method: "POST",
-  headers: {
-    "x-chroma-token": process.env.CHROMA_API_KEY!,
-    "x-upload-content-length": String(statSync(path).size),
-  },
-  body: form,
-});
-
-if (!response.ok) {
-  throw new Error(`Upload failed: ${response.status}`);
-}
-
-const { invocation_id } = await response.json();
-console.log(invocation_id);
-```
-</CodeGroup>
 
 A successful request returns `201 Created` with the invocation ID:
 
@@ -110,7 +51,7 @@ You can then poll [`GET /api/v1/invocations/{invocation_id}`](/reference/sync-ap
 | Field | Required | Description |
 |-------|----------|-------------|
 | `database_name` | Yes | Database in which to index the file. **Must come before `file`.** |
-| `collection_name` | Yes | Target collection. Created on first use. **Must come before `file`.** |
+| `collection_name` | Yes | Target collection. Created on first use, otherwise appended to. **Must come before `file`.** |
 | `file` | Yes | File content. Maximum 200 MiB. The filename in the part header is used as the document name. |
 | `custom_id` | No | Custom document ID (max 120 bytes). Chunk IDs become `custom_id-{chunk}` instead of `sha256(filename)-{chunk}`. |
 | `metadata` | No | JSON object of additional metadata merged with chunk metadata. Maximum 16 KiB. Keys reserved by Chroma (e.g. `chroma_*`) are rejected. |

--- a/docs/mintlify/cloud/sync/file-upload.mdx
+++ b/docs/mintlify/cloud/sync/file-upload.mdx
@@ -5,7 +5,7 @@ description: Upload individual files directly to Chroma Cloud.
 
 The file upload API lets you upload a single file directly to sync. You send a `POST` to `https://sync.trychroma.com/api/v1/add-file` with the file and a target collection; Chroma chunks, embeds, and indexes it just like any other Sync source.
 
-Every upload names a target collection. If a collection with that name already exists in the database, the new content is added to it. Otherwise the collection is created on the first upload.
+File uploads can name a target collection, which sync will [get or create](/docs/collections/manage-collections#getting-collections).
 
 ## Walkthrough
 
@@ -14,16 +14,16 @@ Every upload names a target collection. If a collection with that name already e
 There are two ways to upload files from the dashboard:
 
 - **From the Add data page.** Open a database, choose **Add data**, and select **File upload**. Drop or pick one or more files; Chroma chunks and embeds them into a collection named `file_upload` (created on the first upload).
-- **From a collection page.** Open any collection and click **Upload files**. Files are uploaded into that collection.
+- **From a collection page.** On a collection page, if the [Schema](/cloud/schema/overview) is compatible with sync - an "Upload files" button will be visible. Select this button to upload files into that collection.
 
-Both flows accept the same file types: PDFs, Office documents, spreadsheets, presentations, HTML, ebooks, images, and any UTF-8 text or markdown file. The 200 MB-per-file limit is enforced in the browser before the upload starts.
+Both flows accept the same [file types](/cloud/sync/s3#supported-file-types): PDFs, Office documents, spreadsheets, presentations, HTML, ebooks, images, and any UTF-8 text or markdown file. The 200 MB-per-file limit is enforced in the browser before the upload starts.
 
 ### Uploading via the API
 
 The endpoint is multipart `POST /api/v1/add-file`. Two rules to be aware of:
 
 - The header `x-upload-content-length` (file size in bytes) is required.
-- `database_name` and `collection_name` **must appear before** the `file` part. Chroma authorizes the request and acquires an upload slot before streaming any bytes — so these fields have to arrive first.
+- `database_name` and `collection_name` **must appear before** the `file` part.
 
 ```bash
 curl -X POST https://sync.trychroma.com/api/v1/add-file \

--- a/docs/mintlify/cloud/sync/file-upload.mdx
+++ b/docs/mintlify/cloud/sync/file-upload.mdx
@@ -1,0 +1,127 @@
+---
+title: File Upload
+description: Push individual files directly into Chroma Cloud over HTTP.
+---
+
+The file upload API lets you index a single file in Chroma without first staging it in S3 or GitHub. You send a multipart `POST` to `https://sync.trychroma.com/api/v1/add-file` with the file and target collection; Chroma chunks, embeds, and indexes it just like any other Sync source.
+
+The first time you upload to a database, Chroma creates a `file_upload` source for that database automatically. Every subsequent upload to the same database reuses that source. You don't need to (and can't) create file-upload sources via `POST /api/v1/sources`.
+
+## Walkthrough
+
+### Uploading via the Dashboard
+
+1. Open a collection in Chroma Cloud and click **Add data**.
+2. Choose **Upload file** and drag a file or pick one from your computer.
+3. Optionally set a custom document ID and metadata, then submit.
+
+The dashboard creates an invocation and shows progress on the collection's Sync page. The file is processed using the [same pipeline](/cloud/sync/s3#supported-file-types) as S3 sources — documents are converted to markdown, code is chunked with tree-sitter, and everything else is split line-by-line.
+
+### Uploading via the API
+
+The endpoint is multipart `POST /api/v1/add-file`. Two rules to be aware of:
+
+- The header `x-upload-content-length` (file size in bytes) is required.
+- `database_name` and `collection_name` **must appear before** the `file` part. Chroma authorizes the request and acquires an upload slot before streaming any bytes — so these fields have to arrive first.
+
+<CodeGroup>
+```bash curl
+curl -X POST https://sync.trychroma.com/api/v1/add-file \
+  -H "x-chroma-token: $CHROMA_API_KEY" \
+  -H "x-upload-content-length: $(stat -f%z report.pdf)" \
+  -F "database_name=my-db" \
+  -F "collection_name=my-collection" \
+  -F "custom_id=report-2024-q4" \
+  -F 'metadata={"author":"Jane Doe","year":2024}' \
+  -F "file=@report.pdf"
+```
+
+```python Python
+import os
+import requests
+
+path = "report.pdf"
+
+with open(path, "rb") as f:
+    response = requests.post(
+        "https://sync.trychroma.com/api/v1/add-file",
+        headers={
+            "x-chroma-token": os.environ["CHROMA_API_KEY"],
+            "x-upload-content-length": str(os.path.getsize(path)),
+        },
+        # Order matters: database_name and collection_name must come before file.
+        files=[
+            ("database_name", (None, "my-db")),
+            ("collection_name", (None, "my-collection")),
+            ("custom_id", (None, "report-2024-q4")),
+            ("metadata", (None, '{"author":"Jane Doe","year":2024}')),
+            ("file", ("report.pdf", f, "application/pdf")),
+        ],
+    )
+
+response.raise_for_status()
+print(response.json())  # {"invocation_id": "..."}
+```
+
+```typescript TypeScript
+import { readFileSync, statSync } from "node:fs";
+
+const path = "report.pdf";
+const data = readFileSync(path);
+
+const form = new FormData();
+// Order matters: database_name and collection_name must come before file.
+form.append("database_name", "my-db");
+form.append("collection_name", "my-collection");
+form.append("custom_id", "report-2024-q4");
+form.append("metadata", JSON.stringify({ author: "Jane Doe", year: 2024 }));
+form.append("file", new Blob([data], { type: "application/pdf" }), "report.pdf");
+
+const response = await fetch("https://sync.trychroma.com/api/v1/add-file", {
+  method: "POST",
+  headers: {
+    "x-chroma-token": process.env.CHROMA_API_KEY!,
+    "x-upload-content-length": String(statSync(path).size),
+  },
+  body: form,
+});
+
+if (!response.ok) {
+  throw new Error(`Upload failed: ${response.status}`);
+}
+
+const { invocation_id } = await response.json();
+console.log(invocation_id);
+```
+</CodeGroup>
+
+A successful request returns `201 Created` with the invocation ID:
+
+```json
+{
+  "invocation_id": "9c8c1d1e-..."
+}
+```
+
+You can then poll [`GET /api/v1/invocations/{invocation_id}`](/reference/sync-api) to track progress.
+
+## Multipart Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `database_name` | Yes | Database in which to index the file. **Must come before `file`.** |
+| `collection_name` | Yes | Target collection. Created on first use. **Must come before `file`.** |
+| `file` | Yes | File content. Maximum 200 MiB. The filename in the part header is used as the document name. |
+| `custom_id` | No | Custom document ID (max 120 bytes). Chunk IDs become `custom_id-{chunk}` instead of `sha256(filename)-{chunk}`. |
+| `metadata` | No | JSON object of additional metadata merged with chunk metadata. Maximum 16 KiB. Keys reserved by Chroma (e.g. `chroma_*`) are rejected. |
+| `embedding` | No | JSON `SourceEmbeddingConfig`. Defaults to Qwen3-Embedding-0.6B with `generic_retrieval` task plus Splade sparse embeddings. |
+| `chunking` | No | JSON `SourceChunkingConfig`. Defaults to tree-sitter syntax-aware chunking with markdown/line-based fallbacks. |
+| `content_type` | No | MIME type override. Otherwise inferred from the file part header (if not `application/octet-stream`) or the filename extension. |
+
+## Limits
+
+- **Maximum file size**: 200 MiB per file (enforced via `x-upload-content-length`).
+- **Concurrency**: Each team has a per-tenant cap on simultaneous in-flight uploads. Excess requests return `429 Too Many Requests`.
+- **Database region**: Only available for Chroma databases hosted in `aws-us-east-1`. See [Regions](/cloud/getting-started#regions).
+
+Supported file types and the chunking pipeline are the same as S3 Sync — see [Supported File Types](/cloud/sync/s3#supported-file-types) and [Chunking](/cloud/sync/s3#chunking).

--- a/docs/mintlify/cloud/sync/file-upload.mdx
+++ b/docs/mintlify/cloud/sync/file-upload.mdx
@@ -14,7 +14,7 @@ File uploads can name a target collection, which sync will [get or create](/docs
 There are two ways to upload files from the dashboard:
 
 - **From the Add data page.** Open a database, choose **Add data**, and select **File upload**. Drop or pick one or more files; Chroma chunks and embeds them into a collection named `file_upload` (created on the first upload).
-- **From a collection page.** On a collection page, if the [Schema](/cloud/schema/overview) is compatible with sync - an "Upload files" button will be visible. Select this button to upload files into that collection.
+- **From a collection page.** On a collection page, if the [Schema](/cloud/schema/overview) is compatible with sync — an "Upload files" button will be visible. Select this button to upload files into that collection.
 
 Both flows accept the same [file types](/cloud/sync/s3#supported-file-types): PDFs, Office documents, spreadsheets, presentations, HTML, ebooks, images, and any UTF-8 text or markdown file. The 200 MB-per-file limit is enforced in the browser before the upload starts.
 

--- a/docs/mintlify/cloud/sync/overview.mdx
+++ b/docs/mintlify/cloud/sync/overview.mdx
@@ -6,15 +6,17 @@ Chroma Sync exposes endpoints for developers to chunk, embed, and index various 
 
 # Key Concepts
 
-Chroma Sync has three primary concepts: **source types**, **sources** and **invocations**.
+Chroma Sync has three primary concepts: **source types**, **sources**, and **invocations**.
 
 # Source Types
 
-A source type defines a kind of entity that contains data that can be chunked, embedded, and indexed. Each source type defines its own schema for configuring sources of its type. Chroma Sync currently supports three source types: **S3 buckets**, **GitHub repositories**, and **web scraping**. If there is a specific source type for which you would like support, please reach out to [engineering@trychroma.com](mailto:engineering@trychroma.com).
+A source type defines a kind of entity that contains data that can be chunked, embedded, and indexed. Each source type defines its own schema for configuring sources of its type. Chroma Sync supports four source types: **S3 buckets**, **GitHub repositories**, **web scraping**, and **direct file upload**. If there is a specific source type for which you would like support, please reach out to [engineering@trychroma.com](mailto:engineering@trychroma.com).
 
 ## S3
 
 The S3 source type allows developers to sync files from Amazon S3 buckets into Chroma. It supports documents (PDFs, Office files, images, ebooks), code, and plain text. S3 sources can be configured with auto-sync to automatically index files as they are uploaded to S3. For a detailed walkthrough, see [S3 Sync docs](/cloud/sync/s3).
+
+AWS credentials can be saved in the Chroma dashboard once and reused across multiple S3 sources. See [AWS Credentials](/cloud/sync/s3#aws-credentials).
 
 ## GitHub Repositories
 
@@ -33,6 +35,10 @@ The platform tier grants access to the Chroma Sync API and is ideal for companie
 ## Web
 
 The web source type allows developers to scrape the contents of web pages into Chroma. Given a starting URL, Sync will crawl the page and its links up to a specified depth.
+
+## File Upload
+
+The file upload source type lets you push individual files directly to Chroma over HTTP without staging them in S3 or GitHub first. Each database has at most one file-upload source, which is created automatically the first time you call the upload endpoint for that database. For a detailed walkthrough, see [File Upload docs](/cloud/sync/file-upload).
 
 # Sources
 
@@ -104,7 +110,7 @@ A source of the S3 type is configured with a bucket name, region, collection nam
 - `bucket_name` is the name of the S3 bucket to sync from.
 - `region` is the AWS region of the bucket.
 - `collection_name` is the default target collection name for synced data.
-- `aws_credential_id` is the ID of AWS credentials.
+- `aws_credential_id` is the ID of AWS credentials saved in the Chroma dashboard. As an alternative, you can pass `aws_access_key_id` and `aws_secret_access_key` inline; Chroma will save them on your team and return a credential ID for reuse.
 - `path_prefix` (optional) limits which S3 keys can be synced. Only keys starting with this prefix are allowed.
 - `auto_sync` (optional) sets the auto-sync mode: `none` (default), `direct`, or `metadata`. See [S3 Auto-Sync](/cloud/sync/s3#auto-sync).
 
@@ -138,6 +144,10 @@ A source of the web type is configured with a starting URL and a few other optio
     "max_depth": 2
 }
 ```
+
+## File Upload
+
+File-upload sources are not created via `POST /api/v1/sources`. Instead, the first call to [`POST /api/v1/add-file`](/cloud/sync/file-upload) for a database creates the source automatically; subsequent uploads to the same database reuse it. Each database has at most one file-upload source.
 
 # Invocations
 
@@ -187,5 +197,9 @@ Invocations on sources of the GitHub repository type are sync runs over an indiv
 ```
 
 - `ref_identifier` is either the commit SHA-256 or the name of the branch from which to retrieve the code to be synced. If a branch is provided, the code will be retrieved from the branch's latest commit.
+
+## File Upload
+
+Invocations on file-upload sources are created by calling [`POST /api/v1/add-file`](/cloud/sync/file-upload) directly with a multipart form, not by calling `POST /api/v1/sources/{source_id}/invocations`. Each call to `add-file` creates one invocation that indexes the uploaded file into the target collection.
 
 For all API endpoints, see the [Sync API Reference](/reference/sync-api).

--- a/docs/mintlify/cloud/sync/overview.mdx
+++ b/docs/mintlify/cloud/sync/overview.mdx
@@ -12,7 +12,7 @@ Sync runs the same pipeline regardless of source:
 2. **High throughput.** The pipeline is designed to maximize throughput without dropping work, whether you're syncing a handful of files or millions of documents.
 3. **Parse.** Best-in-class PDF and document parsing. PDFs, Office documents, HTML, ebooks, and images are converted to clean markdown with tables, headings, lists, and layout preserved — so chunks reflect the actual structure of the document, not just the raw text stream. Images inside documents are described in text so their content remains searchable. Code files are kept as-is.
 4. **Chunk.** Tree-sitter syntax-aware chunking for code; structured markdown chunking for documents; line-based fallback for plain text. The strategy is configurable per source.
-5. **Embed.** Dense embeddings are generated automatically with [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B). Optional sparse embeddings are available via [Splade](https://huggingface.co/prithivida/Splade_PP_en_v1) or [BM25](https://en.wikipedia.org/wiki/Okapi_BM25). No extra API keys needed.
+5. **Embed.** Dense embeddings are generated automatically with [Qwen3-Embedding-0.6B](/integrations/embedding-models/chroma-cloud-qwen#chroma-cloud-qwen). Optional sparse embeddings are available via [Splade](/integrations/embedding-models/chroma-cloud-splade#chroma-cloud-splade) or [BM25](https://en.wikipedia.org/wiki/Okapi_BM25). No extra API keys needed.
 6. **Index.** Output is written into the target Chroma collection, ready for vector, full-text, regex, sparse, and hybrid search.
 
 # Source Types

--- a/docs/mintlify/cloud/sync/overview.mdx
+++ b/docs/mintlify/cloud/sync/overview.mdx
@@ -10,7 +10,7 @@ Sync runs the same pipeline regardless of source:
 
 1. **Managed ingestion.** Connect a source once; every invocation runs through Chroma's queue-based pipeline with automatic retries, rate-limit awareness, and error recovery. Monitor invocations in the dashboard or through the [Sync API](/reference/sync-api).
 2. **High throughput.** The pipeline is designed to maximize throughput without dropping work, whether you're syncing a handful of files or millions of documents.
-3. **Parse.** PDFs, Office documents, HTML, ebooks, and images are converted to clean markdown with tables, headings, and structure preserved. Code files are kept as-is.
+3. **Parse.** Best-in-class PDF and document parsing. PDFs, Office documents, HTML, ebooks, and images are converted to clean markdown with tables, headings, lists, and layout preserved — so chunks reflect the actual structure of the document, not just the raw text stream. Images inside documents are described in text so their content remains searchable. Code files are kept as-is.
 4. **Chunk.** Tree-sitter syntax-aware chunking for code; structured markdown chunking for documents; line-based fallback for plain text. The strategy is configurable per source.
 5. **Embed.** Dense embeddings are generated automatically with [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B). Optional sparse embeddings are available via [Splade](https://huggingface.co/prithivida/Splade_PP_en_v1) or [BM25](https://en.wikipedia.org/wiki/Okapi_BM25). No extra API keys needed.
 6. **Index.** Output is written into the target Chroma collection, ready for vector, full-text, regex, sparse, and hybrid search.

--- a/docs/mintlify/cloud/sync/overview.mdx
+++ b/docs/mintlify/cloud/sync/overview.mdx
@@ -2,72 +2,60 @@
 title: Overview
 ---
 
-Chroma Sync exposes endpoints for developers to chunk, embed, and index various data sources. The API is intended for Chroma Cloud users and can be accessed for free (up to $5 in credits) by creating a Chroma Cloud account.
+Chroma Sync is a managed ingestion service for Chroma Cloud. Point a source — an S3 bucket, a GitHub repository, a website, or an individual file upload — at a Chroma database, and Chroma parses, chunks, embeds, and indexes the data into a collection that's ready to query. No ingest infrastructure to write, no embedding API keys to manage. The Sync API is available to all Chroma Cloud users and the first $5 of usage is free with a new account.
 
-# Key Concepts
+# How Chroma Sync Works
 
-Chroma Sync has three primary concepts: **source types**, **sources**, and **invocations**.
+Sync runs the same pipeline regardless of source:
+
+1. **Managed ingestion.** Connect a source once; every invocation runs through Chroma's queue-based pipeline with automatic retries, rate-limit awareness, and error recovery. Monitor invocations in the dashboard or through the [Sync API](/reference/sync-api).
+2. **High throughput.** The pipeline is designed to maximize throughput without dropping work, whether you're syncing a handful of files or millions of documents.
+3. **Parse.** PDFs, Office documents, HTML, ebooks, and images are converted to clean markdown with tables, headings, and structure preserved. Code files are kept as-is.
+4. **Chunk.** Tree-sitter syntax-aware chunking for code; structured markdown chunking for documents; line-based fallback for plain text. The strategy is configurable per source.
+5. **Embed.** Dense embeddings are generated automatically with [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B). Optional sparse embeddings are available via [Splade](https://huggingface.co/prithivida/Splade_PP_en_v1) or [BM25](https://en.wikipedia.org/wiki/Okapi_BM25). No extra API keys needed.
+6. **Index.** Output is written into the target Chroma collection, ready for vector, full-text, regex, sparse, and hybrid search.
 
 # Source Types
 
-A source type defines a kind of entity that contains data that can be chunked, embedded, and indexed. Each source type defines its own schema for configuring sources of its type. Chroma Sync supports four source types: **S3 buckets**, **GitHub repositories**, **web scraping**, and **direct file upload**. If there is a specific source type for which you would like support, please reach out to [engineering@trychroma.com](mailto:engineering@trychroma.com).
+Chroma Sync supports four source types. Each has its own walkthrough and configuration reference:
 
-## S3
+- [**S3 buckets**](/cloud/sync/s3) — sync files from Amazon S3, with optional auto-sync on upload.
+- [**GitHub repositories**](/cloud/sync/github) — sync code from public or private repos, with diff-based incremental updates.
+- [**Web**](/cloud/sync/web) — crawl and ingest websites starting from a seed URL.
+- [**File upload**](/cloud/sync/file-upload) — upload individual files directly from the dashboard or via the API.
 
-The S3 source type allows developers to sync files from Amazon S3 buckets into Chroma. It supports documents (PDFs, Office files, images, ebooks), code, and plain text. S3 sources can be configured with auto-sync to automatically index files as they are uploaded to S3. For a detailed walkthrough, see [S3 Sync docs](/cloud/sync/s3).
+Need a source type that isn't here? Email [engineering@trychroma.com](mailto:engineering@trychroma.com).
 
-AWS credentials can be saved in the Chroma dashboard once and reused across multiple S3 sources. See [AWS Credentials](/cloud/sync/s3#aws-credentials).
+# Concepts
 
-## GitHub Repositories
+Chroma Sync has three primary concepts: **source types**, **sources**, and **invocations**.
 
-The GitHub repository source type allows developers to sync code in public and private GitHub repositories. Public repositories require no setup other than creating a Chroma Cloud account and issuing an API key. Chroma Sync for private repositories is available at two different tiers: direct and platform.
+A **source type** defines a kind of entity that can be chunked, embedded, and indexed (e.g. S3, GitHub, Web, File Upload). A **source** is a configured instance of a source type — for example, a specific S3 bucket with credentials and a path prefix. An **invocation** is one sync run over a source's data; each invocation produces or appends to one Chroma collection.
 
-### Direct Sync
+# Global Source Configuration
 
-The direct tier requires you to install Chroma's GitHub App into any repository for which you wish to perform syncing. The direct tier is only available via the Chroma Cloud UI and does not enable you to perform Sync-related operations via the API. This tier is ideal for developers who wish to sync private repositories that they own. If you are interested in using the direct tier via API, please reach out to us at [engineering@trychroma.com](mailto:engineering@trychroma.com).
-
-### Platform Sync
-
-The platform tier requires you to grant Chroma access to a GitHub App that you own, which has been installed into the private repositories you wish to sync. This GitHub App must have read-only access to the "Contents" and "Metadata" permissions on the list of "Repository permissions".
-
-The platform tier grants access to the Chroma Sync API and is ideal for companies and organizations that offer services which access their users' codebases. For a detailed walkthrough, see [Platform Sync docs](/cloud/sync/github#platform-sync).
-
-## Web
-
-The web source type allows developers to scrape the contents of web pages into Chroma. Given a starting URL, Sync will crawl the page and its links up to a specified depth.
-
-## File Upload
-
-The file upload source type lets you upload individual files directly to sync. Each upload specifies a target collection that is created or appended to. For a detailed walkthrough, see [File Upload docs](/cloud/sync/file-upload).
-
-# Sources
-
-A source is a specific instance of a source type configured according to the global and source type-specific configuration schema. The global source configuration schema refers to the configuration parameters that are required across sources of all types, while the source-type specific configuration schema refers to the configuration parameters required for a specific source type.
-
-The global source configuration schema requires the following parameters:
+Every source, regardless of type, is configured with a target database and an embedding configuration. Source-type-specific fields (bucket name, repository, starting URL, etc.) are documented on each [source type's page](#source-types).
 
 ```json
 {
   "database_name": "string",
   "embedding": {
     "dense": {
-        "model": "Qwen/Qwen3-Embedding-0.6B"
+      "model": "Qwen/Qwen3-Embedding-0.6B"
     }
   }
 }
 ```
 
-- `database_name` defines the Chroma database in which collections should be created by invocations run on this source. A database must exist before creating sources that point to it.
-- `embedding.dense.model` defines the embedding model that should be used to generate dense embeddings for chunked documents. Currently, only the [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) model is supported, but if there is a model you would like to use, please let us know by reaching out to [engineering@trychroma.com](mailto:engineering@trychroma.com).
+- `database_name` is the Chroma database in which collections will be created. The database must already exist.
+- `embedding.dense.model` is the dense embedding model. Currently only `Qwen/Qwen3-Embedding-0.6B` is supported. Reach out to [engineering@trychroma.com](mailto:engineering@trychroma.com) to request additional models.
 
 You can optionally configure sparse embeddings alongside dense embeddings:
 
 ```json
 {
   "embedding": {
-    "dense": {
-      "model": "Qwen/Qwen3-Embedding-0.6B"
-    },
+    "dense": { "model": "Qwen/Qwen3-Embedding-0.6B" },
     "sparse": {
       "model": "Chroma/BM25",
       "key": "sparse_embedding"
@@ -76,10 +64,10 @@ You can optionally configure sparse embeddings alongside dense embeddings:
 }
 ```
 
-- `embedding.sparse.model` defines the sparse embedding model. Supported models: `Chroma/BM25`, `prithivida/Splade_PP_en_v1`.
-- `embedding.sparse.key` defines the metadata key under which sparse embeddings are stored.
+- `embedding.sparse.model` — `Chroma/BM25` or `prithivida/Splade_PP_en_v1`.
+- `embedding.sparse.key` — metadata key under which sparse embeddings are stored.
 
-You can also configure chunking behavior:
+You can also override the chunking strategy:
 
 ```json
 {
@@ -90,116 +78,26 @@ You can also configure chunking behavior:
 }
 ```
 
-- `chunking.type` can be `tree_sitter` (syntax-aware, with `max_size_bytes`) or `lines` (line-based, with `max_lines` and `max_size_bytes`).
+- `chunking.type` — `tree_sitter` (syntax-aware, with `max_size_bytes`) or `lines` (line-based, with `max_lines` and `max_size_bytes`).
 
-## S3
+# Global Invocation Configuration
 
-A source of the S3 type is configured with a bucket name, region, collection name, and AWS credentials:
-
-```json
-{
-    "bucket_name": "string",
-    "region": "string",
-    "collection_name": "string",
-    "aws_credential_id": 0,
-    "path_prefix": "string",
-    "auto_sync": "none"
-}
-```
-
-- `bucket_name` is the name of the S3 bucket to sync from.
-- `region` is the AWS region of the bucket.
-- `collection_name` is the default target collection name for synced data.
-- `aws_credential_id` is the ID of AWS credentials saved in the Chroma dashboard. As an alternative, you can pass `aws_access_key_id` and `aws_secret_access_key` inline; Chroma will save them on your team and return a credential ID for reuse.
-- `path_prefix` (optional) limits which S3 keys can be synced. Only keys starting with this prefix are allowed.
-- `auto_sync` (optional) sets the auto-sync mode: `none` (default), `direct`, or `metadata`. See [S3 Auto-Sync](/cloud/sync/s3#auto-sync).
-
-## GitHub Repositories
-
-A source of the GitHub repository type is an individual GitHub repository configured with the global source configuration parameters, and the GitHub source-specific configuration parameters:
+Each invocation may specify a target collection:
 
 ```json
 {
-	"repository": "string",
-	"app_id": "string" | null, // optional
-	"include_globs": ["string", ...] | null, // optional
+  "target_collection_name": "string"
 }
 ```
 
-- `repository` defines the GitHub repository whose code should be synced. This must be the forward slash-separated combination of the repository owner's GitHub username and the repository name (e.g., `chroma-core/chroma`). Note that changing a repository name after creating a Chroma Sync source for it will result in invocations on that source failing, so a new source with the updated repository name must be created.
-- `app_id` defines the GitHub App ID of the GitHub App that has access to the provided `repository`. This parameter should only be supplied if the provided repository is private.
-- `include_globs` defines a set of glob patterns for which matching files should be synced. If this parameter is not provided, files matching `"*"` will be synced. Note that Chroma will not sync binary data, images, and other large or non-UTF-8 files.
+- `target_collection_name` is the Chroma collection to write into. The collection is created on first use, or appended to if it already exists. Required for GitHub and Web invocations; optional for S3 (defaults to the source's `collection_name`); set automatically for file uploads via the `collection_name` form field. If a collection has already finished an ingest (`finished_ingest=true` metadata), invocation creation returns `409 Conflict`.
 
-## Web
+Source-type-specific invocation fields (S3 `object_key`, GitHub `ref_identifier`, etc.) are documented on each source type's page.
 
-A source of the web type is configured with a starting URL and a few other optional parameters:
+# Authentication
 
-```json
-{
-    "starting_url": "https://docs.trychroma.com",
-    // all below are optional
-    "page_limit": 5,
-    "include_path_regexes": ["/cloud/*"],
-    "exclude_path_regexes": ["/blog/*"],
-    "max_depth": 2
-}
-```
+The Sync API authenticates with a Chroma Cloud API key sent in the `x-chroma-token` header.
 
-## File Upload
+# Reference
 
-File uploads do not require pre-configuring a source. Just call [`POST /api/v1/add-file`](/cloud/sync/file-upload) with the target `database_name` and `collection_name`, and Chroma handles the rest.
-
-# Invocations
-
-Invocations refer to runs of the Sync Function over the data in a source. One invocation corresponds to one sync pass through all of the data in a source. A single invocation will result in the creation of exactly one collection in the database specified by the invocation's source. This collection will contain the chunked, embedded, and indexed data that represents the state of the source at the time of the invocation's creation. Invocations, like sources, have some global configuration parameters, as well as parameters specific to the type of the source for which the invocation is being run.
-
-The global invocation configuration parameters are:
-
-```json
-{
-	"target_collection_name": "string"
-}
-```
-
-- `target_collection_name` defines the name of the Chroma collection in which synced data should be stored. This is required for GitHub and Web sources. For S3 sources, it is optional and defaults to the `collection_name` configured on the source. The target must be a collection that does not already exist with synced data. Chroma Sync uses the metadata key `finished_ingest` to indicate whether a collection contains synced data. If an invocation creation request is received for a collection with metadata in which this key is present and set to true, the API will return a 409 Conflict.
-
-## S3
-
-Invocations on sources of the S3 type sync individual files from the bucket. The configuration parameters specific to S3 invocations are:
-
-```json
-{
-    "object_key": "string",
-    "custom_id": "string",
-    "metadata": {},
-    "target_collection_name": "string"
-}
-```
-
-- `object_key` (required) is the full S3 object key to sync. Must include the `path_prefix` if one is configured on the source.
-- `custom_id` (optional) is a custom document ID (max 120 bytes). Chunk IDs become `custom_id-{chunk}` instead of `sha256(object_key)-{chunk}`.
-- `metadata` (optional) is additional metadata merged with standard chunk metadata. Values can be scalars (string, number, boolean, or null) or homogeneous arrays of scalars (e.g. `["action", "comedy"]`).
-- `target_collection_name` (optional) overrides the source's `collection_name`. If not provided, defaults to the `collection_name` configured on the source.
-
-## GitHub Repositories
-
-Invocations on sources of the GitHub repository type are sync runs over an individual GitHub repository with some set of configuration parameters. The configuration parameters that are specific to invocations on sources of this type are:
-
-```json
-{
-	"ref_identifier": {
-		"$oneOf": {
-			"branch": "string",
-			"sha": "string"
-		}
-	}
-}
-```
-
-- `ref_identifier` is either the commit SHA-256 or the name of the branch from which to retrieve the code to be synced. If a branch is provided, the code will be retrieved from the branch's latest commit.
-
-## File Upload
-
-Each call to [`POST /api/v1/add-file`](/cloud/sync/file-upload) creates one invocation that indexes the uploaded file into the target collection.
-
-For all API endpoints, see the [Sync API Reference](/reference/sync-api).
+For the full request and response schemas of every endpoint, see the [Sync API Reference](/reference/sync-api).

--- a/docs/mintlify/cloud/sync/overview.mdx
+++ b/docs/mintlify/cloud/sync/overview.mdx
@@ -38,7 +38,7 @@ The web source type allows developers to scrape the contents of web pages into C
 
 ## File Upload
 
-The file upload source type lets you push individual files directly to Chroma over HTTP without staging them in S3 or GitHub first. Each database has at most one file-upload source, which is created automatically the first time you call the upload endpoint for that database. For a detailed walkthrough, see [File Upload docs](/cloud/sync/file-upload).
+The file upload source type lets you upload individual files directly to sync. Each upload specifies a target collection that is created or appended to. For a detailed walkthrough, see [File Upload docs](/cloud/sync/file-upload).
 
 # Sources
 
@@ -147,7 +147,7 @@ A source of the web type is configured with a starting URL and a few other optio
 
 ## File Upload
 
-File-upload sources are not created via `POST /api/v1/sources`. Instead, the first call to [`POST /api/v1/add-file`](/cloud/sync/file-upload) for a database creates the source automatically; subsequent uploads to the same database reuse it. Each database has at most one file-upload source.
+File uploads do not require pre-configuring a source. Just call [`POST /api/v1/add-file`](/cloud/sync/file-upload) with the target `database_name` and `collection_name`, and Chroma handles the rest.
 
 # Invocations
 
@@ -200,6 +200,6 @@ Invocations on sources of the GitHub repository type are sync runs over an indiv
 
 ## File Upload
 
-Invocations on file-upload sources are created by calling [`POST /api/v1/add-file`](/cloud/sync/file-upload) directly with a multipart form, not by calling `POST /api/v1/sources/{source_id}/invocations`. Each call to `add-file` creates one invocation that indexes the uploaded file into the target collection.
+Each call to [`POST /api/v1/add-file`](/cloud/sync/file-upload) creates one invocation that indexes the uploaded file into the target collection.
 
 For all API endpoints, see the [Sync API Reference](/reference/sync-api).

--- a/docs/mintlify/cloud/sync/s3.mdx
+++ b/docs/mintlify/cloud/sync/s3.mdx
@@ -16,9 +16,54 @@ The Sync API uses your Chroma Cloud API key for authentication. See the [Sync AP
 
 1. Navigate to a database in Chroma Cloud and select **Sync** from the menu.
 2. Click **Create** and select **S3** as the source type.
-3. Enter your AWS credentials, AWS region, and bucket name.
-4. Configure a collection name and optional path prefix to limit which keys can be synced.
-5. Click **Sync** and enter an S3 object key to index.
+3. Enter your AWS access key ID and secret access key in the **AWS Credentials** step. The credentials are saved on your team and a credential ID is allocated; you can reuse that ID on subsequent sources via the API.
+4. Enter the AWS region and bucket name.
+5. Configure a collection name and optional path prefix to limit which keys can be synced.
+6. Click **Sync** and enter an S3 object key to index.
+
+## AWS Credentials
+
+AWS credentials are managed at the team level and referenced from S3 sources by `aws_credential_id`. The first time you create an S3 source — whether via the dashboard or the API — Chroma saves the access key on your team and allocates a credential ID. Subsequent sources can reuse that ID without resending the secret.
+
+### Supplying credentials via the API
+
+When creating an S3 source via the API, you have two options. Provide **either**:
+
+- `aws_credential_id`: an integer ID returned from a previously saved credential, **or**
+- `aws_access_key_id` + `aws_secret_access_key`: an inline access key. Chroma stores the credential on your team and returns a credential ID that can be reused on subsequent sources.
+
+```bash
+# Reuse an existing credential
+curl -X POST https://sync.trychroma.com/api/v1/sources \
+  -H "x-chroma-token: $CHROMA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "database_name": "my-db",
+    "s3": {
+      "bucket_name": "my-bucket",
+      "region": "us-east-1",
+      "collection_name": "my-collection",
+      "aws_credential_id": 42
+    }
+  }'
+
+# Or pass an inline access key (saved to your team for reuse)
+curl -X POST https://sync.trychroma.com/api/v1/sources \
+  -H "x-chroma-token: $CHROMA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "database_name": "my-db",
+    "s3": {
+      "bucket_name": "my-bucket",
+      "region": "us-east-1",
+      "collection_name": "my-collection",
+      "aws_access_key_id": "AKIA...",
+      "aws_secret_access_key": "..."
+    }
+  }'
+```
+
+The IAM user behind the credential needs `s3:GetObject` (and `s3:ListBucket` if you use a path prefix) on the bucket. For [Auto-Sync](#auto-sync), no extra permissions are required on the credential itself; events flow through an SQS queue managed by Chroma.
 
 ## S3 Source Configuration
 
@@ -27,9 +72,13 @@ The Sync API uses your Chroma Cloud API key for authentication. See the [Sync AP
 | `bucket_name` | Yes | S3 bucket name. |
 | `region` | Yes | AWS region of the bucket. |
 | `collection_name` | Yes | Default target collection name for synced data. |
-| `aws_credential_id` | Yes | ID of AWS credentials created in the Chroma dashboard. |
+| `aws_credential_id` | * | ID of AWS credentials saved in the Chroma dashboard. Mutually exclusive with the inline access-key fields. |
+| `aws_access_key_id` | * | Inline AWS access key ID. Required together with `aws_secret_access_key` if `aws_credential_id` is not provided. |
+| `aws_secret_access_key` | * | Inline AWS secret access key. Required together with `aws_access_key_id` if `aws_credential_id` is not provided. |
 | `path_prefix` | No | Limits which S3 keys can be synced. Only keys starting with this prefix are allowed. Useful for [multi-tenant setups](#multi-tenant-buckets). |
 | `auto_sync` | No | Auto-sync mode: `none` (default), `direct`, or `metadata`. Configured by Chroma during [Auto-Sync](#auto-sync) setup. |
+
+\* Provide either `aws_credential_id`, or both `aws_access_key_id` and `aws_secret_access_key`.
 
 ## S3 Invocation Parameters
 
@@ -64,7 +113,7 @@ All other files must contain valid UTF-8 text. Non-UTF-8 files will fail.
 
 ### Limits
 
-- **Region**: Currently available for databases in the AWS `us-east-1` region only.
+- **Database region**: Chroma Sync is currently only available for Chroma databases hosted in `aws-us-east-1`. Databases in `gcp-europe-west1` cannot use Sync yet. See [Regions](/cloud/getting-started#regions). The S3 bucket itself can be in any AWS region — that is what the source's `region` field controls.
 - **Maximum file size**: 200 MB per file.
 - **Maximum document pages**: 7,000 pages per document. Documents exceeding this limit will fail.
 

--- a/docs/mintlify/docs.json
+++ b/docs/mintlify/docs.json
@@ -145,7 +145,8 @@
               "cloud/sync/overview",
               "cloud/sync/s3",
               "cloud/sync/github",
-              "cloud/sync/web"
+              "cloud/sync/web",
+              "cloud/sync/file-upload"
             ]
           },
           {

--- a/docs/mintlify/docs/run-chroma/clients.mdx
+++ b/docs/mintlify/docs/run-chroma/clients.mdx
@@ -63,7 +63,7 @@ let client = ChromaHttpClient::cloud()?;
 
 ### Connecting to a non-default region
 
-By default, `CloudClient` connects to `api.trychroma.com` (AWS `us-east-1`). To target a database in another region — for example our GCP `europe-west1` region — point the client at that region's hostname. See [Regions](/cloud/getting-started#regions) for the list of available endpoints.
+By default, `CloudClient` connects to `api.trychroma.com` (AWS `us-east-1`). To target a database in another region — for example, our GCP `europe-west1` region — point the client at that region's hostname. See [Regions](/cloud/getting-started#regions) for the list of available endpoints.
 
 <CodeGroup>
 ```python Python

--- a/docs/mintlify/docs/run-chroma/clients.mdx
+++ b/docs/mintlify/docs/run-chroma/clients.mdx
@@ -61,6 +61,56 @@ let client = ChromaHttpClient::cloud()?;
 ```
 </CodeGroup>
 
+### Connecting to a non-default region
+
+By default, `CloudClient` connects to `api.trychroma.com` (AWS `us-east-1`). To target a database in another region — for example our GCP `europe-west1` region — point the client at that region's hostname. See [Regions](/cloud/getting-started#regions) for the list of available endpoints.
+
+<CodeGroup>
+```python Python
+import chromadb
+
+client = chromadb.CloudClient(
+    cloud_host='europe-west1.gcp.trychroma.com',
+    cloud_port=443,
+    api_key='Chroma Cloud API key',
+    tenant='Tenant ID',
+    database='Database name',
+)
+```
+
+```typescript TypeScript
+import { ChromaClient } from "chromadb";
+
+const client = new ChromaClient({
+  host: "europe-west1.gcp.trychroma.com",
+  ssl: true,
+  headers: { "x-chroma-token": "Chroma Cloud API key" },
+  tenant: "Tenant ID",
+  database: "Database name",
+});
+```
+
+```rust Rust
+use chroma::{ChromaAuthMethod, ChromaHttpClient, ChromaHttpClientOptions};
+
+let client = ChromaHttpClient::new(ChromaHttpClientOptions {
+    endpoint: "https://europe-west1.gcp.trychroma.com:443".parse()?,
+    auth_method: ChromaAuthMethod::cloud_api_key("Chroma Cloud API key")?,
+    database_name: Some("Database name".to_string()),
+    ..Default::default()
+});
+```
+</CodeGroup>
+
+The dashboard's **Connect** panel generates a ready-to-paste snippet for whichever region a database lives in, including the corresponding `.env` block. For databases outside `aws-us-east-1`, the snippet sets `CHROMA_HOST` to the region-specific host:
+
+```bash
+CHROMA_HOST=europe-west1.gcp.trychroma.com
+CHROMA_API_KEY=...
+CHROMA_TENANT=...
+CHROMA_DATABASE=...
+```
+
 ## In-Memory Client
 
 In Python, you can run a Chroma server in-memory and connect to it with the ephemeral client:

--- a/docs/mintlify/sync.openapi.json
+++ b/docs/mintlify/sync.openapi.json
@@ -856,6 +856,164 @@
         }
       }
     },
+    "/api/v1/add-file": {
+      "post": {
+        "tags": [
+          "File Upload"
+        ],
+        "summary": "Upload and index a file",
+        "description": "Uploads a file and creates an invocation to index it into the specified collection.\n\nThe first time this endpoint is called for a database, a `file_upload` source is created automatically; subsequent calls reuse that source. The collection is created on the first invocation if it does not already exist.\n\n**Multipart field ordering:** `database_name` and `collection_name` MUST appear before `file`. The server uses these to authorize the request before streaming file bytes to storage.\n\n**Size limits:** maximum 200 MiB per file. The declared size in `x-upload-content-length` is enforced.",
+        "operationId": "add_file",
+        "parameters": [
+          {
+            "name": "x-upload-content-length",
+            "in": "header",
+            "description": "Declared file size in bytes. Must be greater than 0 and not exceed 200 MiB (209,715,200 bytes).",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 209715200
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "database_name",
+                  "collection_name",
+                  "file"
+                ],
+                "properties": {
+                  "database_name": {
+                    "type": "string",
+                    "description": "Database in which to index the file. Must appear before the `file` field."
+                  },
+                  "collection_name": {
+                    "type": "string",
+                    "description": "Target collection. Created on first use. Must appear before the `file` field."
+                  },
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "File content. Maximum 200 MiB. The filename in the part header is used as the document name."
+                  },
+                  "custom_id": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional custom document ID. Chunk IDs become `custom_id-{chunk}` instead of `sha256(filename)-{chunk}`."
+                  },
+                  "metadata": {
+                    "type": "string",
+                    "description": "Optional JSON object of additional metadata to merge with chunk metadata. Maximum 16 KiB. Reserved keys (e.g. `chroma_*`) are rejected."
+                  },
+                  "embedding": {
+                    "type": "string",
+                    "description": "Optional JSON `SourceEmbeddingConfig`. Defaults to Qwen3-Embedding-0.6B with `generic_retrieval` task and Splade sparse embeddings."
+                  },
+                  "chunking": {
+                    "type": "string",
+                    "description": "Optional JSON `SourceChunkingConfig`. Defaults to tree-sitter syntax-aware chunking with markdown/line-based fallbacks."
+                  },
+                  "content_type": {
+                    "type": "string",
+                    "maxLength": 512,
+                    "description": "Optional MIME type override. Otherwise inferred from the file part header (if not `application/octet-stream`) or the filename extension."
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "contentType": "application/octet-stream"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "File accepted and invocation created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddFileResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Database not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many concurrent uploads",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "x-chroma-token": []
+          }
+        ]
+      }
+    },
     "/api/v1/sources/{source_id}/invocations/latest-by-keys": {
       "post": {
         "tags": [
@@ -952,6 +1110,19 @@
   },
   "components": {
     "schemas": {
+      "AddFileResponse": {
+        "type": "object",
+        "required": [
+          "invocation_id"
+        ],
+        "properties": {
+          "invocation_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the newly created invocation."
+          }
+        }
+      },
       "CancelJobResponse": {
         "type": "object"
       },
@@ -1573,9 +1744,9 @@
                 "required": [
                   "bucket_name",
                   "region",
-                  "collection_name",
-                  "aws_credential_id"
+                  "collection_name"
                 ],
+                "description": "Provide either `aws_credential_id` referencing credentials saved in the dashboard, or pass `aws_access_key_id` and `aws_secret_access_key` inline (in which case credentials are stored automatically and a credential ID is allocated for reuse).",
                 "properties": {
                   "auto_sync": {
                     "oneOf": [
@@ -1589,9 +1760,26 @@
                     ]
                   },
                   "aws_credential_id": {
-                    "type": "integer",
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "int32",
-                    "description": "AWS credential ID for accessing the bucket.\nCredentials must be created in Dashboard API first."
+                    "description": "ID of AWS credentials saved in the Chroma dashboard. Mutually exclusive with `aws_access_key_id`/`aws_secret_access_key`."
+                  },
+                  "aws_access_key_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Inline AWS access key ID. Must be provided together with `aws_secret_access_key`. The credentials are stored on your team for reuse."
+                  },
+                  "aws_secret_access_key": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Inline AWS secret access key. Must be provided together with `aws_access_key_id`."
                   },
                   "bucket_name": {
                     "type": "string"
@@ -1609,6 +1797,19 @@
                     "type": "string"
                   }
                 }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "file_upload"
+            ],
+            "description": "File-upload sources are created automatically by the [`POST /api/v1/add-file`](#tag/file-upload) endpoint. They cannot be created directly via this endpoint.",
+            "properties": {
+              "file_upload": {
+                "type": "object",
+                "additionalProperties": false
               }
             }
           }


### PR DESCRIPTION
- Add new `cloud/sync/file-upload` page covering `POST /api/v1/add-file` (multipart format, ordering rule, curl/Python/TypeScript examples, limits).
- Document AWS credential reuse via `aws_credential_id` (and inline `aws_access_key_id` + `aws_secret_access_key` fallback) in `cloud/sync/s3` and `cloud/sync/overview`.
- Add multi-region docs: a `Regions` section in `cloud/getting-started` (endpoint table + per-region feature matrix) and a `Connecting to a non-default region` section in `docs/run-chroma/clients` with Python / TypeScript / Rust examples and the `CHROMA_HOST` `.env` block.
- Update the shimmed `sync.openapi.json` to add the `add-file` endpoint, `AddFileResponse` schema, the `file_upload` `SourceType` variant, and the inline AWS-key alternative on the S3 source — all additive to preserve existing local edits.
- Register the new file-upload page in `docs.json`.
