### PR TITLE
[ENH]: Integrate sysdb with work queue service

### DIFF
--- a/.github/actions/tilt/action.yaml
+++ b/.github/actions/tilt/action.yaml
@@ -20,3 +20,4 @@ runs:
         kubectl -n chroma2 port-forward svc/rust-frontend-service 8001:8000 &
         kubectl -n chroma port-forward svc/minio 9000:9000 &
         kubectl -n chroma port-forward svc/jaeger 16686:16686 &
+        kubectl -n chroma port-forward svc/work-queue-service 50058:50051 &

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -182,6 +182,7 @@ jobs:
           kubectl -n chroma port-forward svc/rust-frontend-service 8000:8000 &
           kubectl -n chroma port-forward svc/minio 9000:9000 &
           kubectl -n chroma port-forward svc/jaeger 16686:16686 &
+          kubectl -n chroma port-forward svc/work-queue-service 50058:50051 &
           # Forward Spanner emulator port for rust-sysdb backend tests
           kubectl -n chroma port-forward svc/spanner 9010:9010 &
       - name: Run mcmr k8s integration tests

--- a/go/pkg/sysdb/metastore/db/dao/task.go
+++ b/go/pkg/sysdb/metastore/db/dao/task.go
@@ -427,7 +427,7 @@ func (s *attachedFunctionDb) AreInvocationsDone(items []dbmodel.InvocationCheckI
 		FROM input_items ii
 		LEFT JOIN attached_functions af
 			ON af.id = ii.fn_id::uuid
-			AND af.input_collection_id = ii.collection_id::uuid
+			AND af.input_collection_id = ii.collection_id
 		ORDER BY ii.ord
 	`, ordinals, fnIDs, collectionIDs, completionOffsets).Rows()
 

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -2757,6 +2757,61 @@ impl SysDb {
     }
 }
 
+//////////////////////////  Work Queue Operations //////////////////////////
+
+impl SysDb {
+    pub async fn try_finish_async_attached_function_invocation(
+        &mut self,
+        request: chroma_types::chroma_proto::TryFinishAsyncAttachedFunctionInvocationRequest,
+    ) -> Result<
+        tonic::Response<
+            chroma_types::chroma_proto::TryFinishAsyncAttachedFunctionInvocationResponse,
+        >,
+        tonic::Status,
+    > {
+        match self {
+            SysDb::Grpc(grpc) => {
+                grpc.client
+                    .clone()
+                    .try_finish_async_attached_function_invocation(request)
+                    .await
+            }
+            SysDb::Sqlite(_) => unimplemented!(),
+            SysDb::Test(_) => unimplemented!(),
+        }
+    }
+
+    pub async fn are_invocations_done(
+        &mut self,
+        request: chroma_types::chroma_proto::AreInvocationsDoneRequest,
+    ) -> Result<
+        tonic::Response<chroma_types::chroma_proto::AreInvocationsDoneResponse>,
+        tonic::Status,
+    > {
+        match self {
+            SysDb::Grpc(grpc) => grpc.client.clone().are_invocations_done(request).await,
+            SysDb::Sqlite(_) => unimplemented!(),
+            SysDb::Test(_) => unimplemented!(),
+        }
+    }
+
+    pub async fn finalize_async_attached_function_repair(
+        &mut self,
+        request: chroma_types::chroma_proto::FinalizeAsyncAttachedFunctionRepairRequest,
+    ) -> Result<(), tonic::Status> {
+        match self {
+            SysDb::Grpc(grpc) => grpc
+                .client
+                .clone()
+                .finalize_async_attached_function_repair(request)
+                .await
+                .map(|_| ()),
+            SysDb::Sqlite(_) => unimplemented!(),
+            SysDb::Test(_) => unimplemented!(),
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum AttachFunctionError {
     #[error("AlreadyExistsError: {0}")]

--- a/rust/worker/src/work_queue/mod.rs
+++ b/rust/worker/src/work_queue/mod.rs
@@ -1,9 +1,11 @@
 pub(crate) mod config;
 pub mod server;
 pub(crate) mod state;
+#[cfg(test)]
+pub(crate) mod tests;
 pub mod types;
 pub mod work_queue_client;
 pub(crate) mod work_queue_manager;
-pub mod work_queue_server;
+pub(crate) mod work_queue_server;
 
 pub use server::service_entrypoint;

--- a/rust/worker/src/work_queue/server.rs
+++ b/rust/worker/src/work_queue/server.rs
@@ -4,6 +4,7 @@ use crate::work_queue::work_queue_server::WorkQueueServer;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_storage::Storage;
+use chroma_sysdb::SysDb;
 
 const CONFIG_PATH_ENV_VAR: &str = "CONFIG_PATH";
 
@@ -42,12 +43,22 @@ pub async fn service_entrypoint() {
         }
     };
 
+    // Create sysdb
+    let sysdb = match SysDb::try_from_config(&(service_config.sysdb, None), &registry).await {
+        Ok(sysdb) => sysdb,
+        Err(err) => {
+            eprintln!("Failed to create sysdb: {:?}", err);
+            return;
+        }
+    };
+
     // Create and start work queue manager
-    let work_queue_manager = WorkQueueManager::new(storage, work_queue_config.clone());
+    let work_queue_manager =
+        WorkQueueManager::new(storage, work_queue_config.clone(), sysdb.clone());
     let work_queue_handle = system.start_component(work_queue_manager);
 
     // Create and start gRPC server
-    let work_queue_server = WorkQueueServer::new(work_queue_handle.clone());
+    let work_queue_server = WorkQueueServer::new(work_queue_handle.clone(), sysdb);
     let server = work_queue_server.into_service();
     let port = service_config.my_port;
 

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -1,0 +1,426 @@
+#[cfg(test)]
+mod tests {
+    use crate::work_queue::work_queue_client::WorkQueueClient;
+    use chroma_config::registry::Registry;
+    use chroma_config::Configurable;
+    use chroma_sysdb::SysDb;
+    use chroma_types::chroma_proto::{AreInvocationsDoneRequest, InvocationCheckItem};
+    use chroma_types::{AttachedFunctionUuid, CollectionUuid};
+    use uuid::Uuid;
+
+    struct TestContext {
+        work_queue_client: WorkQueueClient,
+        sysdb: SysDb,
+        tenant_id: String,
+        database_name: String,
+    }
+
+    async fn setup_test_context() -> Result<TestContext, Box<dyn std::error::Error>> {
+        // Connect to work queue service
+        let work_queue_client = WorkQueueClient::new("http://localhost:50058".to_string()).await?;
+
+        // Connect to Go sysdb (requires Tilt running) using same config as compact.rs test
+        let registry = Registry::new();
+        // Use port-forward to access sysdb in chroma namespace
+        let sysdb_config = chroma_sysdb::SysDbConfig::Grpc(chroma_sysdb::GrpcSysDbConfig {
+            host: "localhost".to_string(),
+            port: 50051,
+            connect_timeout_ms: 5000,
+            request_timeout_ms: 10000,
+            num_channels: 4,
+        });
+        let sysdb = SysDb::try_from_config(&(sysdb_config, None), &registry).await?;
+
+        // Use pre-existing tenant and database
+        let tenant_id = "default_tenant".to_string();
+        let database_name = "default_database".to_string();
+
+        Ok(TestContext {
+            work_queue_client,
+            sysdb,
+            tenant_id,
+            database_name,
+        })
+    }
+
+    async fn with_work_queue_test<F, Fut>(test_fn: F)
+    where
+        F: FnOnce(TestContext) -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let context = setup_test_context()
+            .await
+            .expect("Failed to setup test context. Is Tilt running?");
+        test_fn(context).await
+        // Cleanup if needed - could delete tenant/database here
+    }
+
+    async fn create_test_collection(
+        sysdb: &mut SysDb,
+        collection_id: CollectionUuid,
+        tenant_id: &str,
+        database_name: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use chroma_types::{Segment, SegmentScope, SegmentType, SegmentUuid};
+
+        let collection_name = format!("test_collection_{}", Uuid::new_v4());
+        let db_name = chroma_types::DatabaseName::new(database_name.to_string()).unwrap();
+
+        // Create collection with segments like the AttachFunction does
+        let segments = vec![
+            Segment {
+                r#type: SegmentType::BlockfileMetadata,
+                scope: SegmentScope::METADATA,
+                collection: collection_id,
+                id: SegmentUuid(Uuid::new_v4()),
+                metadata: None,
+                file_path: Default::default(),
+            },
+            Segment {
+                r#type: SegmentType::BlockfileRecord,
+                scope: SegmentScope::RECORD,
+                collection: collection_id,
+                id: SegmentUuid(Uuid::new_v4()),
+                metadata: None,
+                file_path: Default::default(),
+            },
+            Segment {
+                r#type: SegmentType::HnswDistributed,
+                scope: SegmentScope::VECTOR,
+                collection: collection_id,
+                id: SegmentUuid(Uuid::new_v4()),
+                metadata: None,
+                file_path: Default::default(),
+            },
+        ];
+
+        sysdb
+            .create_collection(
+                tenant_id.to_string(),
+                db_name,
+                collection_id,
+                collection_name,
+                segments,
+                None,    // configuration json
+                None,    // schema
+                None,    // metadata
+                Some(1), // dimension
+                false,   // get_or_create
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn create_test_attached_function(
+        sysdb: &mut SysDb,
+        collection_id: CollectionUuid,
+    ) -> Result<AttachedFunctionUuid, Box<dyn std::error::Error>> {
+        // Create a test attached function similar to compact.rs test
+        let fn_name = format!("test_function_{}", Uuid::new_v4());
+        let output_collection_name = format!("output_collection_{}", Uuid::new_v4());
+
+        let (attached_function_id, _created) = sysdb
+            .create_attached_function(
+                fn_name,
+                "dummy_async".to_string(), // Use the async function from migration
+                collection_id,
+                output_collection_name,
+                serde_json::Value::Null,
+                "default_tenant".to_string(),
+                "default_database".to_string(),
+                10, // min_records_for_invocation
+            )
+            .await?;
+
+        // Finish creating the function with output schema
+        let output_schema = serde_json::json!({
+            "test": "schema"
+        });
+        sysdb
+            .finish_create_attached_function(attached_function_id, output_schema.to_string())
+            .await?;
+
+        Ok(attached_function_id)
+    }
+
+    // Note: In a real scenario, updating collection log position would be done
+    // through the log service, not sysdb. For testing work queue repair logic,
+    // we rely on the sysdb methods to simulate repair conditions.
+
+    #[tokio::test]
+    async fn test_k8s_integration_work_queue_lifecycle() {
+        with_work_queue_test(|mut ctx| async move {
+            let coll_id = CollectionUuid::new();
+            let offset = 100;
+
+            // Create collection
+            create_test_collection(&mut ctx.sysdb, coll_id, &ctx.tenant_id, &ctx.database_name)
+                .await
+                .expect("Failed to create collection");
+
+            // Create async attached function
+            let fn_id = create_test_attached_function(&mut ctx.sysdb, coll_id)
+                .await
+                .expect("Failed to create async attached function");
+
+            // Push work
+            ctx.work_queue_client
+                .push_work(fn_id.to_string(), coll_id.to_string(), offset)
+                .await
+                .expect("Failed to push work");
+
+            // Get work
+            let work_items = ctx
+                .work_queue_client
+                .get_work("test_shard".to_string(), 10)
+                .await
+                .expect("Failed to get work");
+
+            println!("Got {} work items", work_items.items.len());
+            for (i, item) in work_items.items.iter().enumerate() {
+                println!(
+                    "  Item {}: fn_id={}, offset={}",
+                    i, item.fn_id, item.completion_offset
+                );
+            }
+
+            // Filter work items to only our function ID
+            let our_items: Vec<_> = work_items
+                .items
+                .iter()
+                .filter(|item| item.fn_id == fn_id.to_string())
+                .collect();
+
+            assert_eq!(our_items.len(), 1, "Expected 1 work item for our function");
+            assert_eq!(our_items[0].completion_offset, offset);
+
+            // Finish work
+            ctx.work_queue_client
+                .finish_work(fn_id.to_string(), coll_id.to_string(), 200)
+                .await
+                .expect("Failed to finish work");
+
+            // Get work again - should not contain our function
+            let work_items = ctx
+                .work_queue_client
+                .get_work("test_shard".to_string(), 10)
+                .await
+                .expect("Failed to get work after finish");
+
+            println!("After finish: got {} work items", work_items.items.len());
+            let our_items_after: Vec<_> = work_items
+                .items
+                .iter()
+                .filter(|item| item.fn_id == fn_id.to_string())
+                .collect();
+            assert_eq!(
+                our_items_after.len(),
+                0,
+                "Expected 0 work items for our function after finish"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_work_queue_fifo_and_filtering() {
+        with_work_queue_test(|mut ctx| async move {
+            let mut work_items = Vec::new();
+
+            // Create multiple collections and attached functions
+            for i in 0..3 {
+                let coll_id = CollectionUuid::new();
+
+                create_test_collection(&mut ctx.sysdb, coll_id, &ctx.tenant_id, &ctx.database_name)
+                    .await
+                    .expect("Failed to create collection");
+
+                let fn_id = create_test_attached_function(&mut ctx.sysdb, coll_id)
+                    .await
+                    .expect("Failed to create async attached function");
+
+                ctx.work_queue_client
+                    .push_work(fn_id.to_string(), coll_id.to_string(), i * 100)
+                    .await
+                    .expect("Failed to push work");
+
+                work_items.push((fn_id, coll_id, i * 100));
+            }
+
+            // Get work - should return in FIFO order
+            let retrieved = ctx
+                .work_queue_client
+                .get_work("test_shard".to_string(), 10)
+                .await
+                .expect("Failed to get work");
+
+            println!("Got {} work items total", retrieved.items.len());
+
+            // Filter to only our test items
+            let our_fn_ids: std::collections::HashSet<String> = work_items
+                .iter()
+                .map(|(fn_id, _, _)| fn_id.to_string())
+                .collect();
+
+            let our_retrieved: Vec<_> = retrieved
+                .items
+                .iter()
+                .filter(|item| our_fn_ids.contains(&item.fn_id))
+                .collect();
+
+            assert_eq!(
+                our_retrieved.len(),
+                3,
+                "Expected 3 work items for our functions"
+            );
+
+            // Check FIFO order by completion offset (assuming same order as pushed)
+            for (i, item) in our_retrieved.iter().enumerate() {
+                let expected_offset = i * 100;
+                assert_eq!(
+                    item.completion_offset, expected_offset as i64,
+                    "Expected offset {} for item {}",
+                    expected_offset, i
+                );
+            }
+
+            // Mark some as completed
+            for i in [0, 2] {
+                ctx.work_queue_client
+                    .finish_work(
+                        work_items[i].0.to_string(),
+                        work_items[i].1.to_string(),
+                        work_items[i].2 + 50,
+                    )
+                    .await
+                    .expect("Failed to finish work");
+            }
+
+            // Get work again - should filter out completed items
+            let filtered = ctx
+                .work_queue_client
+                .get_work("test_shard".to_string(), 10)
+                .await
+                .expect("Failed to get filtered work");
+
+            println!(
+                "After finishing items 0 and 2: got {} work items total",
+                filtered.items.len()
+            );
+
+            // Filter to only our remaining test item
+            let our_filtered: Vec<_> = filtered
+                .items
+                .iter()
+                .filter(|item| item.fn_id == work_items[1].0.to_string())
+                .collect();
+
+            // Should see only item 1 (indices 0 and 2 were completed)
+            assert_eq!(
+                our_filtered.len(),
+                1,
+                "Expected 1 remaining work item for our function"
+            );
+            assert_eq!(our_filtered[0].completion_offset, work_items[1].2);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_work_queue_repair_flow() {
+        with_work_queue_test(|mut ctx| async move {
+            let coll_id = CollectionUuid::new();
+            let initial_offset = 100;
+            let new_offset = 150;
+
+            // Create collection
+            create_test_collection(&mut ctx.sysdb, coll_id, &ctx.tenant_id, &ctx.database_name)
+                .await
+                .expect("Failed to create collection");
+
+            // Create async attached function
+            let fn_id = create_test_attached_function(&mut ctx.sysdb, coll_id)
+                .await
+                .expect("Failed to create async attached function");
+
+            // Push work
+            ctx.work_queue_client
+                .push_work(fn_id.to_string(), coll_id.to_string(), initial_offset)
+                .await
+                .expect("Failed to push work");
+
+            // Finish work - should trigger repair if collection's log position is ahead
+            ctx.work_queue_client
+                .finish_work(fn_id.to_string(), coll_id.to_string(), new_offset)
+                .await
+                .expect("Failed to finish work");
+
+            // Get work - should not contain our finished work
+            let work_items = ctx
+                .work_queue_client
+                .get_work("test_shard".to_string(), 10)
+                .await
+                .expect("Failed to get work after repair");
+
+            println!(
+                "After repair: got {} work items total",
+                work_items.items.len()
+            );
+
+            // Filter to check our function is not in the queue
+            let our_items: Vec<_> = work_items
+                .items
+                .iter()
+                .filter(|item| item.fn_id == fn_id.to_string())
+                .collect();
+
+            // Work should be completed (not in queue)
+            assert_eq!(
+                our_items.len(),
+                0,
+                "Expected 0 work items for our function after repair"
+            );
+
+            // Check invocation status via sysdb
+            let are_done_response = ctx
+                .sysdb
+                .clone()
+                .are_invocations_done(AreInvocationsDoneRequest {
+                    items: vec![
+                        InvocationCheckItem {
+                            function_id: fn_id.to_string(),
+                            input_collection_id: coll_id.to_string(),
+                            completion_offset: initial_offset,
+                        },
+                        InvocationCheckItem {
+                            function_id: fn_id.to_string(),
+                            input_collection_id: coll_id.to_string(),
+                            completion_offset: new_offset,
+                        },
+                    ],
+                })
+                .await
+                .expect("Failed to check invocation status")
+                .into_inner();
+
+            // Verify invocation statuses
+            assert_eq!(are_done_response.done.len(), 2);
+            println!(
+                "Invocation status: initial_offset={} done={}, new_offset={} done={}",
+                initial_offset, are_done_response.done[0], new_offset, are_done_response.done[1]
+            );
+
+            // The initial offset (100) should be marked as done since we finished at 150
+            assert!(are_done_response.done[0], "Initial offset should be done");
+
+            // The new_offset (150) should NOT be done because we never pushed work at that offset
+            // We only pushed work at offset 100, then called finish_work with offset 150
+            assert!(
+                !are_done_response.done[1],
+                "New offset should NOT be done - we never pushed work at that offset"
+            );
+        })
+        .await;
+    }
+}

--- a/rust/worker/src/work_queue/tests/mod.rs
+++ b/rust/worker/src/work_queue/tests/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod integration;

--- a/rust/worker/src/work_queue/types.rs
+++ b/rust/worker/src/work_queue/types.rs
@@ -25,6 +25,18 @@ pub enum WorkQueueError {
 
     #[error("Invalid state: {0}")]
     InvalidState(String),
+
+    #[error("SysDB error: {0}")]
+    SysDb(String),
+
+    #[error("Failed to finish async invocation: {0}")]
+    TryFinishFailed(String),
+
+    #[error("Failed to check invocations: {0}")]
+    CheckInvocationsFailed(String),
+
+    #[error("Failed to repair attached function: {0}")]
+    RepairFailed(String),
 }
 
 impl ChromaError for WorkQueueError {
@@ -34,6 +46,19 @@ impl ChromaError for WorkQueueError {
             WorkQueueError::Serialization(_) => ErrorCodes::Internal,
             WorkQueueError::ETagMismatch => ErrorCodes::AlreadyExists,
             WorkQueueError::InvalidState(_) => ErrorCodes::InvalidArgument,
+            WorkQueueError::SysDb(_) => ErrorCodes::Internal,
+            WorkQueueError::TryFinishFailed(_) => ErrorCodes::Internal,
+            WorkQueueError::CheckInvocationsFailed(_) => ErrorCodes::Internal,
+            WorkQueueError::RepairFailed(_) => ErrorCodes::Internal,
+        }
+    }
+
+    fn should_trace_error(&self) -> bool {
+        match self {
+            // ETagMismatch is expected during normal operation
+            WorkQueueError::ETagMismatch => false,
+            // All other errors should be traced
+            _ => true,
         }
     }
 }

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -11,7 +11,13 @@ enum WorkResponse {
 use async_trait::async_trait;
 use chroma_error::ChromaError;
 use chroma_storage::{GetOptions, PutMode, PutOptions, Storage};
+use chroma_sysdb::SysDb;
 use chroma_system::{Component, ComponentContext, ComponentRuntime, Handler};
+use chroma_types::chroma_proto::{
+    try_finish_async_attached_function_invocation_response::Result as TryFinishResult,
+    AreInvocationsDoneRequest, InvocationCheckItem,
+    TryFinishAsyncAttachedFunctionInvocationRequest,
+};
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -50,26 +56,32 @@ pub struct PeriodicPersistMessage;
 
 // Component implementation
 #[derive(Debug)]
-pub struct WorkQueueManager {
+pub(crate) struct WorkQueueManager {
     state: QueueState,
     storage: Storage,
     storage_path: String,
-    #[allow(dead_code)]
-    sysdb: Option<chroma_sysdb::SysDb>,
+    sysdb: SysDb,
     config: crate::work_queue::config::WorkQueueConfig,
     // Pending responses waiting for persistence (push work responses)
     pending_push_responses: Vec<oneshot::Sender<Result<(), WorkQueueError>>>,
-    // Pending responses waiting for persistence (finish work responses)
-    pending_finish_responses: Vec<oneshot::Sender<Result<FinishResult, WorkQueueError>>>,
+    // Pending responses for finish work
+    pending_finish_responses: Vec<(
+        FinishResult,
+        oneshot::Sender<Result<FinishResult, WorkQueueError>>,
+    )>,
 }
 
 impl WorkQueueManager {
-    pub fn new(storage: Storage, config: crate::work_queue::config::WorkQueueConfig) -> Self {
+    pub fn new(
+        storage: Storage,
+        config: crate::work_queue::config::WorkQueueConfig,
+        sysdb: SysDb,
+    ) -> Self {
         Self {
             state: QueueState::new(),
             storage,
             storage_path: config.storage_path.clone(),
-            sysdb: None, // TODO: inject when sysdb integration ready
+            sysdb,
             config,
             pending_push_responses: Vec::new(),
             pending_finish_responses: Vec::new(),
@@ -170,8 +182,8 @@ impl WorkQueueManager {
             }
         }
 
-        for tx in self.pending_finish_responses.drain(..) {
-            if tx.send(Ok(FinishResult::NeedsRepair)).is_err() {
+        for (result, tx) in self.pending_finish_responses.drain(..) {
+            if tx.send(Ok(result)).is_err() {
                 tracing::error!("Failed to send finish work response - receiver dropped");
             }
         }
@@ -184,7 +196,7 @@ impl WorkQueueManager {
             }
         }
 
-        for tx in self.pending_finish_responses.drain(..) {
+        for (_, tx) in self.pending_finish_responses.drain(..) {
             if tx.send(Err(error.clone())).is_err() {
                 tracing::error!("Failed to send finish work error response - receiver dropped");
             }
@@ -220,7 +232,9 @@ impl WorkQueueManager {
 
         match response {
             WorkResponse::Push(tx) => self.pending_push_responses.push(tx),
-            WorkResponse::Repair(tx) => self.pending_finish_responses.push(tx),
+            WorkResponse::Repair(tx) => self
+                .pending_finish_responses
+                .push((FinishResult::NeedsRepair, tx)),
         }
 
         // Check if persist needed
@@ -231,31 +245,66 @@ impl WorkQueueManager {
         }
     }
 
-    // STUB: Will call sysdb's TryFinishAsyncAttachedFunctionInvocation
-    async fn try_finish_invocation_stub(
-        &self,
-        _fn_id: &AttachedFunctionUuid,
-        _input_coll_id: &CollectionUuid,
-        _completion_offset: i64,
-    ) -> FinishResult {
-        // TODO: When sysdb is available:
-        // if let Some(sysdb) = &self.sysdb {
-        //     match sysdb.try_finish_async_attached_function_invocation(
-        //         fn_id, input_coll_id, completion_offset
-        //     ).await {
-        //         Ok(TryFinishResult::Success) => FinishResult::Success,
-        //         Ok(TryFinishResult::NeedsRepair) => FinishResult::NeedsRepair,
-        //         Err(e) => panic!("sysdb error: {}", e),
-        //     }
-        // }
-        FinishResult::Success
+    // Call sysdb's TryFinishAsyncAttachedFunctionInvocation
+    async fn try_finish_invocation(
+        &mut self,
+        fn_id: &AttachedFunctionUuid,
+        input_coll_id: &CollectionUuid,
+        completion_offset: i64,
+    ) -> Result<FinishResult, WorkQueueError> {
+        let request = TryFinishAsyncAttachedFunctionInvocationRequest {
+            attached_function_id: fn_id.to_string(),
+            collection_id: input_coll_id.to_string(),
+            new_completion_offset: completion_offset as u64,
+        };
+
+        let response = self
+            .sysdb
+            .try_finish_async_attached_function_invocation(request)
+            .await
+            .map_err(|e| WorkQueueError::TryFinishFailed(e.message().to_string()))?;
+
+        let inner = response.into_inner();
+        match inner.result {
+            Some(result) => match result {
+                TryFinishResult::Success(_) => Ok(FinishResult::Success),
+                TryFinishResult::NeedsRepair(_) => Ok(FinishResult::NeedsRepair),
+            },
+            None => Err(WorkQueueError::TryFinishFailed(
+                "Empty response".to_string(),
+            )),
+        }
     }
 
-    // STUB: Will check invocation completion status
-    async fn check_invocations_done_stub(&self, items: &[WorkQueueRecord]) -> Vec<bool> {
-        // TODO: Call sysdb's AreInvocationsDone
-        // For now, return all false (not done)
-        vec![false; items.len()]
+    // Check invocation completion status
+    async fn check_invocations_done(
+        &mut self,
+        items: &[WorkQueueRecord],
+    ) -> Result<Vec<bool>, WorkQueueError> {
+        if items.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let invocation_items: Vec<InvocationCheckItem> = items
+            .iter()
+            .map(|item| InvocationCheckItem {
+                function_id: item.fn_id.to_string(),
+                input_collection_id: item.input_coll_id.to_string(),
+                completion_offset: item.completion_offset,
+            })
+            .collect();
+
+        let request = AreInvocationsDoneRequest {
+            items: invocation_items,
+        };
+
+        let response = self
+            .sysdb
+            .are_invocations_done(request)
+            .await
+            .map_err(|e| WorkQueueError::CheckInvocationsFailed(e.message().to_string()))?;
+
+        Ok(response.into_inner().done)
     }
 }
 
@@ -332,10 +381,19 @@ impl Handler<FinishWorkMessage> for WorkQueueManager {
     type Result = ();
 
     async fn handle(&mut self, msg: FinishWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
-        // STUB: Call sysdb
-        let finish_result = self
-            .try_finish_invocation_stub(&msg.fn_id, &msg.input_coll_id, msg.new_completion_offset)
-            .await;
+        // Call sysdb
+        let finish_result = match self
+            .try_finish_invocation(&msg.fn_id, &msg.input_coll_id, msg.new_completion_offset)
+            .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                if msg.response_tx.send(Err(e)).is_err() {
+                    tracing::error!("Failed to send error response");
+                }
+                return;
+            }
+        };
 
         match finish_result {
             FinishResult::Success => {
@@ -389,8 +447,21 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
             .cloned()
             .collect();
 
-        // STUB: Check invocations done
-        let done_flags = self.check_invocations_done_stub(&items).await;
+        // Check invocations done
+        // TODO(tanujnay112): We won't need this if we make sure finish_work
+        // deletes the work item from the queue and we look for repair on bootup.
+        let done_flags = match self.check_invocations_done(&items).await {
+            Ok(flags) => flags,
+            Err(e) => {
+                tracing::error!("Failed to check invocations done: {}", e);
+                // If we fail to check, return empty results
+                if msg.response_tx.send(Err(e)).is_err() {
+                    tracing::warn!("Failed to send error response - receiver dropped");
+                }
+                return;
+            }
+        };
+
         let filtered: Vec<_> = items
             .into_iter()
             .zip(done_flags.iter())
@@ -430,6 +501,7 @@ impl Handler<PeriodicPersistMessage> for WorkQueueManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::work_queue::state::QueueState;
     use chroma_storage::local::LocalStorage;
     use tempfile::TempDir;
     use uuid::Uuid;
@@ -444,88 +516,89 @@ mod tests {
         }
     }
 
-    fn create_test_manager() -> (WorkQueueManager, TempDir) {
+    fn create_test_sysdb() -> SysDb {
+        // Create a test sysdb for unit tests that only test internal state.
+        // This sysdb is not connected to any backend and is purely for testing.
+        // If a test needs real sysdb interaction, it should be an integration test.
+        SysDb::Test(chroma_sysdb::test_sysdb::TestSysDb::new())
+    }
+
+    async fn create_test_manager() -> (WorkQueueManager, TempDir) {
         let temp_dir = TempDir::new().unwrap();
         let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
         let mut config = create_test_config();
         config.storage_path = "queue.parquet".to_string(); // Use relative path within temp dir
-        (WorkQueueManager::new(storage, config), temp_dir)
+        let sysdb = create_test_sysdb();
+        (WorkQueueManager::new(storage, config, sysdb), temp_dir)
     }
 
-    #[tokio::test]
-    async fn test_push_work_deduplication() {
-        let (mut manager, _temp_dir) = create_test_manager();
+    #[test]
+    fn test_push_work_deduplication() {
+        let mut state = QueueState::new();
 
         let fn_id = AttachedFunctionUuid(Uuid::new_v4());
         let coll_id = CollectionUuid(Uuid::new_v4());
 
         // Test direct state manipulation to verify deduplication logic
-        manager.state.push_work(fn_id, coll_id, 100);
-        assert_eq!(manager.state.pending_work.len(), 1);
-        assert_eq!(manager.state.pending_work[0].completion_offset, 100);
+        state.push_work(fn_id, coll_id, 100);
+        assert_eq!(state.pending_work.len(), 1);
+        assert_eq!(state.pending_work[0].completion_offset, 100);
 
         // Push with lower offset should be ignored
-        manager.state.push_work(fn_id, coll_id, 50);
-        assert_eq!(manager.state.pending_work.len(), 1);
-        assert_eq!(manager.state.pending_work[0].completion_offset, 100);
+        state.push_work(fn_id, coll_id, 50);
+        assert_eq!(state.pending_work.len(), 1);
+        assert_eq!(state.pending_work[0].completion_offset, 100);
 
         // Push with higher offset should replace
-        manager.state.push_work(fn_id, coll_id, 200);
-        assert_eq!(manager.state.pending_work.len(), 1);
-        assert_eq!(manager.state.pending_work[0].completion_offset, 200);
+        state.push_work(fn_id, coll_id, 200);
+        assert_eq!(state.pending_work.len(), 1);
+        assert_eq!(state.pending_work[0].completion_offset, 200);
 
-        assert!(manager.state.dirty);
+        assert!(state.dirty);
     }
 
-    #[tokio::test]
-    async fn test_finish_work_success() {
-        let (mut manager, _temp_dir) = create_test_manager();
+    #[test]
+    fn test_finish_work_success() {
+        let mut state = QueueState::new();
 
         let fn_id = AttachedFunctionUuid(Uuid::new_v4());
         let coll_id = CollectionUuid(Uuid::new_v4());
 
         // Push work
-        manager.state.push_work(fn_id, coll_id, 100);
-        assert_eq!(manager.state.pending_work.len(), 1);
+        state.push_work(fn_id, coll_id, 100);
+        assert_eq!(state.pending_work.len(), 1);
 
         // Finish work
-        manager.state.finish_work_success(&fn_id, &coll_id, 100);
-        assert_eq!(manager.state.pending_work.len(), 0);
-        assert!(manager.state.dirty);
+        state.finish_work_success(&fn_id, &coll_id, 100);
+        assert_eq!(state.pending_work.len(), 0);
+        assert!(state.dirty);
     }
 
-    #[tokio::test]
-    async fn test_get_work_filtering() {
-        let (mut manager, _temp_dir) = create_test_manager();
+    #[test]
+    fn test_get_work_filtering() {
+        let mut state = QueueState::new();
 
         // Add multiple work items
         for i in 0..5 {
-            manager.state.push_work(
+            state.push_work(
                 AttachedFunctionUuid(Uuid::new_v4()),
                 CollectionUuid(Uuid::new_v4()),
                 i * 100,
             );
         }
 
-        let (tx, rx) = oneshot::channel();
-        let msg = GetWorkMessage {
-            shard_id: "shard-1".to_string(),
-            limit: 3,
-            response_tx: tx,
-        };
+        assert_eq!(state.pending_work.len(), 5);
 
-        // Handle without context since we can't create one in tests
-        let filtered: Vec<_> = manager
-            .state
-            .pending_work
-            .iter()
-            .take(msg.limit)
-            .cloned()
-            .collect();
-        let _ = msg.response_tx.send(Ok(filtered));
+        // Test filtering logic (simulating what get_work does)
+        let limit = 3;
+        let filtered: Vec<_> = state.pending_work.iter().take(limit).cloned().collect();
 
-        let result = rx.await.unwrap().unwrap();
-        assert_eq!(result.len(), 3);
+        assert_eq!(filtered.len(), 3);
+
+        // Verify we got the first 3 items (FIFO order)
+        for (i, item) in filtered.iter().enumerate().take(3) {
+            assert_eq!(item.completion_offset, (i as i64) * 100);
+        }
     }
 
     #[tokio::test]
@@ -536,7 +609,8 @@ mod tests {
         // Create and persist state
         {
             let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
-            let mut manager = WorkQueueManager::new(storage, config.clone());
+            let sysdb = create_test_sysdb();
+            let mut manager = WorkQueueManager::new(storage, config.clone(), sysdb);
             manager.state.push_work(
                 AttachedFunctionUuid(Uuid::new_v4()),
                 CollectionUuid(Uuid::new_v4()),
@@ -553,7 +627,8 @@ mod tests {
         // Load state in new manager
         {
             let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
-            let mut manager = WorkQueueManager::new(storage, config);
+            let sysdb = create_test_sysdb();
+            let mut manager = WorkQueueManager::new(storage, config, sysdb);
             manager.load_state().await.unwrap();
             assert_eq!(manager.state.pending_work.len(), 2);
             assert_eq!(manager.state.pending_work[0].completion_offset, 100);
@@ -563,13 +638,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_notify_pending_responses() {
-        let (mut manager, _temp_dir) = create_test_manager();
+        let (mut manager, _temp_dir) = create_test_manager().await;
 
         // Add pending responses
         let (tx1, rx1) = oneshot::channel();
         let (tx2, rx2) = oneshot::channel();
         manager.pending_push_responses.push(tx1);
-        manager.pending_finish_responses.push(tx2);
+        manager
+            .pending_finish_responses
+            .push((FinishResult::NeedsRepair, tx2));
 
         // Notify success
         manager.notify_pending_responses();
@@ -586,13 +663,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_notify_pending_responses_error() {
-        let (mut manager, _temp_dir) = create_test_manager();
+        let (mut manager, _temp_dir) = create_test_manager().await;
 
         // Add pending responses
         let (tx1, rx1) = oneshot::channel();
         let (tx2, rx2) = oneshot::channel();
         manager.pending_push_responses.push(tx1);
-        manager.pending_finish_responses.push(tx2);
+        manager
+            .pending_finish_responses
+            .push((FinishResult::NeedsRepair, tx2));
 
         // Notify error
         let error = WorkQueueError::Storage("test error".to_string());
@@ -622,29 +701,29 @@ mod tests {
     //     // Test disabled for LocalStorage - would require S3 or mock storage
     // }
 
-    #[tokio::test]
-    async fn test_finish_work_multiple_offsets() {
-        let (mut manager, _temp_dir) = create_test_manager();
+    #[test]
+    fn test_finish_work_multiple_offsets() {
+        let mut state = QueueState::new();
 
         let fn_id = AttachedFunctionUuid(Uuid::new_v4());
         let coll_id = CollectionUuid(Uuid::new_v4());
 
         // Push multiple work items with different offsets
-        manager.state.push_work(fn_id, coll_id, 100);
-        manager.state.push_work(fn_id, coll_id, 200);
-        manager.state.push_work(fn_id, coll_id, 300);
-        assert_eq!(manager.state.pending_work.len(), 1);
-        assert_eq!(manager.state.pending_work[0].completion_offset, 300);
+        state.push_work(fn_id, coll_id, 100);
+        state.push_work(fn_id, coll_id, 200);
+        state.push_work(fn_id, coll_id, 300);
+        assert_eq!(state.pending_work.len(), 1);
+        assert_eq!(state.pending_work[0].completion_offset, 300);
 
         // Finish work up to offset 200
-        manager.state.finish_work_success(&fn_id, &coll_id, 200);
+        state.finish_work_success(&fn_id, &coll_id, 200);
 
         // Should still have work with offset 300
-        assert_eq!(manager.state.pending_work.len(), 1);
-        assert_eq!(manager.state.pending_work[0].completion_offset, 300);
+        assert_eq!(state.pending_work.len(), 1);
+        assert_eq!(state.pending_work[0].completion_offset, 300);
 
         // Finish remaining work
-        manager.state.finish_work_success(&fn_id, &coll_id, 300);
-        assert_eq!(manager.state.pending_work.len(), 0);
+        state.finish_work_success(&fn_id, &coll_id, 300);
+        assert_eq!(state.pending_work.len(), 0);
     }
 }

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -2,10 +2,12 @@ use crate::work_queue::types::{FinishResult, WorkQueueError};
 use crate::work_queue::work_queue_manager::{
     FinishWorkMessage, GetWorkMessage, PushWorkMessage, WorkQueueManager,
 };
+use chroma_sysdb::SysDb;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     work_queue_service_server::{WorkQueueService, WorkQueueServiceServer},
-    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest, WorkItemResult,
+    FinalizeAsyncAttachedFunctionRepairRequest, FinishWorkRequest, GetWorkRequest, GetWorkResponse,
+    PushWorkRequest, WorkItemResult,
 };
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use std::str::FromStr;
@@ -14,12 +16,13 @@ use tonic::{Request, Response, Status};
 #[allow(dead_code)]
 pub struct WorkQueueServer {
     manager: ComponentHandle<WorkQueueManager>,
+    sysdb: SysDb,
 }
 
 #[allow(dead_code)]
 impl WorkQueueServer {
-    pub fn new(manager: ComponentHandle<WorkQueueManager>) -> Self {
-        Self { manager }
+    pub fn new(manager: ComponentHandle<WorkQueueManager>, sysdb: SysDb) -> Self {
+        Self { manager, sysdb }
     }
 
     #[allow(dead_code)]
@@ -27,15 +30,23 @@ impl WorkQueueServer {
         WorkQueueServiceServer::new(self)
     }
 
-    // Stub for repair handling - will be replaced with actual sysdb integration
-    #[allow(dead_code)]
-    async fn handle_repair_stub(&self, fn_id: &AttachedFunctionUuid) {
-        // TODO: Implement actual repair logic once sysdb integration is ready
-        // This should:
-        // 1. Call get_attached_functions() to get latest offset
-        // 2. Re-push work with new offset
-        // 3. Call FinalizeAsyncAttachedFunctionRepair()
-        tracing::info!("STUB: Handling repair for function {:?}", fn_id);
+    // Handle repair by finalizing the repair in sysdb
+    async fn handle_repair(&self, fn_id: &AttachedFunctionUuid) -> Result<(), WorkQueueError> {
+        // The work has already been re-pushed by WorkQueueManager
+        // We just need to finalize the repair
+        let repair_request = FinalizeAsyncAttachedFunctionRepairRequest {
+            attached_function_id: fn_id.to_string(),
+        };
+
+        let mut sysdb = self.sysdb.clone();
+        sysdb
+            .finalize_async_attached_function_repair(repair_request)
+            .await
+            .map_err(|e| WorkQueueError::RepairFailed(e.to_string()))?;
+
+        tracing::info!("Repair finalized for function {}", fn_id);
+
+        Ok(())
     }
 }
 
@@ -66,7 +77,7 @@ impl WorkQueueService for WorkQueueServer {
         response_rx
             .await
             .map_err(|e| Status::internal(format!("Failed to receive response: {}", e)))?
-            .map_err(|e: WorkQueueError| Status::internal(format!("Work queue error: {:?}", e)))?;
+            .map_err(|e: WorkQueueError| Status::internal(e.to_string()))?;
 
         Ok(Response::new(()))
     }
@@ -99,7 +110,7 @@ impl WorkQueueService for WorkQueueServer {
         let result = response_rx
             .await
             .map_err(|e| Status::internal(format!("Failed to receive response: {}", e)))?
-            .map_err(|e: WorkQueueError| Status::internal(format!("Work queue error: {:?}", e)))?;
+            .map_err(|e: WorkQueueError| Status::internal(e.to_string()))?;
 
         // Handle the result
         match result {
@@ -108,10 +119,10 @@ impl WorkQueueService for WorkQueueServer {
                 Ok(Response::new(()))
             }
             FinishResult::NeedsRepair => {
-                // NeedsRepair case - handle repair here
-                // TODO: Replace with actual repair handling once sysdb integration is ready
-                // Also need to check for error from this call.
-                self.handle_repair_stub(&fn_id).await;
+                // NeedsRepair case - handle repair
+                self.handle_repair(&fn_id)
+                    .await
+                    .map_err(|e| Status::internal(e.to_string()))?;
                 Ok(Response::new(()))
             }
         }
@@ -139,7 +150,7 @@ impl WorkQueueService for WorkQueueServer {
         let items = response_rx
             .await
             .map_err(|e| Status::internal(format!("Failed to receive response: {}", e)))?
-            .map_err(|e: WorkQueueError| Status::internal(format!("Work queue error: {:?}", e)))?;
+            .map_err(|e: WorkQueueError| Status::internal(e.to_string()))?;
 
         let results: Vec<WorkItemResult> = items
             .into_iter()


### PR DESCRIPTION
## Description of changes

This PR wires up the work queue service to a real sysdb backend, replacing three stub methods with actual gRPC calls. The key changes are:

1. **`SysDb`** client gains three new methods for work queue operations
2. **`WorkQueueManager`** calls sysdb for `try_finish_invocation` and `check_invocations_done` instead of returning hardcoded values
3. **`WorkQueueServer`** calls sysdb for `handle_repair` instead of a no-op stub
4. A Go DAO bug fix for a UUID cast in `AreInvocationsDone`
5. New k8s integration tests and refactored unit tests

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

Integration tests have been added

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_