### PR TITLE
[ENH]: fn_consumer calls finish_work in the register orchestrator

### DIFF
--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -80,7 +80,7 @@ query_service:
   hnsw_provider:
     hnsw_temporary_path: "~/tmp"
     hnsw_cache_config:
-      weighted_lru:
+      memory:
         name: "hnsw_cache"
         capacity: 8589934592 # 8GB
     permitted_parallelism: 180
@@ -88,7 +88,7 @@ query_service:
     adaptive_search_nprobe: false
     usearch_provider:
       cache_config:
-        weighted_lru:
+        memory:
           name: "usearch_cache"
           capacity: 8192 # 8192 MiB = 8GB
   bloom_filter_manager:
@@ -215,7 +215,7 @@ compaction_service:
   hnsw_provider:
     hnsw_temporary_path: "~/tmp"
     hnsw_cache_config:
-      weighted_lru:
+      memory:
         name: "hnsw_cache"
         capacity: 8192 # 8192 MiB = 8GB
     permitted_parallelism: 180
@@ -231,7 +231,7 @@ compaction_service:
       policy: "full_rebuild"
     usearch_provider:
       cache_config:
-        weighted_lru:
+        memory:
           name: "usearch_cache"
           capacity: 8192 # 8192 MiB = 8GB
 work_queue_service:
@@ -428,3 +428,48 @@ fn_consumer_service:
       kube_namespace: "chroma"
       memberlist_name: "query-service-memberlist"
       queue_size: 100
+  task_runner:
+    enabled: true
+  blockfile_provider:
+    arrow:
+      block_manager_config:
+        max_block_size_bytes: 8388608 # 8MB
+        block_cache_config:
+          lru:
+            name: "block_cache"
+            capacity: 1000
+        num_concurrent_block_flushes: 40
+      sparse_index_manager_config:
+        sparse_index_cache_config:
+          lru:
+            name: "sparse_index_cache"
+            capacity: 1000
+  bloom_filter_manager:
+    cache_config:
+      lru:
+        name: "bloom_filter_cache"
+        capacity: 1000
+    enabled_collection_ids: ["all"]
+    storage_fetch_threshold: 100
+  hnsw_provider:
+    hnsw_temporary_path: "~/tmp"
+    hnsw_cache_config:
+      memory:
+        name: "hnsw_cache"
+        capacity: 8192 # 8192 MiB = 8GB
+    permitted_parallelism: 180
+  spann_provider:
+    pl_block_size: 5242880 # 5MiB
+    pl_garbage_collection:
+      enabled: true
+      policy:
+        random_sample:
+          sample_size: 0.1
+    hnsw_garbage_collection:
+      enabled: true
+      policy: "full_rebuild"
+    usearch_provider:
+      cache_config:
+        memory:
+          name: "usearch_cache"
+          capacity: 8192 # 8192 MiB = 8GB

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -574,7 +574,7 @@ fn_consumer_service:
               count_based_policy:
                 max_concurrent_requests: 30
                 bandwidth_allocation: [0.7, 0.3]
-    task_runner:
+  task_runner:
     enabled: true
   blockfile_provider:
     arrow:
@@ -600,7 +600,7 @@ fn_consumer_service:
   hnsw_provider:
     hnsw_temporary_path: "~/tmp"
     hnsw_cache_config:
-      weighted_lru:
+      memory:
         name: "hnsw_cache"
         capacity: 64
     permitted_parallelism: 180
@@ -616,7 +616,7 @@ fn_consumer_service:
       policy: "full_rebuild"
     usearch_provider:
       cache_config:
-        weighted_lru:
+        memory:
           name: "usearch_cache"
           capacity: 8192 # 8192 MiB = 8GB
     topologies:

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -702,20 +702,28 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
         )
         .await?;
 
