### PR TITLE
[ENH]: Compaction pushes to work queue service on async function update

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -18,6 +18,7 @@ use crate::execution::operators::repair_log_offsets::RepairLogOffsetsInput;
 use crate::execution::operators::repair_log_offsets::RepairLogOffsetsOutput;
 use crate::execution::orchestration::compact::{compact, CompactionResponse};
 use crate::utils::fragment_fetch::fragment_fetcher_for_collection as resolve_fragment_fetcher_for_collection;
+use crate::work_queue::work_queue_client::WorkQueueClient;
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
 use chroma_config::assignment::assignment_policy::AssignmentPolicy;
@@ -108,6 +109,7 @@ pub(crate) struct CompactionManagerContext {
     bloom_filter_manager: Option<BloomFilterManager>,
     shard_size: Option<u64>,
     sharding_enabled_tenant_patterns: Vec<String>,
+    work_queue_client: Option<crate::work_queue::work_queue_client::WorkQueueClient>,
 }
 
 pub(crate) struct CompactionManager {
@@ -164,6 +166,7 @@ impl CompactionManager {
         bloom_filter_manager: Option<BloomFilterManager>,
         shard_size: Option<u64>,
         sharding_enabled_tenant_patterns: Vec<String>,
+        work_queue_client: Option<WorkQueueClient>,
     ) -> Result<Self, Box<dyn ChromaError>> {
         let (compact_awaiter_tx, compact_awaiter_rx) =
             mpsc::channel::<CompactionTask>(compaction_manager_queue_size);
@@ -204,6 +207,7 @@ impl CompactionManager {
                 bloom_filter_manager,
                 shard_size,
                 sharding_enabled_tenant_patterns,
+                work_queue_client,
             },
             on_next_memberlist_signal: None,
             compact_awaiter_channel: compact_awaiter_tx,
@@ -509,6 +513,7 @@ impl CompactionManagerContext {
             fragment_fetcher,
             bloom_filter_manager,
             shard_size,
+            self.work_queue_client.clone(),
             #[cfg(test)]
             None,
         ))
@@ -697,6 +702,24 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
         )
         .await?;
 
+        // Initialize WorkQueueClient if endpoint is configured
+        let work_queue_client = match &config.work_queue_endpoint {
+            Some(endpoint) => match WorkQueueClient::new(endpoint.clone()).await {
+                Ok(client) => {
+                    tracing::info!("WorkQueue client initialized for endpoint: {}", endpoint);
+                    Some(client)
+                }
+                Err(err) => {
+                    tracing::warn!("Failed to initialize WorkQueue client: {:?}", err);
+                    None
+                }
+            },
+            None => {
+                tracing::info!("WorkQueue endpoint not configured, async attached functions will not be supported");
+                None
+            }
+        };
+
         CompactionManager::new(
             system.clone(),
             scheduler,
@@ -723,6 +746,7 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
             Some(bloom_filter_manager),
             config.compactor.shard_size,
             config.compactor.sharding_enabled_tenant_patterns.clone(),
+            work_queue_client,
         )
     }
 }
@@ -1307,8 +1331,9 @@ mod tests {
             None,           // bloom_filter_manager
             None,           // shard_size
             Vec::new(),     // sharding_enabled_tenant_patterns
+            None,           // work_queue_client
         )
