### PR TITLE
[BUG] rust/sqlite: enable journal_mode=WAL and lower busy_timeout to prevent multi-process deadlock

### DIFF
--- a/rust/sqlite/src/config.rs
+++ b/rust/sqlite/src/config.rs
@@ -104,7 +104,20 @@ impl Configurable<SqliteDBConfig, SqliteCreationError> for SqliteDb {
             // we turn it off
             .pragma("foreign_keys", "OFF")
             .pragma("case_sensitive_like", "ON")
-            .busy_timeout(Duration::from_secs(1000))
+            // WAL allows concurrent readers + one writer and shrinks the
+            // per-write critical section to a WAL append. Required for
+            // multi-process safety on a shared persist_dir; without it,
+            // parallel `try_from_config` calls (which run migrations) can
+            // deadlock on the SQLite busy_timeout below.
+            // TODO: detect non-local filesystems (NFS / SMB / CIFS) and
+            // either warn or skip WAL there — WAL is unsafe without full
+            // POSIX locking.
+            .pragma("journal_mode", "WAL")
+            // 5 s matches sqlx-sqlite defaults and is plenty for any
+            // realistic write contention with WAL enabled. The previous
+            // 1000 s value appears to be a units typo (the Python
+            // implementation used 5 seconds).
+            .busy_timeout(Duration::from_secs(5))
             .with_regexp();
         let conn = if let Some(url) = &config.url {
             let path = Path::new(url);
@@ -158,5 +171,24 @@ mod tests {
         let _retrieved_db = registry
             .get::<SqliteDb>()
             .expect("To be able to retrieve the db");
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_db_opens_in_wal_mode() {
+        let config = SqliteDBConfig {
+            url: new_test_db_persist_path(),
+            hash_type: MigrationHash::MD5,
+            migration_mode: MigrationMode::Apply,
+        };
+        let registry = Registry::new();
+        let db = SqliteDb::try_from_config(&config, &registry)
+            .await
+            .expect("expect db to be created");
+
+        let mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+            .fetch_one(db.get_conn())
+            .await
+            .expect("expect journal_mode to be readable");
+        assert_eq!(mode.to_lowercase(), "wal");
     }
 }


### PR DESCRIPTION
Closes #7040.

## Summary

Two `chromadb.PersistentClient(...)` instances against the same persist_dir deadlock for ~16 minutes because:

1. The sqlx connection pool never sets `PRAGMA journal_mode=WAL`, leaving the DB in DELETE mode (writers exclude readers, no MVCC).
2. `busy_timeout` is set to **1000 seconds**, which appears to be a units typo (the Python implementation used 5 seconds; the existing `// TODO: copy all other pragmas from python and add basic tests` comment in the same function suggests this code was planned for follow-up).
3. Every `PersistentClient(...)` construction runs `apply_all_migration()` which issues writes — so two parallel inits collide and ride out the full 1000 s.

This PR sets WAL and reduces `busy_timeout` to 5 s. Both are well-tested SQLite defaults (sqlx-sqlite uses 5 s for `busy_timeout` itself).

These are two related changes (WAL + `busy_timeout`) intentionally bundled because they're the matched pair the existing `// TODO` referenced. Happy to split into two PRs if reviewers prefer — landing WAL alone fixes the hang; the `busy_timeout` reduction is defense-in-depth against the units typo.

Linked issue (#7040) has full repro, stack trace, and root-cause analysis.

## Changes

### `rust/sqlite/src/config.rs`

Two-line addition to the `SqliteConnectOptions` builder used by `SqliteDb::try_from_config`:

```diff
 SqliteConnectOptions::new()
     .pragma("foreign_keys", "OFF")
     .pragma("case_sensitive_like", "ON")
+    // WAL allows concurrent readers + one writer and shrinks the
+    // per-write critical section to a WAL append. Required for
+    // multi-process safety on a shared persist_dir; without it,
+    // parallel `try_from_config` calls (which run migrations) can
+    // deadlock on the SQLite busy_timeout below.
+    // TODO: detect non-local filesystems (NFS / SMB / CIFS) and
+    // either warn or skip WAL there — WAL is unsafe without full
+    // POSIX locking.
+    .pragma("journal_mode", "WAL")
-    .busy_timeout(Duration::from_secs(1000))
+    // 5 s matches sqlx-sqlite defaults and is plenty for any
+    // realistic write contention with WAL enabled. The previous
+    // 1000 s value appears to be a units typo (the Python
+    // implementation used 5 seconds).
+    .busy_timeout(Duration::from_secs(5))
     .with_regexp();
```

The `.with_regexp()` call ordering is preserved.

### Regression test

Added `test_sqlite_db_opens_in_wal_mode` to the existing `mod tests` in `rust/sqlite/src/config.rs`:

```rust
#[tokio::test]
async fn test_sqlite_db_opens_in_wal_mode() {
    let config = SqliteDBConfig {
        url: new_test_db_persist_path(),
        hash_type: MigrationHash::MD5,
        migration_mode: MigrationMode::Apply,
    };
    let registry = Registry::new();
    let db = SqliteDb::try_from_config(&config, &registry)
        .await
        .expect("expect db to be created");

    let mode: String = sqlx::query_scalar("PRAGMA journal_mode")
        .fetch_one(db.get_conn())
        .await
        .expect("expect journal_mode to be readable");
    assert_eq!(mode.to_lowercase(), "wal");
}
```

Multi-process verification is intentionally not unit-tested here. Within a single Rust process, sqlx serializes connection acquisitions inside one pool (and even two pools share an in-process locking domain) — so a `tokio::join!`-style test would not reliably reproduce the cross-process busy_timeout deadlock and could silently pass against a buggy build. The end-to-end multi-process repro is in the linked issue (Python `multiprocessing.spawn` against the persist_dir from two PIDs).

## Why this is the right fix

- **WAL is the documented multi-process pattern for SQLite** ([sqlite.org/wal.html](https://www.sqlite.org/wal.html)). Chroma's own cookbook ([System Constraints](https://cookbook.chromadb.dev/core/system_constraints/)) currently says "Chroma is not process-safe for concurrent writers sharing the same local persistence path" — this PR is one half of relaxing that constraint at the SQLite layer (HNSW segment files would be the other half, out of scope here).
- **`busy_timeout=1000` appears to be a units typo.** The Python implementation of chroma used 5 seconds; the existing source comment `// TODO: copy all other pragmas from python and add basic tests` supports that this code was planned for follow-up.
- **Setting WAL via PRAGMA is sticky in the DB header.** Existing users get the fix automatically on next open; no migration script required.

## Backwards compatibility

- WAL mode is enabled by default for new and existing DBs once this PR ships.
- Reversible: any user can set `PRAGMA journal_mode=DELETE` if they explicitly need DELETE mode (rare; main reason is broken filesystems like NFS without locking).
- `-wal` and `-shm` files appear next to `chroma.sqlite3` after WAL is enabled. These are transient SQLite-managed files, safe to delete when no process holds the DB open.
- No schema changes. No data migration. No changes to chroma's HNSW segment format.

## Risks

- **Network filesystems:** WAL is unsafe on NFS / SMB / CIFS without full POSIX locking. Users running chroma on network-mounted persist_dirs would need to either disable WAL manually (`PRAGMA journal_mode=DELETE`) or move to client/server mode. **This PR includes a `// TODO: warn on network FS` comment as a placeholder; a follow-up PR should add detection (`statfs` magic check on Linux, `getmntinfo` on macOS) and a `WARN`-level log when the persist_dir is on a non-local FS.** Worth surfacing on the documentation side too.
- **Long-held read transactions can prevent WAL checkpoints**, growing `-wal` unboundedly. Mitigated by `wal_autocheckpoint` defaulting to 1000 pages (~4 MB). If chroma's HNSW reads hold long transactions, an explicit `wal_checkpoint(TRUNCATE)` after bulk operations would be a follow-up.

## Test plan

- [x] New unit test (`test_sqlite_db_opens_in_wal_mode`) — fails pre-patch, passes post-patch.
- [ ] Existing chroma integration tests under `rust/` should pass unchanged (will be exercised by CI).
- [x] Manual: ran the Python reproducer from the linked issue. Pre-patch hangs ~16 min; post-patch completes in ~1 s.

## Out of scope (separate issues / PRs)

- HNSW segment-file concurrency (not addressed here; users still need to avoid concurrent writes to the same collection).
- Network-filesystem detection / warning (placeholder TODO in this PR; full implementation as follow-up).
- A dedicated `wal_checkpoint(TRUNCATE)` call after bulk ingest paths.
