### PR TITLE
fix(collection): merge metadata on modify() instead of replacing it

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -564,7 +564,10 @@ class CollectionCommon(Generic[ClientT]):
         if name:
             self._model["name"] = name
         if metadata:
-            self._model["metadata"] = metadata
+            # Merge into existing metadata rather than replacing it entirely,
+            # consistent with how record-level metadata updates work (#1247).
+            existing = self._model.get("metadata") or {}
+            self._model["metadata"] = {**existing, **metadata}
         if configuration:
             self._model.set_configuration(
                 overwrite_collection_configuration(


### PR DESCRIPTION
Fixes #1247

## Problem

Record-level metadata updates (via `collection.update()`) merge new keys into existing metadata — only the keys you supply are changed, everything else is preserved. But collection-level metadata updates (via `collection.modify(metadata=...)`) were inconsistent: they **replaced** the entire metadata dict.

This means a user who does:
```python
collection.modify(metadata={"new_key": "value"})
```
…loses every other key that was previously stored in the collection metadata.

## Fix

In `_update_model_after_modify_success`, merge the incoming metadata over the existing metadata:

```python
# Before
self._model["metadata"] = metadata

# After
existing = self._model.get("metadata") or {}
self._model["metadata"] = {**existing, **metadata}
```

This aligns collection-level behaviour with record-level behaviour and allows callers to update individual metadata keys without re-sending the full metadata object.