-        .expect("Failed to create compaction manager in test");
+        .expect("Should create compaction manager in test");
 
         let dispatcher = Dispatcher::new(DispatcherConfig {
             num_worker_threads: 10,

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -410,6 +410,13 @@ pub struct CompactionServiceConfig {
     /// isolates fragment pull I/O from the rest of the compaction pipeline.
     #[serde(default)]
     pub fragment_storage: Option<chroma_storage::config::StorageConfig>,
+
+    /// Optional WorkQueue service endpoint for queuing async attached functions.
+    ///
+    /// When set, async attached functions will be queued for external processing
+    /// instead of being executed during compaction.
+    #[serde(default)]
+    pub work_queue_endpoint: Option<String>,
 }
 
 impl CompactionServiceConfig {

--- a/rust/worker/src/execution/functions/statistics.rs
+++ b/rust/worker/src/execution/functions/statistics.rs
@@ -1408,6 +1408,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             None,
         ))
         .await

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -30,6 +30,7 @@ pub mod quantized_spann_bruteforce;
 pub mod quantized_spann_center_search;
 pub mod quantized_spann_load_center;
 pub mod quantized_spann_load_cluster;
+pub mod queue_function;
 pub mod rank;
 pub mod ranked_group_by;
 pub mod repair_log_offsets;

--- a/rust/worker/src/execution/operators/queue_function.rs
+++ b/rust/worker/src/execution/operators/queue_function.rs
@@ -1,0 +1,89 @@
+use async_trait::async_trait;
+use chroma_error::ChromaError;
+use chroma_system::{Operator, OperatorType};
+use chroma_types::{AttachedFunctionUuid, CollectionUuid};
+use thiserror::Error;
+
+use crate::work_queue::work_queue_client::WorkQueueClient;
+
+/// The queue function operator queues async attached functions for external processing.
+#[derive(Debug)]
+pub struct QueueFunctionOperator {
+    pub work_queue_client: WorkQueueClient,
+}
+
+impl QueueFunctionOperator {
+    pub fn new(work_queue_client: WorkQueueClient) -> Self {
+        Self { work_queue_client }
+    }
+}
+
+/// Input to the queue function operator.
+#[derive(Debug, Clone)]
+pub struct QueueFunctionInput {
+    pub attached_function_id: AttachedFunctionUuid,
+    pub input_collection_id: CollectionUuid,
+    pub completion_offset: i64,
+}
+
+impl QueueFunctionInput {
+    pub fn new(
+        attached_function_id: AttachedFunctionUuid,
+        input_collection_id: CollectionUuid,
+        completion_offset: i64,
+    ) -> Self {
+        Self {
+            attached_function_id,
+            input_collection_id,
+            completion_offset,
+        }
+    }
+}
+
+/// Output from the queue function operator - empty as we only care about success/failure.
+#[derive(Debug, Clone)]
+pub struct QueueFunctionOutput;
+
+#[derive(Debug, Error)]
+pub enum QueueFunctionError {
+    #[error("Failed to queue work: {0}")]
+    QueueError(#[from] Box<dyn ChromaError>),
+}
+
+impl ChromaError for QueueFunctionError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            QueueFunctionError::QueueError(e) => e.code(),
+        }
+    }
+}
+
+#[async_trait]
+impl Operator<QueueFunctionInput, QueueFunctionOutput> for QueueFunctionOperator {
+    type Error = QueueFunctionError;
+
+    fn get_type(&self) -> OperatorType {
+        OperatorType::IO
+    }
+
+    async fn run(&self, input: &QueueFunctionInput) -> Result<QueueFunctionOutput, Self::Error> {
+        tracing::info!(
+            "Queuing async attached function - function_id: {}, collection_id: {}, offset: {}",
+            input.attached_function_id,
+            input.input_collection_id,
+            input.completion_offset
+        );
+
+        let mut client = self.work_queue_client.clone();
+        client
+            .push_work(
+                input.attached_function_id.to_string(),
+                input.input_collection_id.to_string(),
+                input.completion_offset,
+            )
+            .await
+            .map_err(QueueFunctionError::QueueError)?;
+
+        Ok(QueueFunctionOutput)
+    }
+}

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -46,11 +46,14 @@ use crate::execution::{
             MaterializeLogInput, MaterializeLogOperator, MaterializeLogOperatorError,
             MaterializeLogOutput,
         },
+        queue_function::{
+            QueueFunctionError, QueueFunctionInput, QueueFunctionOperator, QueueFunctionOutput,
+        },
     },
-    orchestration::compact::{CompactionContextError, ExecutionState},
+    orchestration::compact::{CompactionContext, CompactionContextError, ExecutionState},
 };
 
-use super::compact::{CollectionCompactInfo, CompactWriters, CompactionContext};
+use super::compact::{CollectionCompactInfo, CompactWriters};
 use chroma_types::AdvanceAttachedFunctionError;
 
 #[derive(Debug, Clone)]
