### PR TITLE
fix: enforce exact name match in get_collection

### DIFF
--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -1076,9 +1076,10 @@ impl ServiceBasedFrontend {
                     .map_err(GetCollectionError::InvalidSchema)?;
             }
         }
-        collections
-            .pop()
-            .ok_or(GetCollectionError::NotFound(collection_name))
+       match collections.pop() {
+            Some(collection) if collection.name == collection_name => Ok(collection),
+            _ => Err(GetCollectionError::NotFound(collection_name)),
+        }
     }
 
     pub async fn get_collection_by_crn(


### PR DESCRIPTION
## Summary
Fixes #7063

`get_collection()` was returning a collection even when the requested 
name didn't exactly match. For example, querying `colls` would return 
`coll` if it existed.

## Root Cause
The `sysdb` query uses a partial/prefix match internally. The frontend 
never verified that the returned collection's name exactly matched the 
requested name.

## Fix
Added an exact name check after fetching from sysdb:
- If the returned collection name matches exactly → return it
- If not → return `NotFound` error

## Testing
- [ ] Existing tests pass
- [ ] Manual test: querying `colls` when only `coll` exists now returns 404