### PR TITLE
[DOC] Add CLAUDE.md, AGENTS.md, scoped Rust rule

### DIFF
--- a/.claude/rules/foundation-rust.md
+++ b/.claude/rules/foundation-rust.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "foundation/**/*.rs"
+---
+
+## Rust File Size
+
+Keep new Rust files under 200 lines where possible. If a file grows beyond that, prefer refactoring — split into submodules rather than continuing to grow the file.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ target/
 
 # Rapid test data
 testdata
+
+# Allow Claude Code rules to be tracked
+!.claude/
+!.claude/rules/
+!.claude/rules/*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Chroma Codebase Guidelines for AI Agents
+
+See [CLAUDE.md](./CLAUDE.md) for codebase conventions (commit message format, etc.).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# Chroma Codebase Guidelines
+
+## Commit Message Style
+
+Use the `[TYPE](scope): Description` format:
+
+```
+[ENH](foundation-cli): Add login command
+[BUG](rust-client): Fix connection timeout on retry
+[TST](gc): Add MCMR hard delete integration test
+[DOC](api): Update embeddings endpoint docs
+[CHORE](deps): Bump reqwest to 0.13
+```
+
+Common types: `ENH` (feature/enhancement), `BUG` (fix), `TST` (test), `DOC`
+(docs), `CHORE` (maintenance/refactor), `BLD` (build system changes).
+
+Scope is optional but encouraged — use the component name (e.g.
+`foundation-cli`, `rust-client`, `gc`, `dashboard-api`).
+
+### 50/72 Rule
+
+- **Subject line: ≤ 50 characters.** Keeps it readable in `git log --oneline`,
+  GitHub PR lists, and rebase tooling.
+- **Blank line** between subject and body (required — many tools use this to
+  split them).
+- **Body lines: wrap at 72 characters.** Leaves room for indentation in
+  80-column terminals and email patch workflows.
+- **Imperative mood** in the subject: "Add login command", not "Added" or
+  "Adds". Matches Git's own generated messages.
+- **Body explains what and why**, not how — the diff shows how.
+
+With the `[TYPE](scope):` prefix, aim to keep the whole subject under 50 chars.
+If the scope makes that tight, drop it — the type alone is fine.


### PR DESCRIPTION
Re-lands #7006, which was merged then immediately reverted on main
so the changes never actually landed. Same diff as the original PR.

- CLAUDE.md - commit format ([TYPE](scope): Description) and the
  50/72 rule (<=50 char subject, 72-char body wrap, imperative mood)
- AGENTS.md - one-liner for OpenAI Codex and other agents pointing
  them at CLAUDE.md
- .claude/rules/foundation-rust.md - <=200-line file-size guideline
  scoped to foundation/**/*.rs via paths: frontmatter
- .gitignore - negation entries so .claude/rules/ can be tracked

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
