### PR TITLE
[ENH]: add client header to Gemini embedding functions

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -1,4 +1,6 @@
 from typing import Dict, Optional, Union
+__version__ = "1.5.8"
+
 import logging
 from chromadb.api.client import Client as ClientCreator
 from chromadb.api.client import (
@@ -108,7 +110,6 @@ logger = logging.getLogger(__name__)
 
 __settings = Settings()
 
-__version__ = "1.5.8"
 
 
 # Workaround to deal with Colab's old sqlite3 version

--- a/chromadb/utils/embedding_functions/google_embedding_function.py
+++ b/chromadb/utils/embedding_functions/google_embedding_function.py
@@ -1,4 +1,5 @@
 from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
+from chromadb import __version__
 from typing import List, Dict, Any, cast, Optional
 import os
 import numpy as np
@@ -63,8 +64,16 @@ class GoogleGeminiEmbeddingFunction(EmbeddingFunction[Documents]):
                 f"The {self.api_key_env_var} environment variable must be set if vertexai is not enabled."
             )
 
+        from google.genai import types
+
         self.client = genai.Client(
-            api_key=self.api_key, vertexai=vertexai, project=project, location=location
+            api_key=self.api_key,
+            vertexai=vertexai,
+            project=project,
+            location=location,
+            http_options=types.HttpOptions(
+                headers={"x-goog-api-client": f"chroma/{__version__}"}
+            ),
         )
 
     def __call__(self, input: Documents) -> Embeddings:
@@ -254,7 +263,10 @@ class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Documents]):
         self.task_type = task_type
         self.dimension = dimension
 
-        genai.configure(api_key=self.api_key)
+        genai.configure(
+            api_key=self.api_key,
+            client_options={"headers": {"x-goog-api-client": f"chroma/{__version__}"}},
+        )
         self._genai = genai
 
     def __call__(self, input: Documents) -> Embeddings:
@@ -399,7 +411,10 @@ class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
 
         self.model_name = model_name
 
-        palm.configure(api_key=self.api_key)
+        palm.configure(
+            api_key=self.api_key,
+            client_options={"headers": {"x-goog-api-client": f"chroma/{__version__}"}},
+        )
         self._palm = palm
 
     def __call__(self, input: Documents) -> Embeddings:
@@ -526,7 +541,11 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction[Documents]):
         self.project_id = project_id
         self.region = region
 
-        vertexai.init(project=project_id, location=region)
+        vertexai.init(
+            project=project_id,
+            location=region,
+            request_metadata=[("x-goog-api-client", f"chroma/{__version__}")],
+        )
         self._model = TextEmbeddingModel.from_pretrained(model_name)
 
     def __call__(self, input: Documents) -> Embeddings:

