### PR TITLE
[ENH](foundation-api): Scaffold crate and binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,6 +3630,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "foundation-api"
+version = "1.0.0"
+dependencies = [
+ "axum 0.8.8",
+ "chroma-error",
+ "chroma-system",
+ "chroma-tracing",
+ "chroma-types",
+ "figment",
+ "frontend-core",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-http 0.6.8",
+ "tracing",
+]
+
+[[package]]
 name = "foyer"
 version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = ["rust/benchmark", "rust/blockstore", "rust/cache", "rust/chroma", "rust/config", "rust/distance", "rust/error", "rust/faults", "rust/frontend", "rust/frontend-core", "rust/garbage_collector", "rust/index", "rust/load", "rust/log", "rust/log-service", "rust/memberlist", "rust/metering-macros", "rust/metering", "rust/storage", "rust/system", "rust/sysdb", "rust/types", "rust/worker", "rust/segment", "rust/python_bindings", "rust/mdac", "rust/tracing", "rust/sqlite", "rust/cli", "rust/wal3", "rust/js_bindings", "rust/jemalloc-pprof-server", "rust/s3heap", "rust/s3heap-service", "rust/api-types", "rust/rust-sysdb", "rust/spanner-migrations"]
+members = ["rust/benchmark", "rust/blockstore", "rust/cache", "rust/chroma", "rust/config", "rust/distance", "rust/error", "rust/faults", "rust/foundation-api", "rust/frontend", "rust/frontend-core", "rust/garbage_collector", "rust/index", "rust/load", "rust/log", "rust/log-service", "rust/memberlist", "rust/metering-macros", "rust/metering", "rust/storage", "rust/system", "rust/sysdb", "rust/types", "rust/worker", "rust/segment", "rust/python_bindings", "rust/mdac", "rust/tracing", "rust/sqlite", "rust/cli", "rust/wal3", "rust/js_bindings", "rust/jemalloc-pprof-server", "rust/s3heap", "rust/s3heap-service", "rust/api-types", "rust/rust-sysdb", "rust/spanner-migrations"]
 
 [workspace.dependencies]
 anyhow = "1.0"
@@ -100,6 +100,7 @@ chroma-distance = { path = "rust/distance" }
 chroma-error = { path = "rust/error", version = "0.14.0" }
 chroma-faults = { path = "rust/faults" }
 chroma-frontend = { path = "rust/frontend" }
+foundation-api = { path = "rust/foundation-api" }
 frontend-core = { path = "rust/frontend-core" }
 chroma-index = { path = "rust/index" }
 chroma-log = { path = "rust/log" }

--- a/rust/foundation-api/Cargo.toml
+++ b/rust/foundation-api/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "foundation-api"
+version = "1.0.0"
+edition = "2021"
+
+[[bin]]
+name = "foundation_service"
+path = "src/bin/foundation_service.rs"
+
+[dependencies]
+axum = { workspace = true }
+figment = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tower-http = { workspace = true }
+tracing = { workspace = true }
+
+chroma-error = { workspace = true, features = ["validator", "http"] }
+chroma-system = { workspace = true }
+chroma-tracing = { workspace = true, features = ["middleware"] }
+chroma-types = { workspace = true }
+frontend-core = { workspace = true }

--- a/rust/foundation-api/src/bin/foundation_service.rs
+++ b/rust/foundation-api/src/bin/foundation_service.rs
@@ -1,0 +1,13 @@
+use chroma_system::thread_stack_size_bytes;
+use foundation_api::foundation_service_entrypoint;
+use std::sync::Arc;
+
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("foundation-api")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(foundation_service_entrypoint(Arc::new(()) as _, true));
+}

--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -1,0 +1,28 @@
+use frontend_core::config::{load_yaml_with_env, BaseServerConfig};
+use serde::{Deserialize, Serialize};
+
+/// Top-level config for the foundation-api HTTP server.
+///
+/// Embeds `BaseServerConfig` (port, listen address, payload size, circuit
+/// breaker, scorecard, OTEL, CORS) flat at the top level so existing
+/// `CHROMA_*` env-var bindings work without nesting. Foundation-specific
+/// fields will land here as handler tickets bring them in.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct FoundationApiConfig {
+    #[serde(flatten)]
+    pub base: BaseServerConfig,
+}
+
+impl Default for FoundationApiConfig {
+    fn default() -> Self {
+        Self {
+            base: BaseServerConfig::default(),
+        }
+    }
+}
+
+impl FoundationApiConfig {
+    pub fn load_from_path(path: &str) -> Self {
+        load_yaml_with_env(path)
+    }
+}