@@ -97,6 +100,8 @@ pub enum AttachedFunctionOrchestratorError {
     NoAttachedFunction,
     #[error("Failed to execute attached function: {0}")]
     ExecuteAttachedFunction(#[from] ExecuteAttachedFunctionError),
+    #[error("Failed to queue function: {0}")]
+    QueueFunction(#[from] QueueFunctionError),
     #[error("Failed to advance attached function: {0}")]
     AdvanceAttachedFunction(#[from] AdvanceAttachedFunctionError),
     #[error("Function context not set")]
@@ -149,6 +154,7 @@ impl ChromaError for AttachedFunctionOrchestratorError {
             AttachedFunctionOrchestratorError::GetCollectionAndSegments(e) => e.code(),
             AttachedFunctionOrchestratorError::NoAttachedFunction => ErrorCodes::NotFound,
             AttachedFunctionOrchestratorError::ExecuteAttachedFunction(e) => e.code(),
+            AttachedFunctionOrchestratorError::QueueFunction(e) => e.code(),
             AttachedFunctionOrchestratorError::AdvanceAttachedFunction(e) => e.code(),
             AttachedFunctionOrchestratorError::MaterializeLog(e) => e.code(),
             AttachedFunctionOrchestratorError::FunctionContextNotSet => ErrorCodes::Internal,
@@ -182,6 +188,7 @@ impl ChromaError for AttachedFunctionOrchestratorError {
             }
             AttachedFunctionOrchestratorError::NoAttachedFunction => false,
             AttachedFunctionOrchestratorError::ExecuteAttachedFunction(e) => e.should_trace_error(),
+            AttachedFunctionOrchestratorError::QueueFunction(e) => e.should_trace_error(),
             AttachedFunctionOrchestratorError::AdvanceAttachedFunction(e) => e.should_trace_error(),
             AttachedFunctionOrchestratorError::MaterializeLog(e) => e.should_trace_error(),
             AttachedFunctionOrchestratorError::FunctionContextNotSet => true,
@@ -391,13 +398,17 @@ impl AttachedFunctionOrchestrator {
             .get_segment_writers()
             .ok()
             .and_then(|writers| writers.record_reader);
-        tracing::info!(
-            "Materializing to collection: {:?}",
-            self.output_context
-                .get_collection_info()
-                .unwrap()
-                .collection_id
-        );
+        match self.output_context.get_collection_info() {
+            Ok(collection_info) => {
+                tracing::info!(
+                    "Materializing to collection: {:?}",
+                    collection_info.collection_id
+                );
+            }
+            Err(e) => {
+                tracing::error!("Failed to get collection info for materialization: {:?}", e);
+            }
+        }
 
         let next_max_offset_ids: Vec<Arc<AtomicU32>> = record_reader
             .as_ref()
@@ -574,7 +585,41 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
                     return;
                 }
 
-                // Get the output collection ID from the attached function
+                // Check if this is an async function and handle it early
+                if attached_function.is_async {
+                    // For async functions, we don't need output collection info
+                    if let Some(work_queue_client) = &self.output_context.work_queue_client {
+                        let operator =
+                            Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
+                        let input = QueueFunctionInput::new(
+                            attached_function.id,
+                            self.input_collection_info.collection_id,
+                            attached_function.completion_offset as i64,
+                        );
+                        let task = wrap(
+                            operator,
+                            input,
+                            ctx.receiver(),
+                            self.context().task_cancellation_token.clone(),
+                        );
+                        let res = self.dispatcher().send(task, None).await;
+                        self.ok_or_terminate(res, ctx).await;
+                    } else {
+                        tracing::error!(
+                            "Async attached function found but no WorkQueue client configured"
+                        );
+                        self.terminate_with_result(
+                            Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                                "Async function requires WorkQueue configuration".to_string(),
+                            )),
+                            ctx,
+                        )
+                        .await;
+                    }
+                    return;
+                }
+
+                // For sync functions, we need to get the output collection info
                 let output_collection_id = match attached_function.output_collection_id {
                     Some(id) => id,
                     None => {
@@ -843,7 +888,7 @@ impl Handler<TaskResult<CollectionAndSegments, GetCollectionAndSegmentsError>>
 
         let input = ExecuteAttachedFunctionInput {
             materialized_logs: self.materialized_log_data.clone(), // Use the actual materialized logs from data fetch
-            tenant_id: "default".to_string(), // TODOItanujnay112): Get actual tenant ID
+            tenant_id: self.input_collection_info.collection.tenant.clone(),
             input_record_segment,
             output_collection_id: message.collection.collection_id,
             completion_offset: collection_info.pulled_log_offset as u64, // Use the completion offset from input collection
@@ -887,5 +932,35 @@ impl Handler<TaskResult<ExecuteAttachedFunctionOutput, ExecuteAttachedFunctionEr
         );
         self.materialize_log(vec![message.output_records], ctx)
             .await;
+    }
+}
+
+#[async_trait]
+impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFunctionOrchestrator {
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        message: TaskResult<QueueFunctionOutput, QueueFunctionError>,
+        ctx: &ComponentContext<Self>,
+    ) {
+        let _message = match self.ok_or_terminate(message.into_inner(), ctx).await {
+            Some(msg) => msg,
+            None => return,
+        };
+
+        tracing::info!(
+            "[AttachedFunctionOrchestrator]: Async function successfully queued for external processing"
+        );
+
+        // For async functions, we don't have any output records to apply
+        // The function will be processed asynchronously by an external consumer
+        let collection_info = self.get_input_collection_info();
+        let job_id = collection_info.collection_id.into();
+        self.terminate_with_result(
+            Ok(AttachedFunctionOrchestratorResponse::NoAttachedFunction { job_id }),
+            ctx,
+        )
+        .await;
     }
 }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -8,6 +8,7 @@ use chroma_log::Log;
 
 use crate::compactor::RebuildInfo;
 use crate::execution::operators::fragment_fetch::FragmentFetcher;
+use crate::work_queue::work_queue_client::WorkQueueClient;
 use chroma_segment::{
     blockfile_metadata::MetadataSegmentWriter,
     blockfile_record::{RecordSegmentReader, RecordSegmentWriter},
@@ -188,6 +189,7 @@ pub struct CompactionContext {
     pub fragment_fetcher: Option<Arc<FragmentFetcher>>,
     pub bloom_filter_manager: Option<BloomFilterManager>,
     pub shard_size: Option<u64>,
+    pub work_queue_client: Option<WorkQueueClient>,
     #[cfg(test)]
     pub poison_offset: Option<u32>,
 }
@@ -213,6 +215,7 @@ impl Clone for CompactionContext {
             fragment_fetcher: self.fragment_fetcher.clone(),
             bloom_filter_manager: self.bloom_filter_manager.clone(),
             shard_size: self.shard_size,
+            work_queue_client: self.work_queue_client.clone(),
             #[cfg(test)]
             poison_offset: self.poison_offset,
         }
@@ -266,6 +269,7 @@ impl CompactionContext {
             fragment_fetcher: self.fragment_fetcher.clone(),
             bloom_filter_manager: self.bloom_filter_manager.clone(),
             shard_size: self.shard_size,
+            work_queue_client: self.work_queue_client.clone(),
             #[cfg(test)]
             poison_offset: self.poison_offset,
         }
@@ -371,6 +375,7 @@ impl CompactionContext {
         fragment_fetcher: Option<Arc<FragmentFetcher>>,
         bloom_filter_manager: Option<BloomFilterManager>,
         shard_size: Option<u64>,
+        work_queue_client: Option<WorkQueueClient>,
     ) -> Self {
         let orchestrator_context = OrchestratorContext::new(dispatcher.clone());
         CompactionContext {
@@ -391,6 +396,7 @@ impl CompactionContext {
             fragment_fetcher,
             bloom_filter_manager,
             shard_size,
+            work_queue_client,
             #[cfg(test)]
             poison_offset: None,
         }
@@ -484,6 +490,7 @@ impl CompactionContext {
             self.dispatcher.clone(),
             self.fragment_fetcher.clone(),
             self.bloom_filter_manager.clone(),
+            self.work_queue_client.clone(),
         );
 
         let log_fetch_response = match log_fetch_orchestrator.run(system.clone()).await {
@@ -768,6 +775,7 @@ impl CompactionContext {
                 materialized_output,
                 function_context,
             } => {
+                // For sync functions, continue with normal flow
                 // Update self to use the output collection for apply_logs
                 self.collection_info = OnceCell::from(output_collection_info.clone());
 
@@ -995,6 +1003,7 @@ pub async fn compact(
     fragment_fetcher: Option<Arc<FragmentFetcher>>,
     bloom_filter_manager: Option<BloomFilterManager>,
     shard_size: Option<u64>,
+    work_queue_client: Option<WorkQueueClient>,
     #[cfg(test)] poison_offset: Option<u32>,
 ) -> Result<CompactionResponse, CompactionError> {
     let mut compaction_context = CompactionContext::new(
@@ -1013,6 +1022,7 @@ pub async fn compact(
         fragment_fetcher,
         bloom_filter_manager,
         shard_size,
+        work_queue_client,
     );
 
     #[cfg(test)]
@@ -1061,8 +1071,9 @@ mod tests {
     use chroma_system::{ComponentHandle, Dispatcher, DispatcherConfig, Orchestrator, System};
     use chroma_types::{
         operator::{Filter, Limit, Projection, ProjectionRecord},
-        Collection, DocumentExpression, DocumentOperator, MetadataExpression, PrimitiveOperator,
-        Segment, SegmentShard, SegmentUuid, Where,
+        Collection, CollectionUuid, DocumentExpression, DocumentOperator, MetadataExpression,
+        Operation, OperationRecord, PrimitiveOperator, Segment, SegmentShard, SegmentUuid,
+        UpdateMetadataValue, Where,
     };
     use futures::TryStreamExt;
     use regex::Regex;
@@ -1291,6 +1302,7 @@ mod tests {
             None,
             None,
             Some(20), // Small shard size to force multiple shards
+            None,     // work_queue_client
             None,
         ))
         .await;
@@ -1404,6 +1416,7 @@ mod tests {
             None,
             None,
             Some(30), // Small shard size to force multiple shards
+            None,     // work_queue_client
             None,
         ))
         .await;
@@ -1556,6 +1569,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             None,
         ))
         .await;
@@ -1651,6 +1665,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             None,
         ))
         .await;
@@ -1788,6 +1803,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             None,
         ))
         .await;
@@ -1843,6 +1859,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             None,
         ))
         .await;
