### PR TITLE
[BUG] CloudClient: propagate CHROMA_API_KEY env var to auth credentials

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -411,6 +411,12 @@ def CloudClient(
             f"Please provide them or set the environment variables: {', '.join([arg.env_var for arg in missing_args])}"
         )
 
+    # Pull the resolved values back into local variables. The env-var fallback
+    # above mutates `arg.value` on each CloudClientArg, but the function-local
+    # `api_key` was never reassigned, so without this the call would proceed
+    # with the original (often None) value and stringify it to "None".
+    api_key = next(arg.value for arg in required_args if arg.name == "api_key")
+
     if settings is None:
         settings = Settings()
 

--- a/chromadb/test/client/test_cloud_client.py
+++ b/chromadb/test/client/test_cloud_client.py
@@ -332,3 +332,66 @@ def test_api_key_with_no_tenant_access() -> None:
             match="Could not determine a tenant from the current authentication method. Please provide a tenant.",
         ):
             CloudClient(api_key="valid_token")
+
+def test_api_key_loaded_from_env_var() -> None:
+    """Regression: CloudClient must propagate CHROMA_API_KEY from the environment.
+
+    Previously the env-var fallback mutated `arg.value` on a CloudClientArg
+    record but never assigned it back to the local `api_key` variable, so
+    the client was constructed with the literal string "None" as its bearer
+    token even though the environment variable was set correctly.
+
+    See https://github.com/chroma-core/chroma/issues/6104
+    """
+    import os
+
+    with (
+        patch(
+            "chromadb.api.fastapi.FastAPI.get_user_identity"
+        ) as mock_get_user_identity,
+        patch("chromadb.api.client.AdminClient.get_tenant") as mock_get_tenant,
+        patch("chromadb.api.client.AdminClient.get_database") as mock_get_database,
+        patch.dict(os.environ, {"CHROMA_API_KEY": "env_token"}, clear=False),
+    ):
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="default_tenant", databases=["testdb"]
+        )
+        mock_get_tenant.return_value = Tenant(name="default_tenant")
+        mock_get_database.return_value = Database(
+            id=uuid4(), name="testdb", tenant="default_tenant"
+        )
+
+        # api_key intentionally NOT passed -- must be picked up from env var.
+        client = CloudClient(database="testdb")
+
+        settings = client.get_settings()
+        assert settings.chroma_client_auth_credentials == "env_token"
+        # The most visible symptom of the old bug:
+        assert settings.chroma_client_auth_credentials != "None"
+        assert settings.chroma_client_auth_credentials is not None
+
+
+def test_api_key_explicit_arg_overrides_env_var() -> None:
+    """An explicit api_key argument must take precedence over the env var."""
+    import os
+
+    with (
+        patch(
+            "chromadb.api.fastapi.FastAPI.get_user_identity"
+        ) as mock_get_user_identity,
+        patch("chromadb.api.client.AdminClient.get_tenant") as mock_get_tenant,
+        patch("chromadb.api.client.AdminClient.get_database") as mock_get_database,
+        patch.dict(os.environ, {"CHROMA_API_KEY": "env_token"}, clear=False),
+    ):
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="default_tenant", databases=["testdb"]
+        )
+        mock_get_tenant.return_value = Tenant(name="default_tenant")
+        mock_get_database.return_value = Database(
+            id=uuid4(), name="testdb", tenant="default_tenant"
+        )
+
+        client = CloudClient(database="testdb", api_key="explicit_token")
+
+        settings = client.get_settings()
+        assert settings.chroma_client_auth_credentials == "explicit_token"


### PR DESCRIPTION
## Repro

`CloudClient` documents that `api_key` is read from `CHROMA_API_KEY`
when not passed explicitly, but on `main` today this is silently broken:

```python
import os
import chromadb

os.environ["CHROMA_API_KEY"] = "ck-real-token"

client = chromadb.CloudClient(tenant="t", database="d")
print(client.get_settings().chroma_client_auth_credentials)
# 'None'   <-- literal string, env var dropped
```

Every Cloud request then 401s with no obvious indication that the
problem is on the client side.  Same symptom reported in #6104.

## Fix

In `chromadb/__init__.py::CloudClient`, the env-var fallback loop
mutates `arg.value` on a `CloudClientArg` record but never assigns
the resolved value back to the local `api_key`:

```python
if not all([arg.value for arg in required_args]):
    for arg in required_args:
        arg.value = arg.value or os.environ.get(arg.env_var)   # arg.value updated
                                                                # local `api_key` stays None
...
api_key = str(api_key)        # 'None' (literal string)
settings.chroma_client_auth_credentials = api_key   # bad creds sent
```

Pull the resolved value back into the local before downstream use:

```python
api_key = next(arg.value for arg in required_args if arg.name == "api_key")
```

Diff is 6 lines in `chromadb/__init__.py` plus 63 lines of new tests --
no existing assertions changed.

## Test

Two new regression tests in `chromadb/test/client/test_cloud_client.py`:

- `test_api_key_loaded_from_env_var` -- exact regression: sets
  `CHROMA_API_KEY=env_token`, calls `CloudClient(database='testdb')`
  with no `api_key=` arg, asserts
  `settings.chroma_client_auth_credentials == 'env_token'` and
  `!= 'None'`.
- `test_api_key_explicit_arg_overrides_env_var` -- guards against the
  obvious overcorrection (explicit arg getting clobbered by env).

```
$ python3 -m pytest chromadb/test/client/test_cloud_client.py -v
============================== 19 passed in 0.48s ==============================
```

(17 existing + 2 new -- no existing tests regressed.)

Verified the new test fails on `main` (without the fix):
`settings.chroma_client_auth_credentials` resolves to `'None'`.

Closes #6104