### PR TITLE
[ENH]: Implement gRPC service for work queue

### DIFF
--- a/rust/worker/src/work_queue/mod.rs
+++ b/rust/worker/src/work_queue/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod config;
 pub(crate) mod state;
 pub mod types;
+pub(crate) mod work_queue_client;
 pub(crate) mod work_queue_manager;
+pub(crate) mod work_queue_server;

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -249,34 +249,31 @@ impl QueueState {
         true
     }
 
+    /// Mark work as successfully completed
+    /// Returns true if any work was actually removed
     pub fn finish_work_success(
         &mut self,
         fn_id: &AttachedFunctionUuid,
         input_coll_id: &CollectionUuid,
         completion_offset: i64,
-    ) {
+    ) -> bool {
         let key = (*fn_id, *input_coll_id);
 
-        self.pending_work.retain(|r| {
-            !(r.fn_id == *fn_id
-                && r.input_coll_id == *input_coll_id
-                && r.completion_offset <= completion_offset)
-        });
+        // Check if there's an entry to remove
+        if let Some(&existing_offset) = self.dedup_index.get(&key) {
+            if existing_offset <= completion_offset {
+                // Remove the single entry for this key
+                self.pending_work
+                    .retain(|r| !(r.fn_id == *fn_id && r.input_coll_id == *input_coll_id));
 
-        let max_remaining = self
-            .pending_work
-            .iter()
-            .filter(|r| r.fn_id == *fn_id && r.input_coll_id == *input_coll_id)
-            .map(|r| r.completion_offset)
-            .max();
-
-        if let Some(max) = max_remaining {
-            self.dedup_index.insert(key, max);
-        } else {
-            self.dedup_index.remove(&key);
+                // Remove from dedup index
+                self.dedup_index.remove(&key);
+                self.dirty = true;
+                return true;
+            }
         }
 
-        self.dirty = true;
+        false
     }
 }
 

--- a/rust/worker/src/work_queue/types.rs
+++ b/rust/worker/src/work_queue/types.rs
@@ -45,3 +45,11 @@ pub enum FinishResult {
     Success,
     NeedsRepair,
 }
+
+// Response type for FinishWork operations
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum FinishWorkResponse {
+    Success,
+    NeedsRepair { fn_id: AttachedFunctionUuid },
+}