-        // Initialize WorkQueueClient if endpoint is configured
-        let work_queue_client = match &config.work_queue_endpoint {
-            Some(endpoint) => match WorkQueueClient::new(endpoint.clone()).await {
-                Ok(client) => {
-                    tracing::info!("WorkQueue client initialized for endpoint: {}", endpoint);
-                    Some(client)
+        // Initialize WorkQueueClient if config is provided
+        let work_queue_client = match &config.work_queue {
+            Some(work_queue_config) => {
+                match WorkQueueClient::try_from_config(work_queue_config).await {
+                    Ok(client) => {
+                        tracing::info!(
+                            "WorkQueue client initialized for {}:{}",
+                            work_queue_config.host,
+                            work_queue_config.port
+                        );
+                        Some(client)
+                    }
+                    Err(err) => {
+                        tracing::warn!("Failed to initialize WorkQueue client: {:?}", err);
+                        None
+                    }
                 }
-                Err(err) => {
-                    tracing::warn!("Failed to initialize WorkQueue client: {:?}", err);
-                    None
-                }
-            },
+            }
             None => {
-                tracing::info!("WorkQueue endpoint not configured, async attached functions will not be supported");
+                tracing::info!(
+                    "WorkQueue not configured, async attached functions will not be supported"
+                );
                 None
             }
         };

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -40,6 +40,10 @@ pub struct WorkQueueServiceConfig {
     /// The configuration for connecting to the chroma data storage (S3, etc.) service.
     #[serde(alias = "storage", default)]
     pub storage: chroma_storage::config::StorageConfig,
+
+    /// The configuration for the work queue.
+    #[serde(default)]
+    pub work_queue: crate::work_queue::config::WorkQueueConfig,
 }
 
 impl WorkQueueServiceConfig {
@@ -161,10 +165,6 @@ pub struct RootConfig {
     /// The configuration for the compaction service.
     #[serde(default)]
     pub compaction_service: CompactionServiceConfig,
-
-    /// The configuration for the work queue.
-    #[serde(default)]
-    pub work_queue: crate::work_queue::config::WorkQueueConfig,
 
     /// The configuration for the work queue service.
     #[serde(default)]
@@ -505,7 +505,7 @@ pub struct CompactionServiceConfig {
     /// When set, async attached functions will be queued for external processing
     /// instead of being executed during compaction.
     #[serde(default)]
-    pub work_queue_endpoint: Option<String>,
+    pub work_queue: Option<crate::fn_consumer::config::GrpcWorkQueueConfig>,
 }
 
 impl CompactionServiceConfig {

--- a/rust/worker/src/execution/operators/finish_async_work.rs
+++ b/rust/worker/src/execution/operators/finish_async_work.rs
@@ -1,0 +1,99 @@
+use crate::work_queue::work_queue_client::WorkQueueClient;
+use async_trait::async_trait;
+use chroma_error::ChromaError;
+use chroma_system::Operator;
+use chroma_types::{AttachedFunctionUuid, CollectionUuid};
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub struct FinishAsyncWorkInput {
+    pub function_id: AttachedFunctionUuid,
+    pub input_collection_id: CollectionUuid,
+    pub completion_offset: i64,
+    pub work_queue_client: WorkQueueClient,
+}
+
+impl FinishAsyncWorkInput {
+    pub fn new(
+        function_id: AttachedFunctionUuid,
+        input_collection_id: CollectionUuid,
+        completion_offset: i64,
+        work_queue_client: WorkQueueClient,
+    ) -> Self {
+        Self {
+            function_id,
+            input_collection_id,
+            completion_offset,
+            work_queue_client,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FinishAsyncWorkOutput {}
+
+#[derive(Error, Debug)]
+pub enum FinishAsyncWorkError {
+    #[error("Failed to finish work in work queue: {0}")]
+    WorkQueueError(#[from] Box<dyn ChromaError>),
+}
+
+impl ChromaError for FinishAsyncWorkError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            FinishAsyncWorkError::WorkQueueError(e) => e.code(),
+        }
+    }
+}
+
+/// FinishAsyncWorkOperator is responsible for marking async work as complete in the work queue.
+/// This is used for async consumer functions that process data asynchronously.
+#[derive(Debug)]
+pub struct FinishAsyncWorkOperator {}
+
+impl FinishAsyncWorkOperator {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for FinishAsyncWorkOperator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Operator<FinishAsyncWorkInput, FinishAsyncWorkOutput> for FinishAsyncWorkOperator {
+    type Error = FinishAsyncWorkError;
+
+    fn get_name(&self) -> &'static str {
+        "FinishAsyncWorkOperator"
+    }
+
+    async fn run(
+        &self,
+        input: &FinishAsyncWorkInput,
+    ) -> Result<FinishAsyncWorkOutput, FinishAsyncWorkError> {
+        let mut work_queue_client = input.work_queue_client.clone();
+
+        // Call finish_work on the work queue client
+        work_queue_client
+            .finish_work(
+                input.function_id.0.to_string(),
+                input.input_collection_id.0.to_string(),
+                input.completion_offset,
+            )
+            .await?;
+
+        tracing::info!(
+            "Successfully marked async work as complete - function: {}, collection: {}, offset: {}",
+            input.function_id.0,
+            input.input_collection_id.0,
+            input.completion_offset
+        );
+
+        Ok(FinishAsyncWorkOutput {})
+    }
+}

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -3,6 +3,7 @@ pub mod commit_segment_writer;
 pub mod count_records;
 pub mod execute_task;
 pub mod fetch_log;
+pub mod finish_async_work;
 pub mod finish_attached_function;
 pub mod flush_segment_writer;
 pub mod fragment_fetch;

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -61,6 +61,7 @@ pub struct FunctionContext {
     pub attached_function_id: AttachedFunctionUuid,
     pub function_id: Uuid,
     pub updated_completion_offset: u64,
+    pub input_collection_id: CollectionUuid,
     pub is_async: bool,
 }
 
@@ -86,6 +87,8 @@ pub struct AttachedFunctionOrchestrator {
     dispatcher: ComponentHandle<Dispatcher>,
 
     is_for_backfill: bool,
+
+    is_fn_consumer: bool,
 }
 
 #[derive(Error, Debug)]
@@ -252,6 +255,7 @@ impl AttachedFunctionOrchestrator {
         dispatcher: ComponentHandle<Dispatcher>,
         data_fetch_records: Vec<MaterializeLogOutput>,
         is_for_backfill: bool,
+        is_fn_consumer: bool,
     ) -> Self {
         let orchestrator_context = OrchestratorContext::new(dispatcher.clone());
 
@@ -265,6 +269,7 @@ impl AttachedFunctionOrchestrator {
             orchestrator_context,
             dispatcher,
             is_for_backfill,
+            is_fn_consumer,
         }
     }
 
@@ -358,7 +363,7 @@ impl AttachedFunctionOrchestrator {
         // Update the completion offset from the input collection's pulled log offset
         // For async functions, we don't update the completion offset here as they will
         // be processed through a separate queue mechanism
-        if !function_context.is_async {
+        if !function_context.is_async || self.is_fn_consumer {
             function_context.updated_completion_offset = collection_info.pulled_log_offset as u64;
         }
 
@@ -571,6 +576,7 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
                         attached_function_id: attached_function.id,
                         function_id: attached_function.function_id,
                         updated_completion_offset: attached_function.completion_offset,
+                        input_collection_id: attached_function.input_collection_id,
                         is_async: attached_function.is_async,
                     })
                     .is_err()

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -191,6 +191,7 @@ pub struct CompactionContext {
     pub bloom_filter_manager: Option<BloomFilterManager>,
     pub shard_size: Option<u64>,
     pub work_queue_client: Option<WorkQueueClient>,
+    pub log_start_offset: Option<i64>,
     #[cfg(test)]
     pub poison_offset: Option<u32>,
 }
@@ -218,6 +219,7 @@ impl Clone for CompactionContext {
             bloom_filter_manager: self.bloom_filter_manager.clone(),
             shard_size: self.shard_size,
             work_queue_client: self.work_queue_client.clone(),
+            log_start_offset: self.log_start_offset,
             #[cfg(test)]
             poison_offset: self.poison_offset,
         }
@@ -273,6 +275,7 @@ impl CompactionContext {
             bloom_filter_manager: self.bloom_filter_manager.clone(),
             shard_size: self.shard_size,
             work_queue_client: self.work_queue_client.clone(),
+            log_start_offset: self.log_start_offset,
             #[cfg(test)]
             poison_offset: self.poison_offset,
         }
@@ -402,9 +405,56 @@ impl CompactionContext {
             bloom_filter_manager,
             shard_size,
             work_queue_client,
+            log_start_offset: None,
             #[cfg(test)]
             poison_offset: None,
         }
+    }
+
+    /// Create a new CompactionContext with a specific log start offset.
+    /// This is used by the function consumer to start processing from a specific offset.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_log_offset(
+        rebuild_info: Option<RebuildInfo>,
+        fetch_log_batch_size: u32,
+        fetch_log_concurrency: usize,
+        max_compaction_size: usize,
+        max_partition_size: usize,
+        log: Log,
+        sysdb: SysDb,
+        blockfile_provider: BlockfileProvider,
+        hnsw_provider: HnswIndexProvider,
+        spann_provider: SpannProvider,
+        dispatcher: ComponentHandle<Dispatcher>,
+        is_function_disabled: bool,
+        is_fn_consumer: bool,
+        fragment_fetcher: Option<Arc<FragmentFetcher>>,
+        bloom_filter_manager: Option<BloomFilterManager>,
+        shard_size: Option<u64>,
+        work_queue_client: Option<WorkQueueClient>,
+        log_start_offset: i64,
+    ) -> Self {
+        let mut context = Self::new(
+            rebuild_info,
+            fetch_log_batch_size,
+            fetch_log_concurrency,
+            max_compaction_size,
+            max_partition_size,
+            log,
+            sysdb,
+            blockfile_provider,
+            hnsw_provider,
+            spann_provider,
+            dispatcher,
+            is_function_disabled,
+            is_fn_consumer,
+            fragment_fetcher,
+            bloom_filter_manager,
+            shard_size,
+            work_queue_client,
+        );
+        context.log_start_offset = Some(log_start_offset);
+        context
     }
 
     #[cfg(test)]
@@ -496,6 +546,7 @@ impl CompactionContext {
             self.fragment_fetcher.clone(),
             self.bloom_filter_manager.clone(),
             self.work_queue_client.clone(),
+            self.log_start_offset,
         );
 
         let log_fetch_response = match log_fetch_orchestrator.run(system.clone()).await {
@@ -610,6 +661,7 @@ impl CompactionContext {
             self.dispatcher.clone(),
             data_fetch_records,
             is_backfill,
+            self.is_fn_consumer,
         );
 
         let attached_function_response =
@@ -973,13 +1025,6 @@ impl CompactionContext {
             }
 
             results.push(compact_result);
-        }
-
-        // Skip registration if fn_consumer
-        if self.is_fn_consumer {
-            return Ok(CompactionResponse::Success {
-                job_id: collection_id.into(),
-            });
         }
 
         let _ =

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -344,8 +344,9 @@ impl LogFetchOrchestrator {
         fragment_fetcher: Option<Arc<FragmentFetcher>>,
         bloom_filter_manager: Option<BloomFilterManager>,
         work_queue_client: Option<WorkQueueClient>,
+        log_start_offset: Option<i64>,
     ) -> Self {
-        let context = CompactionContext::new(
+        let mut context = CompactionContext::new(
             rebuild_info,
             fetch_log_batch_size,
             fetch_log_concurrency,
@@ -364,6 +365,7 @@ impl LogFetchOrchestrator {
             None, // shard_size
             work_queue_client,
         );
+        context.log_start_offset = log_start_offset;
         LogFetchOrchestrator {
             collection_id,
             database_name,
@@ -575,13 +577,23 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                     return;
                 }
             };
+            if self.context.log_start_offset.is_some() {
+                tracing::info!(
+                    "Starting fetch log operation with log_start_offset: {:?}",
+                    self.context.log_start_offset
+                );
+            } else {
+                tracing::info!("Starting fetch log operation without log_start_offset");
+            }
             wrap(
                 Box::new(FetchLogOperator {
                     log_client: self.context.log.clone(),
                     batch_size: self.context.fetch_log_batch_size,
                     // We need to start fetching from the first log that has not been compacted
-                    start_log_offset_id: u64::try_from(collection.log_position + 1)
-                        .unwrap_or_default(),
+                    start_log_offset_id: match self.context.log_start_offset {
+                        Some(offset) => u64::try_from(offset + 1).unwrap_or_default(),
+                        None => u64::try_from(collection.log_position + 1).unwrap_or_default(),
+                    },
                     maximum_fetch_count: Some(self.context.max_compaction_size as u32),
                     collection_uuid: collection.collection_id,
                     tenant: collection.tenant.clone(),

--- a/rust/worker/src/execution/orchestration/register_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/register_orchestrator.rs
@@ -11,6 +11,9 @@ use tokio::sync::oneshot::error::RecvError;
 use tokio::sync::oneshot::Sender;
 use tracing::Span;
 
+use crate::execution::operators::finish_async_work::{
+    FinishAsyncWorkError, FinishAsyncWorkInput, FinishAsyncWorkOperator, FinishAsyncWorkOutput,
+};
 use crate::execution::operators::finish_attached_function::{
     FinishAttachedFunctionError, FinishAttachedFunctionInput, FinishAttachedFunctionOperator,
     FinishAttachedFunctionOutput,
@@ -100,6 +103,8 @@ pub enum RegisterOrchestratorError {
     RecvError(#[from] RecvError),
     #[error("Error registering compaction result: {0}")]
     Register(#[from] RegisterError),
+    #[error("Error finishing async work: {0}")]
+    FinishAsyncWork(#[from] FinishAsyncWorkError),
 }
 
 impl ChromaError for RegisterOrchestratorError {
@@ -119,6 +124,7 @@ impl ChromaError for RegisterOrchestratorError {
             RegisterOrchestratorError::Panic(e) => e.should_trace_error(),
             RegisterOrchestratorError::Register(e) => e.should_trace_error(),
             RegisterOrchestratorError::RecvError(_) => true,
+            RegisterOrchestratorError::FinishAsyncWork(e) => e.should_trace_error(),
         }
     }
 }
@@ -205,24 +211,57 @@ impl Orchestrator for RegisterOrchestrator {
             }
         };
         if let Some(function_context) = &self.function_context {
-            vec![(
-                wrap(
-                    FinishAttachedFunctionOperator::new(),
-                    FinishAttachedFunctionInput::new(
-                        collection_flush_infos,
-                        function_context.attached_function_id,
-                        function_context.updated_completion_offset,
-                        self.context.sysdb.clone(),
-                        self.context.log.clone(),
+            if function_context.is_async && self.context.is_fn_consumer {
+                // For async functions, use FinishAsyncWorkOperator to call work queue
+                if let Some(work_queue_client) = self.context.work_queue_client.clone() {
+                    vec![(
+                        wrap(
+                            Box::new(FinishAsyncWorkOperator::new()),
+                            FinishAsyncWorkInput::new(
+                                function_context.attached_function_id,
+                                function_context.input_collection_id,
+                                function_context.updated_completion_offset as i64,
+                                work_queue_client,
+                            ),
+                            ctx.receiver(),
+                            self.context
+                                .orchestrator_context
+                                .task_cancellation_token
+                                .clone(),
+                        ),
+                        Some(Span::current()),
+                    )]
+                } else {
+                    self.terminate_with_result(
+                        Err(RegisterOrchestratorError::InvariantViolation(
+                            "Work queue client not available for async function",
+                        )),
+                        ctx,
+                    )
+                    .await;
+                    return vec![];
+                }
+            } else {
+                // For sync functions, use FinishAttachedFunctionOperator
+                vec![(
+                    wrap(
+                        FinishAttachedFunctionOperator::new(),
+                        FinishAttachedFunctionInput::new(
+                            collection_flush_infos,
+                            function_context.attached_function_id,
+                            function_context.updated_completion_offset,
+                            self.context.sysdb.clone(),
+                            self.context.log.clone(),
+                        ),
+                        ctx.receiver(),
+                        self.context
+                            .orchestrator_context
+                            .task_cancellation_token
+                            .clone(),
                     ),
-                    ctx.receiver(),
-                    self.context
-                        .orchestrator_context
-                        .task_cancellation_token
-                        .clone(),
-                ),
-                Some(Span::current()),
-            )]
+                    Some(Span::current()),
+                )]
+            }
         } else {
             // Use regular RegisterOperator for normal compaction
             // INVARIANT: We should have exactly one collection register info
@@ -358,6 +397,41 @@ impl Handler<TaskResult<FinishAttachedFunctionOutput, FinishAttachedFunctionErro
                 .map_err(|e| match e {
                     TaskError::TaskFailed(inner_error) => {
                         RegisterOrchestratorError::Register(inner_error.into())
+                    }
+                    other_error => other_error.into(),
+                })
+                .map(|_| RegisterOrchestratorResponse {
+                    job_id: collection_info.collection_id.into(),
+                }),
+            ctx,
+        )
+        .await;
+    }
+}
+
+#[async_trait]
+impl Handler<TaskResult<FinishAsyncWorkOutput, FinishAsyncWorkError>> for RegisterOrchestrator {
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        message: TaskResult<FinishAsyncWorkOutput, FinishAsyncWorkError>,
+        ctx: &ComponentContext<Self>,
+    ) {
+        let collection_info = match self.context.get_collection_info() {
+            Ok(collection_info) => collection_info,
+            Err(e) => {
+                self.terminate_with_result(Err(e.into()), ctx).await;
+                return;
+            }
+        };
+
+        self.terminate_with_result(
+            message
+                .into_inner()
+                .map_err(|e| match e {
+                    TaskError::TaskFailed(inner_error) => {
+                        RegisterOrchestratorError::FinishAsyncWork(inner_error)
                     }
                     other_error => other_error.into(),
                 })

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -1,13 +1,16 @@
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
+use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::hnsw_provider::HnswIndexProvider;
 use chroma_log::Log;
 use chroma_segment::spann_provider::SpannProvider;
 use chroma_sysdb::SysDb;
 use chroma_system::{Component, ComponentContext, ComponentHandle, Dispatcher, Handler, System};
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
+use futures::future::join_all;
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
+use thiserror::Error;
 use tracing::span;
 
 use crate::execution::orchestration::compact::CompactionContext;
@@ -30,6 +33,24 @@ impl InProgressFn {
 
     pub fn is_expired(&self) -> bool {
         SystemTime::now() >= self.expires_at
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum DispatchError {
+    #[error("Dispatcher not initialized")]
+    DispatcherNotInitialized,
+
+    #[error("Compaction workflow failed: {0}")]
+    CompactionFailed(#[from] crate::execution::orchestration::compact::CompactionError),
+}
+
+impl ChromaError for DispatchError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            DispatchError::DispatcherNotInitialized => ErrorCodes::Internal,
+            DispatchError::CompactionFailed(_) => ErrorCodes::Internal,
+        }
     }
 }
 
@@ -124,26 +145,16 @@ impl FnConsumerManager {
             .saturating_sub(self.in_progress.len())
     }
 
-    /// Records dispatch and (will) run the orchestrator inline. v1 stubs
-    /// the dispatch — only the in-flight bookkeeping is wired up. A later
-    /// change replaces this with the real compaction workflow. Returns
-    /// false if a matching (fn_id, input_coll_id) is already in flight or
-    /// the dispatcher hasn't been wired yet.
+    /// Runs the compaction workflow for the given function and collection.
     async fn dispatch_item(
-        &mut self,
+        &self,
         fn_id: AttachedFunctionUuid,
         input_coll_id: CollectionUuid,
-        _completion_offset: i64,
-    ) -> bool {
-        let key = (fn_id, input_coll_id);
-        if self.in_progress.contains_key(&key) {
-            tracing::debug!(?key, "skipping: in progress");
-            return false;
-        }
-
+        completion_offset: i64,
+    ) -> Result<(), DispatchError> {
         let Some(dispatcher) = self.context.dispatcher.clone() else {
             tracing::error!("Dispatcher not set on FnConsumerManager");
-            return false;
+            return Err(DispatchError::DispatcherNotInitialized);
         };
 
         // Fetch collection information to get the database name
@@ -160,7 +171,11 @@ impl FnConsumerManager {
                     "Failed to fetch collection information: {}",
                     e,
                 );
-                return false;
+                return Err(DispatchError::CompactionFailed(
+                    crate::execution::orchestration::compact::CompactionError::InvariantViolation(
+                        "Failed to fetch collection information",
+                    ),
+                ));
             }
         };
 
@@ -174,16 +189,16 @@ impl FnConsumerManager {
                         database = collection_info.collection.database,
                         "Invalid database name"
                     );
-                    return false;
+                    return Err(DispatchError::CompactionFailed(
+                    crate::execution::orchestration::compact::CompactionError::InvariantViolation(
+                        "Invalid database name",
+                    ),
+                ));
                 }
             };
 
-        // Now that all validations have passed, mark the work as in progress
-        self.in_progress
-            .insert(key, InProgressFn::new(self.context.job_expiry_seconds));
-
         // Create CompactionContext with is_fn_consumer = true
-        let mut compaction_context = CompactionContext::new(
+        let mut compaction_context = CompactionContext::new_with_log_offset(
             None,  // rebuild_info
             100,   // fetch_log_batch_size
             10,    // fetch_log_concurrency
@@ -201,6 +216,7 @@ impl FnConsumerManager {
             None,                                 // bloom_filter_manager
             None,                                 // shard_size
             Some(self.work_queue_client.clone()), // work_queue_client
+            completion_offset,                    // log_start_offset
         );
 
         // Run compaction workflow
@@ -211,9 +227,6 @@ impl FnConsumerManager {
         ))
         .await;
 
-        // Always remove from in_progress map after completion
-        self.in_progress.remove(&key);
-
         match result {
             Ok(_response) => {
                 tracing::info!(
@@ -221,7 +234,7 @@ impl FnConsumerManager {
                     input_coll_id = %input_coll_id,
                     "Function consumer workflow completed successfully"
                 );
-                true
+                Ok(())
             }
             Err(e) => {
                 tracing::error!(
@@ -230,8 +243,7 @@ impl FnConsumerManager {
                     "Function consumer workflow failed: {}",
                     e,
                 );
-                // Return false on error so caller knows it failed
-                false
+                Err(e.into())
             }
         }
     }
@@ -255,6 +267,8 @@ impl FnConsumerManager {
                 return;
             }
         };
+        // Collect valid work items first
+        let mut work_items = Vec::new();
         for item in resp.items {
             let Ok(fn_id) = item.fn_id.parse::<AttachedFunctionUuid>() else {
                 tracing::error!(fn_id = item.fn_id, "skipping work item: invalid fn_id");
@@ -267,7 +281,58 @@ impl FnConsumerManager {
                 );
                 continue;
             };
-            Box::pin(self.dispatch_item(fn_id, input_coll_id, item.completion_offset)).await;
+            work_items.push((fn_id, input_coll_id, item.completion_offset));
+        }
+
+        let mut items_to_process = Vec::new();
+        for (fn_id, input_coll_id, completion_offset) in work_items {
+            let key = (fn_id, input_coll_id);
+
+            if self.in_progress.contains_key(&key) {
+                tracing::debug!(?key, "skipping: already in progress");
+                continue;
+            }
+
+            self.in_progress
+                .insert(key, InProgressFn::new(self.context.job_expiry_seconds));
+
+            items_to_process.push((fn_id, input_coll_id, completion_offset));
+        }
+
+        let futures: Vec<_> = items_to_process
+            .into_iter()
+            .map(|(fn_id, input_coll_id, completion_offset)| {
+                let fut = self.dispatch_item(fn_id, input_coll_id, completion_offset);
+                Box::pin(async move {
+                    let result = fut.await;
+                    (fn_id, input_coll_id, result)
+                })
+            })
+            .collect();
+
+        let results = join_all(futures).await;
+
+        for (fn_id, input_coll_id, result) in results {
+            let key = (fn_id, input_coll_id);
+            self.in_progress.remove(&key);
+
+            match result {
+                Ok(()) => {
+                    tracing::debug!(
+                        fn_id = %fn_id,
+                        input_coll_id = %input_coll_id,
+                        "Successfully completed work item"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        fn_id = %fn_id,
+                        input_coll_id = %input_coll_id,
+                        error = %e,
+                        "Failed to process work item"
+                    );
+                }
+            }
         }
     }
 }

--- a/rust/worker/src/work_queue/server.rs
+++ b/rust/worker/src/work_queue/server.rs
@@ -22,7 +22,7 @@ pub async fn service_entrypoint() {
     };
 
     let service_config = config.work_queue_service.clone();
-    let work_queue_config = config.work_queue.clone();
+    let work_queue_config = service_config.work_queue.clone();
     let registry = Registry::new();
 
     // Initialize tracing


### PR DESCRIPTION
## Description of changes

This PR wires up the `fn_consumer` path so that after compaction completes, it calls `finish_work` on the work queue instead of silently skipping registration. The key changes are:

1. A new `FinishAsyncWorkOperator` that calls `work_queue_client.finish_work()`
2. `RegisterOrchestrator` now branches on `is_async && is_fn_consumer` to dispatch either the new operator or the existing `FinishAttachedFunctionOperator`
3. `fn_consumer_manager` dispatches work items concurrently with proper in-flight bookkeeping
4. `CompactionContext` gains a `log_start_offset` field so the fn_consumer can start fetching from a specific offset

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_