@@ -1901,6 +1918,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             None,
         ))
         .await;
@@ -2045,6 +2063,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             None,
         ))
         .await;
@@ -2227,6 +2246,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             None,
         ))
         .await;
@@ -2423,6 +2443,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             Some(2),
         ))
         .await;
@@ -2621,6 +2642,7 @@ mod tests {
             None,
             None,
             Some(30), // Small shard size to force multiple shards
+            None,     // work_queue_client
             None,
         ))
         .await;
@@ -2660,6 +2682,7 @@ mod tests {
             None,
             None,
             Some(30), // Small shard size to force multiple shards
+            None,     // work_queue_client
             None,
         ))
         .await;
@@ -2894,6 +2917,7 @@ mod tests {
             None,
             None,
             Some(30), // Small shard size to force multiple shards
+            None,     // work_queue_client
             None,
         ))
         .await;
@@ -3110,6 +3134,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             None,
         ))
         .await;
@@ -3199,6 +3224,7 @@ mod tests {
             None,
             None,
             None,
+            None, // work_queue_client
             None,
         ))
         .await;
@@ -3450,6 +3476,7 @@ mod tests {
             None,
             None,
             None, // shard_size
+            None, // work_queue_client
         );
 
         // Start compaction 1's log_fetch_orchestrator
