### PR TITLE
[ENH] Add word based FTS tokenizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "hnswlib",
  "indicatif",
  "itertools 0.13.0",
+ "murmur3",
  "opentelemetry",
  "parking_lot",
  "parquet",

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -33,6 +33,7 @@ base64 = { workspace = true }
 bitpacking = { workspace = true }
 bytemuck = { workspace = true }
 itertools = { workspace = true }
+murmur3 = { workspace = true }
 hnswlib = { workspace = true }
 opentelemetry = { version = "0.27.0", default-features = false, features = ["trace", "metrics"] }
 simsimd = { workspace = true }

--- a/rust/index/src/fulltext/README.md
+++ b/rust/index/src/fulltext/README.md
@@ -1,0 +1,42 @@
+# Full-Text Bitmap Index
+
+Word-based full-text substring search using hashed token buckets with roaring bitmaps.
+
+## Architecture
+
+- **Tokenizer** (`tokenizer.rs`): Decomposes documents and queries into numeric keys. Owns the linguistic pipeline (word splitting, lowercasing, ASCII folding, short/long filtering) and hash mapping (murmur3 → bucket IDs). Produces `DocumentTokens` for indexing and `QueryPlan` for search. The index receives fully resolved keys and never performs string analysis.
+
+- **Writer** (`bitmap_index.rs`): Accumulates per-batch deltas and writes bucket, trigram, and transition bitmaps to a single blockfile. Takes pre-computed `DocumentTokens` from the tokenizer.
+
+- **Reader** (`bitmap_index.rs`): Executes a `QueryPlan` through a 2-stage pipeline and returns candidate doc IDs as a roaring bitmap. The result is an over-estimate — brute-force verification (Stage 3) is the caller's responsibility.
+
+## Blockfile Layout
+
+A single blockfile typed as `(prefix: &str, key: u32) → RoaringBitmap` with three logical partitions:
+
+1. **Token buckets** — `prefix=""`, `key ∈ [0, 2^24)`. Each token is hashed to a bucket ID. The bitmap stores doc IDs containing tokens in that bucket.
+
+2. **Transitions** — `prefix=""`, `key ∈ [2^24, 2^26)`. For each adjacent token pair, the boundary characters are hashed. Two entries per transition: `key = hash | (1 << 24)` for doc-ID bitmap, `key = hash | (1 << 25)` for bucket-ID bitmap.
+
+3. **Trigrams** — `prefix="{trigram}"`, `key ∈ {0, 1, 2}`. Maps character trigrams to bucket IDs with disjoint positional keys: 0 = prefix (first trigram of token), 1 = infix, 2 = suffix (last trigram). Single-trigram tokens (3 chars) are stored under both key=0 and key=2.
+
+Entries are written in `(prefix, key)` sorted order: all token buckets, then transitions, then trigrams.
+
+## Query Pipeline
+
+**Stage 1 — Candidate resolution.** For each query token:
+- Body tokens (known word boundaries on both sides): hash directly to a single bucket ID.
+- Partial tokens (prefix, suffix, or singleton): resolve via trigram index. For each trigram, load the appropriate positional keys and AND across trigrams to get candidate bucket IDs.
+- Between adjacent tokens: filter bucket sets with transition bucket bitmaps.
+
+**Stage 2 — Doc bitmap intersection.** Load doc-ID bitmaps for surviving bucket IDs, OR within each token, AND across all tokens and transition doc bitmaps. Sort by cardinality (smallest first) for early termination.
+
+**Stage 3 — Brute-force verification.** Not implemented in this module. The caller scans each candidate document's raw text with substring matching to eliminate false positives.
+
+## Design Choices
+
+- **24-bit hash** — 16M buckets. At 40M docs with 7.1M unique tokens, 80% of occupied buckets are singletons.
+- **Bigram transitions** — Boundary characters use 2 chars per side (TRANSITION_CHARS=2), reducing transition entries and index size compared to trigram boundaries.
+- **Disjoint trigram keys** — Positional keys (prefix/infix/suffix) are stored separately, allowing the query to narrow candidates based on where a trigram appears within a token.
+- **Over-estimation semantics** — The index is a sieve. All stages produce supersets of true matches. Stage 3 brute-force verification produces exact results.
+- **Stale entries on delete** — Deleting a document removes it from token bucket and transition doc bitmaps. Trigram and transition bucket bitmaps are left stale — they only cause slightly larger candidate sets, which Stage 3 filters out.

--- a/rust/index/src/fulltext/mod.rs
+++ b/rust/index/src/fulltext/mod.rs
@@ -1,2 +1,3 @@
+pub mod tokenizer;
 pub mod types;
 mod util;

