### PR TITLE
docs: fix source comment typos

### DIFF
--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -221,7 +221,7 @@ class LocalHnswSegment(VectorReader):
 
     @trace_method("LocalHnswSegment._ensure_index", OpenTelemetryGranularity.ALL)
     def _ensure_index(self, n: int, dim: int) -> None:
-        """Create or resize the index as necessary to accomodate N new records"""
+        """Create or resize the index as necessary to accommodate N new records"""
         if not self._index:
             self._dimensionality = dim
             self._init_index(dim)

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -43,7 +43,7 @@ type CacheKey = CollectionUuid;
 // 1. get index version v1
 // 2. get index version v2 (> v1)
 // 3. get index version v1 (can happen due to an inflight query
-//    that started before compaction of v2 occured) -- this will
+//    that started before compaction of v2 occurred) -- this will
 //    evict v2 even though it is more recent and will be used again in future.
 // Once we have versioning propagated throughout the system we can make
 // this better. We can also do a deferred eviction for such entries when

--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -53,8 +53,8 @@ use tracing::{trace_span, Instrument, Span};
 ## Implementation notes
 - The dispatcher has a queue of tasks that it distributes to worker threads
 - A worker thread sends a TaskRequestMessage to the dispatcher when it is ready for a new task
-- If no task is available for the worker thread, the dispatcher will place that worker's reciever
-  in a queue and send a task to the worker when it recieves another one
+- If no task is available for the worker thread, the dispatcher will place that worker's receiver
+  in a queue and send a task to the worker when it receives another one
 - The reason to introduce this abstraction is to allow us to control fairness and dynamically adjust
   system utilization. It also makes mechanisms like pausing/stopping work easier.
   It would have likely been more performant to use the Tokio MT runtime, but we chose to use
@@ -616,7 +616,7 @@ mod tests {
     #[derive(Debug)]
     struct MockIoDispatchUser {
         pub dispatcher: ComponentHandle<Dispatcher>,
-        counter: Arc<AtomicUsize>, // We expect to recieve DISPATCH_COUNT messages
+        counter: Arc<AtomicUsize>, // We expect to receive DISPATCH_COUNT messages
         sent_tasks: Arc<Mutex<HashSet<Uuid>>>,
         received_tasks: Arc<Mutex<HashSet<Uuid>>>,
     }
@@ -684,7 +684,7 @@ mod tests {
     #[derive(Debug)]
     struct MockDispatchUser {
         pub dispatcher: ComponentHandle<Dispatcher>,
-        counter: Arc<AtomicUsize>, // We expect to recieve DISPATCH_COUNT messages
+        counter: Arc<AtomicUsize>, // We expect to receive DISPATCH_COUNT messages
         sent_tasks: Arc<Mutex<HashSet<Uuid>>>,
         received_tasks: Arc<Mutex<HashSet<Uuid>>>,
     }
@@ -773,7 +773,7 @@ mod tests {
         assert_eq!(counter.load(Ordering::SeqCst), DISPATCH_COUNT);
         // The sent tasks should be equal to the received tasks
         assert_eq!(*sent_tasks.lock(), *received_tasks.lock());
-        // The length of the sent/recieved tasks should be equal to the number of dispatched tasks
+        // The length of the sent/received tasks should be equal to the number of dispatched tasks
         assert_eq!(sent_tasks.lock().len(), DISPATCH_COUNT);
         assert_eq!(received_tasks.lock().len(), DISPATCH_COUNT);
     }
@@ -809,7 +809,7 @@ mod tests {
         assert_eq!(counter.load(Ordering::SeqCst), DISPATCH_COUNT);
         // The sent tasks should be equal to the received tasks
         assert_eq!(*sent_tasks.lock(), *received_tasks.lock());
-        // The length of the sent/recieved tasks should be equal to the number of dispatched tasks
+        // The length of the sent/received tasks should be equal to the number of dispatched tasks
         assert_eq!(sent_tasks.lock().len(), DISPATCH_COUNT);
         assert_eq!(received_tasks.lock().len(), DISPATCH_COUNT);
     }

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -99,7 +99,7 @@ impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
                 match *e {
                     RecordSegmentReaderShardCreationError::UninitializedSegment => {
                         tracing::info!("[CountQueryOrchestrator] Record segment is uninitialized; using {} records from log", input.log_records.len());
-                        // This means there no compaction has occured.
+                        // This means there no compaction has occurred.
                         // So we can just traverse the log records
                         // and count the number of records.
                         let mut seen_id_set = HashSet::new();


### PR DESCRIPTION
## Description of changes

Fix a handful of misspellings in source comments/docstrings:

- `accomodate` -> `accommodate`
- `reciever`/`recieves`/`recieve`/`recieved` -> `receiver`/`receives`/`receive`/`received`
- `occured` -> `occurred`

This is comment/documentation-only cleanup; runtime behavior is unchanged.

## Test plan

- `git diff --check`
- Targeted grep confirmed the corrected misspellings are absent from the touched files.

Full tests were not run because the patch only updates comments/docstrings.
