### PR TITLE
fix: use idiomatic Jest rejects.toThrow in admin tests

### DIFF
--- a/clients/js/packages/chromadb-core/test/admin.test.ts
+++ b/clients/js/packages/chromadb-core/test/admin.test.ts
@@ -119,17 +119,12 @@ describe("AdminClient", () => {
     const tenantName = "foo";
     await adminClient.createDatabase({ name: dbName, tenantName: tenantName });
 
-    // Attempt to create it again, should fail
-    try {
-      await adminClient.createDatabase({
+    // Attempt to create it again, should fail with ChromaUniqueError
+    await expect(
+      adminClient.createDatabase({
         name: dbName,
         tenantName: tenantName,
-      });
-      // If it reaches here, the test failed because no error was thrown
-      expect(true).toBe(false);
-    } catch (error) {
-      expect(error).toBeInstanceOf(Error);
-      expect(error).toBeInstanceOf(ChromaUniqueError);
-    }
+      }),
+    ).rejects.toThrow(ChromaUniqueError);
   });
 });


### PR DESCRIPTION
Replaces the non-idiomatic try/catch/expect(true).toBe(false) pattern 
in the "it should throw well-formatted errors" test with Jest's native 
await expect(...).rejects.toThrow() syntax.

Before:
```ts
try {
  await adminClient.createDatabase({ name: dbName, tenantName });
  expect(true).toBe(false);
} catch (error) {
  expect(error).toBeInstanceOf(ChromaUniqueError);
}
```

After:
```ts
await expect(
  adminClient.createDatabase({ name: dbName, tenantName }),
).rejects.toThrow(ChromaUniqueError);
```

Closes #2801