--- a/rust/index/src/fulltext/tokenizer.rs
+++ b/rust/index/src/fulltext/tokenizer.rs
@@ -1,0 +1,373 @@
+use tantivy::tokenizer::{
+    AsciiFoldingFilter, LowerCaser, RemoveLongFilter, SimpleTokenizer, TextAnalyzer, Token,
+    TokenFilter, TokenStream, Tokenizer,
+};
+use thiserror::Error;
+
+const MIN_TOKEN_LENGTH: usize = 2;
+const MAX_TOKEN_LENGTH: usize = 128;
+
+/// `TokenFilter` that removes tokens shorter than a given number of bytes.
+#[derive(Clone)]
+struct RemoveShortFilter {
+    min_length: usize,
+}
+
+impl TokenFilter for RemoveShortFilter {
+    type Tokenizer<T: Tokenizer> = RemoveShortFilterWrapper<T>;
+
+    fn transform<T: Tokenizer>(self, tokenizer: T) -> Self::Tokenizer<T> {
+        RemoveShortFilterWrapper {
+            min_length: self.min_length,
+            inner: tokenizer,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RemoveShortFilterWrapper<T> {
+    min_length: usize,
+    inner: T,
+}
+
+impl<T: Tokenizer> Tokenizer for RemoveShortFilterWrapper<T> {
+    type TokenStream<'a> = RemoveShortFilterStream<T::TokenStream<'a>>;
+
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+        RemoveShortFilterStream {
+            min_length: self.min_length,
+            inner: self.inner.token_stream(text),
+        }
+    }
+}
+
+struct RemoveShortFilterStream<T> {
+    min_length: usize,
+    inner: T,
+}
+
+impl<T: TokenStream> TokenStream for RemoveShortFilterStream<T> {
+    fn advance(&mut self) -> bool {
+        while self.inner.advance() {
+            if self.inner.token().text.len() >= self.min_length {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn token(&self) -> &Token {
+        self.inner.token()
+    }
+
+    fn token_mut(&mut self) -> &mut Token {
+        self.inner.token_mut()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum QueryError {
+    #[error("Query \"{query}\" has no token with at least {MIN_TOKEN_LENGTH} characters")]
+    NoSelectiveToken { query: String },
+}
+
+/// A decomposed full-text query.
+///
+/// `prefix` is set if the query starts with its first token (the token may be
+/// a suffix of a longer word in the document). `suffix` is set if the query
+/// ends with its last token (the token may be a prefix of a longer word).
+/// `tokens` contains all middle tokens that must match as complete words,
+/// plus any boundary tokens that are not prefix/suffix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FullTextQuery {
+    /// First token if the query starts with it — may be a suffix of a longer word.
+    pub prefix: Option<String>,
+    /// Tokens that must match as complete words.
+    pub tokens: Vec<String>,
+    /// Last token if the query ends with it — may be a prefix of a longer word.
+    pub suffix: Option<String>,
+}
+
+/// Word-based text analyzer for the full-text index.
+///
+/// Pipeline: `SimpleTokenizer` (split on non-alphanumeric) → `LowerCaser`
+/// → `AsciiFoldingFilter` (Unicode normalization) → `RemoveShortFilter(2)`
+/// → `RemoveLongFilter(128)`.
+#[derive(Clone)]
+pub struct WordAnalyzer {
+    inner: TextAnalyzer,
+}
+
+impl WordAnalyzer {
+    pub fn new() -> Self {
+        Self {
+            inner: TextAnalyzer::builder(SimpleTokenizer::default())
+                .filter(LowerCaser)
+                .filter(AsciiFoldingFilter)
+                .filter(RemoveShortFilter {
+                    min_length: MIN_TOKEN_LENGTH,
+                })
+                .filter(RemoveLongFilter::limit(MAX_TOKEN_LENGTH))
+                .build(),
+        }
+    }
+
+    /// Tokenize text, returning owned token strings.
+    pub fn tokenize(&mut self, text: &str) -> Vec<String> {
+        let mut tokens = Vec::new();
+        let mut stream = self.inner.token_stream(text);
+        while let Some(token) = stream.next() {
+            tokens.push(token.text.clone());
+        }
+        tokens
+    }
+
+    /// Decompose a query string into a [`FullTextQuery`].
+    ///
+    /// Returns `Err` if no token survives the analyzer.
+    pub fn tokenize_query(&mut self, query: &str) -> Result<FullTextQuery, QueryError> {
+        let mut stream = self.inner.token_stream(query);
+
+        let mut prefix = None;
+        let mut tokens = Vec::new();
+        let mut last_offset_to = 0;
+
+        while let Some(token) = stream.next() {
+            if tokens.is_empty() && prefix.is_none() {
+                // First token.
+                if token.offset_from == 0 {
+                    prefix = Some(token.text.clone());
+                } else {
+                    tokens.push(token.text.clone());
+                }
+            } else {
+                tokens.push(token.text.clone());
+            }
+            last_offset_to = token.offset_to;
+        }
+
+        if prefix.is_none() && tokens.is_empty() {
+            return Err(QueryError::NoSelectiveToken {
+                query: query.to_string(),
+            });
+        }
+
+        let suffix = if last_offset_to == query.len() {
+            tokens.pop().or(prefix.clone())
+        } else {
+            None
+        };
+
+        Ok(FullTextQuery {
+            prefix,
+            tokens,
+            suffix,
+        })
+    }
+}
+
+impl Default for WordAnalyzer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_tokenization() {
+        let mut a = WordAnalyzer::new();
+        assert_eq!(a.tokenize("Hello World"), vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn test_short_tokens_removed() {
+        let mut a = WordAnalyzer::new();
+        assert_eq!(
+            a.tokenize("a is the big house"),
+            vec!["is", "the", "big", "house"]
+        );
+    }
+
+    #[test]
+    fn test_unicode_normalization() {
+        let mut a = WordAnalyzer::new();
+        assert_eq!(
+            a.tokenize("café résumé naïve über"),
+            vec!["cafe", "resume", "naive", "uber"]
+        );
+    }
+
+    #[test]
+    fn test_punctuation_splits() {
+        let mut a = WordAnalyzer::new();
+        assert_eq!(
+            a.tokenize("hello, world! foo-bar"),
+            vec!["hello", "world", "foo", "bar"]
+        );
+    }
+
+    #[test]
+    fn test_code_tokenization() {
+        let mut a = WordAnalyzer::new();
+        assert_eq!(
+            a.tokenize("item.price = calculate_total(items)"),
+            vec!["item", "price", "calculate", "total", "items"]
+        );
+    }
+
+    #[test]
+    fn test_long_tokens_removed() {
+        let mut a = WordAnalyzer::new();
+        let text = format!("hello {} world", "a".repeat(129));
+        assert_eq!(a.tokenize(&text), vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let mut a = WordAnalyzer::new();
+        assert!(a.tokenize("").is_empty());
+    }
+
+    #[test]
+    fn test_only_single_char_tokens() {
+        let mut a = WordAnalyzer::new();
+        assert!(a.tokenize("a b c").is_empty());
+    }
+
+    #[test]
+    fn test_mixed_case_and_numbers() {
+        let mut a = WordAnalyzer::new();
+        assert_eq!(
+            a.tokenize("HTTP2 StatusCode 404"),
+            vec!["http2", "statuscode", "404"]
+        );
+    }
+
+    // --- tokenize_query tests ---
+
+    fn query(q: &str) -> FullTextQuery {
+        WordAnalyzer::new().tokenize_query(q).unwrap()
+    }
+
+    #[test]
+    fn test_query_single_word() {
+        let q = query("hello");
+        assert_eq!(q.prefix.as_deref(), Some("hello"));
+        assert!(q.tokens.is_empty());
+        assert_eq!(q.suffix.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn test_query_two_words() {
+        let q = query("hello world");
+        assert_eq!(q.prefix.as_deref(), Some("hello"));
+        assert!(q.tokens.is_empty());
+        assert_eq!(q.suffix.as_deref(), Some("world"));
+    }
+
+    #[test]
+    fn test_query_three_words() {
+        let q = query("hello beautiful world");
+        assert_eq!(q.prefix.as_deref(), Some("hello"));
+        assert_eq!(q.tokens, vec!["beautiful"]);
+        assert_eq!(q.suffix.as_deref(), Some("world"));
+    }
+
+    #[test]
+    fn test_query_many_words() {
+        let q = query("the quick brown fox");
+        assert_eq!(q.prefix.as_deref(), Some("the"));
+        assert_eq!(q.tokens, vec!["quick", "brown"]);
+        assert_eq!(q.suffix.as_deref(), Some("fox"));
+    }
+
+    #[test]
+    fn test_query_leading_punctuation() {
+        let q = query(". start end");
+        assert!(q.prefix.is_none());
+        assert_eq!(q.tokens, vec!["start"]);
+        assert_eq!(q.suffix.as_deref(), Some("end"));
+    }
+
+    #[test]
+    fn test_query_trailing_punctuation() {
+        let q = query("start end .");
+        assert_eq!(q.prefix.as_deref(), Some("start"));
+        assert_eq!(q.tokens, vec!["end"]);
+        assert!(q.suffix.is_none());
+    }
+
+    #[test]
+    fn test_query_both_punctuation() {
+        let q = query(". hello .");
+        assert!(q.prefix.is_none());
+        assert_eq!(q.tokens, vec!["hello"]);
+        assert!(q.suffix.is_none());
+    }
+
+    #[test]
+    fn test_query_leading_space() {
+        let q = query(" hello world");
+        assert!(q.prefix.is_none());
+        assert_eq!(q.tokens, vec!["hello"]);
+        assert_eq!(q.suffix.as_deref(), Some("world"));
+    }
+
+    #[test]
+    fn test_query_code() {
+        let q = query("calculate_total");
+        assert_eq!(q.prefix.as_deref(), Some("calculate"));
+        assert!(q.tokens.is_empty());
+        assert_eq!(q.suffix.as_deref(), Some("total"));
+    }
+
+    #[test]
+    fn test_query_unicode() {
+        let q = query("café résumé");
+        assert_eq!(q.prefix.as_deref(), Some("cafe"));
+        assert!(q.tokens.is_empty());
+        assert_eq!(q.suffix.as_deref(), Some("resume"));
+    }
+
+    #[test]
+    fn test_query_short_tokens_filtered() {
+        let q = query("a beautiful day");
+        assert!(q.prefix.is_none());
+        assert_eq!(q.tokens, vec!["beautiful"]);
+        assert_eq!(q.suffix.as_deref(), Some("day"));
+    }
+
+    #[test]
+    fn test_query_reject_empty() {
+        assert!(WordAnalyzer::new().tokenize_query("").is_err());
+    }
+
+    #[test]
+    fn test_query_reject_whitespace() {
+        assert!(WordAnalyzer::new().tokenize_query("   ").is_err());
+    }
+
+    #[test]
+    fn test_query_accept_two_chars() {
+        assert!(WordAnalyzer::new().tokenize_query("ab").is_ok());
+    }
+
+    #[test]
+    fn test_query_reject_single_char() {
+        assert!(WordAnalyzer::new().tokenize_query("a").is_err());
+    }
+
+    #[test]
+    fn test_query_reject_no_tokens() {
+        assert!(WordAnalyzer::new().tokenize_query("...").is_err());
+    }
+
+    #[test]
+    fn test_query_error_contains_query() {
+        let err = WordAnalyzer::new().tokenize_query("a").unwrap_err();
+        assert!(err.to_string().contains("a"));
+    }
+}

--- a/rust/index/src/fulltext/tokenizer.rs
+++ b/rust/index/src/fulltext/tokenizer.rs
@@ -3,8 +3,8 @@ use std::io::Cursor;
 
 use murmur3::murmur3_32;
 use tantivy::tokenizer::{
-    AsciiFoldingFilter, LowerCaser, NgramTokenizer, RemoveLongFilter, SimpleTokenizer,
-    TextAnalyzer, Token, TokenFilter, TokenStream, Tokenizer,
+    LowerCaser, NgramTokenizer, RemoveLongFilter, SimpleTokenizer, TextAnalyzer, Token,
+    TokenFilter, TokenStream, Tokenizer,
 };
 use thiserror::Error;
 
@@ -13,19 +13,41 @@ use thiserror::Error;
 // ---------------------------------------------------------------------------
 
 const TRIGRAM_LENGTH: usize = 3;
+
+/// Tokens longer than this are dropped by the word tokenizer and not indexed.
+/// 128 chars covers essentially all natural-language words and programming
+/// identifiers while avoiding pathological inputs (base64 blobs, minified code).
 const MAX_TOKEN_LENGTH: usize = 128;
+
 const DEFAULT_HASH_BITS: u32 = 24;
 
 /// Murmur3 seed. Fixed — changing it invalidates all existing blockfiles.
+///
+/// Murmur3 is a fast, non-cryptographic hash with good distribution,
+/// and is already a dependency in the Chroma codebase.
 const HASH_SEED: u32 = 0x5f3759df;
 
-/// Boundary characters hashed for cross-token transitions.
+/// Number of boundary characters hashed for cross-token transitions.
+///
+/// Benchmarked bigram (2) vs trigram (3) transitions: bigrams give 28-33%
+/// smaller index with ≤1.3% precision loss. Fixed at 2 — changing this
+/// value invalidates all existing blockfiles.
 const TRANSITION_CHARS: usize = 2;
 
 // ---------------------------------------------------------------------------
 // RemoveShortFilter
 // ---------------------------------------------------------------------------
 
+/// Drops tokens shorter than `min_length` bytes.
+///
+/// Used to filter out very short tokens (e.g. "a", "of") that are too small
+/// for trigram extraction and would create excessive hash collisions.
+///
+/// Follows the tantivy `TokenFilter` pattern: a config struct
+/// (`RemoveShortFilter`), a wrapper that implements `Tokenizer`
+/// (`RemoveShortFilterWrapper`), and a stream that implements `TokenStream`
+/// (`RemoveShortFilterStream`) where the actual filtering happens in
+/// `advance()`.
 #[derive(Clone)]
 struct RemoveShortFilter {
     min_length: usize,
@@ -163,9 +185,10 @@ fn first_n_chars(s: &str, n: usize) -> &str {
 /// fully resolved numeric keys and never performs string analysis.
 ///
 /// Two internal pipelines:
-/// - **Word**: `SimpleTokenizer` → `LowerCaser` → `AsciiFoldingFilter`
-///   → `RemoveShortFilter(3)` → `RemoveLongFilter(128)`.
-/// - **Trigram**: `NgramTokenizer(3,3)` → `LowerCaser`.
+/// - **Word**: `SimpleTokenizer` → `LowerCaser` → `RemoveShortFilter(3)`
+///   → `RemoveLongFilter(128)`.
+/// - **Trigram**: `NgramTokenizer(3,3)` (no additional filters — input is
+///   already lowercased by the word pipeline).
 #[derive(Clone)]
 pub struct WordAnalyzer {
     num_buckets: u32,
@@ -179,10 +202,9 @@ impl WordAnalyzer {
             .map_err(|e| TokenizerError::Config(e.to_string()))?;
         Ok(Self {
             num_buckets: 1u32 << hash_bits,
-            trigram_tokenizer: TextAnalyzer::builder(ngram).filter(LowerCaser).build(),
+            trigram_tokenizer: TextAnalyzer::builder(ngram).build(),
             word_tokenizer: TextAnalyzer::builder(SimpleTokenizer::default())
                 .filter(LowerCaser)
-                .filter(AsciiFoldingFilter)
                 .filter(RemoveShortFilter {
                     min_length: TRIGRAM_LENGTH,
                 })
@@ -374,10 +396,11 @@ mod tests {
     #[test]
     fn test_document_filters() {
         let mut a = WordAnalyzer::default();
-        // "a" (1 char) and "is" (2 chars) removed; ASCII folding on "café".
+        // "a" (1 char) and "is" (2 chars) removed by RemoveShortFilter.
+        // "café" is lowercased to "café" (no ASCII folding).
         let dt = a.tokenize_document("a is café").unwrap();
         assert_eq!(dt.buckets.len(), 1);
-        assert!(dt.buckets.contains(&a.hash_token("cafe").unwrap()));
+        assert!(dt.buckets.contains(&a.hash_token("café").unwrap()));
     }
 
     #[test]

--- a/rust/index/src/fulltext/tokenizer.rs
+++ b/rust/index/src/fulltext/tokenizer.rs
@@ -86,6 +86,10 @@ pub struct FullTextQuery {
     pub tokens: Vec<String>,
     /// Last token if the query ends with it — may be a prefix of a longer word.
     pub suffix: Option<String>,
+    /// True when the query produces exactly one token that is both prefix
+    /// and suffix. The search layer should OR both prefix and suffix
+    /// dictionary lookups for this token.
+    pub singleton: bool,
 }
 
 /// Word-based text analyzer for the full-text index.
@@ -158,10 +162,13 @@ impl WordAnalyzer {
             None
         };
 
+        let singleton = prefix.is_some() && tokens.is_empty() && suffix == prefix;
+
         Ok(FullTextQuery {
             prefix,
             tokens,
             suffix,
+            singleton,
         })
     }
 }
@@ -258,6 +265,7 @@ mod tests {
         assert_eq!(q.prefix.as_deref(), Some("hello"));
         assert!(q.tokens.is_empty());
         assert_eq!(q.suffix.as_deref(), Some("hello"));
+        assert!(q.singleton);
     }
 
     #[test]
@@ -266,6 +274,7 @@ mod tests {
         assert_eq!(q.prefix.as_deref(), Some("hello"));
         assert!(q.tokens.is_empty());
         assert_eq!(q.suffix.as_deref(), Some("world"));
+        assert!(!q.singleton);
     }
 
     #[test]

--- a/rust/index/src/fulltext/tokenizer.rs
+++ b/rust/index/src/fulltext/tokenizer.rs
@@ -299,9 +299,7 @@ impl WordAnalyzer {
         let mut trigrams = Vec::new();
         let mut stream = self.trigram_tokenizer.token_stream(s);
         while let Some(token) = stream.next() {
-            if !trigrams.contains(&token.text) {
-                trigrams.push(token.text.clone());
-            }
+            trigrams.push(token.text.clone());
         }
         trigrams
     }

--- a/rust/index/src/fulltext/tokenizer.rs
+++ b/rust/index/src/fulltext/tokenizer.rs
@@ -1,13 +1,31 @@
+use std::collections::HashSet;
+use std::io::Cursor;
+
+use murmur3::murmur3_32;
 use tantivy::tokenizer::{
     AsciiFoldingFilter, LowerCaser, NgramTokenizer, RemoveLongFilter, SimpleTokenizer,
     TextAnalyzer, Token, TokenFilter, TokenStream, Tokenizer,
 };
 use thiserror::Error;
 
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
 const TRIGRAM_LENGTH: usize = 3;
 const MAX_TOKEN_LENGTH: usize = 128;
+const DEFAULT_HASH_BITS: u32 = 24;
 
-/// `TokenFilter` that removes tokens shorter than a given number of bytes.
+/// Murmur3 seed. Fixed — changing it invalidates all existing blockfiles.
+const HASH_SEED: u32 = 0x5f3759df;
+
+/// Boundary characters hashed for cross-token transitions.
+const TRANSITION_CHARS: usize = 2;
+
+// ---------------------------------------------------------------------------
+// RemoveShortFilter
+// ---------------------------------------------------------------------------
+
 #[derive(Clone)]
 struct RemoveShortFilter {
     min_length: usize,
@@ -65,48 +83,103 @@ impl<T: TokenStream> TokenStream for RemoveShortFilterStream<T> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Error)]
-pub enum QueryError {
+pub enum TokenizerError {
     #[error("Query \"{query}\" has no token with at least {TRIGRAM_LENGTH} characters")]
     NoSelectiveToken { query: String },
+    #[error("Hash error: {0}")]
+    Hash(#[from] std::io::Error),
+    #[error("Invalid tokenizer configuration: {0}")]
+    Config(String),
 }
 
-/// A decomposed full-text query.
-///
-/// `prefix` is set if the query starts with its first token (the token may be
-/// a suffix of a longer word in the document). `suffix` is set if the query
-/// ends with its last token (the token may be a prefix of a longer word).
-/// `tokens` contains all middle tokens that must match as complete words,
-/// plus any boundary tokens that are not prefix/suffix.
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+/// Decomposed document for the index writer.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FullTextQuery {
-    /// First token if the query starts with it — may be a suffix of a longer word.
-    pub prefix: Option<String>,
-    /// Tokens that must match as complete words.
-    pub tokens: Vec<String>,
-    /// Last token if the query ends with it — may be a prefix of a longer word.
-    pub suffix: Option<String>,
-    /// True when the query produces exactly one token that is both prefix
-    /// and suffix. The search layer should OR both prefix and suffix
-    /// dictionary lookups for this token.
+pub struct DocumentTokens {
+    /// Unique bucket IDs this document contributes to (sorted, deduplicated).
+    pub buckets: Vec<u32>,
+    /// `(trigram, positional_key, bucket_id)` for the trigram index.
+    /// Keys: 0 = prefix (first trigram), 1 = infix, 2 = suffix (last trigram).
+    /// Single-trigram tokens emit both key=0 and key=2.
+    pub trigrams: Vec<(String, u32, u32)>,
+    /// `(transition_hash, prev_bucket, curr_bucket)` for adjacent token pairs.
+    pub transitions: Vec<(u32, u32, u32)>,
+}
+
+/// A single token's lookup strategy during query evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenLookup {
+    /// Body token: direct bucket ID lookup.
+    Direct(u32),
+    /// Partial token: ordered trigrams for resolution via the trigram index.
+    /// First element is the token's first trigram, last is last.
+    Trigram(Vec<String>),
+}
+
+/// Decomposed query for the index reader.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryPlan {
+    /// Ordered token lookups. The index uses position to determine which
+    /// trigram positional keys to consult (first Trigram = prefix-side,
+    /// last Trigram = suffix-side).
+    pub lookups: Vec<TokenLookup>,
+    /// Transition hashes between adjacent query tokens.
+    pub transitions: Vec<u32>,
+    /// Single partial token — no transitions, no adjacent pairs.
     pub singleton: bool,
 }
 
+// ---------------------------------------------------------------------------
+// String helpers
+// ---------------------------------------------------------------------------
+
+fn last_n_chars(s: &str, n: usize) -> &str {
+    let skip = s.chars().count().saturating_sub(n);
+    let byte_offset = s.char_indices().nth(skip).map_or(0, |(i, _)| i);
+    &s[byte_offset..]
+}
+
+fn first_n_chars(s: &str, n: usize) -> &str {
+    let end = s.char_indices().nth(n).map_or(s.len(), |(i, _)| i);
+    &s[..end]
+}
+
+// ---------------------------------------------------------------------------
+// WordAnalyzer
+// ---------------------------------------------------------------------------
+
 /// Word-based text analyzer for the full-text index.
 ///
-/// Two pipelines:
-/// - **Word tokenizer**: `SimpleTokenizer` → `LowerCaser` → `AsciiFoldingFilter`
+/// Owns the linguistic pipeline (tokenization, trigram extraction) and the
+/// hash mapping (token → bucket ID, transition → hash). The index receives
+/// fully resolved numeric keys and never performs string analysis.
+///
+/// Two internal pipelines:
+/// - **Word**: `SimpleTokenizer` → `LowerCaser` → `AsciiFoldingFilter`
 ///   → `RemoveShortFilter(3)` → `RemoveLongFilter(128)`.
-/// - **Trigram tokenizer**: `NgramTokenizer(3,3)` → `LowerCaser`.
+/// - **Trigram**: `NgramTokenizer(3,3)` → `LowerCaser`.
 #[derive(Clone)]
 pub struct WordAnalyzer {
-    word_tokenizer: TextAnalyzer,
+    num_buckets: u32,
     trigram_tokenizer: TextAnalyzer,
+    word_tokenizer: TextAnalyzer,
 }
 
 impl WordAnalyzer {
-    pub fn new() -> Self {
-        Self {
+    pub fn new(hash_bits: u32) -> Result<Self, TokenizerError> {
+        let ngram = NgramTokenizer::new(TRIGRAM_LENGTH, TRIGRAM_LENGTH, false)
+            .map_err(|e| TokenizerError::Config(e.to_string()))?;
+        Ok(Self {
+            num_buckets: 1u32 << hash_bits,
+            trigram_tokenizer: TextAnalyzer::builder(ngram).filter(LowerCaser).build(),
             word_tokenizer: TextAnalyzer::builder(SimpleTokenizer::default())
                 .filter(LowerCaser)
                 .filter(AsciiFoldingFilter)
@@ -115,17 +188,105 @@ impl WordAnalyzer {
                 })
                 .filter(RemoveLongFilter::limit(MAX_TOKEN_LENGTH))
                 .build(),
-            trigram_tokenizer: TextAnalyzer::builder(
-                NgramTokenizer::new(TRIGRAM_LENGTH, TRIGRAM_LENGTH, false)
-                    .expect("valid ngram parameters"),
-            )
-            .filter(LowerCaser)
-            .build(),
-        }
+        })
     }
 
-    /// Tokenize text, returning owned token strings.
-    pub fn tokenize(&mut self, text: &str) -> Vec<String> {
+    /// Decompose a document into bucket IDs, trigram entries, and transitions.
+    pub fn tokenize_document(&mut self, text: &str) -> Result<DocumentTokens, TokenizerError> {
+        let tokens = self.tokenize(text);
+
+        let mut seen = HashSet::new();
+        let mut trigrams = Vec::new();
+        let mut transitions = Vec::new();
+        let mut prev: Option<(String, u32)> = None;
+
+        for token in &tokens {
+            let bucket = self.hash_token(token)?;
+
+            if seen.insert(bucket) {
+                self.emit_trigrams(token, bucket, &mut trigrams);
+            }
+
+            if let Some((ref prev_tok, prev_bucket)) = prev {
+                let h = self.hash_transition(
+                    last_n_chars(prev_tok, TRANSITION_CHARS),
+                    first_n_chars(token, TRANSITION_CHARS),
+                )?;
+                transitions.push((h, prev_bucket, bucket));
+            }
+            prev = Some((token.clone(), bucket));
+        }
+
+        let mut buckets: Vec<u32> = seen.into_iter().collect();
+        buckets.sort_unstable();
+        Ok(DocumentTokens {
+            buckets,
+            trigrams,
+            transitions,
+        })
+    }
+
+    /// Decompose a query into a plan the index reader can execute directly.
+    pub fn plan_query(&mut self, query: &str) -> Result<QueryPlan, TokenizerError> {
+        let (tokens, has_prefix, has_suffix) = {
+            let mut tokens = Vec::new();
+            let mut first_offset_from = None;
+            let mut last_offset_to = 0;
+            let mut stream = self.word_tokenizer.token_stream(query);
+            while let Some(token) = stream.next() {
+                if first_offset_from.is_none() {
+                    first_offset_from = Some(token.offset_from);
+                }
+                last_offset_to = token.offset_to;
+                tokens.push(token.text.clone());
+            }
+            (
+                tokens,
+                first_offset_from == Some(0),
+                last_offset_to == query.len(),
+            )
+        };
+
+        if tokens.is_empty() {
+            return Err(TokenizerError::NoSelectiveToken {
+                query: query.to_string(),
+            });
+        }
+
+        let singleton = tokens.len() == 1 && has_prefix && has_suffix;
+
+        let lookups = tokens
+            .iter()
+            .enumerate()
+            .map(|(i, token)| {
+                if (i == 0 && has_prefix) || (i == tokens.len() - 1 && has_suffix) {
+                    Ok(TokenLookup::Trigram(self.trigrams(token)))
+                } else {
+                    Ok(TokenLookup::Direct(self.hash_token(token)?))
+                }
+            })
+            .collect::<Result<Vec<_>, TokenizerError>>()?;
+
+        let transitions = tokens
+            .windows(2)
+            .map(|w| {
+                self.hash_transition(
+                    last_n_chars(&w[0], TRANSITION_CHARS),
+                    first_n_chars(&w[1], TRANSITION_CHARS),
+                )
+            })
+            .collect::<Result<Vec<_>, TokenizerError>>()?;
+
+        Ok(QueryPlan {
+            lookups,
+            singleton,
+            transitions,
+        })
+    }
+
+    // --- Private helpers ---
+
+    fn tokenize(&mut self, text: &str) -> Vec<String> {
         let mut tokens = Vec::new();
         let mut stream = self.word_tokenizer.token_stream(text);
         while let Some(token) = stream.next() {
@@ -134,57 +295,7 @@ impl WordAnalyzer {
         tokens
     }
 
-    /// Decompose a query string into a [`FullTextQuery`].
-    ///
-    /// Returns `Err` if no token survives the analyzer.
-    pub fn tokenize_query(&mut self, query: &str) -> Result<FullTextQuery, QueryError> {
-        let mut stream = self.word_tokenizer.token_stream(query);
-
-        let mut prefix = None;
-        let mut tokens = Vec::new();
-        let mut last_offset_to = 0;
-
-        while let Some(token) = stream.next() {
-            if tokens.is_empty() && prefix.is_none() {
-                // First token.
-                if token.offset_from == 0 {
-                    prefix = Some(token.text.clone());
-                } else {
-                    tokens.push(token.text.clone());
-                }
-            } else {
-                tokens.push(token.text.clone());
-            }
-            last_offset_to = token.offset_to;
-        }
-
-        if prefix.is_none() && tokens.is_empty() {
-            return Err(QueryError::NoSelectiveToken {
-                query: query.to_string(),
-            });
-        }
-
-        let suffix = if last_offset_to == query.len() {
-            tokens.pop().or(prefix.clone())
-        } else {
-            None
-        };
-
-        let singleton = prefix.is_some() && tokens.is_empty() && suffix == prefix;
-
-        Ok(FullTextQuery {
-            prefix,
-            tokens,
-            suffix,
-            singleton,
-        })
-    }
-
-    /// Extract deduplicated character trigrams from a string.
-    /// The output is lowercased.
-    ///
-    /// E.g., `trigrams("Hello")` → `["hel", "ell", "llo"]`.
-    pub fn trigrams(&mut self, s: &str) -> Vec<String> {
+    fn trigrams(&mut self, s: &str) -> Vec<String> {
         let mut trigrams = Vec::new();
         let mut stream = self.trigram_tokenizer.token_stream(s);
         while let Some(token) = stream.next() {
@@ -194,241 +305,195 @@ impl WordAnalyzer {
         }
         trigrams
     }
+
+    fn hash_token(&self, token: &str) -> Result<u32, TokenizerError> {
+        let hash = murmur3_32(&mut Cursor::new(token.as_bytes()), HASH_SEED)?;
+        Ok(hash % self.num_buckets)
+    }
+
+    /// Hash a cross-token transition. The index applies flag bits to
+    /// distinguish transition keys from bucket keys in the blockfile.
+    fn hash_transition(&self, prev_suffix: &str, curr_prefix: &str) -> Result<u32, TokenizerError> {
+        // Max bytes: each side is at most TRANSITION_CHARS chars × 4 bytes/char (UTF-8),
+        // plus 1 null separator.
+        const CAP: usize = TRANSITION_CHARS * 4 * 2 + 1;
+        let mut buf = [0u8; CAP];
+        let a = prev_suffix.as_bytes();
+        let b = curr_prefix.as_bytes();
+        let len = a.len() + 1 + b.len();
+        buf[..a.len()].copy_from_slice(a);
+        buf[a.len()] = 0;
+        buf[a.len() + 1..len].copy_from_slice(b);
+        let hash = murmur3_32(&mut Cursor::new(&buf[..len]), HASH_SEED)?;
+        Ok(hash % self.num_buckets)
+    }
+
+    /// Emit trigram entries with positional keys for a token.
+    fn emit_trigrams(&mut self, token: &str, bucket: u32, out: &mut Vec<(String, u32, u32)>) {
+        let tris = self.trigrams(token);
+        let last = tris.len().saturating_sub(1);
+        for (i, tri) in tris.into_iter().enumerate() {
+            match i {
+                _ if i == 0 && i == last => {
+                    // Single-trigram token: both prefix and suffix.
+                    out.push((tri.clone(), 0, bucket));
+                    out.push((tri, 2, bucket));
+                }
+                0 => out.push((tri, 0, bucket)),
+                i if i == last => out.push((tri, 2, bucket)),
+                _ => out.push((tri, 1, bucket)),
+            }
+        }
+    }
 }
 
 impl Default for WordAnalyzer {
     fn default() -> Self {
-        Self::new()
+        Self::new(DEFAULT_HASH_BITS).expect("default configuration should be valid")
     }
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // --- tokenize_document ---
+
     #[test]
-    fn test_basic_tokenization() {
-        let mut a = WordAnalyzer::new();
-        assert_eq!(a.tokenize("Hello World"), vec!["hello", "world"]);
+    fn test_document_buckets() {
+        let mut a = WordAnalyzer::default();
+        let dt = a.tokenize_document("hello world hello").unwrap();
+        // Deduped: 2 unique tokens.
+        assert_eq!(dt.buckets.len(), 2);
+        assert!(dt.buckets.contains(&a.hash_token("hello").unwrap()));
+        assert!(dt.buckets.contains(&a.hash_token("world").unwrap()));
     }
 
     #[test]
-    fn test_short_tokens_removed() {
-        let mut a = WordAnalyzer::new();
-        // "a" (1), "is" (2) removed; "the" (3) kept with min_length=3
-        assert_eq!(
-            a.tokenize("a is the big house"),
-            vec!["the", "big", "house"]
-        );
+    fn test_document_filters() {
+        let mut a = WordAnalyzer::default();
+        // "a" (1 char) and "is" (2 chars) removed; ASCII folding on "café".
+        let dt = a.tokenize_document("a is café").unwrap();
+        assert_eq!(dt.buckets.len(), 1);
+        assert!(dt.buckets.contains(&a.hash_token("cafe").unwrap()));
     }
 
     #[test]
-    fn test_unicode_normalization() {
-        let mut a = WordAnalyzer::new();
-        assert_eq!(
-            a.tokenize("café résumé naïve über"),
-            vec!["cafe", "resume", "naive", "uber"]
-        );
+    fn test_document_trigrams() {
+        let mut a = WordAnalyzer::default();
+        // Multi-trigram: "hello" → "hel"(0), "ell"(1), "llo"(2).
+        let dt = a.tokenize_document("hello the").unwrap();
+        let hello_b = a.hash_token("hello").unwrap();
+        let the_b = a.hash_token("the").unwrap();
+        let hello_tri: Vec<(&str, u32)> = dt
+            .trigrams
+            .iter()
+            .filter(|(_, _, b)| *b == hello_b)
+            .map(|(s, k, _)| (s.as_str(), *k))
+            .collect();
+        assert_eq!(hello_tri, vec![("hel", 0), ("ell", 1), ("llo", 2)]);
+        // Single-trigram: "the" → key=0 and key=2, no infix.
+        let the_tri: Vec<(&str, u32)> = dt
+            .trigrams
+            .iter()
+            .filter(|(_, _, b)| *b == the_b)
+            .map(|(s, k, _)| (s.as_str(), *k))
+            .collect();
+        assert_eq!(the_tri, vec![("the", 0), ("the", 2)]);
     }
 
     #[test]
-    fn test_punctuation_splits() {
-        let mut a = WordAnalyzer::new();
-        assert_eq!(
-            a.tokenize("hello, world! foo-bar"),
-            vec!["hello", "world", "foo", "bar"]
-        );
+    fn test_document_transitions() {
+        let mut a = WordAnalyzer::default();
+        let dt = a.tokenize_document("hello world peace").unwrap();
+        assert_eq!(dt.transitions.len(), 2);
+        assert_eq!(dt.transitions[0].1, a.hash_token("hello").unwrap());
+        assert_eq!(dt.transitions[0].2, a.hash_token("world").unwrap());
+        assert_eq!(dt.transitions[1].1, a.hash_token("world").unwrap());
+        assert_eq!(dt.transitions[1].2, a.hash_token("peace").unwrap());
+        // Filtered tokens produce no pairs: only "the" survives → 0 transitions.
+        let dt2 = a.tokenize_document("a is the").unwrap();
+        assert!(dt2.transitions.is_empty());
     }
 
     #[test]
-    fn test_code_tokenization() {
-        let mut a = WordAnalyzer::new();
-        assert_eq!(
-            a.tokenize("item.price = calculate_total(items)"),
-            vec!["item", "price", "calculate", "total", "items"]
-        );
+    fn test_document_empty() {
+        let mut a = WordAnalyzer::default();
+        let dt = a.tokenize_document("").unwrap();
+        assert!(dt.buckets.is_empty());
+        assert!(dt.trigrams.is_empty());
+        assert!(dt.transitions.is_empty());
+    }
+
+    // --- plan_query ---
+
+    #[test]
+    fn test_query_singleton() {
+        let mut a = WordAnalyzer::default();
+        let plan = a.plan_query("hello").unwrap();
+        assert!(plan.singleton);
+        assert_eq!(plan.lookups.len(), 1);
+        let TokenLookup::Trigram(ref tris) = plan.lookups[0] else {
+            panic!("expected Trigram");
+        };
+        assert_eq!(tris, &["hel", "ell", "llo"]);
+        assert!(plan.transitions.is_empty());
     }
 
     #[test]
-    fn test_long_tokens_removed() {
-        let mut a = WordAnalyzer::new();
-        let text = format!("hello {} world", "a".repeat(129));
-        assert_eq!(a.tokenize(&text), vec!["hello", "world"]);
+    fn test_query_body_tokens() {
+        let mut a = WordAnalyzer::default();
+        // Three words: prefix(Trigram) + body(Direct) + suffix(Trigram).
+        let plan = a.plan_query("hello beautiful world").unwrap();
+        assert!(!plan.singleton);
+        assert_eq!(plan.lookups.len(), 3);
+        assert!(matches!(&plan.lookups[0], TokenLookup::Trigram(_)));
+        assert!(matches!(&plan.lookups[1], TokenLookup::Direct(_)));
+        assert!(matches!(&plan.lookups[2], TokenLookup::Trigram(_)));
+        assert_eq!(plan.transitions.len(), 2);
     }
 
     #[test]
-    fn test_empty_input() {
-        let mut a = WordAnalyzer::new();
-        assert!(a.tokenize("").is_empty());
-    }
-
-    #[test]
-    fn test_only_single_char_tokens() {
-        let mut a = WordAnalyzer::new();
-        assert!(a.tokenize("a b c").is_empty());
-    }
-
-    #[test]
-    fn test_mixed_case_and_numbers() {
-        let mut a = WordAnalyzer::new();
-        assert_eq!(
-            a.tokenize("HTTP2 StatusCode 404"),
-            vec!["http2", "statuscode", "404"]
-        );
-    }
-
-    // --- tokenize_query tests ---
-
-    fn query(q: &str) -> FullTextQuery {
-        WordAnalyzer::new().tokenize_query(q).unwrap()
-    }
-
-    #[test]
-    fn test_query_single_word() {
-        let q = query("hello");
-        assert_eq!(q.prefix.as_deref(), Some("hello"));
-        assert!(q.tokens.is_empty());
-        assert_eq!(q.suffix.as_deref(), Some("hello"));
-        assert!(q.singleton);
-    }
-
-    #[test]
-    fn test_query_two_words() {
-        let q = query("hello world");
-        assert_eq!(q.prefix.as_deref(), Some("hello"));
-        assert!(q.tokens.is_empty());
-        assert_eq!(q.suffix.as_deref(), Some("world"));
-        assert!(!q.singleton);
-    }
-
-    #[test]
-    fn test_query_three_words() {
-        let q = query("hello beautiful world");
-        assert_eq!(q.prefix.as_deref(), Some("hello"));
-        assert_eq!(q.tokens, vec!["beautiful"]);
-        assert_eq!(q.suffix.as_deref(), Some("world"));
-    }
-
-    #[test]
-    fn test_query_many_words() {
-        let q = query("the quick brown fox");
-        assert_eq!(q.prefix.as_deref(), Some("the"));
-        assert_eq!(q.tokens, vec!["quick", "brown"]);
-        assert_eq!(q.suffix.as_deref(), Some("fox"));
-    }
-
-    #[test]
-    fn test_query_leading_punctuation() {
-        let q = query(". start end");
-        assert!(q.prefix.is_none());
-        assert_eq!(q.tokens, vec!["start"]);
-        assert_eq!(q.suffix.as_deref(), Some("end"));
-    }
-
-    #[test]
-    fn test_query_trailing_punctuation() {
-        let q = query("start end .");
-        assert_eq!(q.prefix.as_deref(), Some("start"));
-        assert_eq!(q.tokens, vec!["end"]);
-        assert!(q.suffix.is_none());
-    }
-
-    #[test]
-    fn test_query_both_punctuation() {
-        let q = query(". hello .");
-        assert!(q.prefix.is_none());
-        assert_eq!(q.tokens, vec!["hello"]);
-        assert!(q.suffix.is_none());
-    }
-
-    #[test]
-    fn test_query_leading_space() {
-        let q = query(" hello world");
-        assert!(q.prefix.is_none());
-        assert_eq!(q.tokens, vec!["hello"]);
-        assert_eq!(q.suffix.as_deref(), Some("world"));
-    }
-
-    #[test]
-    fn test_query_code() {
-        let q = query("calculate_total");
-        assert_eq!(q.prefix.as_deref(), Some("calculate"));
-        assert!(q.tokens.is_empty());
-        assert_eq!(q.suffix.as_deref(), Some("total"));
-    }
-
-    #[test]
-    fn test_query_unicode() {
-        let q = query("café résumé");
-        assert_eq!(q.prefix.as_deref(), Some("cafe"));
-        assert!(q.tokens.is_empty());
-        assert_eq!(q.suffix.as_deref(), Some("resume"));
-    }
-
-    #[test]
-    fn test_query_short_tokens_filtered() {
-        let q = query("a beautiful day");
-        assert!(q.prefix.is_none());
-        assert_eq!(q.tokens, vec!["beautiful"]);
-        assert_eq!(q.suffix.as_deref(), Some("day"));
-    }
-
-    #[test]
-    fn test_query_reject_empty() {
-        assert!(WordAnalyzer::new().tokenize_query("").is_err());
-    }
-
-    #[test]
-    fn test_query_reject_whitespace() {
-        assert!(WordAnalyzer::new().tokenize_query("   ").is_err());
-    }
-
-    #[test]
-    fn test_query_reject_two_chars() {
-        // "ab" is 2 chars, below MIN_TOKEN_LENGTH=3.
-        assert!(WordAnalyzer::new().tokenize_query("ab").is_err());
-    }
-
-    #[test]
-    fn test_query_reject_single_char() {
-        assert!(WordAnalyzer::new().tokenize_query("a").is_err());
+    fn test_query_boundaries() {
+        let mut a = WordAnalyzer::default();
+        // Leading space → first token becomes Direct (not prefix).
+        let plan = a.plan_query(" hello world").unwrap();
+        assert!(matches!(&plan.lookups[0], TokenLookup::Direct(_)));
+        assert!(matches!(&plan.lookups[1], TokenLookup::Trigram(_)));
+        // Trailing punctuation → last token becomes Direct (not suffix).
+        let plan = a.plan_query("hello world.").unwrap();
+        assert!(matches!(&plan.lookups[0], TokenLookup::Trigram(_)));
+        assert!(matches!(&plan.lookups[1], TokenLookup::Direct(_)));
+        // Both → all Direct, verify hash value.
+        let plan = a.plan_query(" hello ").unwrap();
+        assert_eq!(plan.lookups.len(), 1);
+        let TokenLookup::Direct(bucket) = plan.lookups[0] else {
+            panic!("expected Direct");
+        };
+        assert_eq!(bucket, a.hash_token("hello").unwrap());
     }
 
     #[test]
     fn test_query_reject_no_tokens() {
-        assert!(WordAnalyzer::new().tokenize_query("...").is_err());
+        let mut a = WordAnalyzer::default();
+        assert!(a.plan_query("").is_err());
+        assert!(a.plan_query("ab").is_err());
+        assert!(a.plan_query("   ").is_err());
     }
 
-    #[test]
-    fn test_query_error_contains_query() {
-        let err = WordAnalyzer::new().tokenize_query("a").unwrap_err();
-        assert!(err.to_string().contains("a"));
-    }
-
-    // --- trigrams ---
+    // --- hash_bits ---
 
     #[test]
-    fn test_trigrams_basic() {
-        let mut a = WordAnalyzer::new();
-        assert_eq!(a.trigrams("hello"), vec!["hel", "ell", "llo"]);
-    }
-
-    #[test]
-    fn test_trigrams_short() {
-        let mut a = WordAnalyzer::new();
-        assert!(a.trigrams("ab").is_empty());
-        assert_eq!(a.trigrams("abc"), vec!["abc"]);
-    }
-
-    #[test]
-    fn test_trigrams_dedup() {
-        let mut a = WordAnalyzer::new();
-        assert_eq!(a.trigrams("aaaa"), vec!["aaa"]);
-    }
-
-    #[test]
-    fn test_trigrams_lowercase() {
-        let mut a = WordAnalyzer::new();
-        assert_eq!(a.trigrams("Hello"), vec!["hel", "ell", "llo"]);
+    fn test_hash_bits() {
+        let mut a = WordAnalyzer::new(16).unwrap();
+        assert!(a.hash_token("hello").unwrap() < (1 << 16));
+        let dt = a.tokenize_document("hello world").unwrap();
+        for &bucket in &dt.buckets {
+            assert!(bucket < (1 << 16));
+        }
     }
 }

--- a/rust/index/src/fulltext/tokenizer.rs
+++ b/rust/index/src/fulltext/tokenizer.rs
@@ -4,7 +4,7 @@ use tantivy::tokenizer::{
 };
 use thiserror::Error;
 
-const MIN_TOKEN_LENGTH: usize = 2;
+const MIN_TOKEN_LENGTH: usize = 3;
 const MAX_TOKEN_LENGTH: usize = 128;
 
 /// `TokenFilter` that removes tokens shorter than a given number of bytes.
@@ -95,7 +95,7 @@ pub struct FullTextQuery {
 /// Word-based text analyzer for the full-text index.
 ///
 /// Pipeline: `SimpleTokenizer` (split on non-alphanumeric) → `LowerCaser`
-/// → `AsciiFoldingFilter` (Unicode normalization) → `RemoveShortFilter(2)`
+/// → `AsciiFoldingFilter` (Unicode normalization) → `RemoveShortFilter(3)`
 /// → `RemoveLongFilter(128)`.
 #[derive(Clone)]
 pub struct WordAnalyzer {
@@ -192,9 +192,10 @@ mod tests {
     #[test]
     fn test_short_tokens_removed() {
         let mut a = WordAnalyzer::new();
+        // "a" (1), "is" (2) removed; "the" (3) kept with min_length=3
         assert_eq!(
             a.tokenize("a is the big house"),
-            vec!["is", "the", "big", "house"]
+            vec!["the", "big", "house"]
         );
     }
 
@@ -360,8 +361,9 @@ mod tests {
     }
 
     #[test]
-    fn test_query_accept_two_chars() {
-        assert!(WordAnalyzer::new().tokenize_query("ab").is_ok());
+    fn test_query_reject_two_chars() {
+        // "ab" is 2 chars, below MIN_TOKEN_LENGTH=3.
+        assert!(WordAnalyzer::new().tokenize_query("ab").is_err());
     }
 
     #[test]

--- a/rust/index/src/fulltext/tokenizer.rs
+++ b/rust/index/src/fulltext/tokenizer.rs
@@ -1,10 +1,10 @@
 use tantivy::tokenizer::{
-    AsciiFoldingFilter, LowerCaser, RemoveLongFilter, SimpleTokenizer, TextAnalyzer, Token,
-    TokenFilter, TokenStream, Tokenizer,
+    AsciiFoldingFilter, LowerCaser, NgramTokenizer, RemoveLongFilter, SimpleTokenizer,
+    TextAnalyzer, Token, TokenFilter, TokenStream, Tokenizer,
 };
 use thiserror::Error;
 
-const MIN_TOKEN_LENGTH: usize = 3;
+const TRIGRAM_LENGTH: usize = 3;
 const MAX_TOKEN_LENGTH: usize = 128;
 
 /// `TokenFilter` that removes tokens shorter than a given number of bytes.
@@ -67,7 +67,7 @@ impl<T: TokenStream> TokenStream for RemoveShortFilterStream<T> {
 
 #[derive(Debug, Error)]
 pub enum QueryError {
-    #[error("Query \"{query}\" has no token with at least {MIN_TOKEN_LENGTH} characters")]
+    #[error("Query \"{query}\" has no token with at least {TRIGRAM_LENGTH} characters")]
     NoSelectiveToken { query: String },
 }
 
@@ -94,32 +94,40 @@ pub struct FullTextQuery {
 
 /// Word-based text analyzer for the full-text index.
 ///
-/// Pipeline: `SimpleTokenizer` (split on non-alphanumeric) → `LowerCaser`
-/// → `AsciiFoldingFilter` (Unicode normalization) → `RemoveShortFilter(3)`
-/// → `RemoveLongFilter(128)`.
+/// Two pipelines:
+/// - **Word tokenizer**: `SimpleTokenizer` → `LowerCaser` → `AsciiFoldingFilter`
+///   → `RemoveShortFilter(3)` → `RemoveLongFilter(128)`.
+/// - **Trigram tokenizer**: `NgramTokenizer(3,3)` → `LowerCaser`.
 #[derive(Clone)]
 pub struct WordAnalyzer {
-    inner: TextAnalyzer,
+    word_tokenizer: TextAnalyzer,
+    trigram_tokenizer: TextAnalyzer,
 }
 
 impl WordAnalyzer {
     pub fn new() -> Self {
         Self {
-            inner: TextAnalyzer::builder(SimpleTokenizer::default())
+            word_tokenizer: TextAnalyzer::builder(SimpleTokenizer::default())
                 .filter(LowerCaser)
                 .filter(AsciiFoldingFilter)
                 .filter(RemoveShortFilter {
-                    min_length: MIN_TOKEN_LENGTH,
+                    min_length: TRIGRAM_LENGTH,
                 })
                 .filter(RemoveLongFilter::limit(MAX_TOKEN_LENGTH))
                 .build(),
+            trigram_tokenizer: TextAnalyzer::builder(
+                NgramTokenizer::new(TRIGRAM_LENGTH, TRIGRAM_LENGTH, false)
+                    .expect("valid ngram parameters"),
+            )
+            .filter(LowerCaser)
+            .build(),
         }
     }
 
     /// Tokenize text, returning owned token strings.
     pub fn tokenize(&mut self, text: &str) -> Vec<String> {
         let mut tokens = Vec::new();
-        let mut stream = self.inner.token_stream(text);
+        let mut stream = self.word_tokenizer.token_stream(text);
         while let Some(token) = stream.next() {
             tokens.push(token.text.clone());
         }
@@ -130,7 +138,7 @@ impl WordAnalyzer {
     ///
     /// Returns `Err` if no token survives the analyzer.
     pub fn tokenize_query(&mut self, query: &str) -> Result<FullTextQuery, QueryError> {
-        let mut stream = self.inner.token_stream(query);
+        let mut stream = self.word_tokenizer.token_stream(query);
 
         let mut prefix = None;
         let mut tokens = Vec::new();
@@ -170,6 +178,21 @@ impl WordAnalyzer {
             suffix,
             singleton,
         })
+    }
+
+    /// Extract deduplicated character trigrams from a string.
+    /// The output is lowercased.
+    ///
+    /// E.g., `trigrams("Hello")` → `["hel", "ell", "llo"]`.
+    pub fn trigrams(&mut self, s: &str) -> Vec<String> {
+        let mut trigrams = Vec::new();
+        let mut stream = self.trigram_tokenizer.token_stream(s);
+        while let Some(token) = stream.next() {
+            if !trigrams.contains(&token.text) {
+                trigrams.push(token.text.clone());
+            }
+        }
+        trigrams
     }
 }
 
@@ -380,5 +403,32 @@ mod tests {
     fn test_query_error_contains_query() {
         let err = WordAnalyzer::new().tokenize_query("a").unwrap_err();
         assert!(err.to_string().contains("a"));
+    }
+
+    // --- trigrams ---
+
+    #[test]
+    fn test_trigrams_basic() {
+        let mut a = WordAnalyzer::new();
+        assert_eq!(a.trigrams("hello"), vec!["hel", "ell", "llo"]);
+    }
+
+    #[test]
+    fn test_trigrams_short() {
+        let mut a = WordAnalyzer::new();
+        assert!(a.trigrams("ab").is_empty());
+        assert_eq!(a.trigrams("abc"), vec!["abc"]);
+    }
+
+    #[test]
+    fn test_trigrams_dedup() {
+        let mut a = WordAnalyzer::new();
+        assert_eq!(a.trigrams("aaaa"), vec!["aaa"]);
+    }
+
+    #[test]
+    fn test_trigrams_lowercase() {
+        let mut a = WordAnalyzer::new();
+        assert_eq!(a.trigrams("Hello"), vec!["hel", "ell", "llo"]);
     }
 }


### PR DESCRIPTION
## Summary
First PR in a series to redesign the full-text index for larger scale. Adds the
tokenizer module that fully decomposes documents and queries into numeric keys
the index consumes. The index (PR 2+) performs zero string analysis.
## This PR
`WordAnalyzer` in `rust/index/src/fulltext/tokenizer.rs`:
- **Linguistic pipeline**: `SimpleTokenizer → LowerCaser → RemoveShortFilter(3) →
  RemoveLongFilter(128)` for words, `NgramTokenizer(3,3)` for trigram extraction.
- **Hash mapping**: murmur3 (seed `0x5f3759df`) with configurable bit width
  (default 24-bit = 16M buckets). Tokens, transitions, and trigrams are all
  hashed in the tokenizer.
- **`tokenize_document(text) → DocumentTokens`**: Returns bucket IDs, trigram
  entries with positional keys (prefix/infix/suffix), and transition hashes for
  adjacent token pairs. Used by the index writer.
- **`plan_query(query) → QueryPlan`**: Decomposes a query into `TokenLookup`
  entries (`Direct` for body tokens, `Trigram` for partial tokens) and transition
  hashes. Used by the index reader.
- **Bigram transitions**: Boundary characters use 2 chars per side
  (`TRANSITION_CHARS=2`).
Output types: `DocumentTokens`, `QueryPlan`, `TokenLookup`, `TokenizerError`.
Also includes `README.md` with architecture overview, blockfile layout, query
pipeline, and design choices.