@@ -3504,6 +3531,7 @@ mod tests {
             None,
             None,
             None, // shard_size
+            None, // work_queue_client
         );
 
         // Now start compaction 2 and let it run completely using the compact() function
@@ -3529,6 +3557,7 @@ mod tests {
             None,
             None,
             Some(30), // Small shard size to force multiple shards
+            None,     // work_queue_client
             None,
         ));
 
@@ -3689,6 +3718,7 @@ mod tests {
                 None,
                 None,
                 Some(150), // Shard size 50 to create 1 shard per batch
+                None,      // work_queue_client
                 None,
             ))
             .await;
@@ -3810,10 +3840,6 @@ mod tests {
     /// 6. Verify statistics: red=6, blue=4, green=5, total=15
     #[tokio::test]
     async fn test_k8s_integration_rebuild_with_attached_function() {
-        use chroma_log::in_memory_log::{InMemoryLog, InternalLogRecord};
-        use chroma_segment::blockfile_record::RecordSegmentReaderShard;
-        use chroma_types::{CollectionUuid, Operation, OperationRecord, UpdateMetadataValue};
-
         // Setup test environment
         let config = RootConfig::default();
         let system = System::default();
@@ -3974,6 +4000,7 @@ mod tests {
             None,
             None,
             Some(30), // Small shard size to force multiple shards
+            None,     // work_queue_client
             None,
         ))
         .await
@@ -4064,6 +4091,7 @@ mod tests {
             None,
             None,
             None,
+            None, // poison_offset
         ))
         .await
         .expect("Second compaction should succeed");
@@ -4130,6 +4158,7 @@ mod tests {
             None,
             None,
             None,
+            None, // poison_offset
         ))
         .await
         .expect("Rebuild should succeed");
