### PR TITLE
[ENH] Add FTS algorithm field in schema

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1607,9 +1607,11 @@ def _create_extra_fields_validator(valid_fields: list[str]) -> Any:
 class FtsIndexConfig(BaseModel):
     """Configuration for Full-Text Search index. No parameters required."""
 
-    model_config = {"extra": "forbid"}
-
-    pass
+    _validate_extra_fields = _create_extra_fields_validator(
+        [
+            "algorithm",
+        ]
+    )
 
 
 class HnswIndexConfig(BaseModel):

--- a/chromadb/test/api/test_schema.py
+++ b/chromadb/test/api/test_schema.py
@@ -3173,7 +3173,11 @@ def test_config_classes_reject_invalid_fields() -> None:
 
     error_msg = str(exc_info.value)
     assert "invalid_field" in error_msg.lower()
-    assert "extra" in error_msg.lower() or "permitted" in error_msg.lower()
+    assert (
+        "extra" in error_msg.lower()
+        or "permitted" in error_msg.lower()
+        or "not a valid field" in error_msg.lower()
+    )
 
     # Test StringInvertedIndexConfig rejects invalid fields
     with pytest.raises((ValueError, ValidationError)) as exc_info:

--- a/clients/new-js/packages/chromadb/src/api/types.gen.ts
+++ b/clients/new-js/packages/chromadb/src/api/types.gen.ts
@@ -280,7 +280,7 @@ export type FtsAlgorithm = 'trigram' | 'token_bitmap';
 
 export type FtsIndexConfig = {
     /**
-     * FTS index algorithm (cloud-only, tenant-gated).
+     * FTS index algorithm.
      * Omitted from JSON when set to the default (Trigram) so that old
      * servers/clients that do not know about this field can still
      * deserialize the schema.

--- a/clients/new-js/packages/chromadb/src/api/types.gen.ts
+++ b/clients/new-js/packages/chromadb/src/api/types.gen.ts
@@ -270,8 +270,22 @@ export type ForkCountResponse = {
     count: number;
 };
 
+/**
+ * Full-text search index algorithm.
+ *
+ * Controls which index format and query pipeline are used for
+ * document substring search within a collection.
+ */
+export type FtsAlgorithm = 'trigram' | 'token_bitmap';
+
 export type FtsIndexConfig = {
-    [key: string]: never;
+    /**
+     * FTS index algorithm (cloud-only, tenant-gated).
+     * Omitted from JSON when set to the default (Trigram) so that old
+     * servers/clients that do not know about this field can still
+     * deserialize the schema.
+     */
+    algorithm?: FtsAlgorithm;
 };
 
 export type FtsIndexType = {

--- a/go/pkg/sysdb/coordinator/model/collection_configuration.go
+++ b/go/pkg/sysdb/coordinator/model/collection_configuration.go
@@ -237,7 +237,9 @@ type FloatInvertedIndexConfig struct{}
 
 type BoolInvertedIndexConfig struct{}
 
-type FtsIndexConfig struct{}
+type FtsIndexConfig struct {
+	Algorithm *string `json:"algorithm,omitempty"`
+}
 
 type SparseVectorIndexConfig struct {
 	EmbeddingFunction *EmbeddingFunctionConfiguration `json:"embedding_function,omitempty"`

--- a/rust/chroma/src/types.rs
+++ b/rust/chroma/src/types.rs
@@ -51,6 +51,7 @@ pub use chroma_types::FloatInvertedIndexType;
 pub use chroma_types::FloatListValueType;
 pub use chroma_types::FloatValueType;
 pub use chroma_types::ForkCollectionRequest;
+pub use chroma_types::FtsAlgorithm;
 pub use chroma_types::FtsIndexConfig;
 pub use chroma_types::FtsIndexType;
 pub use chroma_types::GetCollectionWithSegmentsError;

--- a/rust/frontend-core/src/collection_ops.rs
+++ b/rust/frontend-core/src/collection_ops.rs
@@ -12,9 +12,9 @@
 use std::collections::HashSet;
 
 use chroma_types::{
-    CollectionUuid, CreateCollectionError, InternalCollectionConfiguration, KnnIndex, Quantization,
-    Schema, SchemaError, Segment, SegmentScope, SegmentType, SegmentUuid, SparseIndexAlgorithm,
-    VectorIndexConfiguration,
+    CollectionUuid, CreateCollectionError, FtsAlgorithm, InternalCollectionConfiguration, KnnIndex,
+    Quantization, Schema, SchemaError, Segment, SegmentScope, SegmentType, SegmentUuid,
+    SparseIndexAlgorithm, VectorIndexConfiguration,
 };
 
 /// Discriminant for which executor will serve the collection. Carries no
@@ -31,8 +31,9 @@ pub enum ExecutorKind {
 /// planner stays stateless.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct TenantFeatureFlags {
-    pub enable_quantization: bool,
     pub enable_maxscore: bool,
+    pub enable_quantization: bool,
+    pub enable_token_bitmap_fts: bool,
 }
 
 /// The output of planning a create-collection: everything the caller needs
@@ -149,6 +150,9 @@ pub fn plan_create_collection(
         }
         if tenant_flags.enable_maxscore {
             schema.set_sparse_algorithm(SparseIndexAlgorithm::MaxScore);
+        }
+        if tenant_flags.enable_token_bitmap_fts {
+            schema.set_fts_algorithm(FtsAlgorithm::TokenBitmap);
         }
     }
 

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -86,4 +86,5 @@ tenants_to_migrate_immediately:
 tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
 tenants_with_quantization_enabled: []
 tenants_with_maxscore_enabled: []
+tenants_with_token_bitmap_fts_enabled: []
 enable_log_scouting: true

--- a/rust/frontend/sample_configs/distributed2.yaml
+++ b/rust/frontend/sample_configs/distributed2.yaml
@@ -76,4 +76,5 @@ tenants_to_migrate_immediately:
 tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
 tenants_with_quantization_enabled: []
 tenants_with_maxscore_enabled: []
+tenants_with_token_bitmap_fts_enabled: []
 enable_log_scouting: true

--- a/rust/frontend/sample_configs/distributed_mcmr.yaml
+++ b/rust/frontend/sample_configs/distributed_mcmr.yaml
@@ -76,4 +76,5 @@ tenants_to_migrate_immediately:
 tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
 tenants_with_quantization_enabled: []
 tenants_with_maxscore_enabled: []
+tenants_with_token_bitmap_fts_enabled: []
 enable_log_scouting: true

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -76,6 +76,8 @@ pub struct FrontendConfig {
     pub tenants_with_quantization_enabled: Vec<String>,
     #[serde(default = "Default::default")]
     pub tenants_with_maxscore_enabled: Vec<String>,
+    #[serde(default = "Default::default")]
+    pub tenants_with_token_bitmap_fts_enabled: Vec<String>,
     #[serde(default = "default_enable_log_scouting")]
     pub enable_log_scouting: bool,
 }
@@ -101,6 +103,7 @@ impl FrontendConfig {
             min_records_for_invocation: default_min_records_for_invocation(),
             tenants_with_quantization_enabled: vec![],
             tenants_with_maxscore_enabled: vec![],
+            tenants_with_token_bitmap_fts_enabled: vec![],
             enable_log_scouting: false,
         }
     }

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -84,6 +84,7 @@ pub struct ServiceBasedFrontend {
     min_records_for_invocation: u64,
     tenants_with_quantization_enabled: Vec<String>,
     tenants_with_maxscore_enabled: Vec<String>,
+    tenants_with_token_bitmap_fts_enabled: Vec<String>,
     enable_log_scouting: bool,
 }
 
@@ -101,6 +102,7 @@ impl ServiceBasedFrontend {
         min_records_for_invocation: u64,
         tenants_with_quantization_enabled: Vec<String>,
         tenants_with_maxscore_enabled: Vec<String>,
+        tenants_with_token_bitmap_fts_enabled: Vec<String>,
         enable_log_scouting: bool,
     ) -> Self {
         let meter = global::meter("chroma");
@@ -150,6 +152,7 @@ impl ServiceBasedFrontend {
             min_records_for_invocation,
             tenants_with_quantization_enabled,
             tenants_with_maxscore_enabled,
+            tenants_with_token_bitmap_fts_enabled,
             enable_log_scouting,
         }
     }
@@ -799,6 +802,13 @@ impl ServiceBasedFrontend {
             .any(|t| t == "*" || t == tenant_id)
     }
 
+    /// Check if TokenBitmap FTS index should be enabled for the given tenant.
+    fn should_enable_token_bitmap_fts_for_tenant(&self, tenant_id: &str) -> bool {
+        self.tenants_with_token_bitmap_fts_enabled
+            .iter()
+            .any(|t| t == "*" || t == tenant_id)
+    }
+
     pub fn get_default_knn_index(&self) -> KnnIndex {
         self.default_knn_index
     }
@@ -1167,6 +1177,7 @@ impl ServiceBasedFrontend {
             frontend_core::collection_ops::TenantFeatureFlags {
                 enable_quantization: self.should_enable_quantization_for_tenant(&tenant_id),
                 enable_maxscore: self.should_enable_maxscore_for_tenant(&tenant_id),
+                enable_token_bitmap_fts: self.should_enable_token_bitmap_fts_for_tenant(&tenant_id),
             },
         )?;
 
@@ -2773,6 +2784,7 @@ impl Configurable<(FrontendConfig, System)> for ServiceBasedFrontend {
             config.min_records_for_invocation,
             config.tenants_with_quantization_enabled.clone(),
             config.tenants_with_maxscore_enabled.clone(),
+            config.tenants_with_token_bitmap_fts_enabled.clone(),
             config.enable_log_scouting,
         ))
     }

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -132,6 +132,7 @@ impl Bindings {
             min_records_for_invocation: default_min_records_for_invocation(),
             tenants_with_quantization_enabled: vec![],
             tenants_with_maxscore_enabled: vec![],
+            tenants_with_token_bitmap_fts_enabled: vec![],
             enable_log_scouting: false,
         };
 

