### PR TITLE
[ENH] Verify file path for compaction

### DIFF
--- a/rust/types/src/segment.rs
+++ b/rust/types/src/segment.rs
@@ -2,6 +2,7 @@ use super::{
     CollectionUuid, Metadata, MetadataValueConversionError, SegmentScope,
     SegmentScopeConversionError,
 };
+use crate::collection_schema::Schema;
 use crate::{chroma_proto, DatabaseUuid};
 use chroma_error::{ChromaError, ErrorCodes};
 use std::{collections::HashMap, str::FromStr};
@@ -237,6 +238,136 @@ impl Segment {
         }
     }
 
+    /// Check that the on-disk file_path shape matches what the collection schema
+    /// implies. Returns `Ok(())` when they agree or the segment is uninitialized
+    /// (empty file_path). Returns `Err(SchemaMismatchError)` on the first
+    /// mismatch detected.
+    ///
+    /// Validates that all file_path keys have the same shard count and that the
+    /// set of keys present is consistent with the schema.
+    pub fn matches_schema(&self, schema: &Schema) -> Result<(), SchemaMismatchError> {
+        if self.file_path.is_empty() {
+            return Ok(());
+        }
+        // Validate all keys have the same number of shards.
+        self.num_shards().map_err(SchemaMismatchError::ShardError)?;
+
+        match self.scope {
+            SegmentScope::VECTOR => self.check_vector_consistency(schema),
+            SegmentScope::METADATA => self.check_metadata_consistency(schema),
+            SegmentScope::RECORD => self.check_record_consistency(),
+            SegmentScope::SQLITE => Ok(()),
+        }
+    }
+
+    fn mismatch(&self, detail: String) -> SchemaMismatchError {
+        SchemaMismatchError::Mismatch {
+            segment_id: self.id,
+            scope: self.scope.clone(),
+            detail,
+        }
+    }
+
+    /// Verify that all `required` keys exist in file_path and no `denied` keys
+    /// exist. Uninitialized segments (no relevant keys at all) pass.
+    fn require_keys(&self, required: &[&str], denied: &[&str]) -> Result<(), SchemaMismatchError> {
+        let has_required: Vec<&str> = required
+            .iter()
+            .filter(|k| self.file_path.contains_key(**k))
+            .copied()
+            .collect();
+        let has_denied: Vec<&str> = denied
+            .iter()
+            .filter(|k| self.file_path.contains_key(**k))
+            .copied()
+            .collect();
+
+        // No relevant keys at all — uninitialized, OK.
+        if has_required.is_empty() && has_denied.is_empty() {
+            return Ok(());
+        }
+
+        // Denied keys must not be present.
+        if !has_denied.is_empty() {
+            return Err(self.mismatch(format!(
+                "unexpected keys present: {}",
+                has_denied.join(", ")
+            )));
+        }
+
+        // All required keys must be present — no partial state.
+        if has_required.len() != required.len() {
+            let missing: Vec<&str> = required
+                .iter()
+                .filter(|k| !self.file_path.contains_key(**k))
+                .copied()
+                .collect();
+            return Err(self.mismatch(format!("missing required keys: {}", missing.join(", "))));
+        }
+
+        Ok(())
+    }
+
+    fn check_vector_consistency(&self, schema: &Schema) -> Result<(), SchemaMismatchError> {
+        if schema.get_spann_config().is_none() {
+            return Ok(());
+        }
+
+        let spann_keys: &[&str] = &[
+            HNSW_PATH,
+            VERSION_MAP_PATH,
+            POSTING_LIST_PATH,
+            MAX_HEAD_ID_BF_PATH,
+        ];
+        let qspann_keys: &[&str] = &[
+            QUANTIZED_SPANN_CLUSTER,
+            QUANTIZED_SPANN_SCALAR_METADATA,
+            QUANTIZED_SPANN_EMBEDDING_METADATA,
+            QUANTIZED_SPANN_RAW_CENTROID,
+            QUANTIZED_SPANN_QUANTIZED_CENTROID,
+        ];
+
+        if schema.is_quantization_enabled() {
+            self.require_keys(qspann_keys, spann_keys)
+        } else {
+            self.require_keys(spann_keys, qspann_keys)
+        }
+    }
+
+    fn check_metadata_consistency(&self, schema: &Schema) -> Result<(), SchemaMismatchError> {
+        let base_keys: &[&str] = &[
+            FULL_TEXT_PLS,
+            STRING_METADATA,
+            BOOL_METADATA,
+            F32_METADATA,
+            U32_METADATA,
+        ];
+        self.require_keys(base_keys, &[])?;
+
+        if schema.is_sparse_index_enabled() {
+            let wand_keys: &[&str] = &[SPARSE_MAX, SPARSE_OFFSET_VALUE];
+            let maxscore_keys: &[&str] = &[SPARSE_POSTING];
+
+            if schema.is_maxscore_enabled() {
+                self.require_keys(maxscore_keys, wand_keys)
+            } else {
+                self.require_keys(wand_keys, maxscore_keys)
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    fn check_record_consistency(&self) -> Result<(), SchemaMismatchError> {
+        let required: &[&str] = &[
+            USER_ID_TO_OFFSET_ID,
+            OFFSET_ID_TO_USER_ID,
+            OFFSET_ID_TO_DATA,
+            MAX_OFFSET_ID,
+        ];
+        self.require_keys(required, &[])
+    }
+
     pub fn extract_prefix_and_id(path: &str) -> Result<(&str, uuid::Uuid), uuid::Error> {
         let (prefix, id) = match path.rfind('/') {
             Some(pos) => (&path[..pos], &path[pos + 1..]),
@@ -302,6 +433,29 @@ pub enum SegmentShardError {
 impl ChromaError for SegmentShardError {
     fn code(&self) -> ErrorCodes {
         ErrorCodes::Internal
+    }
+}
+
+/// Error returned by [`Segment::matches_schema`] when the on-disk file_path
+/// shape does not match what the collection schema implies.
+#[derive(Error, Debug)]
+pub enum SchemaMismatchError {
+    #[error("Schema/file_path mismatch on segment {segment_id} (scope {scope:?}): {detail}")]
+    Mismatch {
+        segment_id: SegmentUuid,
+        scope: SegmentScope,
+        detail: String,
+    },
+    #[error("Error inspecting shards: {0}")]
+    ShardError(SegmentShardError),
+}
+
+impl ChromaError for SchemaMismatchError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            Self::Mismatch { .. } => ErrorCodes::FailedPrecondition,
+            Self::ShardError(e) => e.code(),
+        }
     }
 }
 
@@ -705,5 +859,283 @@ mod tests {
             segment.file_path.get("metadata").unwrap()[0],
             "/path/to/shard0/metadata"
         );
+    }
+
+    // ── matches_schema tests ────────────────────────────────────────────────
+
+    use crate::collection_configuration::KnnIndex;
+    use crate::collection_schema::{
+        Quantization, Schema, SparseIndexAlgorithm, SparseVectorIndexConfig, SparseVectorIndexType,
+        SparseVectorValueType,
+    };
+
+    /// Helper: create a Spann schema (full precision, no quantization).
+    fn spann_schema() -> Schema {
+        Schema::new_default(KnnIndex::Spann)
+    }
+
+    /// Helper: create a Spann schema with quantization enabled.
+    fn quantized_spann_schema() -> Schema {
+        let mut schema = Schema::new_default(KnnIndex::Spann);
+        if let Some(spann_config) = schema.get_spann_config_mut() {
+            spann_config.quantize = Quantization::FourBitRabitQWithUSearch;
+        }
+        schema
+    }
+
+    /// Helper: create an HNSW schema.
+    fn hnsw_schema() -> Schema {
+        Schema::new_default(KnnIndex::Hnsw)
+    }
+
+    /// Helper: create a schema with sparse index enabled (Wand).
+    fn sparse_wand_schema() -> Schema {
+        let mut schema = Schema::new_default(KnnIndex::Hnsw);
+        schema
+            .keys
+            .entry("sparse_key".to_string())
+            .or_default()
+            .sparse_vector = Some(SparseVectorValueType {
+            sparse_vector_index: Some(SparseVectorIndexType {
+                enabled: true,
+                config: SparseVectorIndexConfig {
+                    embedding_function: None,
+                    source_key: None,
+                    bm25: None,
+                    algorithm: SparseIndexAlgorithm::Wand,
+                },
+            }),
+        });
+        schema
+    }
+
+    /// Helper: create a schema with sparse index enabled (MaxScore).
+    fn sparse_maxscore_schema() -> Schema {
+        let mut schema = sparse_wand_schema();
+        schema.set_sparse_algorithm(SparseIndexAlgorithm::MaxScore);
+        schema
+    }
+
+    fn make_vector_segment(file_path: HashMap<String, Vec<String>>) -> Segment {
+        Segment {
+            id: SegmentUuid(Uuid::nil()),
+            r#type: SegmentType::Spann,
+            scope: SegmentScope::VECTOR,
+            collection: CollectionUuid(Uuid::nil()),
+            metadata: None,
+            file_path,
+        }
+    }
+
+    fn make_metadata_segment(file_path: HashMap<String, Vec<String>>) -> Segment {
+        Segment {
+            id: SegmentUuid(Uuid::nil()),
+            r#type: SegmentType::BlockfileMetadata,
+            scope: SegmentScope::METADATA,
+            collection: CollectionUuid(Uuid::nil()),
+            metadata: None,
+            file_path,
+        }
+    }
+
+    #[test]
+    fn test_matches_schema_empty_file_path() {
+        let seg = make_vector_segment(HashMap::new());
+        assert!(seg.matches_schema(&spann_schema()).is_ok());
+        assert!(seg.matches_schema(&quantized_spann_schema()).is_ok());
+        assert!(seg.matches_schema(&hnsw_schema()).is_ok());
+    }
+
+    #[test]
+    fn test_matches_schema_spann_matches_spann() {
+        let mut fp = HashMap::new();
+        fp.insert(HNSW_PATH.to_string(), vec!["path/a".to_string()]);
+        fp.insert(VERSION_MAP_PATH.to_string(), vec!["path/b".to_string()]);
+        fp.insert(POSTING_LIST_PATH.to_string(), vec!["path/c".to_string()]);
+        fp.insert(MAX_HEAD_ID_BF_PATH.to_string(), vec!["path/d".to_string()]);
+        let seg = make_vector_segment(fp);
+        assert!(seg.matches_schema(&spann_schema()).is_ok());
+    }
+
+    #[test]
+    fn test_matches_schema_qspann_matches_qspann() {
+        let mut fp = HashMap::new();
+        fp.insert(
+            QUANTIZED_SPANN_CLUSTER.to_string(),
+            vec!["path/a".to_string()],
+        );
+        fp.insert(
+            QUANTIZED_SPANN_SCALAR_METADATA.to_string(),
+            vec!["path/b".to_string()],
+        );
+        fp.insert(
+            QUANTIZED_SPANN_EMBEDDING_METADATA.to_string(),
+            vec!["path/c".to_string()],
+        );
+        fp.insert(
+            QUANTIZED_SPANN_RAW_CENTROID.to_string(),
+            vec!["path/d".to_string()],
+        );
+        fp.insert(
+            QUANTIZED_SPANN_QUANTIZED_CENTROID.to_string(),
+            vec!["path/e".to_string()],
+        );
+        let seg = make_vector_segment(fp);
+        assert!(seg.matches_schema(&quantized_spann_schema()).is_ok());
+    }
+
+    #[test]
+    fn test_matches_schema_spann_on_disk_qspann_in_schema() {
+        let mut fp = HashMap::new();
+        fp.insert(HNSW_PATH.to_string(), vec!["path/a".to_string()]);
+        fp.insert(VERSION_MAP_PATH.to_string(), vec!["path/b".to_string()]);
+        fp.insert(POSTING_LIST_PATH.to_string(), vec!["path/c".to_string()]);
+        fp.insert(MAX_HEAD_ID_BF_PATH.to_string(), vec!["path/d".to_string()]);
+        let seg = make_vector_segment(fp);
+        let err = seg.matches_schema(&quantized_spann_schema()).unwrap_err();
+        assert!(matches!(err, SchemaMismatchError::Mismatch { .. }));
+    }
+
+    #[test]
+    fn test_matches_schema_qspann_on_disk_spann_in_schema() {
+        let mut fp = HashMap::new();
+        fp.insert(
+            QUANTIZED_SPANN_CLUSTER.to_string(),
+            vec!["path/a".to_string()],
+        );
+        fp.insert(
+            QUANTIZED_SPANN_SCALAR_METADATA.to_string(),
+            vec!["path/b".to_string()],
+        );
+        fp.insert(
+            QUANTIZED_SPANN_EMBEDDING_METADATA.to_string(),
+            vec!["path/c".to_string()],
+        );
+        fp.insert(
+            QUANTIZED_SPANN_RAW_CENTROID.to_string(),
+            vec!["path/d".to_string()],
+        );
+        fp.insert(
+            QUANTIZED_SPANN_QUANTIZED_CENTROID.to_string(),
+            vec!["path/e".to_string()],
+        );
+        let seg = make_vector_segment(fp);
+        let err = seg.matches_schema(&spann_schema()).unwrap_err();
+        assert!(matches!(err, SchemaMismatchError::Mismatch { .. }));
+    }
+
+    #[test]
+    fn test_matches_schema_hnsw_schema_always_ok() {
+        // HNSW schema does not check file_path — no migration variants.
+        let mut fp = HashMap::new();
+        fp.insert(HNSW_PATH.to_string(), vec!["path/a".to_string()]);
+        let seg = make_vector_segment(fp);
+        assert!(seg.matches_schema(&hnsw_schema()).is_ok());
+    }
+
+    fn make_record_segment(file_path: HashMap<String, Vec<String>>) -> Segment {
+        Segment {
+            id: SegmentUuid(Uuid::nil()),
+            r#type: SegmentType::BlockfileRecord,
+            scope: SegmentScope::RECORD,
+            collection: CollectionUuid(Uuid::nil()),
+            metadata: None,
+            file_path,
+        }
+    }
+
+    #[test]
+    fn test_matches_schema_record_empty() {
+        let seg = make_record_segment(HashMap::new());
+        assert!(seg.matches_schema(&spann_schema()).is_ok());
+    }
+
+    #[test]
+    fn test_matches_schema_record_complete() {
+        let mut fp = HashMap::new();
+        fp.insert(USER_ID_TO_OFFSET_ID.to_string(), vec!["a".to_string()]);
+        fp.insert(OFFSET_ID_TO_USER_ID.to_string(), vec!["b".to_string()]);
+        fp.insert(OFFSET_ID_TO_DATA.to_string(), vec!["c".to_string()]);
+        fp.insert(MAX_OFFSET_ID.to_string(), vec!["d".to_string()]);
+        let seg = make_record_segment(fp);
+        assert!(seg.matches_schema(&spann_schema()).is_ok());
+    }
+
+    #[test]
+    fn test_matches_schema_record_missing_key() {
+        let mut fp = HashMap::new();
+        fp.insert(USER_ID_TO_OFFSET_ID.to_string(), vec!["a".to_string()]);
+        fp.insert(OFFSET_ID_TO_USER_ID.to_string(), vec!["b".to_string()]);
+        fp.insert(OFFSET_ID_TO_DATA.to_string(), vec!["c".to_string()]);
+        // MAX_OFFSET_ID intentionally omitted
+        let seg = make_record_segment(fp);
+        let err = seg.matches_schema(&spann_schema()).unwrap_err();
+        assert!(matches!(err, SchemaMismatchError::Mismatch { .. }));
+    }
+
+    #[test]
+    fn test_matches_schema_sparse_wand_matches_wand() {
+        let mut fp = HashMap::new();
+        fp.insert(SPARSE_MAX.to_string(), vec!["path/a".to_string()]);
+        fp.insert(SPARSE_OFFSET_VALUE.to_string(), vec!["path/b".to_string()]);
+        let seg = make_metadata_segment(fp);
+        assert!(seg.matches_schema(&sparse_wand_schema()).is_ok());
+    }
+
+    #[test]
+    fn test_matches_schema_sparse_maxscore_matches_maxscore() {
+        let mut fp = HashMap::new();
+        fp.insert(SPARSE_POSTING.to_string(), vec!["path/a".to_string()]);
+        let seg = make_metadata_segment(fp);
+        assert!(seg.matches_schema(&sparse_maxscore_schema()).is_ok());
+    }
+
+    #[test]
+    fn test_matches_schema_sparse_wand_on_disk_maxscore_in_schema() {
+        let mut fp = HashMap::new();
+        fp.insert(SPARSE_MAX.to_string(), vec!["path/a".to_string()]);
+        fp.insert(SPARSE_OFFSET_VALUE.to_string(), vec!["path/b".to_string()]);
+        let seg = make_metadata_segment(fp);
+        let err = seg.matches_schema(&sparse_maxscore_schema()).unwrap_err();
+        assert!(matches!(err, SchemaMismatchError::Mismatch { .. }));
+    }
+
+    #[test]
+    fn test_matches_schema_sparse_maxscore_on_disk_wand_in_schema() {
+        let mut fp = HashMap::new();
+        fp.insert(SPARSE_POSTING.to_string(), vec!["path/a".to_string()]);
+        let seg = make_metadata_segment(fp);
+        let err = seg.matches_schema(&sparse_wand_schema()).unwrap_err();
+        assert!(matches!(err, SchemaMismatchError::Mismatch { .. }));
+    }
+
+    #[test]
+    fn test_matches_schema_sparse_empty_file_path() {
+        let seg = make_metadata_segment(HashMap::new());
+        assert!(seg.matches_schema(&sparse_maxscore_schema()).is_ok());
+        assert!(seg.matches_schema(&sparse_wand_schema()).is_ok());
+    }
+
+    #[test]
+    fn test_matches_schema_sparse_disabled_index_no_check() {
+        // Schema with no sparse index enabled — should not check.
+        let schema = hnsw_schema();
+        assert!(!schema.is_sparse_index_enabled());
+        let mut fp = HashMap::new();
+        fp.insert(SPARSE_POSTING.to_string(), vec!["path/a".to_string()]);
+        let seg = make_metadata_segment(fp);
+        assert!(seg.matches_schema(&schema).is_ok());
+    }
+
+    #[test]
+    fn test_matches_schema_sparse_both_keys_present() {
+        // Both Wand and MaxScore keys present — invalid state.
+        let mut fp = HashMap::new();
+        fp.insert(SPARSE_POSTING.to_string(), vec!["path/a".to_string()]);
+        fp.insert(SPARSE_MAX.to_string(), vec!["path/b".to_string()]);
+        fp.insert(SPARSE_OFFSET_VALUE.to_string(), vec!["path/c".to_string()]);
+        let seg = make_metadata_segment(fp);
+        let err = seg.matches_schema(&sparse_maxscore_schema()).unwrap_err();
+        assert!(matches!(err, SchemaMismatchError::Mismatch { .. }));
     }
 }

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -22,8 +22,8 @@ use chroma_system::{
     OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
-    Chunk, CollectionUuid, JobId, LogRecord, SegmentFlushInfo, SegmentScope, SegmentShard,
-    SegmentShardError,
+    Chunk, CollectionUuid, JobId, LogRecord, SchemaMismatchError, SegmentFlushInfo, SegmentScope,
+    SegmentShard, SegmentShardError,
 };
 use opentelemetry::trace::TraceContextExt;
 use std::sync::{atomic::AtomicU32, Arc};
@@ -99,6 +99,10 @@ pub enum LogFetchOrchestratorError {
     RecvError(#[from] RecvError),
     #[error("Error creating quantized spann writer: {0}")]
     QuantizedSpannSegment(#[from] chroma_segment::quantized_spann::QuantizedSpannSegmentError),
+    #[error("Schema/file_path mismatch: {0}")]
+    SchemaMismatch(SchemaMismatchError),
+    #[error("Multi-shard migration via rebuild is not supported: {0}")]
+    MultiShardMigrationNotSupported(SchemaMismatchError),
     #[error(transparent)]
     SegmentShard(#[from] SegmentShardError),
     #[error("Error creating spann writer: {0}")]
@@ -119,6 +123,10 @@ impl ChromaError for LogFetchOrchestratorError {
     fn code(&self) -> ErrorCodes {
         match self {
             LogFetchOrchestratorError::Aborted => ErrorCodes::Aborted,
+            LogFetchOrchestratorError::SchemaMismatch(_)
+            | LogFetchOrchestratorError::MultiShardMigrationNotSupported(_) => {
+                ErrorCodes::FailedPrecondition
+            }
             _ => ErrorCodes::Internal,
         }
     }
@@ -138,10 +146,12 @@ impl ChromaError for LogFetchOrchestratorError {
                 Self::InvariantViolation(_) => true,
                 Self::MaterializeLogs(e) => e.should_trace_error(),
                 Self::MetadataSegment(e) => e.should_trace_error(),
+                Self::MultiShardMigrationNotSupported(_) => true,
                 Self::Panic(e) => e.should_trace_error(),
                 Self::Partition(e) => e.should_trace_error(),
                 Self::PrefetchSegment(e) => e.should_trace_error(),
                 Self::QuantizedSpannSegment(e) => e.should_trace_error(),
+                Self::SchemaMismatch(_) => true,
                 Self::SegmentShard(e) => e.should_trace_error(),
                 Self::RecordSegmentReader(e) => e.should_trace_error(),
                 Self::RecordSegmentReaderShard(e) => e.should_trace_error(),
@@ -630,6 +640,69 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                 return;
             }
         };
+
+        // Check that on-disk file_path shape matches what the schema implies.
+        // During migration the two diverge; incremental compaction is blocked
+        // until a rebuild reconciles them.
+        if let Some(schema) = collection.schema.as_ref() {
+            let mismatch = output
+                .vector_segment
+                .matches_schema(schema)
+                .err()
+                .or_else(|| output.metadata_segment.matches_schema(schema).err())
+                .or_else(|| output.record_segment.matches_schema(schema).err());
+
+            if let Some(m) = mismatch {
+                if !self.context.is_rebuild() {
+                    tracing::error!(
+                        collection_id = %collection.collection_id,
+                        mismatch = %m,
+                        "Schema/file_path mismatch — blocking incremental compaction. \
+                         Run rebuild to migrate. This is expected during schema migrations."
+                    );
+                    self.terminate_with_result(
+                        Err(LogFetchOrchestratorError::SchemaMismatch(m)),
+                        ctx,
+                    )
+                    .await;
+                    return;
+                }
+
+                let num_shards = match output.record_segment.num_shards() {
+                    Ok(n) => n,
+                    Err(e) => {
+                        self.terminate_with_result(
+                            Err(LogFetchOrchestratorError::SegmentShard(e)),
+                            ctx,
+                        )
+                        .await;
+                        return;
+                    }
+                };
+                if num_shards > 1 {
+                    tracing::error!(
+                        collection_id = %collection.collection_id,
+                        mismatch = %m,
+                        num_shards,
+                        "Multi-shard migration via rebuild is not supported."
+                    );
+                    self.terminate_with_result(
+                        Err(LogFetchOrchestratorError::MultiShardMigrationNotSupported(
+                            m,
+                        )),
+                        ctx,
+                    )
+                    .await;
+                    return;
+                }
+
+                tracing::info!(
+                    collection_id = %collection.collection_id,
+                    mismatch = %m,
+                    "Migrating collection shape via rebuild"
+                );
+            }
+        }
 
         let mut metadata_segment = output.metadata_segment.clone();
         let mut record_segment = output.record_segment.clone();


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - N/A
- New functionality
  - Validate whether collection schema matches segment file paths during compaction, emit traces accordingly

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