--- a/clients/new-js/packages/ai-embeddings/google-gemini/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/google-gemini/src/index.test.ts
@@ -12,10 +12,10 @@ describe("GoogleGeminiEmbeddingFunction", () => {
   } else {
     it(defaultParametersTest, () => {
       const embedder = new GoogleGeminiEmbeddingFunction();
-      expect(embedder.name).toBe("google-generative-ai");
+      expect(embedder.name).toBe("google-gemini");
 
       const config = embedder.getConfig();
-      expect(config.model_name).toBe("text-embedding-004");
+      expect(config.model_name).toBe("gemini-embedding-001");
       expect(config.api_key_env_var).toBe("GEMINI_API_KEY");
       expect(config.task_type).toBeUndefined();
     });
@@ -37,15 +37,19 @@ describe("GoogleGeminiEmbeddingFunction", () => {
     });
   }
 
-  it("should initialize with custom error for a API key", () => {
+  it("should warn if API key is missing", () => {
     const originalEnv = process.env.GEMINI_API_KEY;
     delete process.env.GEMINI_API_KEY;
 
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
     try {
-      expect(() => {
-        new GoogleGeminiEmbeddingFunction();
-      }).toThrow("Gemini API key is required");
+      new GoogleGeminiEmbeddingFunction();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Gemini API key is not set. Please provide it in the constructor or set the environment variable GEMINI_API_KEY.",
+      );
     } finally {
+      warnSpy.mockRestore();
       if (originalEnv) {
         process.env.GEMINI_API_KEY = originalEnv;
       }

--- a/clients/new-js/packages/ai-embeddings/google-gemini/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/google-gemini/src/index.ts
@@ -6,6 +6,9 @@ import {
 } from "chromadb";
 import { validateConfigSchema } from "@chroma-core/ai-embeddings-common";
 import { GoogleGenAI } from "@google/genai";
+import packageJson from "../package.json";
+
+const version = packageJson.version;
 
 const NAME = "google-gemini";
 
@@ -53,7 +56,14 @@ export class GoogleGeminiEmbeddingFunction implements EmbeddingFunction {
     this.apiKeyEnvVar = apiKeyEnvVar;
     this.taskType = taskType;
     this.dimension = dimension;
-    this.client = new GoogleGenAI({ apiKey });
+    this.client = new GoogleGenAI({
+      apiKey,
+      httpOptions: {
+        headers: {
+          "x-goog-api-client": `chroma/${version}`,
+        },
+      },
+    });
   }
 
   public async generate(texts: string[]): Promise<number[][]> {

--- a/clients/new-js/pnpm-lock.yaml
+++ b/clients/new-js/pnpm-lock.yaml
@@ -744,20 +744,20 @@ importers:
         version: 8.0.3
     optionalDependencies:
       chromadb-js-bindings-darwin-arm64:
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.3
+        version: 1.3.3
       chromadb-js-bindings-darwin-x64:
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.3
+        version: 1.3.3
       chromadb-js-bindings-linux-arm64-gnu:
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.3
+        version: 1.3.3
       chromadb-js-bindings-linux-x64-gnu:
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.3
+        version: 1.3.3
       chromadb-js-bindings-win32-x64-msvc:
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.3
+        version: 1.3.3
 
   packages/integration-test:
     dependencies:
@@ -1345,72 +1345,85 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.1':
     resolution: {integrity: sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.1':
     resolution: {integrity: sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.1':
     resolution: {integrity: sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.1':
     resolution: {integrity: sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.1':
     resolution: {integrity: sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.1':
     resolution: {integrity: sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.1':
     resolution: {integrity: sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==}
@@ -1630,56 +1643,67 @@ packages:
     resolution: {integrity: sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.40.2':
     resolution: {integrity: sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.40.2':
     resolution: {integrity: sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.40.2':
     resolution: {integrity: sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.40.2':
     resolution: {integrity: sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.40.2':
     resolution: {integrity: sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.40.2':
     resolution: {integrity: sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.40.2':
     resolution: {integrity: sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.40.2':
     resolution: {integrity: sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.40.2':
     resolution: {integrity: sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.40.2':
     resolution: {integrity: sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.40.2':
     resolution: {integrity: sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==}
@@ -2382,32 +2406,34 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  chromadb-js-bindings-darwin-arm64@1.3.1:
-    resolution: {integrity: sha512-MMo+TX8tRrhy/0KGrA30kVTZ+EwrRoXRSQA7EGLuKW6FTEVX7hbF5l0EFWgDTw6YPX/KY2ySYNQH3VFwRyxYFA==}
+  chromadb-js-bindings-darwin-arm64@1.3.3:
+    resolution: {integrity: sha512-fygMqw+Qsnc7zlh59tYAUfW5g859ZVLnA5cG0tyO7NZG2lQz1QKZCTqG49TVU7vfmeC7LzjIZvEQ0jrTqFKaMQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  chromadb-js-bindings-darwin-x64@1.3.1:
-    resolution: {integrity: sha512-zboZ29wtP7vrevfYhNXFToSM9sTaXP+KALYF4B6wJNp4jymBRSAzhAsHBrVmAJQxgPEJatoODAWqsVxaGLYkog==}
+  chromadb-js-bindings-darwin-x64@1.3.3:
+    resolution: {integrity: sha512-OwaNmkEo8gYp5inp88pa0vLUSNYs9nBouvumbt+YI1JYShpDs6cnBKAOfNCFbljjBunqCsv70PPxQqZmkyEzlQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  chromadb-js-bindings-linux-arm64-gnu@1.3.1:
-    resolution: {integrity: sha512-JPzoIy5vb4Gzu7kZnCkcMtsv+HPx/LWBFu72IDbnkUp8UleNyXup7fVX/tUvwHq+OPtj7ZB4YWwiP3SzKIWEgA==}
+  chromadb-js-bindings-linux-arm64-gnu@1.3.3:
+    resolution: {integrity: sha512-98O7kBw2z9kLCbQqElebrV9SAcKf5QKDI9yD144ooLz+jOgj39ccF6q0R13FB3AwYxVvHhKiIKMjO3hOFCx5iw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  chromadb-js-bindings-linux-x64-gnu@1.3.1:
-    resolution: {integrity: sha512-nQvVhmHs2XXbzA+Xka8A4UMiyMlk86AFmiy1Pt+kzQkuJT5vOMKOcgJW/Nh2m0CtEjkzvj4Mxr2/31BiLil7Hg==}
+  chromadb-js-bindings-linux-x64-gnu@1.3.3:
+    resolution: {integrity: sha512-yqJRHDiLNQFfNcCDm/iILdf5gCBR0BxG1d+esX4ViHAP41h4WqbWq9MIAla+OKHKlyMpSq9BiqSfHBaL8rr5nQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  chromadb-js-bindings-win32-x64-msvc@1.3.1:
-    resolution: {integrity: sha512-3B3WwT1aM9vxFZBqlDgnA+R025b8pOudGM4hEZTmxV2rHND3Hn7C87mQO5WsUMarOUmX4Sd1NlhC2ANKCIWfLw==}
+  chromadb-js-bindings-win32-x64-msvc@1.3.3:
+    resolution: {integrity: sha512-X5zuolLBqh3+2GFh9BbjkBPFhPsmezc/HkYAk/rQvYayBqD39e/BT0JwYVbGr+gcqsZI3QO87xZ2FyHL8g8f9Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -6796,19 +6822,19 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  chromadb-js-bindings-darwin-arm64@1.3.1:
+  chromadb-js-bindings-darwin-arm64@1.3.3:
     optional: true
 
-  chromadb-js-bindings-darwin-x64@1.3.1:
+  chromadb-js-bindings-darwin-x64@1.3.3:
     optional: true
 
-  chromadb-js-bindings-linux-arm64-gnu@1.3.1:
+  chromadb-js-bindings-linux-arm64-gnu@1.3.3:
     optional: true
 
-  chromadb-js-bindings-linux-x64-gnu@1.3.1:
+  chromadb-js-bindings-linux-x64-gnu@1.3.3:
     optional: true
 
-  chromadb-js-bindings-win32-x64-msvc@1.3.1:
+  chromadb-js-bindings-win32-x64-msvc@1.3.3:
     optional: true
 
   ci-info@3.9.0: {}


### PR DESCRIPTION
## Description of changes

Adds platform and version headers to Gemini API Python & JS requests. This is a Gemini API [best practice](https://ai.google.dev/gemini-api/docs/partner-integration#client-id).

- Updated all 4 Python embedding functions.
- Moved `__version__` in `__init__.py` to top-of-file so that it can be imported without circular references.
- Use `package.json` for version tracking in JS embedding func.
- Fixed a few JS tests too.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Observability plan

This should help with o11y.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

No, this should be opaque to users.