### PR TITLE
refactor(test): use idiomatic Jest async error assertions in offline test

### DIFF
--- a/clients/js/packages/chromadb-core/test/offline.test.ts
+++ b/clients/js/packages/chromadb-core/test/offline.test.ts
@@ -4,13 +4,12 @@ import { ChromaConnectionError } from "../src/Errors";
 
 test("it fails with a nice error when offline", async () => {
   const chroma = new ChromaClient({ path: "http://example.invalid" });
-  try {
-    await chroma.createCollection({ name: "test" });
-    throw new Error("Should have thrown an error.");
-  } catch (e) {
-    expect(e).toBeInstanceOf(ChromaConnectionError);
-    expect((e as Error).message).toMatchInlineSnapshot(
-      `"Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable."`,
-    );
-  }
+  await expect(
+    chroma.createCollection({ name: "test" }),
+  ).rejects.toThrow(ChromaConnectionError);
+  await expect(
+    chroma.createCollection({ name: "test" }),
+  ).rejects.toThrow(
+    "Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable.",
+  );
 });


### PR DESCRIPTION
## Summary
Refactor `offline.test.ts` to use idiomatic Jest async error assertions.
## Problem
The offline test uses a manual `try/catch` with a sentinel `throw new Error("Should have thrown")` instead of Jest's built-in `expect().rejects.toThrow()` matcher. This is less readable and doesn't leverage Jest's async testing capabilities.
Relates to #2801
## Changes
- `clients/js/packages/chromadb-core/test/offline.test.ts` — Replace `try/catch` pattern with `await expect(...).rejects.toThrow(...)`. Preserves both the error type (`ChromaConnectionError`) and message assertions.
## Before
```typescript
try {
  await chroma.createCollection({ name: "test" });
  throw new Error("Should have thrown an error.");
} catch (e) {
  expect(e).toBeInstanceOf(ChromaConnectionError);
  expect((e as Error).message).toMatchInlineSnapshot(`"..."`);
}
After
await expect(
  chroma.createCollection({ name: "test" }),
).rejects.toThrow(ChromaConnectionError);
await expect(
  chroma.createCollection({ name: "test" }),
).rejects.toThrow("Failed to connect to chromadb...");
Notes
- Intentionally small PR (one file) per maintainer preference — previous large PRs were closed (#2135, #6523, #6673)
- Same pattern exists in other test files and can be addressed in follow-up PRs