--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -7,18 +7,10 @@ use serde::{Deserialize, Serialize};
 /// breaker, scorecard, OTEL, CORS) flat at the top level so existing
 /// `CHROMA_*` env-var bindings work without nesting. Foundation-specific
 /// fields will land here as handler tickets bring them in.
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct FoundationApiConfig {
     #[serde(flatten)]
     pub base: BaseServerConfig,
-}
-
-impl Default for FoundationApiConfig {
-    fn default() -> Self {
-        Self {
-            base: BaseServerConfig::default(),
-        }
-    }
 }
 
 impl FoundationApiConfig {

--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -1,0 +1,55 @@
+//! Foundation API HTTP server.
+//!
+//! Per ADR "Foundation API: Long-Term Home", this crate hosts the foundation
+//! HTTP route surface (`/api/foundation/{ask,recall,brief,init}`, future
+//! sync-domain endpoints). It depends on `frontend-core` for Axum scaffolding,
+//! middleware, the `AuthenticateAndAuthorize` trait, config primitives, error
+//! types, and OTEL bootstrap. It does NOT depend on `chroma-frontend`, and it
+//! does NOT serve any Chroma CRUD routes.
+
+use std::sync::Arc;
+
+pub mod config;
+pub(crate) mod routes;
+pub mod server;
+
+pub use frontend_core::{ac, auth, errors, middleware as server_middleware, traced_json};
+
+use config::FoundationApiConfig;
+use server::FoundationApiServer;
+
+pub const CONFIG_PATH_ENV_VAR: &str = "FOUNDATION_API_CONFIG_PATH";
+
+pub async fn foundation_service_entrypoint(
+    auth: Arc<dyn auth::AuthenticateAndAuthorize>,
+    init_otel_tracing: bool,
+) {
+    let config = match std::env::var(CONFIG_PATH_ENV_VAR) {
+        Ok(config_path) => FoundationApiConfig::load_from_path(&config_path),
+        Err(_) => FoundationApiConfig::default(),
+    };
+    foundation_service_entrypoint_with_config(auth, &config, init_otel_tracing).await;
+}
+
+pub fn init_foundation_otel_tracing(config: &FoundationApiConfig) {
+    frontend_core::tracing::init_server_otel_tracing(
+        config.base.open_telemetry.as_ref(),
+        config.base.stdout_tracing,
+    );
+}
+
+pub async fn foundation_service_entrypoint_with_config(
+    auth: Arc<dyn auth::AuthenticateAndAuthorize>,
+    config: &FoundationApiConfig,
+    init_otel_tracing: bool,
+) {
+    let system = chroma_system::System::new();
+
+    if init_otel_tracing {
+        init_foundation_otel_tracing(config);
+    }
+
+    FoundationApiServer::new(config.clone(), auth, system)
+        .run(None)
+        .await;
+}

--- a/rust/foundation-api/src/routes/mod.rs
+++ b/rust/foundation-api/src/routes/mod.rs
@@ -1,0 +1,9 @@
+use crate::server::FoundationApiServer;
+use axum::Router;
+
+/// Empty foundation route module. Handler tickets (#7442, #7507, #7508, #7509)
+/// register `/api/foundation/{ask,recall,brief,init}` and future sync-domain
+/// endpoints here.
+pub(crate) fn router() -> Router<FoundationApiServer> {
+    Router::new()
+}

--- a/rust/foundation-api/src/server.rs
+++ b/rust/foundation-api/src/server.rs
@@ -1,0 +1,169 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{DefaultBodyLimit, State},
+    response::IntoResponse,
+    routing::get,
+    Json, Router, ServiceExt,
+};
+use chroma_system::System;
+use chroma_tracing::add_tracing_middleware;
+#[cfg(unix)]
+use tokio::signal::unix::{signal, SignalKind};
+#[cfg(windows)]
+use tokio::signal::windows::ctrl_c;
+use tower_http::cors::CorsLayer;
+
+use crate::{
+    ac::AdmissionControlledService,
+    auth::AuthenticateAndAuthorize,
+    config::FoundationApiConfig,
+    routes,
+    server_middleware::{always_json_errors_middleware, default_json_content_type_middleware},
+};
+
+#[derive(Clone)]
+pub struct FoundationApiServer {
+    pub(crate) config: FoundationApiConfig,
+    #[allow(dead_code)]
+    pub(crate) auth: Arc<dyn AuthenticateAndAuthorize>,
+    pub(crate) system: System,
+}
+
+impl FoundationApiServer {
+    pub fn new(
+        config: FoundationApiConfig,
+        auth: Arc<dyn AuthenticateAndAuthorize>,
+        system: System,
+    ) -> FoundationApiServer {
+        FoundationApiServer {
+            config,
+            auth,
+            system,
+        }
+    }
+
+    /// Accepts an optional `ready_tx` channel that emits the bound port when
+    /// the server is ready.
+    pub async fn run(self, ready_tx: Option<tokio::sync::oneshot::Sender<u16>>) {
+        let system = self.system.clone();
+
+        let FoundationApiConfig { base } = self.config.clone();
+        let port = base.port;
+        let listen_address = base.listen_address.clone();
+        let max_payload_size_bytes = base.max_payload_size_bytes;
+        let circuit_breaker = base.circuit_breaker.clone();
+        let cors_allow_origins = base.cors_allow_origins.clone();
+
+        let app = Router::new()
+            .route("/api/v2/healthcheck", get(healthcheck))
+            .merge(routes::router())
+            .with_state(self)
+            .layer(DefaultBodyLimit::max(max_payload_size_bytes))
+            .layer(axum::middleware::from_fn(
+                default_json_content_type_middleware,
+            ))
+            .layer(axum::middleware::from_fn(always_json_errors_middleware));
+
+        let mut app = add_tracing_middleware(app);
+
+        if let Some(cors_allow_origins) = cors_allow_origins {
+            let origins = cors_allow_origins
+                .into_iter()
+                .map(|origin| {
+                    origin
+                        .parse()
+                        .unwrap_or_else(|_| panic!("Invalid origin: {}", origin))
+                })
+                .collect::<Vec<_>>();
+
+            let mut cors_builder = CorsLayer::new()
+                .allow_headers(tower_http::cors::Any)
+                .allow_methods(tower_http::cors::Any);
+            if origins.len() == 1 && origins[0] == "*" {
+                cors_builder = cors_builder.allow_origin(tower_http::cors::Any);
+            } else {
+                cors_builder = cors_builder.allow_origin(origins);
+            }
+
+            app = app.layer(cors_builder);
+        }
+
+        let addr = format!("{}:{}", listen_address, port);
+        tracing::info!(%addr, "Foundation API server listening on address");
+        let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+        let bound_port = listener
+            .local_addr()
+            .expect("Failed to get local address of server")
+            .port();
+        if let Some(ready_tx) = ready_tx {
+            ready_tx
+                .send(bound_port)
+                .expect("Failed to send bound port. Receiver has been dropped.");
+        }
+        if circuit_breaker.enabled() {
+            let service = AdmissionControlledService::new(circuit_breaker, app);
+            axum::serve(listener, service.into_make_service())
+                .with_graceful_shutdown(graceful_shutdown(system))
+                .await
+                .unwrap();
+        } else {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(graceful_shutdown(system))
+                .await
+                .unwrap();
+        }
+    }
+}
+
+async fn healthcheck(State(_server): State<FoundationApiServer>) -> impl IntoResponse {
+    (
+        axum::http::StatusCode::OK,
+        Json(serde_json::json!({ "is_executor_ready": true })),
+    )
+}
+
+async fn graceful_shutdown(system: System) {
+    #[cfg(unix)]
+    {
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(err) => {
+                tracing::error!("Failed to create SIGTERM handler: {err}");
+                return;
+            }
+        };
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(err) => {
+                tracing::error!("Failed to create SIGINT handler: {err}");
+                return;
+            }
+        };
+        tokio::select! {
+            _ = sigterm.recv() => {
+                tracing::info!("Received SIGTERM, shutting down service");
+            }
+            _ = sigint.recv() => {
+                tracing::info!("Received SIGINT, shutting down service");
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        match ctrl_c() {
+            Ok(mut ctrl_c_signal) => {
+                ctrl_c_signal.recv().await;
+                tracing::info!("Received Ctrl+C, shutting down service");
+            }
+            Err(err) => {
+                tracing::error!("Failed to create Ctrl+C handler: {err}");
+                return;
+            }
+        }
+    }
+
+    system.stop().await;
+    system.join().await;
+}


### PR DESCRIPTION
New library + binary crate at rust/foundation-api/. Hosts the future
foundation HTTP route surface as a sibling to chroma-frontend, per the
"Foundation API: Long-Term Home" ADR.

Depends on frontend-core (#7070) for Axum scaffolding, middleware, the
AuthenticateAndAuthorize trait, config primitives, error types, and OTEL
bootstrap. Does NOT depend on chroma-frontend and does NOT register any
Chroma CRUD routes. The /api/foundation/* handlers will land via #7442,
#7507, #7508, #7509 by registering on the empty routes module.

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
