### PR TITLE
[ENH](foundation-api): Add POST /api/foundation/init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,17 +3634,22 @@ name = "foundation-api"
 version = "1.0.0"
 dependencies = [
  "axum 0.8.8",
+ "chroma-config",
  "chroma-error",
+ "chroma-sysdb",
  "chroma-system",
  "chroma-tracing",
  "chroma-types",
  "figment",
  "frontend-core",
+ "mdac",
  "serde",
  "serde_json",
+ "thiserror 1.0.69",
  "tokio",
  "tower-http 0.6.8",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/rust/foundation-api/Cargo.toml
+++ b/rust/foundation-api/Cargo.toml
@@ -12,12 +12,17 @@ axum = { workspace = true }
 figment = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
+uuid = { workspace = true }
 
+chroma-config = { workspace = true }
 chroma-error = { workspace = true, features = ["validator", "http"] }
+chroma-sysdb = { workspace = true }
 chroma-system = { workspace = true }
 chroma-tracing = { workspace = true, features = ["middleware"] }
 chroma-types = { workspace = true }
 frontend-core = { workspace = true }
+mdac = { workspace = true }

--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -1,3 +1,4 @@
+use chroma_sysdb::SysDbConfig;
 use frontend_core::config::{load_yaml_with_env, BaseServerConfig};
 use serde::{Deserialize, Serialize};
 
@@ -11,6 +12,48 @@ use serde::{Deserialize, Serialize};
 pub struct FoundationApiConfig {
     #[serde(flatten)]
     pub base: BaseServerConfig,
+    #[serde(default)]
+    pub sysdb: SysDbConfig,
+    #[serde(default)]
+    pub foundation: FoundationConfig,
+}
+
+/// Names of the database and collections that `POST /api/foundation/init`
+/// ensures. Overridable via env vars (e.g. `CHROMA_FOUNDATION__DATABASE_NAME`)
+/// so deployments and tests can point at non-default workspaces without a
+/// code change.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct FoundationConfig {
+    #[serde(default = "FoundationConfig::default_database_name")]
+    pub database_name: String,
+    // TODO(hammadb): collection identities should move onto Chroma collection
+    // metadata rather than living as a deployment-side config field.
+    #[serde(default = "FoundationConfig::default_wiki_collection")]
+    pub wiki_collection: String,
+    #[serde(default = "FoundationConfig::default_wiki_revisions_collection")]
+    pub wiki_revisions_collection: String,
+}
+
+impl FoundationConfig {
+    fn default_database_name() -> String {
+        "FOUNDATION".to_string()
+    }
+    fn default_wiki_collection() -> String {
+        "wiki".to_string()
+    }
+    fn default_wiki_revisions_collection() -> String {
+        "wiki_revisions".to_string()
+    }
+}
+
+impl Default for FoundationConfig {
+    fn default() -> Self {
+        Self {
+            database_name: Self::default_database_name(),
+            wiki_collection: Self::default_wiki_collection(),
+            wiki_revisions_collection: Self::default_wiki_revisions_collection(),
+        }
+    }
 }
 
 impl FoundationApiConfig {

--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -44,12 +44,68 @@ pub async fn foundation_service_entrypoint_with_config(
     init_otel_tracing: bool,
 ) {
     let system = chroma_system::System::new();
+    let registry = chroma_config::registry::Registry::new();
 
     if init_otel_tracing {
         init_foundation_otel_tracing(config);
     }
 
-    FoundationApiServer::new(config.clone(), auth, system)
+    let sysdb = match <chroma_sysdb::SysDb as chroma_config::Configurable<(
+        chroma_sysdb::SysDbConfig,
+        Option<chroma_sysdb::GrpcSysDbConfig>,
+    )>>::try_from_config(&(config.sysdb.clone(), None), &registry)
+    .await
+    {
+        Ok(sysdb) => sysdb,
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                "foundation-api startup failed: could not construct SysDb client from config",
+            );
+            return;
+        }
+    };
+
+    let rules = match build_scorecard_rules(&config.base.scorecard) {
+        Ok(rules) => rules,
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                "foundation-api startup failed: invalid scorecard rule pattern",
+            );
+            return;
+        }
+    };
+
+    FoundationApiServer::new(config.clone(), auth, sysdb, rules, system)
         .run(None)
         .await;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ScorecardRuleError {
+    #[error("Invalid scorecard pattern: {0}")]
+    InvalidPattern(String),
+}
+
+fn build_scorecard_rules(
+    config_rules: &[frontend_core::config::ScorecardRule],
+) -> Result<Vec<mdac::Rule>, ScorecardRuleError> {
+    config_rules
+        .iter()
+        .map(|rule| {
+            let patterns = rule
+                .patterns
+                .iter()
+                .map(|p| {
+                    mdac::Pattern::new(p)
+                        .ok_or_else(|| ScorecardRuleError::InvalidPattern(p.clone()))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(mdac::Rule {
+                patterns,
+                limit: rule.score as usize,
+            })
+        })
+        .collect()
 }

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -1,0 +1,151 @@
+use axum::{extract::State, http::HeaderMap, Json};
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_sysdb::SysDb;
+use chroma_types::{Collection, CreateDatabaseError, DatabaseName, KnnIndex};
+use frontend_core::collection_ops::{
+    plan_create_collection, supported_segment_types, ExecutorKind, TenantFeatureFlags,
+};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::{
+    auth::{AuthzAction, AuthzResource},
+    errors::ServerError,
+    server::FoundationApiServer,
+};
+
+#[derive(Serialize)]
+pub struct FoundationInitResponse {
+    pub tenant: String,
+    pub database: String,
+    pub database_id: String,
+    pub wiki_collection_id: String,
+    pub wiki_revisions_collection_id: String,
+}
+
+/// `POST /api/foundation/init` — idempotent bootstrap for a team's Foundation
+/// workspace. Ensures the configured Foundation database and the wiki +
+/// wiki_revisions collections (names overridable via
+/// `CHROMA_FOUNDATION__*` env vars) exist in the tenant resolved from the
+/// auth context. Safe to call repeatedly.
+pub async fn foundation_init(
+    headers: HeaderMap,
+    State(server): State<FoundationApiServer>,
+) -> Result<Json<FoundationInitResponse>, ServerError> {
+    let identity = server
+        .auth
+        .authenticate_and_authorize(
+            &headers,
+            AuthzAction::CreateDatabase,
+            AuthzResource {
+                tenant: None,
+                database: None,
+                collection: None,
+            },
+        )
+        .await?;
+    let tenant = identity.tenant.clone();
+
+    let _guard =
+        server.scorecard_request(&["op:foundation_init", &format!("tenant:{}", tenant)])?;
+
+    let foundation_cfg = &server.config.foundation;
+    let db_name = DatabaseName::new(&foundation_cfg.database_name)
+        .ok_or(FoundationInitError::DatabaseNameTooShort)?;
+
+    let mut sysdb = server.sysdb.clone();
+    let database_id = ensure_database(&mut sysdb, db_name.clone(), tenant.clone()).await?;
+    let wiki = ensure_collection(
+        &mut sysdb,
+        tenant.clone(),
+        db_name.clone(),
+        &foundation_cfg.wiki_collection,
+    )
+    .await?;
+    let wiki_revisions = ensure_collection(
+        &mut sysdb,
+        tenant.clone(),
+        db_name,
+        &foundation_cfg.wiki_revisions_collection,
+    )
+    .await?;
+
+    Ok(Json(FoundationInitResponse {
+        tenant,
+        database: foundation_cfg.database_name.clone(),
+        database_id: database_id.to_string(),
+        wiki_collection_id: wiki.collection_id.to_string(),
+        wiki_revisions_collection_id: wiki_revisions.collection_id.to_string(),
+    }))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum FoundationInitError {
+    #[error("Configured foundation database name is shorter than the 3-character minimum")]
+    DatabaseNameTooShort,
+}
+
+impl ChromaError for FoundationInitError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::InvalidArgument
+    }
+}
+
+async fn ensure_database(
+    sysdb: &mut SysDb,
+    database_name: DatabaseName,
+    tenant: String,
+) -> Result<Uuid, ServerError> {
+    match sysdb
+        .create_database(Uuid::new_v4(), database_name.clone(), tenant.clone())
+        .await
+    {
+        Ok(_) | Err(CreateDatabaseError::AlreadyExists(_)) => {}
+        Err(e) => return Err(e.into()),
+    }
+    let db = sysdb.get_database(database_name, tenant).await?;
+    Ok(db.id)
+}
+
+/// SysDb's `create_collection` takes a `get_or_create: bool`. When true, an
+/// existing collection with the same (tenant, database, name) is returned
+/// instead of failing with `AlreadyExists` — atomic idempotency in one round
+/// trip, so we don't need the try-then-fallback dance we use for databases.
+const GET_OR_CREATE: bool = true;
+
+/// Plan a fresh distributed-mode collection with the shared
+/// `frontend_core::collection_ops` planner and hand it to sysdb. Foundation-api
+/// has no user-supplied schema/config and (today) no per-tenant feature
+/// flags, so most planner inputs are defaults. Sharing the planner keeps
+/// us in lock-step with chroma-frontend on segment-type dispatch.
+async fn ensure_collection(
+    sysdb: &mut SysDb,
+    tenant: String,
+    database_name: DatabaseName,
+    collection_name: &str,
+) -> Result<Collection, ServerError> {
+    let plan = plan_create_collection(
+        None,
+        None,
+        ExecutorKind::Distributed,
+        &supported_segment_types(ExecutorKind::Distributed),
+        false,
+        KnnIndex::Hnsw,
+        TenantFeatureFlags::default(),
+    )?;
+    let collection = sysdb
+        .create_collection(
+            tenant,
+            database_name,
+            plan.collection_id,
+            collection_name.to_string(),
+            plan.segments,
+            plan.configuration,
+            plan.schema,
+            None,
+            None,
+            GET_OR_CREATE,
+        )
+        .await?;
+    Ok(collection)
+}

--- a/rust/foundation-api/src/routes/mod.rs
+++ b/rust/foundation-api/src/routes/mod.rs
@@ -1,9 +1,8 @@
 use crate::server::FoundationApiServer;
-use axum::Router;
+use axum::{routing::post, Router};
 
-/// Empty foundation route module. Handler tickets (#7442, #7507, #7508, #7509)
-/// register `/api/foundation/{ask,recall,brief,init}` and future sync-domain
-/// endpoints here.
+pub(crate) mod init;
+
 pub(crate) fn router() -> Router<FoundationApiServer> {
-    Router::new()
+    Router::new().route("/api/foundation/init", post(init::foundation_init))
 }

--- a/rust/foundation-api/src/server.rs
+++ b/rust/foundation-api/src/server.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use axum::{
     extract::{DefaultBodyLimit, State},
@@ -6,8 +9,11 @@ use axum::{
     routing::get,
     Json, Router, ServiceExt,
 };
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_sysdb::SysDb;
 use chroma_system::System;
 use chroma_tracing::add_tracing_middleware;
+use mdac::{Rule, Scorecard, ScorecardGuard};
 #[cfg(unix)]
 use tokio::signal::unix::{signal, SignalKind};
 #[cfg(windows)]
@@ -22,11 +28,23 @@ use crate::{
     server_middleware::{always_json_errors_middleware, default_json_content_type_middleware},
 };
 
+#[derive(Clone, Copy, Debug, thiserror::Error)]
+#[error("Too many requests; backoff and try again")]
+struct RateLimitError;
+
+impl ChromaError for RateLimitError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::ResourceExhausted
+    }
+}
+
 #[derive(Clone)]
 pub struct FoundationApiServer {
     pub(crate) config: FoundationApiConfig,
-    #[allow(dead_code)]
     pub(crate) auth: Arc<dyn AuthenticateAndAuthorize>,
+    pub(crate) sysdb: SysDb,
+    pub(crate) scorecard_enabled: Arc<AtomicBool>,
+    pub(crate) scorecard: Arc<Scorecard<'static>>,
     pub(crate) system: System,
 }
 
