### PR TITLE
fix(types): narrow # type: ignore comment on tenacity @retry in onnx_mini_lm_l6_v2

### DIFF
--- a/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
+++ b/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
@@ -89,7 +89,7 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
 
     # Borrowed from https://gist.github.com/yanqd0/c13ed29e29432e3cf3e7c38467f42f51
     # Download with tqdm to preserve the sentence-transformers experience
-    @retry(  # type: ignore
+    @retry(  # type: ignore[misc]  # tenacity.retry does not preserve the decorated function's type signature
         reraise=True,
         stop=stop_after_attempt(3),
         wait=wait_random(min=1, max=3),


### PR DESCRIPTION
Addresses #1169

## Problem

`chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py` has a bare `# type: ignore` on the `@retry` decorator from tenacity. This silences **all** mypy errors on that line, not just the one caused by tenacity's lack of type-preserving decorator stubs.

## Fix

Replace with `# type: ignore[misc]`, which narrows the suppression to the specific mypy error code (`misc`) that tenacity raises — "Untyped decorator makes function 'X' have type 'Any'". Any other mypy errors that might appear on this line in future will now surface normally.

This is one of the type annotation improvements tracked in #1169.