### PR TITLE
[BUG]: Allow fn-consumer to read memberlists

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -287,6 +287,10 @@ k8s_resource(
     'compaction-service-serviceaccount:ServiceAccount:chroma',
     'compaction-service-serviceaccount-rolebinding:RoleBinding:chroma',
 
+    'fn-consumer-rust-log-service-memberlist-binding:RoleBinding:chroma',
+    'fn-consumer-service-account:ServiceAccount:chroma',
+    'fn-consumer-service-serviceaccount-rolebinding:RoleBinding:chroma',
+
     'rust-frontend-service-serviceaccount:ServiceAccount:chroma',
     'rust-frontend-service-rolebinding:RoleBinding:chroma',
     'rust-frontend-service-query-service-memberlist-binding:RoleBinding:chroma',

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.85
+version: 0.1.86
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-log-service-memberlist-cr.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service-memberlist-cr.yaml
@@ -60,3 +60,20 @@ subjects:
 - kind: ServiceAccount
   name: rust-frontend-service-serviceaccount
   namespace: {{ .Values.namespace }}
+
+---
+
+# Allows the fn-consumer service to read the rust-log-service-memberlist
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fn-consumer-rust-log-service-memberlist-binding
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rust-log-service-memberlist-readerwriter
+subjects:
+- kind: ServiceAccount
+  name: fn-consumer-service-account
+  namespace: {{ .Values.namespace }}


### PR DESCRIPTION
## Description of changes

fn-consumer service needs to be able to read memberlists.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_