### PR TITLE
Persist HNSW state on clean shutdown

### DIFF
--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -551,6 +551,20 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
     @override
     def stop(self) -> None:
         super().stop()
+        with WriteRWLock(self._lock):
+            if self._index_initialized:
+                if (
+                    self._num_log_records_since_last_batch > 0
+                    and len(self._curr_batch) > 0
+                ):
+                    self._apply_batch(self._curr_batch)
+                    self._curr_batch = Batch()
+                    self._brute_force_index = cast(
+                        BruteForceIndex, self._brute_force_index
+                    )
+                    self._brute_force_index.clear()
+                if self._num_log_records_since_last_persist > 0:
+                    self._persist()
         self.close_persistent_index()
 
     def close_persistent_index(self) -> None:

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -230,6 +230,50 @@ def test_sync_threshold(settings: Settings) -> None:
     last_modified_at = get_index_last_modified_at()
 
 
+def test_clean_shutdown_persists_hnsw_below_sync_threshold() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        settings = Settings(
+            chroma_api_impl="chromadb.api.segment.SegmentAPI",
+            chroma_sysdb_impl="chromadb.db.impl.sqlite.SqliteDB",
+            chroma_producer_impl="chromadb.db.impl.sqlite.SqliteDB",
+            chroma_consumer_impl="chromadb.db.impl.sqlite.SqliteDB",
+            chroma_segment_manager_impl=(
+                "chromadb.segment.impl.manager.local.LocalSegmentManager"
+            ),
+            allow_reset=True,
+            is_persistent=True,
+            persist_directory=tmpdir,
+        )
+        system = System(settings)
+        system.start()
+        client = ClientCreator.from_system(system)
+        collection = client.create_collection(
+            name="test",
+            metadata={"hnsw:batch_size": 3, "hnsw:sync_threshold": 10},
+        )
+        manager = system.instance(LocalSegmentManager)
+        segment = manager.get_segment(collection.id, VectorReader)
+        metadata_file = segment._get_metadata_file()  # type: ignore[attr-defined]
+
+        collection.upsert(
+            ids=["1", "2", "3"],
+            embeddings=[[1.0], [2.0], [3.0]],  # type: ignore[arg-type]
+        )
+
+        system.stop()
+        assert os.path.exists(metadata_file)
+
+        system = System(settings)
+        system.start()
+        client = ClientCreator.from_system(system)
+        collection = client.get_collection("test")
+        result = collection.query(query_embeddings=[[1.0]], n_results=3)
+
+        assert set(result["ids"][0]) == {"1", "2", "3"}
+
+        system.stop()
+
+
 def load_and_check(
     settings: Settings,
     collection_name: str,


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Fixes a clean shutdown durability issue where `PersistentLocalHnswSegment` could lose vector index state when records were written below `hnsw:sync_threshold`.
  - Flushes pending in-memory batch state on `stop()` before closing the persistent HNSW index.
  - Persists dirty HNSW state on clean shutdown when there are unpersisted records.
  - Adds a regression test that verifies vector `query()` works after restarting from the same persist directory.

- New functionality
  - None.

Fixes #6975.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Tested with:

```bash
.venv/bin/pytest chromadb/test/property/test_persist.py::test_clean_shutdown_persists_hnsw_below_sync_threshold -q
.venv/bin/pytest chromadb/test/property/test_persist.py::test_sync_threshold -q