### PR TITLE
[BUG] support CHROMA_HOST as endpoint fallback

### DIFF
--- a/rust/chroma/README.md
+++ b/rust/chroma/README.md
@@ -42,6 +42,8 @@ let client = ChromaHttpClient::cloud()?;
 This will automatically read the following environment variables to set up a Chroma client:
 - `CHROMA_ENDPOINT` sets the URL for Chroma.  For Chroma Cloud this is `https://api.trychroma.com`.
   There is no need to set this environment variable if you want to work with Cloud directly.
+  `CHROMA_HOST` is also supported as a fallback when `CHROMA_ENDPOINT` is unset, and may be
+  a bare host such as `api.devchroma.com`.
 - `CHROMA_API_KEY` sets the API key to authenticate to Chroma.  This should be a Chroma-provided API
   key.  To generate a key, log in to [the Chroma dashboard](https://trychroma.com), create or select
   a database, and look for how to connect to your database under "settings".

--- a/rust/chroma/src/client/chroma_http_client.rs
+++ b/rust/chroma/src/client/chroma_http_client.rs
@@ -32,12 +32,12 @@ const USER_AGENT: &str = concat!(
 #[derive(Error, Debug)]
 pub enum ChromaHttpClientError {
     /// Network-level HTTP request failed.
-    #[error("Request error: {0:?}")]
+    #[error("Request error: {0}")]
     RequestError(#[from] reqwest::Error),
     /// Chroma API returned an error status with a structured error message.
     ///
     /// Contains the error message from the server and the HTTP status code that triggered the error.
-    #[error("API error: {0:?} ({1})")]
+    #[error("API error: {0} ({1})")]
     ApiError(String, reqwest::StatusCode),
     /// Client lacks access to a unique database or cannot determine which database to use.
     #[error("Could not resolve database ID: {0}")]
@@ -268,8 +268,9 @@ impl ChromaHttpClient {
 
     /// Constructs a client from environment variables.
     ///
-    /// Reads configuration from `CHROMA_ENDPOINT`, `CHROMA_TENANT`, and `CHROMA_DATABASE`.
-    /// Falls back to default local endpoint if `CHROMA_ENDPOINT` is not set.
+    /// Reads configuration from `CHROMA_ENDPOINT`, `CHROMA_HOST`, `CHROMA_TENANT`,
+    /// and `CHROMA_DATABASE`. Falls back to default local endpoint if neither
+    /// `CHROMA_ENDPOINT` nor `CHROMA_HOST` is set.
     ///
     /// # Errors
     ///
@@ -291,8 +292,9 @@ impl ChromaHttpClient {
 
     /// Constructs a client configured for Chroma Cloud from environment variables.
     ///
-    /// Reads `CHROMA_API_KEY` (required), `CHROMA_ENDPOINT` (defaults to Chroma Cloud),
-    /// `CHROMA_TENANT`, and `CHROMA_DATABASE` from the environment.
+    /// Reads `CHROMA_API_KEY` (required), `CHROMA_ENDPOINT` or `CHROMA_HOST`
+    /// (defaults to Chroma Cloud), `CHROMA_TENANT`, and `CHROMA_DATABASE` from
+    /// the environment.
     ///
     /// # Errors
     ///

--- a/rust/chroma/src/client/options.rs
+++ b/rust/chroma/src/client/options.rs
@@ -110,6 +110,37 @@ pub enum ChromaHttpClientOptionsError {
 const DEFAULT_LOCAL_ENDPOINT: &str = "http://localhost:8000";
 const DEFAULT_CLOUD_ENDPOINT: &str = "https://api.trychroma.com";
 
+fn endpoint_from_env(default_endpoint: &str) -> Result<reqwest::Url, ChromaHttpClientOptionsError> {
+    let default_endpoint = default_endpoint.parse().expect("valid URL");
+
+    if let Ok(endpoint) = std::env::var("CHROMA_ENDPOINT") {
+        return endpoint
+            .parse::<reqwest::Url>()
+            .map_err(|err| ChromaHttpClientOptionsError::InvalidEndpoint(err.to_string()));
+    }
+
+    if let Ok(host) = std::env::var("CHROMA_HOST") {
+        return endpoint_from_host(&host, &default_endpoint);
+    }
+
+    Ok(default_endpoint)
+}
+
+fn endpoint_from_host(
+    host: &str,
+    default_endpoint: &reqwest::Url,
+) -> Result<reqwest::Url, ChromaHttpClientOptionsError> {
+    let endpoint = if host.contains("://") {
+        host.to_string()
+    } else {
+        format!("{}://{}", default_endpoint.scheme(), host)
+    };
+
+    endpoint
+        .parse::<reqwest::Url>()
+        .map_err(|err| ChromaHttpClientOptionsError::InvalidEndpoint(err.to_string()))
+}
+
 /// Configuration bundle for initializing a Chroma client.
 ///
 /// Aggregates connection parameters, authentication credentials, and operational policies
@@ -151,6 +182,7 @@ impl ChromaHttpClientOptions {
     ///
     /// Reads:
     /// - `CHROMA_ENDPOINT` (optional, defaults to `http://localhost:8000`)
+    /// - `CHROMA_HOST` (optional URL or bare host fallback when `CHROMA_ENDPOINT` is unset)
     /// - `CHROMA_TENANT` (optional, defaults to `"default_tenant"`)
     /// - `CHROMA_DATABASE` (optional, defaults to `"default_database"`)
     ///
@@ -158,7 +190,7 @@ impl ChromaHttpClientOptions {
     ///
     /// # Errors
     ///
-    /// Returns an error if `CHROMA_ENDPOINT` is set but cannot be parsed as a URL.
+    /// Returns an error if `CHROMA_ENDPOINT` or `CHROMA_HOST` is set but cannot be parsed as a URL.
     ///
     /// # Examples
     ///
@@ -171,10 +203,7 @@ impl ChromaHttpClientOptions {
     /// # }
     /// ```
     pub fn from_env() -> Result<Self, ChromaHttpClientOptionsError> {
-        let endpoint = std::env::var("CHROMA_ENDPOINT")
-            .map(|s| s.parse())
-            .unwrap_or(Ok(ChromaHttpClientOptions::default().endpoint))
-            .map_err(|err| ChromaHttpClientOptionsError::InvalidEndpoint(err.to_string()))?;
+        let endpoint = endpoint_from_env(DEFAULT_LOCAL_ENDPOINT)?;
 
         let tenant_id = std::env::var("CHROMA_TENANT").unwrap_or("default_tenant".to_string());
         let database_name =
@@ -193,6 +222,7 @@ impl ChromaHttpClientOptions {
     /// Reads:
     /// - `CHROMA_API_KEY` (required)
     /// - `CHROMA_ENDPOINT` (optional, defaults to `https://api.trychroma.com`)
+    /// - `CHROMA_HOST` (optional URL or bare host fallback when `CHROMA_ENDPOINT` is unset)
     /// - `CHROMA_TENANT` (optional, will be auto-resolved if not provided)
     /// - `CHROMA_DATABASE` (optional, will be auto-resolved if not provided)
     ///
@@ -200,7 +230,7 @@ impl ChromaHttpClientOptions {
     ///
     /// Returns an error if:
     /// - `CHROMA_API_KEY` is not set
-    /// - `CHROMA_ENDPOINT` is set but cannot be parsed as a URL
+    /// - `CHROMA_ENDPOINT` or `CHROMA_HOST` is set but cannot be parsed as a URL
     /// - The API key contains invalid header characters
     ///
     /// # Examples
@@ -214,10 +244,7 @@ impl ChromaHttpClientOptions {
     /// # }
     /// ```
     pub fn from_cloud_env() -> Result<Self, ChromaHttpClientOptionsError> {
-        let endpoint = std::env::var("CHROMA_ENDPOINT")
-            .map(|s| s.parse::<reqwest::Url>())
-            .unwrap_or(Ok(DEFAULT_CLOUD_ENDPOINT.parse().expect("valid URL")))
-            .map_err(|err| ChromaHttpClientOptionsError::InvalidEndpoint(err.to_string()))?;
+        let endpoint = endpoint_from_env(DEFAULT_CLOUD_ENDPOINT)?;
 
         let api_key = std::env::var("CHROMA_API_KEY").map_err(|_| {
             ChromaHttpClientOptionsError::MissingConfiguration("CHROMA_API_KEY".to_string())
@@ -321,5 +348,128 @@ impl ChromaHttpClientOptions {
             ChromaAuthMethod::None => {}
         }
         headers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    const ENV_KEYS: [&str; 5] = [
+        "CHROMA_API_KEY",
+        "CHROMA_DATABASE",
+        "CHROMA_ENDPOINT",
+        "CHROMA_HOST",
+        "CHROMA_TENANT",
+    ];
+
+    struct EnvSnapshot {
+        values: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvSnapshot {
+        fn capture() -> Self {
+            Self {
+                values: ENV_KEYS
+                    .into_iter()
+                    .map(|key| (key, std::env::var(key).ok()))
+                    .collect(),
+            }
+        }
+
+        fn clear() {
+            for key in ENV_KEYS {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (key, value) in &self.values {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    fn with_chroma_env<T>(vars: &[(&'static str, &'static str)], test: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _snapshot = EnvSnapshot::capture();
+        EnvSnapshot::clear();
+        for (key, value) in vars {
+            std::env::set_var(key, value);
+        }
+        test()
+    }
+
+    #[test]
+    fn from_env_uses_chroma_host_when_endpoint_is_unset() {
+        with_chroma_env(&[("CHROMA_HOST", "http://example.com:9000")], || {
+            let options = ChromaHttpClientOptions::from_env().unwrap();
+
+            assert_eq!(options.endpoint.as_str(), "http://example.com:9000/");
+        });
+    }
+
+    #[test]
+    fn from_env_uses_bare_chroma_host_with_local_scheme() {
+        with_chroma_env(&[("CHROMA_HOST", "localhost:9000")], || {
+            let options = ChromaHttpClientOptions::from_env().unwrap();
+
+            assert_eq!(options.endpoint.as_str(), "http://localhost:9000/");
+        });
+    }
+
+    #[test]
+    fn from_env_prefers_chroma_endpoint_over_chroma_host() {
+        with_chroma_env(
+            &[
+                ("CHROMA_ENDPOINT", "http://endpoint.example.com:9000"),
+                ("CHROMA_HOST", "http://host.example.com:9000"),
+            ],
+            || {
+                let options = ChromaHttpClientOptions::from_env().unwrap();
+
+                assert_eq!(
+                    options.endpoint.as_str(),
+                    "http://endpoint.example.com:9000/"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn from_cloud_env_uses_chroma_host_when_endpoint_is_unset() {
+        with_chroma_env(
+            &[
+                ("CHROMA_API_KEY", "test-key"),
+                ("CHROMA_HOST", "https://cloud.example.com"),
+            ],
+            || {
+                let options = ChromaHttpClientOptions::from_cloud_env().unwrap();
+
+                assert_eq!(options.endpoint.as_str(), "https://cloud.example.com/");
+            },
+        );
+    }
+
+    #[test]
+    fn from_cloud_env_uses_bare_chroma_host_with_cloud_scheme() {
+        with_chroma_env(
+            &[
+                ("CHROMA_API_KEY", "test-key"),
+                ("CHROMA_HOST", "api.devchroma.com"),
+            ],
+            || {
+                let options = ChromaHttpClientOptions::from_cloud_env().unwrap();
+
+                assert_eq!(options.endpoint.as_str(), "https://api.devchroma.com/");
+            },
+        );
     }
 }


### PR DESCRIPTION
## Description of changes

Add CHROMA_HOST environment variable as a fallback when CHROMA_ENDPOINT
is unset. A bare hostname like "api.devchroma.com" inherits the scheme
from the default endpoint (http for local, https for cloud). A full URL
is used as-is.

- Extract endpoint_from_env and endpoint_from_host helpers in options.rs
- Update from_env and from_cloud_env to use the shared helpers
- Fix Display formatting for RequestError and ApiError (remove :?)
- Update README.md to document CHROMA_HOST
- Add unit tests for host fallback, scheme inference, and precedence

## Test plan

CI

## Migration plan

backwards-compat

## Observability plan

N/A

## Documentation Changes

README.md updated.

Co-authored-by: AI
