### PR TITLE
[DOC] Add CLAUDE.md, AGENTS.md, and scoped foundation Rust file-size rule

### DIFF
--- a/.claude/rules/foundation-rust.md
+++ b/.claude/rules/foundation-rust.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "foundation/**/*.rs"
+---
+
+## Rust File Size
+
+Keep new Rust files under 200 lines where possible. If a file grows beyond that, prefer refactoring — split into submodules rather than continuing to grow the file.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ target/
 
 # Rapid test data
 testdata
+
+# Allow Claude Code rules to be tracked
+!.claude/
+!.claude/rules/
+!.claude/rules/*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Chroma Codebase Guidelines for AI Agents
+
+See [CLAUDE.md](./CLAUDE.md) for codebase conventions (commit message format, etc.).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# Chroma Codebase Guidelines
+
+## Commit Message Style
+
+Use the `[TYPE](scope): Description` format:
+
+```
+[ENH](foundation-cli): Add login command
+[BUG](rust-client): Fix connection timeout on retry
+[TST](gc): Add MCMR hard delete integration test
+[DOC](api): Update embeddings endpoint docs
+[CHORE](deps): Bump reqwest to 0.13
+```
+
+Common types: `ENH` (feature/enhancement), `BUG` (fix), `TST` (test), `DOC`
+(docs), `CHORE` (maintenance/refactor), `BLD` (build system changes).
+
+Scope is optional but encouraged — use the component name (e.g.
+`foundation-cli`, `rust-client`, `gc`, `dashboard-api`).
+
+### 50/72 Rule
+
+- **Subject line: ≤ 50 characters.** Keeps it readable in `git log --oneline`,
+  GitHub PR lists, and rebase tooling.
+- **Blank line** between subject and body (required — many tools use this to
+  split them).
+- **Body lines: wrap at 72 characters.** Leaves room for indentation in
+  80-column terminals and email patch workflows.
+- **Imperative mood** in the subject: "Add login command", not "Added" or
+  "Adds". Matches Git's own generated messages.
+- **Body explains what and why**, not how — the diff shows how.
+
+With the `[TYPE](scope):` prefix, aim to keep the whole subject under 50 chars.
+If the scope makes that tight, drop it — the type alone is fine.


### PR DESCRIPTION
## Summary

- **`CLAUDE.md`** — repo-wide commit message conventions (`[TYPE](scope): Description`)
- **`AGENTS.md`** — one-liner for OpenAI Codex and other agents pointing them to `CLAUDE.md`
- **`.claude/rules/foundation-rust.md`** — file-size guideline (≤200 lines, split into submodules) scoped to `foundation/**/*.rs` via `paths:` frontmatter so it only activates when working in the Foundation CLI
- **`.gitignore`** — negation entries so `.claude/rules/` can be tracked despite the global gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)