### PR TITLE
[ENH](frontend-core): Extract create-collection planner

### DIFF
--- a/rust/frontend-core/src/collection_ops.rs
+++ b/rust/frontend-core/src/collection_ops.rs
@@ -1,0 +1,351 @@
+//! Shared library logic for collection lifecycle operations (currently:
+//! create-collection planning). Both `chroma-frontend`'s HTTP CRUD handlers
+//! and `foundation-api`'s init handler call into this module so the rules
+//! for how a collection is laid out (segment dispatch, schema reconciliation,
+//! tenant feature flags) live in exactly one place.
+//!
+//! The planner is a pure function — no async, no I/O, no caller-specific
+//! state. Callers compute their own inputs (executor kind, supported segment
+//! types, tenant flags) and hand the returned [`CreateCollectionPlan`] to
+//! `SysDb::create_collection`.
+
+use std::collections::HashSet;
+
+use chroma_types::{
+    CollectionUuid, CreateCollectionError, InternalCollectionConfiguration, KnnIndex, Quantization,
+    Schema, SchemaError, Segment, SegmentScope, SegmentType, SegmentUuid, SparseIndexAlgorithm,
+    VectorIndexConfiguration,
+};
+
+/// Discriminant for which executor will serve the collection. Carries no
+/// executor state — callers pass this to indicate deployment mode without
+/// dragging the full `Executor` type into this crate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExecutorKind {
+    Distributed,
+    Local,
+}
+
+/// Per-tenant feature flags that influence the planned schema. Callers
+/// compute these from their own tenant config and pass them in so the
+/// planner stays stateless.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TenantFeatureFlags {
+    pub enable_quantization: bool,
+    pub enable_maxscore: bool,
+}
+
+/// The output of planning a create-collection: everything the caller needs
+/// to hand to `SysDb::create_collection`.
+#[derive(Clone, Debug)]
+pub struct CreateCollectionPlan {
+    pub collection_id: CollectionUuid,
+    pub segments: Vec<Segment>,
+    pub configuration: Option<InternalCollectionConfiguration>,
+    pub schema: Option<Schema>,
+}
+
+/// The canonical set of segment types an executor of the given kind can
+/// host. Callers that don't already track this (e.g. `foundation-api`,
+/// which has no `Executor`) can pass `&supported_segment_types(kind)`
+/// directly to [`plan_create_collection`].
+pub fn supported_segment_types(kind: ExecutorKind) -> Vec<SegmentType> {
+    match kind {
+        ExecutorKind::Distributed => vec![
+            SegmentType::HnswDistributed,
+            SegmentType::Spann,
+            SegmentType::QuantizedSpann,
+            SegmentType::BlockfileRecord,
+            SegmentType::BlockfileMetadata,
+        ],
+        ExecutorKind::Local => vec![
+            SegmentType::HnswLocalMemory,
+            SegmentType::HnswLocalPersisted,
+            SegmentType::Sqlite,
+        ],
+    }
+}
+
+/// Plan the creation of a collection. Validates the user-supplied
+/// configuration against the executor's supported segment types,
+/// reconciles schema + config (if `enable_schema`), applies tenant feature
+/// flags, and emits the segment set appropriate for the executor / schema
+/// combination.
+///
+/// Returns a [`CreateCollectionPlan`] containing the fresh `collection_id`,
+/// the segment list, and the (possibly-reconciled) configuration and schema
+/// to pass to `SysDb::create_collection`. The caller is responsible for the
+/// sysdb call, cache invalidation, and read-side schema reconciliation.
+pub fn plan_create_collection(
+    mut configuration: Option<InternalCollectionConfiguration>,
+    schema: Option<Schema>,
+    executor_kind: ExecutorKind,
+    supported_segment_types: &[SegmentType],
+    enable_schema: bool,
+    default_knn_index: KnnIndex,
+    tenant_flags: TenantFeatureFlags,
+) -> Result<CreateCollectionPlan, CreateCollectionError> {
+    let collection_id = CollectionUuid::new();
+    let supported: HashSet<SegmentType> = supported_segment_types.iter().copied().collect();
+
+    if let Some(config) = configuration.as_ref() {
+        match &config.vector_index {
+            VectorIndexConfiguration::Spann { .. } => {
+                if !supported.contains(&SegmentType::Spann)
+                    && !supported.contains(&SegmentType::QuantizedSpann)
+                {
+                    return Err(CreateCollectionError::SpannNotImplemented);
+                }
+            }
+            VectorIndexConfiguration::Hnsw { .. } => {
+                if !supported.contains(&SegmentType::HnswDistributed)
+                    && !supported.contains(&SegmentType::HnswLocalMemory)
+                    && !supported.contains(&SegmentType::HnswLocalPersisted)
+                {
+                    return Err(CreateCollectionError::HnswNotSupported);
+                }
+            }
+        }
+    }
+
+    match default_knn_index {
+        KnnIndex::Spann => {
+            if !supported.contains(&SegmentType::Spann)
+                && !supported.contains(&SegmentType::QuantizedSpann)
+            {
+                return Err(CreateCollectionError::SpannNotImplemented);
+            }
+        }
+        KnnIndex::Hnsw => {
+            if !supported.contains(&SegmentType::HnswDistributed)
+                && !supported.contains(&SegmentType::HnswLocalMemory)
+                && !supported.contains(&SegmentType::HnswLocalPersisted)
+            {
+                return Err(CreateCollectionError::HnswNotSupported);
+            }
+        }
+    }
+
+    let mut reconciled_schema = if enable_schema {
+        // It's safe to take here, bc we're moving all config info to schema
+        // when configuration is None, we then populate in sysdb with empty
+        // config {} — this allows for easier migration paths in the future.
+        let config_for_reconcile = configuration.take();
+        match Schema::reconcile_schema_and_config(
+            schema.as_ref(),
+            config_for_reconcile.as_ref(),
+            default_knn_index,
+        ) {
+            Ok(schema) => Some(schema),
+            Err(e) => return Err(CreateCollectionError::InvalidSchema(e)),
+        }
+    } else {
+        None
+    };
+
+    if let Some(ref mut schema) = reconciled_schema {
+        if tenant_flags.enable_quantization {
+            schema.quantize(Quantization::FourBitRabitQWithUSearch);
+        }
+        if tenant_flags.enable_maxscore {
+            schema.set_sparse_algorithm(SparseIndexAlgorithm::MaxScore);
+        }
+    }
+
+    let segments = match executor_kind {
+        ExecutorKind::Distributed => {
+            let mut vector_segment_type = SegmentType::HnswDistributed;
+            if enable_schema {
+                if let Some(schema) = reconciled_schema.as_ref() {
+                    if schema.get_internal_spann_config().is_some() {
+                        // Use QuantizedSpann if quantization is enabled,
+                        // otherwise plain Spann.
+                        if schema.is_quantization_enabled() {
+                            vector_segment_type = SegmentType::QuantizedSpann;
+                        } else {
+                            vector_segment_type = SegmentType::Spann;
+                        }
+                    }
+                }
+            }
+            if let Some(config) = configuration.as_ref() {
+                if matches!(config.vector_index, VectorIndexConfiguration::Spann(_)) {
+                    vector_segment_type = SegmentType::Spann;
+                }
+            }
+
+            vec![
+                Segment {
+                    id: SegmentUuid::new(),
+                    r#type: vector_segment_type,
+                    scope: SegmentScope::VECTOR,
+                    collection: collection_id,
+                    metadata: None,
+                    file_path: Default::default(),
+                },
+                Segment {
+                    id: SegmentUuid::new(),
+                    r#type: SegmentType::BlockfileMetadata,
+                    scope: SegmentScope::METADATA,
+                    collection: collection_id,
+                    metadata: None,
+                    file_path: Default::default(),
+                },
+                Segment {
+                    id: SegmentUuid::new(),
+                    r#type: SegmentType::BlockfileRecord,
+                    scope: SegmentScope::RECORD,
+                    collection: collection_id,
+                    metadata: None,
+                    file_path: Default::default(),
+                },
+            ]
+        }
+        ExecutorKind::Local => {
+            if enable_schema {
+                if let Some(schema) = reconciled_schema.as_ref() {
+                    if schema.is_sparse_index_enabled() {
+                        return Err(CreateCollectionError::InvalidSchema(
+                            SchemaError::InvalidUserInput {
+                                reason: "Sparse vector indexing is not enabled in local"
+                                    .to_string(),
+                            },
+                        ));
+                    }
+                }
+            }
+
+            vec![
+                Segment {
+                    id: SegmentUuid::new(),
+                    r#type: SegmentType::HnswLocalPersisted,
+                    scope: SegmentScope::VECTOR,
+                    collection: collection_id,
+                    metadata: None,
+                    file_path: Default::default(),
+                },
+                Segment {
+                    id: SegmentUuid::new(),
+                    r#type: SegmentType::Sqlite,
+                    scope: SegmentScope::METADATA,
+                    collection: collection_id,
+                    metadata: None,
+                    file_path: Default::default(),
+                },
+            ]
+        }
+    };
+
+    Ok(CreateCollectionPlan {
+        collection_id,
+        segments,
+        configuration,
+        schema: reconciled_schema,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn distributed_supported() -> Vec<SegmentType> {
+        supported_segment_types(ExecutorKind::Distributed)
+    }
+
+    fn local_supported() -> Vec<SegmentType> {
+        supported_segment_types(ExecutorKind::Local)
+    }
+
+    #[test]
+    fn distributed_default_is_hnsw_trio() {
+        let plan = plan_create_collection(
+            None,
+            None,
+            ExecutorKind::Distributed,
+            &distributed_supported(),
+            false,
+            KnnIndex::Hnsw,
+            TenantFeatureFlags::default(),
+        )
+        .expect("plan");
+
+        assert_eq!(plan.segments.len(), 3);
+        assert!(plan
+            .segments
+            .iter()
+            .any(|s| s.r#type == SegmentType::HnswDistributed && s.scope == SegmentScope::VECTOR));
+        assert!(plan.segments.iter().any(
+            |s| s.r#type == SegmentType::BlockfileMetadata && s.scope == SegmentScope::METADATA
+        ));
+        assert!(plan
+            .segments
+            .iter()
+            .any(|s| s.r#type == SegmentType::BlockfileRecord && s.scope == SegmentScope::RECORD));
+    }
+
+    #[test]
+    fn local_default_is_two_segments() {
+        let plan = plan_create_collection(
+            None,
+            None,
+            ExecutorKind::Local,
+            &local_supported(),
+            false,
+            KnnIndex::Hnsw,
+            TenantFeatureFlags::default(),
+        )
+        .expect("plan");
+
+        assert_eq!(plan.segments.len(), 2);
+        assert!(plan
+            .segments
+            .iter()
+            .any(|s| s.r#type == SegmentType::HnswLocalPersisted));
+        assert!(plan
+            .segments
+            .iter()
+            .any(|s| s.r#type == SegmentType::Sqlite));
+    }
+
+    #[test]
+    fn rejects_spann_when_unsupported() {
+        // Local supports no Spann variants; if the default knn is Spann the
+        // planner must refuse.
+        let err = plan_create_collection(
+            None,
+            None,
+            ExecutorKind::Local,
+            &local_supported(),
+            false,
+            KnnIndex::Spann,
+            TenantFeatureFlags::default(),
+        )
+        .expect_err("should reject Spann default on local executor");
+        assert!(matches!(err, CreateCollectionError::SpannNotImplemented));
+    }
+
+    #[test]
+    fn distinct_collection_ids_per_plan() {
+        let plan_a = plan_create_collection(
+            None,
+            None,
+            ExecutorKind::Distributed,
+            &distributed_supported(),
+            false,
+            KnnIndex::Hnsw,
+            TenantFeatureFlags::default(),
+        )
+        .unwrap();
+        let plan_b = plan_create_collection(
+            None,
+            None,
+            ExecutorKind::Distributed,
+            &distributed_supported(),
+            false,
+            KnnIndex::Hnsw,
+            TenantFeatureFlags::default(),
+        )
+        .unwrap();
+        assert_ne!(plan_a.collection_id, plan_b.collection_id);
+    }
+}

--- a/rust/frontend-core/src/lib.rs
+++ b/rust/frontend-core/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod ac;
 pub mod auth;
+pub mod collection_ops;
 pub mod config;
 pub mod errors;
 pub mod middleware;

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -43,17 +43,15 @@ use chroma_types::{
     GetTenantResponse, HealthCheckResponse, HeartbeatError, Include, IndexStatusError,
     IndexStatusResponse, KnnIndex, ListCollectionsRequest, ListCollectionsResponse,
     ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse, Operation, OperationRecord,
-    Quantization, QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse, Schema,
-    SchemaError, SearchRequest, SearchResponse, Segment, SegmentScope, SegmentType, SegmentUuid,
-    SparseIndexAlgorithm, UpdateCollectionError, UpdateCollectionRecordsError,
+    QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse, Schema, SearchRequest,
+    SearchResponse, SegmentType, UpdateCollectionError, UpdateCollectionRecordsError,
     UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse, UpdateCollectionRequest,
     UpdateCollectionResponse, UpdateTenantError, UpdateTenantRequest, UpdateTenantResponse,
     UpsertCollectionRecordsError, UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse,
-    VectorIndexConfiguration, Where,
+    Where,
 };
 use opentelemetry::global;
 use opentelemetry::metrics::Counter;
-use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -1153,182 +1151,35 @@ impl ServiceBasedFrontend {
             database_name,
             name,
             metadata,
-            mut configuration,
+            configuration,
             schema,
             get_or_create,
             ..
         }: CreateCollectionRequest,
     ) -> Result<CreateCollectionResponse, CreateCollectionError> {
-        let collection_id = CollectionUuid::new();
-
-        let supported_segment_types: HashSet<SegmentType> =
-            self.get_supported_segment_types().into_iter().collect();
-
-        if let Some(config) = configuration.as_ref() {
-            match &config.vector_index {
-                VectorIndexConfiguration::Spann { .. } => {
-                    if !supported_segment_types.contains(&SegmentType::Spann)
-                        && !supported_segment_types.contains(&SegmentType::QuantizedSpann)
-                    {
-                        return Err(CreateCollectionError::SpannNotImplemented);
-                    }
-                }
-                VectorIndexConfiguration::Hnsw { .. } => {
-                    if !supported_segment_types.contains(&SegmentType::HnswDistributed)
-                        && !supported_segment_types.contains(&SegmentType::HnswLocalMemory)
-                        && !supported_segment_types.contains(&SegmentType::HnswLocalPersisted)
-                    {
-                        return Err(CreateCollectionError::HnswNotSupported);
-                    }
-                }
-            }
-        }
-
-        // Check default server configuration's index type
-        match self.default_knn_index {
-            KnnIndex::Spann => {
-                if !supported_segment_types.contains(&SegmentType::Spann)
-                    && !supported_segment_types.contains(&SegmentType::QuantizedSpann)
-                {
-                    return Err(CreateCollectionError::SpannNotImplemented);
-                }
-            }
-            KnnIndex::Hnsw => {
-                if !supported_segment_types.contains(&SegmentType::HnswDistributed)
-                    && !supported_segment_types.contains(&SegmentType::HnswLocalMemory)
-                    && !supported_segment_types.contains(&SegmentType::HnswLocalPersisted)
-                {
-                    return Err(CreateCollectionError::HnswNotSupported);
-                }
-            }
-        }
-
-        let mut reconciled_schema = if self.enable_schema {
-            // its safe to take here, bc we're moving all config info to schema
-            // when configuration is None, we then populate in sysdb with empty config {}
-            // this allows for easier migration paths in the future
-            let config_for_reconcile = configuration.take();
-            match Schema::reconcile_schema_and_config(
-                schema.as_ref(),
-                config_for_reconcile.as_ref(),
-                self.default_knn_index,
-            ) {
-                Ok(schema) => Some(schema),
-                Err(e) => {
-                    return Err(CreateCollectionError::InvalidSchema(e));
-                }
-            }
-        } else {
-            None
-        };
-
-        // Enable quantization for tenants in the config list (or all tenants if "*" is present)
-        if let Some(ref mut schema) = reconciled_schema {
-            if self.should_enable_quantization_for_tenant(&tenant_id) {
-                schema.quantize(Quantization::FourBitRabitQWithUSearch);
-            }
-        }
-
-        // Enable MaxScore sparse index for tenants in the config list
-        if let Some(ref mut schema) = reconciled_schema {
-            if self.should_enable_maxscore_for_tenant(&tenant_id) {
-                schema.set_sparse_algorithm(SparseIndexAlgorithm::MaxScore);
-            }
-        }
-
-        let segments = match self.executor {
-            Executor::Distributed(_) => {
-                let mut vector_segment_type = SegmentType::HnswDistributed;
-                if self.enable_schema {
-                    if let Some(schema) = reconciled_schema.as_ref() {
-                        if schema.get_internal_spann_config().is_some() {
-                            // Use QuantizedSpann if quantization is enabled, otherwise use Spann
-                            if schema.is_quantization_enabled() {
-                                vector_segment_type = SegmentType::QuantizedSpann;
-                            } else {
-                                vector_segment_type = SegmentType::Spann;
-                            }
-                        }
-                    }
-                }
-                if let Some(config) = configuration.as_ref() {
-                    if matches!(config.vector_index, VectorIndexConfiguration::Spann(_)) {
-                        vector_segment_type = SegmentType::Spann;
-                    }
-                }
-
-                vec![
-                    Segment {
-                        id: SegmentUuid::new(),
-                        r#type: vector_segment_type,
-                        scope: SegmentScope::VECTOR,
-                        collection: collection_id,
-                        metadata: None,
-                        file_path: Default::default(),
-                    },
-                    Segment {
-                        id: SegmentUuid::new(),
-                        r#type: SegmentType::BlockfileMetadata,
-                        scope: SegmentScope::METADATA,
-                        collection: collection_id,
-                        metadata: None,
-                        file_path: Default::default(),
-                    },
-                    Segment {
-                        id: SegmentUuid::new(),
-                        r#type: SegmentType::BlockfileRecord,
-                        scope: SegmentScope::RECORD,
-                        collection: collection_id,
-                        metadata: None,
-                        file_path: Default::default(),
-                    },
-                ]
-            }
-            Executor::Local(_) => {
-                if self.enable_schema {
-                    if let Some(schema) = reconciled_schema.as_ref() {
-                        if schema.is_sparse_index_enabled() {
-                            return Err(CreateCollectionError::InvalidSchema(
-                                SchemaError::InvalidUserInput {
-                                    reason: "Sparse vector indexing is not enabled in local"
-                                        .to_string(),
-                                },
-                            ));
-                        }
-                    }
-                }
-
-                vec![
-                    Segment {
-                        id: SegmentUuid::new(),
-                        r#type: SegmentType::HnswLocalPersisted,
-                        scope: SegmentScope::VECTOR,
-                        collection: collection_id,
-                        metadata: None,
-                        file_path: Default::default(),
-                    },
-                    Segment {
-                        id: SegmentUuid::new(),
-                        r#type: SegmentType::Sqlite,
-                        scope: SegmentScope::METADATA,
-                        collection: collection_id,
-                        metadata: None,
-                        file_path: Default::default(),
-                    },
-                ]
-            }
-        };
+        let plan = frontend_core::collection_ops::plan_create_collection(
+            configuration,
+            schema,
+            executor_kind(&self.executor),
+            &self.get_supported_segment_types(),
+            self.enable_schema,
+            self.default_knn_index,
+            frontend_core::collection_ops::TenantFeatureFlags {
+                enable_quantization: self.should_enable_quantization_for_tenant(&tenant_id),
+                enable_maxscore: self.should_enable_maxscore_for_tenant(&tenant_id),
+            },
+        )?;
 
         let mut collection = self
             .sysdb_client
             .create_collection(
                 tenant_id.clone(),
                 database_name,
-                collection_id,
+                plan.collection_id,
                 name,
-                segments,
-                configuration,
-                reconciled_schema,
+                plan.segments,
+                plan.configuration,
+                plan.schema,
                 metadata,
                 None,
                 get_or_create,
@@ -1337,10 +1188,11 @@ impl ServiceBasedFrontend {
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
         self.collections_with_segments_provider
             .collections_with_segments_cache
-            .remove(&collection_id)
+            .remove(&plan.collection_id)
             .await;
-        // this is done in the case that get_or_create was a get, in which case we should reconcile the schema and config
-        // that was retrieved from sysdb, rather than the one that was passed in
+        // this is done in the case that get_or_create was a get, in which
+        // case we should reconcile the schema and config that was retrieved
+        // from sysdb, rather than the one that was passed in.
         if self.enable_schema {
             collection
                 .reconcile_schema_for_read()
@@ -2851,6 +2703,15 @@ impl ServiceBasedFrontend {
     }
 }
 
+/// Map the heavyweight `Executor` enum to the lightweight discriminant the
+/// shared collection-ops planner consumes.
+fn executor_kind(executor: &Executor) -> frontend_core::collection_ops::ExecutorKind {
+    match executor {
+        Executor::Distributed(_) => frontend_core::collection_ops::ExecutorKind::Distributed,
+        Executor::Local(_) => frontend_core::collection_ops::ExecutorKind::Local,
+    }
+}
+
 #[async_trait::async_trait]
 impl Configurable<(FrontendConfig, System)> for ServiceBasedFrontend {
     async fn try_from_config(
@@ -2922,6 +2783,7 @@ mod tests {
     use chroma_config::registry::Registry;
     use chroma_sysdb::GrpcSysDbConfig;
     use chroma_types::Collection;
+    use chroma_types::SegmentScope;
     use uuid::Uuid;
 
     use chroma_types::CreateCollectionPayload;


### PR DESCRIPTION
Pull the segment dispatch, schema reconciliation, and tenant feature-flag
application out of ServiceBasedFrontend::create_collection into a new
pure-library crate so chroma-frontend and foundation-api can share one
source of truth for how a Chroma collection is laid out.

The planner is stateless: callers pass executor kind (a discriminant
only, no executor state), supported segment types, the schema/quantize
toggles, and per-tenant flags as inputs; it returns a CreateCollectionPlan
containing the collection_id, segment list, reconciled configuration, and
reconciled schema, ready to hand to SysDb::create_collection.

ServiceBasedFrontend::create_collection becomes a ~30-line wrapper around
the planner that still owns the chroma-frontend-specific concerns
(sysdb call, cache invalidation via CollectionsWithSegmentsProvider,
read-side schema reconcile). Behavior is unchanged.

No new crate dependencies on chroma-frontend, chroma-sysdb, or
chroma-segment — the planner only needs chroma-types and chroma-error.

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
