### PR TITLE
[ENH] Add service account to work queue service

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.82
+version: 0.1.83
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/work-queue-service.yaml
+++ b/k8s/distributed-chroma/templates/work-queue-service.yaml
@@ -27,6 +27,7 @@ spec:
       labels:
         app: work-queue-service
     spec:
+      serviceAccountName: work-queue-service-serviceaccount
       volumes:
         {{if .Values.workQueueService.configuration}}
         - name: work-queue-service-config
@@ -85,3 +86,29 @@ spec:
     - name: grpc
       port: 50051
       targetPort: 50051
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: work-queue-service-serviceaccount
+  namespace: {{ .Values.namespace }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: work-queue-service-serviceaccount-rolebinding
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-watcher
+subjects:
+- kind: ServiceAccount
+  name: work-queue-service-serviceaccount
+  namespace: {{ .Values.namespace }}
+
+---


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Adds a service account and role binding to work queue service so we can configure s3 access in deployed envs
- New functionality
  - None

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None
## Observability plan
None

## Documentation Changes
None