### PR TITLE
[BUG]: Push fnConsumer to correct repo

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -190,10 +190,10 @@ target "fn-consumer" {
     "ADDRESS_SANITIZER" = "${ADDRESS_SANITIZER}"
   }
   target = "fn_consumer"
-  tags = LOCAL_BUILD == "true" ? ["fn-consumer:${COMMIT_SHORT_SHA}"] : [
-    "${REGISTRY_AWS}/fn-consumer:${COMMIT_SHORT_SHA}",
-    "${REGISTRY_GCP}/fn-consumer:${COMMIT_SHORT_SHA}",
-    "${REGISTRY_DOCKERHUB}/fn-consumer:${COMMIT_SHORT_SHA}",
+  tags = LOCAL_BUILD == "true" ? ["fn-consumer-service:${COMMIT_SHORT_SHA}"] : [
+    "${REGISTRY_AWS}/fn-consumer-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_GCP}/fn-consumer-service:${COMMIT_SHORT_SHA}",
+    "${REGISTRY_DOCKERHUB}/fn-consumer-service:${COMMIT_SHORT_SHA}",
   ]
 }
 


### PR DESCRIPTION
## Description of changes

fnConsumer images were being pushed to the wrong repo before this

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_