--- a/rust/worker/src/work_queue/work_queue_client.rs
+++ b/rust/worker/src/work_queue/work_queue_client.rs
@@ -1,0 +1,118 @@
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_types::chroma_proto::{
+    work_queue_service_client::WorkQueueServiceClient, FinishWorkRequest, GetWorkRequest,
+    GetWorkResponse, PushWorkRequest,
+};
+use tonic::Request;
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct WorkQueueClient {
+    client: WorkQueueServiceClient<tonic::transport::Channel>,
+}
+
+#[allow(dead_code)]
+impl WorkQueueClient {
+    pub async fn new(endpoint: String) -> Result<Self, Box<dyn ChromaError>> {
+        let client = WorkQueueServiceClient::connect(endpoint)
+            .await
+            .map_err(|e| {
+                let err: Box<dyn ChromaError> =
+                    Box::new(WorkQueueClientError::ConnectionError(e.to_string()));
+                err
+            })?;
+
+        Ok(Self { client })
+    }
+
+    pub async fn push_work(
+        &mut self,
+        fn_id: String,
+        input_coll_id: String,
+        completion_offset: i64,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        let request = Request::new(PushWorkRequest {
+            fn_id,
+            input_coll_id,
+            completion_offset,
+        });
+
+        self.client
+            .push_work(request)
+            .await
+            .map_err(|e| Box::new(WorkQueueClientError::RequestError(e)) as Box<dyn ChromaError>)?;
+
+        Ok(())
+    }
+
+    pub async fn finish_work(
+        &mut self,
+        fn_id: String,
+        input_coll_id: String,
+        completion_offset: i64,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        let request = Request::new(FinishWorkRequest {
+            fn_id,
+            input_coll_id,
+            completion_offset,
+        });
+
+        self.client.finish_work(request).await.map_err(|e| {
+            let err: Box<dyn ChromaError> = Box::new(WorkQueueClientError::RequestError(e));
+            err
+        })?;
+
+        Ok(())
+    }
+
+    pub async fn get_work(
+        &mut self,
+        shard_id: String,
+        limit: u32,
+    ) -> Result<GetWorkResponse, Box<dyn ChromaError>> {
+        let request = Request::new(GetWorkRequest { shard_id, limit });
+
+        let response =
+            self.client.get_work(request).await.map_err(|e| {
+                Box::new(WorkQueueClientError::RequestError(e)) as Box<dyn ChromaError>
+            })?;
+
+        Ok(response.into_inner())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)]
+pub enum WorkQueueClientError {
+    #[error("Failed to connect: {0}")]
+    ConnectionError(String),
+
+    #[error("Request failed: {0}")]
+    RequestError(tonic::Status),
+}
+
+impl ChromaError for WorkQueueClientError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            WorkQueueClientError::ConnectionError(_) => ErrorCodes::Unavailable,
+            WorkQueueClientError::RequestError(status) => match status.code() {
+                tonic::Code::Unavailable => ErrorCodes::Unavailable,
+                tonic::Code::DeadlineExceeded => ErrorCodes::DeadlineExceeded,
+                tonic::Code::ResourceExhausted => ErrorCodes::ResourceExhausted,
+                tonic::Code::Aborted => ErrorCodes::Aborted,
+                tonic::Code::InvalidArgument => ErrorCodes::InvalidArgument,
+                tonic::Code::NotFound => ErrorCodes::NotFound,
+                tonic::Code::AlreadyExists => ErrorCodes::AlreadyExists,
+                tonic::Code::PermissionDenied => ErrorCodes::PermissionDenied,
+                tonic::Code::Unauthenticated => ErrorCodes::Unauthenticated,
+                tonic::Code::FailedPrecondition => ErrorCodes::FailedPrecondition,
+                tonic::Code::OutOfRange => ErrorCodes::OutOfRange,
+                tonic::Code::Unimplemented => ErrorCodes::Unimplemented,
+                tonic::Code::Internal => ErrorCodes::Internal,
+                tonic::Code::DataLoss => ErrorCodes::Internal,
+                tonic::Code::Unknown => ErrorCodes::Internal,
+                _ => ErrorCodes::Internal,
+            },
+        }
+    }
+}

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -369,8 +369,8 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
     type Result = ();
 
     async fn handle(&mut self, msg: GetWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
-        // TODO: Add memberlist and rendezvous hashing
         // For now, return all items up to limit
+        // TODO: In the future, this will be filtered based on work assignment
 
         let items: Vec<_> = self
             .state

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -1,0 +1,155 @@
+use crate::work_queue::types::FinishResult;
+use crate::work_queue::work_queue_manager::{
+    FinishWorkMessage, GetWorkMessage, PushWorkMessage, WorkQueueManager,
+};
+use chroma_system::ComponentHandle;
+use chroma_types::chroma_proto::{
+    work_queue_service_server::{WorkQueueService, WorkQueueServiceServer},
+    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest, WorkItemResult,
+};
+use chroma_types::{AttachedFunctionUuid, CollectionUuid};
+use std::str::FromStr;
+use tonic::{Request, Response, Status};
+
+#[allow(dead_code)]
+pub struct WorkQueueServer {
+    manager: ComponentHandle<WorkQueueManager>,
+}
+
+#[allow(dead_code)]
+impl WorkQueueServer {
+    pub fn new(manager: ComponentHandle<WorkQueueManager>) -> Self {
+        Self { manager }
+    }
+
+    #[allow(dead_code)]
+    pub fn into_service(self) -> WorkQueueServiceServer<Self> {
+        WorkQueueServiceServer::new(self)
+    }
+
+    // Stub for repair handling - will be replaced with actual sysdb integration
+    #[allow(dead_code)]
+    async fn handle_repair_stub(&self, fn_id: &AttachedFunctionUuid) {
+        // TODO: Implement actual repair logic once sysdb integration is ready
+        // This should:
+        // 1. Call get_attached_functions() to get latest offset
+        // 2. Re-push work with new offset
+        // 3. Call FinalizeAsyncAttachedFunctionRepair()
+        tracing::info!("STUB: Handling repair for function {:?}", fn_id);
+    }
+}
+
+#[tonic::async_trait]
+impl WorkQueueService for WorkQueueServer {
+    async fn push_work(&self, request: Request<PushWorkRequest>) -> Result<Response<()>, Status> {
+        let req = request.into_inner();
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        let fn_id = AttachedFunctionUuid::from_str(&req.fn_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid fn_id: {}", e)))?;
+        let input_coll_id = CollectionUuid::from_str(&req.input_coll_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid collection_id: {}", e)))?;
+
+        let msg = PushWorkMessage {
+            fn_id,
+            input_coll_id,
+            completion_offset: req.completion_offset,
+            response_tx,
+        };
+
+        self.manager
+            .receiver()
+            .send(msg, None)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to send message: {}", e)))?;
+
+        response_rx
+            .await
+            .map_err(|e| Status::internal(format!("Failed to receive response: {}", e)))?
+            .map_err(|e| Status::internal(format!("Operation failed: {}", e)))?;
+
+        Ok(Response::new(()))
+    }
+
+    async fn finish_work(
+        &self,
+        request: Request<FinishWorkRequest>,
+    ) -> Result<Response<()>, Status> {
+        let req = request.into_inner();
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        let fn_id = AttachedFunctionUuid::from_str(&req.fn_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid fn_id: {}", e)))?;
+        let input_coll_id = CollectionUuid::from_str(&req.input_coll_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid collection_id: {}", e)))?;
+
+        let msg = FinishWorkMessage {
+            fn_id,
+            input_coll_id,
+            new_completion_offset: req.completion_offset,
+            response_tx,
+        };
+
+        self.manager
+            .receiver()
+            .send(msg, None)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to send message: {}", e)))?;
+
+        let result = response_rx
+            .await
+            .map_err(|e| Status::internal(format!("Failed to receive response: {}", e)))?
+            .map_err(|e| Status::internal(format!("Operation failed: {}", e)))?;
+
+        // Handle the result
+        match result {
+            FinishResult::Success => {
+                // Success case - just return ok
+                Ok(Response::new(()))
+            }
+            FinishResult::NeedsRepair => {
+                // NeedsRepair case - handle repair here
+                // TODO: Replace with actual repair handling once sysdb integration is ready
+                // Also need to check for error from this call.
+                self.handle_repair_stub(&fn_id).await;
+                Ok(Response::new(()))
+            }
+        }
+    }
+
+    async fn get_work(
+        &self,
+        request: Request<GetWorkRequest>,
+    ) -> Result<Response<GetWorkResponse>, Status> {
+        let req = request.into_inner();
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        let msg = GetWorkMessage {
+            shard_id: req.shard_id,
+            limit: req.limit as usize,
+            response_tx,
+        };
+
+        self.manager
+            .receiver()
+            .send(msg, None)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to send message: {}", e)))?;
+
+        let items = response_rx
+            .await
+            .map_err(|e| Status::internal(format!("Failed to receive response: {}", e)))?
+            .map_err(|e| Status::internal(format!("Operation failed: {}", e)))?;
+
+        let results: Vec<WorkItemResult> = items
+            .into_iter()
+            .map(|record| WorkItemResult {
+                fn_id: record.fn_id.to_string(),
+                input_coll_id: record.input_coll_id.to_string(),
+                completion_offset: record.completion_offset,
+            })
+            .collect();
+
+        Ok(Response::new(GetWorkResponse { items: results }))
+    }
+}


### PR DESCRIPTION
## Description of changes

This PR adds the gRPC transport layer for the work queue system. It introduces two new files, a server (`work_queue_server.rs`) and a client (`work_queue_client.rs`)  and makes a semantics change to handler for `FinishWorkMessage` , allowing it to participate in group commit behavior during repair scenarios.

The server bridges incoming gRPC calls to the `WorkQueueManager` component via `ComponentHandle`, using oneshot channels for request/response. The client wraps the generated tonic stub for callers outside the process. This is useful for group commit scenarios where a `push_work` call may finish and queue up a persistence to object storage but the oneshot channel that came with the call will only get written to once this persistence is done.

- Improvements & Bug fixes
    - ...
- New functionality
    - Can do RPC calls on the `WorkQueueManager` interface. An RPC client has also been provided.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_ to the