### PR TITLE
[CHORE](chroma-frontend): Scaffold foundation module

### DIFF
--- a/rust/frontend/src/foundation/mod.rs
+++ b/rust/frontend/src/foundation/mod.rs
@@ -1,0 +1,7 @@
+use axum::Router;
+
+use crate::server::FrontendServer;
+
+pub(crate) fn router() -> Router<FrontendServer> {
+    Router::new()
+}

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -5,6 +5,7 @@ pub mod auth;
 pub mod config;
 #[allow(dead_code)]
 pub mod executor;
+pub mod foundation;
 pub mod get_collection_with_segments_provider;
 pub mod impls;
 pub mod quota;

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -57,6 +57,7 @@ use crate::{
     ac::AdmissionControlledService,
     auth::{AuthenticateAndAuthorize, AuthzAction, AuthzResource},
     config::FrontendServerConfig,
+    foundation,
     quota::{Action, QuotaEnforcer, QuotaPayload},
     server_middleware::{always_json_errors_middleware, default_json_content_type_middleware},
     traced_json::TracedJson,
@@ -380,6 +381,7 @@ impl FrontendServer {
                 "/api/v2/tenants/{tenant}/databases/{database}/collections/{collection_id}/attached_functions/{name}/detach",
                 post(detach_function),
             )
+            .merge(foundation::router())
             .merge(docs_router)
             .with_state(self)
             .layer(DefaultBodyLimit::max(max_payload_size_bytes))


### PR DESCRIPTION
Empty plumbing so the follow-up tickets that add /api/foundation/*
handlers (chroma-core/hosted-chroma#7509 and #7442) can plug in
without each reinventing the module + router wiring.

- New rust/frontend/src/foundation/mod.rs exporting a router()
  that returns Router::new().
- pub mod foundation; in rust/frontend/src/lib.rs.
- .merge(foundation::router()) in the top-level router chain in
  rust/frontend/src/server.rs, just before .merge(docs_router).

Refs chroma-core/hosted-chroma#7511.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
