### PR TITLE
[ENH]: Add work queue proto definitions and core types

### DIFF
--- a/idl/chromadb/proto/workqueue.proto
+++ b/idl/chromadb/proto/workqueue.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package chroma;
+
+import "google/protobuf/empty.proto";
+
+message WorkQueueRecord {
+    string fn_id = 1;
+    string input_coll_id = 2;
+    int64 completion_offset = 3;
+}
+
+message PushWorkRequest {
+    string fn_id = 1;
+    string input_coll_id = 2;
+    int64 completion_offset = 3;
+}
+
+message FinishWorkRequest {
+    string fn_id = 1;
+    string input_coll_id = 2;
+    int64 completion_offset = 3;
+}
+
+message GetWorkRequest {
+    string shard_id = 1;
+    uint32 limit = 2;
+}
+
+message WorkItemResult {
+    string fn_id = 1;
+    string input_coll_id = 2;
+    int64 completion_offset = 3;
+}
+
+message GetWorkResponse {
+    repeated WorkItemResult items = 1;
+}
+
+service WorkQueueService {
+    rpc PushWork(PushWorkRequest) returns (google.protobuf.Empty);
+    rpc FinishWork(FinishWorkRequest) returns (google.protobuf.Empty);
+    rpc GetWork(GetWorkRequest) returns (GetWorkResponse);
+}

--- a/rust/types/build.rs
+++ b/rust/types/build.rs
@@ -9,6 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "idl/chromadb/proto/query_executor.proto",
         "idl/chromadb/proto/garbage_collector.proto",
         "idl/chromadb/proto/fault_injection.proto",
+        "idl/chromadb/proto/workqueue.proto",
     ];
 
     // Can't use #[cfg(test)] here because a build for tests is technically a regular debug build, meaning that #[cfg(test)] is useless in build.rs.

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -1,6 +1,7 @@
 mod compactor;
 mod server;
 mod utils;
+pub(crate) mod work_queue;
 
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;

--- a/rust/worker/src/work_queue/mod.rs
+++ b/rust/worker/src/work_queue/mod.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/rust/worker/src/work_queue/types.rs
+++ b/rust/worker/src/work_queue/types.rs
@@ -1,0 +1,47 @@
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_types::{AttachedFunctionUuid, CollectionUuid};
+use thiserror::Error;
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+#[allow(dead_code)]
+pub struct WorkQueueRecord {
+    pub fn_id: AttachedFunctionUuid,
+    pub input_coll_id: CollectionUuid,
+    pub completion_offset: i64,
+    pub insertion_order: u64,
+}
+
+#[derive(Error, Debug)]
+#[allow(dead_code)]
+pub enum WorkQueueError {
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+
+    #[error("ETag mismatch - another instance is active")]
+    ETagMismatch,
+
+    #[error("Invalid state: {0}")]
+    InvalidState(String),
+}
+
+impl ChromaError for WorkQueueError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            WorkQueueError::Storage(_) => ErrorCodes::Internal,
+            WorkQueueError::Serialization(_) => ErrorCodes::Internal,
+            WorkQueueError::ETagMismatch => ErrorCodes::AlreadyExists,
+            WorkQueueError::InvalidState(_) => ErrorCodes::InvalidArgument,
+        }
+    }
+}
+
+// Stub types for future sysdb integration
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum FinishResult {
+    Success,
+    NeedsRepair,
+}


### PR DESCRIPTION
## Description of changes

This is the base PR for the work queue service stack. It introduces two things:

1. A protobuf contract (`workqueue.proto`) defining the gRPC API surface
2. Rust core types (`WorkQueueRecord`, `WorkQueueError`, `FinishResult`) that the rest of the stack builds on

Nothing is wired up in this change. This is scaffolding for later PRs.

- Improvements & Bug fixes
    - N/A
- New functionality
    - N/A

## Test plan

N/A

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_