### PR TITLE
[CHORE]: Turn off MCMR testing for now

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -137,7 +137,7 @@ jobs:
           - "chromadb/test/property/test_collections.py"
           - "chromadb/test/property/test_add_gc.py"
           - "chromadb/test/property/test_add.py"
-          - "chromadb/test/property/test_add_mcmr.py"
+          # - "chromadb/test/property/test_add_mcmr.py" disabling while we figure out a way to re-enable mcmr testing on tilt
           - "chromadb/test/property/test_filtering.py"
           - "chromadb/test/property/test_fork.py"
           - "chromadb/test/property/test_embeddings.py"
@@ -163,8 +163,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      MULTI_REGION: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -142,56 +142,53 @@ jobs:
       - name: Run benchmark
         run: cargo bench ${{ matrix.bench-command }}
 
-  test-mcmr-integration:
-    runs-on: blacksmith-16vcpu-ubuntu-2404
-    # OIDC token auth for AWS
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      CARGO_TERM_COLOR: always
-      RUST_MIN_STACK_SIZE: 8388608
-      MULTI_REGION: "true"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Set up Docker
-        uses: ./.github/actions/docker
-        with:
-          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
-          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Tilt Setup & Pre-Build
-        uses: ./.github/actions/tilt-setup-prebuild
-      - name: Start Tilt with MULTI_REGION
-        shell: bash
-        env:
-          MULTI_REGION: "true"
-        run: tilt ci
-      - name: Forward ports
-        shell: bash
-        run: |
-          # tilt ci does not forward ports
-          # https://github.com/tilt-dev/tilt/issues/5964
-          kubectl -n chroma port-forward svc/sysdb 50051:50051 &
-          kubectl -n chroma port-forward svc/rust-log-service 50054:50051 &
-          kubectl -n chroma port-forward svc/query-service 50053:50051 &
-          kubectl -n chroma port-forward svc/rust-frontend-service 8000:8000 &
-          kubectl -n chroma port-forward svc/minio 9000:9000 &
-          kubectl -n chroma port-forward svc/jaeger 16686:16686 &
-          kubectl -n chroma port-forward svc/work-queue-service 50058:50051 &
-          # Forward Spanner emulator port for rust-sysdb backend tests
-          kubectl -n chroma port-forward svc/spanner 9010:9010 &
-      - name: Run mcmr k8s integration tests
-        run: cargo nextest run --profile mcmr_k8s_integration --test-threads 1
-      - name: Save service logs to artifact
-        if: always()
-        uses: ./.github/actions/export-tilt-logs
-        with:
-          artifact-name: "mcmr-integration-test"
+  # test-mcmr-integration:
+  #   runs-on: blacksmith-16vcpu-ubuntu-2404
+  #   # OIDC token auth for AWS
+  #   permissions:
+  #     contents: read
+  #     id-token: write
+  #   env:
+  #     CARGO_TERM_COLOR: always
+  #     RUST_MIN_STACK_SIZE: 8388608
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Setup
+  #       uses: ./.github/actions/rust
+  #       with:
+  #         github-token: ${{ github.token }}
+  #     - name: Set up Docker
+  #       uses: ./.github/actions/docker
+  #       with:
+  #         dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
+  #         dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #     - name: Tilt Setup & Pre-Build
+  #       uses: ./.github/actions/tilt-setup-prebuild
+  #     - name: Start Tilt with MULTI_REGION (disabled for now)
+  #       shell: bash
+  #       run: tilt ci
+  #     - name: Forward ports
+  #       shell: bash
+  #       run: |
+  #         # tilt ci does not forward ports
+  #         # https://github.com/tilt-dev/tilt/issues/5964
+  #         kubectl -n chroma port-forward svc/sysdb 50051:50051 &
+  #         kubectl -n chroma port-forward svc/rust-log-service 50054:50051 &
+  #         kubectl -n chroma port-forward svc/query-service 50053:50051 &
+  #         kubectl -n chroma port-forward svc/rust-frontend-service 8000:8000 &
+  #         kubectl -n chroma port-forward svc/minio 9000:9000 &
+  #         kubectl -n chroma port-forward svc/jaeger 16686:16686 &
+  #         kubectl -n chroma port-forward svc/work-queue-service 50058:50051 &
+  #         # Forward Spanner emulator port for rust-sysdb backend tests
+  #         kubectl -n chroma port-forward svc/spanner 9010:9010 &
+  #     - name: Run mcmr k8s integration tests
+  #       run: cargo nextest run --profile mcmr_k8s_integration --test-threads 1
+  #     - name: Save service logs to artifact
+  #       if: always()
+  #       uses: ./.github/actions/export-tilt-logs
+  #       with:
+  #         artifact-name: "mcmr-integration-test"
 
   can-build-release:
     runs-on: blacksmith-16vcpu-ubuntu-2404


### PR DESCRIPTION
## Description of changes

Temporarily disabling this to allow CI resources to stand up functions services.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_