@@ -4366,6 +4395,7 @@ mod tests {
                 None,
                 None,
                 Some(50), // Shard size 50 to create 1 shard per batch
+                None,     // work_queue_client
                 None,
             ))
             .await;
@@ -4459,6 +4489,7 @@ mod tests {
                 None,
                 None,
                 Some(50), // Use same shard size as initial compaction
+                None,     // work_queue_client
                 None,
             ))
             .await;
@@ -4650,6 +4681,7 @@ mod tests {
                 None,
                 None,
                 Some(50), // Shard size 50 to create 1 shard per batch
+                None,     // work_queue_client
                 None,
             ))
             .await;
@@ -4738,6 +4770,7 @@ mod tests {
                 None,
                 None,
                 Some(50), // Use same shard size as initial compaction
+                None,     // work_queue_client
                 None,
             ))
             .await;
@@ -4822,5 +4855,241 @@ mod tests {
             // Update old_cas for next iteration
             old_cas = new_cas;
         }
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_async_attached_function() {
+        // Setup test environment
+        let config = RootConfig::default();
+        let system = System::default();
+        let registry = Registry::new();
+        let dispatcher = Dispatcher::try_from_config(&config.query_service.dispatcher, &registry)
+            .await
+            .expect("Should be able to initialize dispatcher");
+        let dispatcher_handle = system.start_component(dispatcher);
+
+        // Connect to Grpc SysDb (requires Tilt running)
+        let grpc_sysdb = chroma_sysdb::GrpcSysDb::try_from_config(
+            &(
+                chroma_sysdb::GrpcSysDbConfig {
+                    host: "localhost".to_string(),
+                    port: 50051,
+                    connect_timeout_ms: 5000,
+                    request_timeout_ms: 10000,
+                    num_channels: 4,
+                },
+                None,
+            ),
+            &registry,
+        )
+        .await
+        .expect("Should connect to grpc sysdb");
+        let mut sysdb = SysDb::Grpc(grpc_sysdb);
+
+        // Connect to WorkQueue (requires Tilt running)
+        let work_queue_client = crate::work_queue::work_queue_client::WorkQueueClient::new(
+            "http://localhost:50058".to_string(),
+        )
+        .await
+        .expect("Should connect to work queue");
+
+        let test_segments = TestDistributedSegment::new().await;
+        let mut in_memory_log = InMemoryLog::new();
+
+        // Create input collection
+        let collection_id = CollectionUuid::new();
+        let database_name =
+            chroma_types::DatabaseName::new(test_segments.collection.database.clone())
+                .expect("database name should be valid");
+
+        let collection_name = format!("test_async_fn_{}", uuid::Uuid::new_v4());
+        sysdb
+            .create_collection(
+                test_segments.collection.tenant.clone(),
+                database_name.clone(),
+                collection_id,
+                collection_name,
+                vec![
+                    test_segments.record_segment.clone(),
+                    test_segments.metadata_segment.clone(),
+                    test_segments.vector_segment.clone(),
+                ],
+                None,
+                None,
+                None,
+                test_segments.collection.dimension,
+                false,
+            )
+            .await
+            .expect("Collection create should be successful");
+
+        let tenant = "default_tenant".to_string();
+        let db = "default_database".to_string();
+
+        // Set initial log position
+        sysdb
+            .flush_compaction(
+                tenant.clone(),
+                DatabaseName::new(db.clone()).expect("database name should be valid"),
+                collection_id,
+                -1,
+                0,
+                std::sync::Arc::new([]),
+                0,
+                0,
+                None,
+            )
+            .await
+            .expect("Should be able to update log_position");
+
+        // Create async attached function via sysdb
+        let test_run_id = uuid::Uuid::new_v4();
+        let attached_function_name = format!("test_async_fn_{}", test_run_id);
+        let output_collection_name = format!("test_async_output_{}", test_run_id);
+
+        let (attached_function_id, _created) = sysdb
+            .create_attached_function(
+                attached_function_name.clone(),
+                "dummy_async".to_string(), // This is the async operator
+                collection_id,
+                output_collection_name.clone(),
+                serde_json::Value::Object(serde_json::Map::new()), // Empty params
+                tenant.clone(),
+                db.clone(),
+                1, // min_records_for_invocation
+            )
+            .await
+            .expect("Attached function creation should succeed");
+
+        let mut output_schema = chroma_types::Schema::new_default(chroma_types::KnnIndex::Hnsw);
+        output_schema.source_attached_function_id = Some(attached_function_id.0.to_string());
+        let output_schema_str = serde_json::to_string(&output_schema).unwrap();
+        sysdb
+            .finish_create_attached_function(attached_function_id, output_schema_str)
+            .await
+            .unwrap();
+
+        // Add 5 records
+        for i in 0..300 {
+            let log_record = chroma_types::LogRecord {
+                log_offset: i,
+                record: OperationRecord {
+                    id: format!("record_{}", i),
+                    embedding: Some(vec![
+                        0.0;
+                        test_segments.collection.dimension.unwrap_or(384)
+                            as usize
+                    ]),
+                    encoding: None,
+                    metadata: None,
+                    document: None,
+                    operation: Operation::Add,
+                },
+            };
+
+            in_memory_log.add_log(
+                collection_id,
+                InternalLogRecord {
+                    collection_id,
+                    log_offset: i,
+                    log_ts: i,
+                    record: log_record,
+                },
+            );
+        }
+
+        let log = Log::InMemory(in_memory_log);
+
+        // Run compaction with work queue client
+        let compact_result = Box::pin(compact(
+            system.clone(),
+            collection_id,
+            database_name.clone(),
+            None,
+            50,
+            10,
+            1000,
+            50,
+            log,
+            sysdb.clone(),
+            test_segments.blockfile_provider.clone(),
+            test_segments.hnsw_provider.clone(),
+            test_segments.spann_provider.clone(),
+            dispatcher_handle.clone(),
+            false,
+            None,
+            None,
+            None,
+            Some(work_queue_client.clone()),
+            None, // poison_offset for test
+        ))
+        .await;
+
+        assert!(
+            compact_result.is_ok(),
+            "Compaction should succeed: {:?}",
+            compact_result.err()
+        );
+
+        // Verify the attached function was found
+        let attached_functions = sysdb
+            .get_attached_functions(
+                None,
+                Some(attached_function_name.clone()),
+                Some(collection_id),
+                true,
+            )
+            .await
+            .expect("Attached function query should succeed");
+        let attached_function_after_compact = attached_functions
+            .into_iter()
+            .next()
+            .expect("Attached function should be found");
+
+        assert!(
+            attached_function_after_compact
+                .output_collection_id
+                .is_some(),
+            "Output collection should be created"
+        );
+
+        let _output_collection_id = attached_function_after_compact
+            .output_collection_id
+            .expect("Output collection should exist");
+
+        // Check work queue for the async function
+        let mut wq_client = work_queue_client.clone();
+        let work_response = wq_client
+            .get_work("test_shard".to_string(), 10)
+            .await
+            .expect("Should be able to get work from queue");
+
+        // Filter for our specific function
+        println!("Got {} items, expected {}", work_response.items.len(), 1);
+        println!(
+            "Looking for fn_id: {}, coll_id: {}",
+            attached_function_id.0, collection_id
+        );
+
+        for item in &work_response.items {
+            println!(
+                "Work item: fn_id: {}, coll_id: {}, offset: {}",
+                item.fn_id, item.input_coll_id, item.completion_offset
+            );
+        }
+
+        let our_work_item = work_response.items.into_iter().find(|item| {
+            item.fn_id == attached_function_id.0.to_string()
+                && item.input_coll_id == collection_id.to_string()
+        });
+
+        assert!(
+            our_work_item.is_some(),
+            "Should find our async function in the work queue"
+        );
+
+        // Clean up - delete the collections
+        // Note: We don't have segment IDs easily available here, so we can't delete
+        // the collections. In a real test cleanup, you'd want to track the segment IDs.
     }
 }

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -32,33 +32,37 @@ use tokio::sync::oneshot::{error::RecvError, Sender};
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::execution::{
-    operators::{
-        fetch_log::{FetchLogError, FetchLogOperator, FetchLogOutput},
-        fragment_fetch::FragmentFetcher,
-        get_collection_and_segments::{
-            GetCollectionAndSegmentsError, GetCollectionAndSegmentsOperator,
-            GetCollectionAndSegmentsOutput,
+use crate::{
+    compactor::RebuildInfo,
+    execution::{
+        operators::{
+            fetch_log::{FetchLogError, FetchLogOperator, FetchLogOutput},
+            fragment_fetch::FragmentFetcher,
+            get_collection_and_segments::{
+                GetCollectionAndSegmentsError, GetCollectionAndSegmentsOperator,
+                GetCollectionAndSegmentsOutput,
+            },
+            materialize_logs::{
+                MaterializeLogInput, MaterializeLogOperator, MaterializeLogOperatorError,
+                MaterializeLogOutput,
+            },
+            partition_log::{PartitionError, PartitionInput, PartitionOperator, PartitionOutput},
+            prefetch_segment::{
+                PrefetchSegmentError, PrefetchSegmentInput, PrefetchSegmentOperator,
+                PrefetchSegmentOutput,
+            },
+            source_record_segment::{SourceRecordSegmentError, SourceRecordSegmentOutput},
+            source_record_segment_v2::{
+                SourceRecordSegmentV2Error, SourceRecordSegmentV2Input,
+                SourceRecordSegmentV2Operator, SourceRecordSegmentV2Output,
+            },
         },
-        materialize_logs::{
-            MaterializeLogInput, MaterializeLogOperator, MaterializeLogOperatorError,
-            MaterializeLogOutput,
-        },
-        partition_log::{PartitionError, PartitionInput, PartitionOperator, PartitionOutput},
-        prefetch_segment::{
-            PrefetchSegmentError, PrefetchSegmentInput, PrefetchSegmentOperator,
-            PrefetchSegmentOutput,
-        },
-        source_record_segment::{SourceRecordSegmentError, SourceRecordSegmentOutput},
-        source_record_segment_v2::{
-            SourceRecordSegmentV2Error, SourceRecordSegmentV2Input, SourceRecordSegmentV2Operator,
-            SourceRecordSegmentV2Output,
+        orchestration::compact::{
+            CollectionCompactInfo, CompactWriters, CompactionContext, CompactionContextError,
+            ExecutionState,
         },
     },
-    orchestration::compact::{
-        CollectionCompactInfo, CompactWriters, CompactionContext, CompactionContextError,
-        ExecutionState,
-    },
+    work_queue::work_queue_client::WorkQueueClient,
 };
 
 #[derive(Error, Debug)]
@@ -326,7 +330,7 @@ impl LogFetchOrchestrator {
     pub fn new(
         collection_id: CollectionUuid,
         database_name: chroma_types::DatabaseName,
-        rebuild_info: Option<crate::compactor::RebuildInfo>,
+        rebuild_info: Option<RebuildInfo>,
         fetch_log_batch_size: u32,
         fetch_log_concurrency: usize,
         max_compaction_size: usize,
@@ -339,6 +343,7 @@ impl LogFetchOrchestrator {
         dispatcher: ComponentHandle<Dispatcher>,
         fragment_fetcher: Option<Arc<FragmentFetcher>>,
         bloom_filter_manager: Option<BloomFilterManager>,
+        work_queue_client: Option<WorkQueueClient>,
     ) -> Self {
         let context = CompactionContext::new(
             rebuild_info,
@@ -356,6 +361,7 @@ impl LogFetchOrchestrator {
             fragment_fetcher,
             bloom_filter_manager,
             None, // shard_size
+            work_queue_client,
         );
         LogFetchOrchestrator {
             collection_id,

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -366,6 +366,12 @@ impl Handler<PushWorkMessage> for WorkQueueManager {
     type Result = ();
 
     async fn handle(&mut self, msg: PushWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
+        tracing::info!(
+            "Received PushWorkMessage for fn_id: {}, input_coll_id: {}, completion_offset: {}",
+            msg.fn_id,
+            msg.input_coll_id,
+            msg.completion_offset
+        );
         self.push_work_and_queue_response(
             msg.fn_id,
             msg.input_coll_id,
@@ -469,6 +475,7 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
             .map(|(item, _)| item)
             .take(msg.limit)
             .collect();
+        tracing::info!("Filtered {} items from get work response", filtered.len());
 
         if msg.response_tx.send(Ok(filtered)).is_err() {
             tracing::warn!("Failed to send get work response - receiver dropped");


### PR DESCRIPTION
## Description of changes

This PR wires a `WorkQueueClient` through the compaction pipeline so that when an **async** attached function is encountered during compaction, instead of trying to execute it inline, the compactor pushes a work item to an external work queue service. Sync attached functions continue to execute as before.

The key design decision: async vs. sync branching happens in `AttachedFunctionOrchestrator` right after the attached function is fetched — if `is_async` is true and a `WorkQueueClient` is configured, a `QueueFunctionOperator` is dispatched; otherwise the existing sync path runs.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

An integration test has been added.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_