@@ -34,12 +52,40 @@ impl FoundationApiServer {
     pub fn new(
         config: FoundationApiConfig,
         auth: Arc<dyn AuthenticateAndAuthorize>,
+        sysdb: SysDb,
+        rules: Vec<Rule>,
         system: System,
     ) -> FoundationApiServer {
+        // NOTE(rescrv): Assume statically no more than 128 threads because we
+        // won't deploy on hardware with that many threads anytime soon for
+        // frontends, if ever. Matches chroma-frontend's choice.
+        let scorecard_enabled = Arc::new(AtomicBool::new(config.base.scorecard_enabled));
+        // SAFETY(rescrv): This is safe because 128 is non-zero.
+        let scorecard = Arc::new(Scorecard::new(&(), rules, 128.try_into().unwrap()));
         FoundationApiServer {
             config,
             auth,
+            sysdb,
+            scorecard_enabled,
+            scorecard,
             system,
+        }
+    }
+
+    /// Track this request against the scorecard rate limiter. Returns a guard
+    /// that must be held for the duration of the request; drop it and the slot
+    /// is released. Returns `RateLimitError` (429) if the limiter rejects.
+    pub(crate) fn scorecard_request(
+        &self,
+        tags: &[&str],
+    ) -> Result<ScorecardGuard, Box<dyn ChromaError>> {
+        if self.scorecard_enabled.load(Ordering::Relaxed) {
+            self.scorecard
+                .track(tags)
+                .map(|ticket| ScorecardGuard::new(Arc::clone(&self.scorecard), Some(ticket)))
+                .ok_or_else(|| Box::new(RateLimitError) as _)
+        } else {
+            Ok(ScorecardGuard::new(Arc::clone(&self.scorecard), None))
         }
     }
 
@@ -48,7 +94,7 @@ impl FoundationApiServer {
     pub async fn run(self, ready_tx: Option<tokio::sync::oneshot::Sender<u16>>) {
         let system = self.system.clone();
 
-        let FoundationApiConfig { base } = self.config.clone();
+        let FoundationApiConfig { base, .. } = self.config.clone();
         let port = base.port;
         let listen_address = base.listen_address.clone();
         let max_payload_size_bytes = base.max_payload_size_bytes;


### PR DESCRIPTION
Idempotent bootstrap for a team's Foundation workspace. Resolves the
calling tenant from the auth context, then ensures the FOUNDATION
database, wiki collection, and wiki_revisions collection all exist.
Safe to call repeatedly.

Also wires a SysDb client into FoundationApiServer (Cargo deps,
config field, server field, lib entrypoint) so the route can perform
collection/database operations directly via the sysdb library rather
than HTTP, per the "Foundation API: Long-Term Home" ADR.

The wiki -> wiki_revisions function attachment (step 5 of #7509) is
deferred to a follow-up; the underlying function isn't registered
yet (only record_counter, statistics, dummy_async exist).

Refs: hosted-chroma#7509

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
