### PR TITLE
[BUG]: Include soft deleted collections in manual GC GetCollection

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -545,6 +545,7 @@ impl GarbageCollector {
             .sysdb_client
             .get_collections(GetCollectionsOptions {
                 collection_ids: Some(vec![collection_id]),
+                include_soft_deleted: true,
                 ..Default::default()
             })
             .await?;


### PR DESCRIPTION
The manual garbage collection GetCollection call doesn't include soft deleted collections, rendering it impossible to manually garbage collect soft deleted collections. This change fixes that issue;

- Improvements & Bug fixes
  - ^
- New functionality
  - ^

## Test plan

Locally tested on tilt

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