--- a/rust/rust-sysdb/src/spanner.rs
+++ b/rust/rust-sysdb/src/spanner.rs
@@ -4173,7 +4173,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: false,
@@ -5189,7 +5189,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: false,
@@ -5278,7 +5278,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: true,
@@ -5358,7 +5358,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: false,
@@ -5377,7 +5377,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: true,
@@ -5494,7 +5494,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: true,
@@ -5590,7 +5590,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: false,
@@ -5608,7 +5608,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: true,
@@ -5722,7 +5722,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: false,
@@ -5749,7 +5749,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: true,
@@ -5876,7 +5876,7 @@ pub mod tests {
                     string: Some(StringValueType {
                         fts_index: Some(FtsIndexType {
                             enabled: i % 2 == 0, // Alternate FTS enabled
-                            config: FtsIndexConfig {},
+                            config: FtsIndexConfig::default(),
                         }),
                         string_inverted_index: Some(StringInvertedIndexType {
                             enabled: true,
@@ -6057,7 +6057,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: false,
@@ -6798,7 +6798,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: false,
@@ -6939,7 +6939,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: true,
@@ -7247,7 +7247,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: false,
@@ -7398,7 +7398,7 @@ pub mod tests {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: true,

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -3882,7 +3882,10 @@ mod test {
 
         // Build a schema with FTS disabled
         let fts_disabled_schema = Schema::new_default(KnnIndex::Hnsw)
-            .delete_index(Some(DOCUMENT_KEY), IndexConfig::Fts(FtsIndexConfig {}))
+            .delete_index(
+                Some(DOCUMENT_KEY),
+                IndexConfig::Fts(FtsIndexConfig::default()),
+            )
             .expect("FTS deletion should succeed");
         assert!(!fts_disabled_schema.is_fts_enabled());
 

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -3126,7 +3126,7 @@ fn is_default_fts_algorithm(v: &FtsAlgorithm) -> bool {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
 pub struct FtsIndexConfig {
-    /// FTS index algorithm (cloud-only, tenant-gated).
+    /// FTS index algorithm.
     /// Omitted from JSON when set to the default (Trigram) so that old
     /// servers/clients that do not know about this field can still
     /// deserialize the schema.

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -468,6 +468,37 @@ impl Schema {
             })
             .is_none_or(|idx| idx.enabled)
     }
+
+    /// Check if the FTS index is configured to use TokenBitmap.
+    pub fn is_token_bitmap_fts_enabled(&self) -> bool {
+        let check = |s: &StringValueType| -> bool {
+            s.fts_index.as_ref().is_some_and(|idx| {
+                idx.enabled && matches!(idx.config.algorithm, FtsAlgorithm::TokenBitmap)
+            })
+        };
+        self.keys
+            .get(DOCUMENT_KEY)
+            .and_then(|vt| vt.string.as_ref())
+            .is_some_and(check)
+            || self.defaults.string.as_ref().is_some_and(check)
+    }
+
+    /// Set the FTS index algorithm on all FTS index configs
+    /// (defaults and every key-specific config).
+    pub fn set_fts_algorithm(&mut self, algorithm: FtsAlgorithm) {
+        if let Some(s) = &mut self.defaults.string {
+            if let Some(idx) = &mut s.fts_index {
+                idx.config.algorithm = algorithm.clone();
+            }
+        }
+        for vt in self.keys.values_mut() {
+            if let Some(s) = &mut vt.string {
+                if let Some(idx) = &mut s.fts_index {
+                    idx.config.algorithm = algorithm.clone();
+                }
+            }
+        }
+    }
 }
 
 impl Default for Schema {
@@ -493,7 +524,7 @@ impl Default for Schema {
             string: Some(StringValueType {
                 fts_index: Some(FtsIndexType {
                     enabled: false,
-                    config: FtsIndexConfig {},
+                    config: FtsIndexConfig::default(),
                 }),
                 string_inverted_index: Some(StringInvertedIndexType {
                     enabled: true,
@@ -553,7 +584,7 @@ impl Default for Schema {
                 string: Some(StringValueType {
                     fts_index: Some(FtsIndexType {
                         enabled: true,
-                        config: FtsIndexConfig {},
+                        config: FtsIndexConfig::default(),
                     }),
                     string_inverted_index: Some(StringInvertedIndexType {
                         enabled: false,
@@ -862,7 +893,7 @@ impl Schema {
                 }),
                 fts_index: Some(FtsIndexType {
                     enabled: false,
-                    config: FtsIndexConfig {},
+                    config: FtsIndexConfig::default(),
                 }),
             }),
             float: Some(FloatValueType {
@@ -958,7 +989,7 @@ impl Schema {
             string: Some(StringValueType {
                 fts_index: Some(FtsIndexType {
                     enabled: true,
-                    config: FtsIndexConfig {},
+                    config: FtsIndexConfig::default(),
                 }),
                 string_inverted_index: Some(StringInvertedIndexType {
                     enabled: false,
@@ -1559,9 +1590,15 @@ impl Schema {
         user: Option<&FtsIndexType>,
     ) -> Result<Option<FtsIndexType>, SchemaError> {
         match (default, user) {
-            (Some(_default), Some(user)) => Ok(Some(FtsIndexType {
+            (Some(default), Some(user)) => Ok(Some(FtsIndexType {
                 enabled: user.enabled,
-                config: user.config.clone(),
+                config: FtsIndexConfig {
+                    algorithm: if !is_default_fts_algorithm(&user.config.algorithm) {
+                        user.config.algorithm.clone()
+                    } else {
+                        default.config.algorithm.clone()
+                    },
+                },
             })),
             (Some(default), None) => Ok(Some(default.clone())),
             (None, Some(user)) => Ok(Some(user.clone())),
@@ -3068,11 +3105,41 @@ pub struct SparseVectorIndexConfig {
     pub algorithm: SparseIndexAlgorithm,
 }
 
+/// Full-text search index algorithm.
+///
+/// Controls which index format and query pipeline are used for
+/// document substring search within a collection.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum FtsAlgorithm {
+    #[default]
+    Trigram,
+    TokenBitmap,
+}
+
+fn is_default_fts_algorithm(v: &FtsAlgorithm) -> bool {
+    v == &FtsAlgorithm::default()
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
 pub struct FtsIndexConfig {
-    // FTS index typically has no additional parameters
+    /// FTS index algorithm (cloud-only, tenant-gated).
+    /// Omitted from JSON when set to the default (Trigram) so that old
+    /// servers/clients that do not know about this field can still
+    /// deserialize the schema.
+    #[serde(default, skip_serializing_if = "is_default_fts_algorithm")]
+    pub algorithm: FtsAlgorithm,
+}
+
+impl Default for FtsIndexConfig {
+    fn default() -> Self {
+        Self {
+            algorithm: FtsAlgorithm::Trigram,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -3416,7 +3483,7 @@ mod tests {
             string: Some(StringValueType {
                 fts_index: Some(FtsIndexType {
                     enabled: true,
-                    config: FtsIndexConfig {},
+                    config: FtsIndexConfig::default(),
                 }),
                 string_inverted_index: Some(StringInvertedIndexType {
                     enabled: false,
@@ -3950,7 +4017,7 @@ mod tests {
             }),
             fts_index: Some(FtsIndexType {
                 enabled: false,
-                config: FtsIndexConfig {},
+                config: FtsIndexConfig::default(),
             }),
         };
 
@@ -4168,6 +4235,62 @@ mod tests {
     }
 
     #[test]
+    fn test_fts_algorithm_serde_roundtrip() {
+        // Old schema JSON without algorithm field -> defaults to Trigram
+        let json_no_algorithm = r#"{}"#;
+        let config: FtsIndexConfig = serde_json::from_str(json_no_algorithm).unwrap();
+        assert_eq!(config.algorithm, FtsAlgorithm::Trigram);
+
+        // Serialize with Trigram -> algorithm field absent from JSON
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(
+            !serialized.contains("algorithm"),
+            "Trigram (default) must not appear in JSON: {serialized}"
+        );
+
+        // Deserialize with "algorithm": "token_bitmap" -> TokenBitmap
+        let json_token_bitmap = r#"{"algorithm": "token_bitmap"}"#;
+        let config: FtsIndexConfig = serde_json::from_str(json_token_bitmap).unwrap();
+        assert_eq!(config.algorithm, FtsAlgorithm::TokenBitmap);
+
+        // Serialize with TokenBitmap -> algorithm field present in JSON
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(
+            serialized.contains(r#""algorithm":"token_bitmap""#),
+            "TokenBitmap must appear in JSON: {serialized}"
+        );
+    }
+
+    #[test]
+    fn test_is_token_bitmap_fts_enabled() {
+        // Default schema -> Trigram -> false
+        let schema = Schema::default();
+        assert!(!schema.is_token_bitmap_fts_enabled());
+
+        // Schema with FTS enabled but Trigram algorithm -> false
+        let mut schema = Schema::new_default(KnnIndex::Hnsw);
+        assert!(!schema.is_token_bitmap_fts_enabled());
+
+        // Set algorithm to TokenBitmap -> true
+        schema.set_fts_algorithm(FtsAlgorithm::TokenBitmap);
+        assert!(schema.is_token_bitmap_fts_enabled());
+
+        // Disabled FTS with TokenBitmap -> false
+        schema
+            .keys
+            .get_mut(DOCUMENT_KEY)
+            .unwrap()
+            .string
+            .as_mut()
+            .unwrap()
+            .fts_index
+            .as_mut()
+            .unwrap()
+            .enabled = false;
+        assert!(!schema.is_token_bitmap_fts_enabled());
+    }
+
+    #[test]
     fn test_complex_nested_merging_scenario() {
         // Test a complex scenario with multiple levels of merging
         let mut user_schema = Schema {
@@ -4185,7 +4308,7 @@ mod tests {
             }),
             fts_index: Some(FtsIndexType {
                 enabled: true,
-                config: FtsIndexConfig {},
+                config: FtsIndexConfig::default(),
             }),
         });
 
@@ -4215,7 +4338,7 @@ mod tests {
             string: Some(StringValueType {
                 fts_index: Some(FtsIndexType {
                     enabled: true,
-                    config: FtsIndexConfig {},
+                    config: FtsIndexConfig::default(),
                 }),
                 string_inverted_index: None,
             }),
@@ -4935,7 +5058,7 @@ mod tests {
         schema.defaults.string = Some(StringValueType {
             fts_index: Some(FtsIndexType {
                 enabled: true,
-                config: FtsIndexConfig {},
+                config: FtsIndexConfig::default(),
             }),
             string_inverted_index: None,
         });
@@ -5971,7 +6094,7 @@ mod tests {
 
         // Error: FTS index on non-#document key
         let result = Schema::new_default(KnnIndex::Hnsw)
-            .create_index(Some("my_text"), IndexConfig::Fts(FtsIndexConfig {}));
+            .create_index(Some("my_text"), IndexConfig::Fts(FtsIndexConfig::default()));
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -5980,7 +6103,10 @@ mod tests {
 
         // Success: FTS index on #document key
         let schema = Schema::new_default(KnnIndex::Hnsw)
-            .create_index(Some(DOCUMENT_KEY), IndexConfig::Fts(FtsIndexConfig {}))
+            .create_index(
+                Some(DOCUMENT_KEY),
+                IndexConfig::Fts(FtsIndexConfig::default()),
+            )
             .expect("FTS on #document should succeed");
         assert!(schema.is_fts_enabled());
 
@@ -6097,7 +6223,10 @@ mod tests {
 
         // FTS index deletion is now supported (disables FTS)
         let schema = Schema::new_default(KnnIndex::Hnsw)
-            .delete_index(Some(DOCUMENT_KEY), IndexConfig::Fts(FtsIndexConfig {}))
+            .delete_index(
+                Some(DOCUMENT_KEY),
+                IndexConfig::Fts(FtsIndexConfig::default()),
+            )
             .expect("FTS deletion should succeed");
         assert!(!schema.is_fts_enabled());
 
@@ -6133,7 +6262,7 @@ mod tests {
     fn test_fts_create_global_without_key_rejected() {
         // FTS create_index without key (global) should fail with FtsIndexOnlyOnDocument
         let result = Schema::new_default(KnnIndex::Hnsw)
-            .create_index(None, IndexConfig::Fts(FtsIndexConfig {}));
+            .create_index(None, IndexConfig::Fts(FtsIndexConfig::default()));
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -6145,7 +6274,7 @@ mod tests {
     fn test_fts_delete_global_without_key_rejected() {
         // FTS delete_index without key (global) should fail with FtsIndexDeletionOnlyOnDocument
         let result = Schema::new_default(KnnIndex::Hnsw)
-            .delete_index(None, IndexConfig::Fts(FtsIndexConfig {}));
+            .delete_index(None, IndexConfig::Fts(FtsIndexConfig::default()));
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -6157,7 +6286,7 @@ mod tests {
     fn test_fts_delete_on_custom_key_rejected() {
         // FTS delete_index on a custom key (not #document) should fail
         let result = Schema::new_default(KnnIndex::Hnsw)
-            .delete_index(Some("my_text"), IndexConfig::Fts(FtsIndexConfig {}));
+            .delete_index(Some("my_text"), IndexConfig::Fts(FtsIndexConfig::default()));
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -6213,7 +6342,10 @@ mod tests {
     fn test_is_fts_enabled_after_disable() {
         // After disabling FTS on #document, is_fts_enabled should return false
         let schema = Schema::new_default(KnnIndex::Hnsw)
-            .delete_index(Some(DOCUMENT_KEY), IndexConfig::Fts(FtsIndexConfig {}))
+            .delete_index(
+                Some(DOCUMENT_KEY),
+                IndexConfig::Fts(FtsIndexConfig::default()),
+            )
             .expect("FTS deletion should succeed");
         assert!(!schema.is_fts_enabled());
     }
@@ -6222,9 +6354,15 @@ mod tests {
     fn test_is_fts_enabled_after_reenable() {
         // After disabling then re-enabling FTS on #document, is_fts_enabled should return true
         let schema = Schema::new_default(KnnIndex::Hnsw)
-            .delete_index(Some(DOCUMENT_KEY), IndexConfig::Fts(FtsIndexConfig {}))
+            .delete_index(
+                Some(DOCUMENT_KEY),
+                IndexConfig::Fts(FtsIndexConfig::default()),
+            )
             .expect("FTS deletion should succeed")
-            .create_index(Some(DOCUMENT_KEY), IndexConfig::Fts(FtsIndexConfig {}))
+            .create_index(
+                Some(DOCUMENT_KEY),
+                IndexConfig::Fts(FtsIndexConfig::default()),
+            )
             .expect("FTS creation should succeed");
         assert!(schema.is_fts_enabled());
     }
@@ -6235,7 +6373,10 @@ mod tests {
 
         // Create schema with FTS disabled
         let schema = Schema::new_default(KnnIndex::Hnsw)
-            .delete_index(Some(DOCUMENT_KEY), IndexConfig::Fts(FtsIndexConfig {}))
+            .delete_index(
+                Some(DOCUMENT_KEY),
+                IndexConfig::Fts(FtsIndexConfig::default()),
+            )
             .expect("FTS deletion should succeed");
 
         // Where::Document query should be rejected
@@ -6856,7 +6997,7 @@ mod tests {
         fn fts_index_type_strategy() -> impl Strategy<Value = FtsIndexType> {
             any::<bool>().prop_map(|enabled| FtsIndexType {
                 enabled,
-                config: FtsIndexConfig {},
+                config: FtsIndexConfig::default(),
             })
         }
 


### PR DESCRIPTION
## Summary
Adds `FtsAlgorithm` enum to the collection schema, enabling tenant-gated
rollout of the new full-text index alongside the existing trigram index.
## This PR
- `FtsAlgorithm` enum (`Trigram` default, `TokenBitmap`) in
  `collection_schema.rs` with `set_fts_algorithm` on `Schema`.
- `enable_token_bitmap_fts` in `TenantFeatureFlags`, applied in
  `plan_create_collection`.
- Tenant gating via `tenants_with_token_bitmap_fts_enabled` config field.
- Spanner persistence for the new field.
- Python, JS, and Go client type updates.