### PR TITLE
[ENH] add client-side embedding support to Rust Chroma client

### DIFF
--- a/rust/chroma/README.md
+++ b/rust/chroma/README.md
@@ -42,6 +42,8 @@ let client = ChromaHttpClient::cloud()?;
 This will automatically read the following environment variables to set up a Chroma client:
 - `CHROMA_ENDPOINT` sets the URL for Chroma.  For Chroma Cloud this is `https://api.trychroma.com`.
   There is no need to set this environment variable if you want to work with Cloud directly.
+  `CHROMA_HOST` is also supported as a fallback when `CHROMA_ENDPOINT` is unset, and may be
+  a bare host such as `api.devchroma.com`.
 - `CHROMA_API_KEY` sets the API key to authenticate to Chroma.  This should be a Chroma-provided API
   key.  To generate a key, log in to [the Chroma dashboard](https://trychroma.com), create or select
   a database, and look for how to connect to your database under "settings".

--- a/rust/chroma/examples/cloud-embeddings.rs
+++ b/rust/chroma/examples/cloud-embeddings.rs
@@ -1,0 +1,399 @@
+//! End-to-end Chroma Cloud embedding example.
+//!
+//! This example uses `ChromaHttpClientOptions::from_cloud_env()` so credentials
+//! and routing come from:
+//!
+//! - `CHROMA_API_KEY` (required)
+//! - `CHROMA_TENANT` (optional if the API key resolves to one tenant)
+//! - `CHROMA_DATABASE` (optional if the API key resolves to one database)
+//! - `CHROMA_ENDPOINT` (optional, defaults to Chroma Cloud)
+//! - `CHROMA_HOST` (optional URL or bare host fallback when `CHROMA_ENDPOINT` is unset)
+//! - `CHROMA_EMBED_URL` (optional, defaults to Chroma Cloud embeddings)
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run -p chroma --example cloud-embeddings
+//! ```
+
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chroma::client::{ChromaHttpClientError, ChromaHttpClientOptions, CreateCollectionOptions};
+use chroma::embed::chroma_cloud::{
+    ChromaCloudQwenEmbeddingFunction, ChromaCloudQwenOptions, ChromaCloudSpladeEmbeddingFunction,
+    ChromaCloudSpladeOptions,
+};
+use chroma::embed::{DenseEmbeddingFunction, SparseEmbeddingFunction};
+use chroma::types::{
+    Include, IncludeList, Key, Metadata, ReadLevel, Schema, SparseVectorIndexConfig,
+    UpdateMetadata, VectorIndexConfig,
+};
+use chroma::{
+    AddRecordsOptions, ChromaHttpClient, QueryRecordsOptions, SearchRecordsOptions,
+    UpdateRecordsOptions, UpsertRecordsOptions,
+};
+
+const SPARSE_KEY: &str = "sparse_embedding";
+
+type ExampleResult<T> = Result<T, ExampleError>;
+
+#[derive(Debug)]
+struct ExampleError {
+    context: String,
+    cause: Box<dyn Error + Send + Sync>,
+}
+
+impl ExampleError {
+    fn new(context: impl Into<String>, cause: impl Error + Send + Sync + 'static) -> Self {
+        Self {
+            context: context.into(),
+            cause: Box::new(cause),
+        }
+    }
+
+    fn contains_unauthorized_api_error(&self) -> bool {
+        let mut source: Option<&(dyn Error + 'static)> = Some(self.cause.as_ref());
+        while let Some(error) = source {
+            if let Some(ChromaHttpClientError::ApiError(_, status)) =
+                error.downcast_ref::<ChromaHttpClientError>()
+            {
+                if status.as_u16() == 401 {
+                    return true;
+                }
+            }
+            source = error.source();
+        }
+        false
+    }
+}
+
+impl Display for ExampleError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.context, self.cause)
+    }
+}
+
+impl Error for ExampleError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.cause.as_ref())
+    }
+}
+
+trait ResultContext<T> {
+    fn with_context(self, context: impl Into<String>) -> ExampleResult<T>;
+}
+
+impl<T, E> ResultContext<T> for Result<T, E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn with_context(self, context: impl Into<String>) -> ExampleResult<T> {
+        self.map_err(|error| ExampleError::new(context, error))
+    }
+}
+
+fn log_error(error: &ExampleError) {
+    eprintln!("\ncloud-embeddings failed while {}", error.context);
+    eprintln!("  error: {}", error.cause);
+
+    let mut source = error.cause.source();
+    while let Some(cause) = source {
+        eprintln!("  caused by: {cause}");
+        source = cause.source();
+    }
+
+    if error.contains_unauthorized_api_error() {
+        eprintln!(
+            "  hint: verify CHROMA_API_KEY, CHROMA_TENANT, CHROMA_DATABASE, and API key permissions"
+        );
+    }
+}
+
+fn metadata(topic: &str, operation: &str, priority: i64) -> Metadata {
+    Metadata::from([
+        ("topic".to_string(), topic.into()),
+        ("operation".to_string(), operation.into()),
+        ("priority".to_string(), priority.into()),
+    ])
+}
+
+fn update_metadata(topic: &str, operation: &str, priority: i64) -> UpdateMetadata {
+    UpdateMetadata::from([
+        ("topic".to_string(), topic.into()),
+        ("operation".to_string(), operation.into()),
+        ("priority".to_string(), priority.into()),
+    ])
+}
+
+fn print_get(label: &str, response: &chroma::types::GetResponse) {
+    println!("\n{label}");
+    for (index, id) in response.ids.iter().enumerate() {
+        let document = response
+            .documents
+            .as_ref()
+            .and_then(|documents| documents.get(index))
+            .and_then(|document| document.as_ref())
+            .map(String::as_str)
+            .unwrap_or("<no document>");
+        let topic = response
+            .metadatas
+            .as_ref()
+            .and_then(|metadatas| metadatas.get(index))
+            .and_then(|metadata| metadata.as_ref())
+            .and_then(|metadata| metadata.get("topic"));
+
+        println!("  {id}: topic={topic:?}; {document}");
+    }
+}
+
+fn print_query(label: &str, response: &chroma::types::QueryResponse) {
+    println!("\n{label}");
+    for (query_index, ids) in response.ids.iter().enumerate() {
+        println!("  query {query_index}");
+        for (rank, id) in ids.iter().enumerate() {
+            let distance = response
+                .distances
+                .as_ref()
+                .and_then(|distances| distances.get(query_index))
+                .and_then(|distances| distances.get(rank))
+                .and_then(|distance| *distance);
+            let document = response
+                .documents
+                .as_ref()
+                .and_then(|documents| documents.get(query_index))
+                .and_then(|documents| documents.get(rank))
+                .and_then(|document| document.as_ref())
+                .map(String::as_str)
+                .unwrap_or("<no document>");
+
+            println!("    {}. {id} distance={distance:?}; {document}", rank + 1);
+        }
+    }
+}
+
+fn print_search(label: &str, response: &chroma::types::SearchResponse) {
+    println!("\n{label}");
+    for (payload_index, ids) in response.ids.iter().enumerate() {
+        println!("  payload {payload_index}");
+        for (rank, id) in ids.iter().enumerate() {
+            let score = response
+                .scores
+                .get(payload_index)
+                .and_then(|scores| scores.as_ref())
+                .and_then(|scores| scores.get(rank))
+                .and_then(|score| *score);
+            let topic = response
+                .metadatas
+                .get(payload_index)
+                .and_then(|metadatas| metadatas.as_ref())
+                .and_then(|metadatas| metadatas.get(rank))
+                .and_then(|metadata| metadata.as_ref())
+                .and_then(|metadata| metadata.get("topic"));
+
+            println!("    {}. {id} score={score:?} topic={topic:?}", rank + 1);
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            log_error(&error);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> ExampleResult<()> {
+    let client = ChromaHttpClient::new(
+        ChromaHttpClientOptions::from_cloud_env()
+            .with_context("reading Chroma Cloud options from environment")?,
+    );
+    let tenant = client
+        .get_tenant_id()
+        .await
+        .with_context("resolving tenant")?;
+    let database = client
+        .get_database_name()
+        .await
+        .with_context("resolving database")?;
+    println!("Connected to Chroma Cloud tenant={tenant} database={database}");
+
+    let dense_embedding_function =
+        ChromaCloudQwenEmbeddingFunction::new(ChromaCloudQwenOptions::default());
+    let sparse_embedding_function =
+        ChromaCloudSpladeEmbeddingFunction::new(ChromaCloudSpladeOptions::default());
+
+    let schema = Schema::default()
+        .create_index(
+            None,
+            VectorIndexConfig {
+                space: Some(dense_embedding_function.default_space()),
+                embedding_function: Some(dense_embedding_function.configuration()),
+                source_key: None,
+                hnsw: None,
+                spann: None,
+            }
+            .into(),
+        )
+        .with_context("configuring dense vector index")?
+        .create_index(
+            Some(SPARSE_KEY),
+            SparseVectorIndexConfig {
+                embedding_function: Some(sparse_embedding_function.configuration()),
+                source_key: Some(Key::Document.to_string()),
+                bm25: Some(false),
+                algorithm: Default::default(),
+            }
+            .into(),
+        )
+        .with_context("configuring sparse vector index")?;
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .with_context("building collection name")?
+        .as_nanos();
+    let collection_name = format!("rust_cloud_embeddings_{suffix}");
+    let collection = client
+        .create_collection_with_options(
+            &collection_name,
+            CreateCollectionOptions {
+                schema: Some(schema),
+                metadata: Some(metadata("example", "create_collection", 0)),
+                configuration: None,
+                embedding_function: None,
+            },
+        )
+        .await
+        .with_context(format!("creating collection {collection_name}"))?;
+    println!("Created collection {}", collection.name());
+
+    collection
+        .add_records(AddRecordsOptions {
+            ids: vec![
+                "rust-client".to_string(),
+                "hybrid-search".to_string(),
+                "schema-guide".to_string(),
+            ],
+            documents: vec![
+                "The Rust client can embed documents before adding them.".to_string(),
+                "Hybrid search combines dense semantic retrieval with sparse lexical retrieval."
+                    .to_string(),
+                "Collection schemas configure vector and sparse vector indexes.".to_string(),
+            ],
+            metadatas: Some(vec![
+                Some(metadata("rust", "add", 1)),
+                Some(metadata("search", "add", 2)),
+                Some(metadata("schema", "add", 3)),
+            ]),
+            uris: None,
+        })
+        .await
+        .with_context("adding records")?;
+    println!("Added records with schema-defined dense and sparse embeddings");
+
+    collection
+        .update_records(UpdateRecordsOptions {
+            ids: vec!["schema-guide".to_string()],
+            documents: Some(vec![Some(
+                "Collection schemas can persist embedding functions for later queries.".to_string(),
+            )]),
+            metadatas: Some(vec![Some(update_metadata("schema", "update", 4))]),
+            uris: None,
+        })
+        .await
+        .with_context("updating records")?;
+    println!("Updated one record and regenerated its embeddings from the new document");
+
+    collection
+        .upsert_records(UpsertRecordsOptions {
+            ids: vec!["hybrid-search".to_string(), "operations-guide".to_string()],
+            documents: vec![
+                "Hybrid search can rank by dense and sparse vectors in one payload.".to_string(),
+                "Get, query, and search calls can reuse persisted cloud embedding configuration."
+                    .to_string(),
+            ],
+            metadatas: Some(vec![
+                Some(update_metadata("search", "upsert", 5)),
+                Some(update_metadata("operations", "upsert", 6)),
+            ]),
+            uris: None,
+        })
+        .await
+        .with_context("upserting records")?;
+    println!("Upserted existing and new records with embedding generation");
+
+    let collection = client
+        .get_collection(&collection_name)
+        .await
+        .with_context(format!("fetching collection {collection_name}"))?;
+    println!("Fetched collection again; embedding config is now loaded from Cloud");
+
+    let get_response = collection
+        .get(
+            Some(vec![
+                "rust-client".to_string(),
+                "hybrid-search".to_string(),
+                "operations-guide".to_string(),
+            ]),
+            None,
+            Some(10),
+            Some(0),
+            Some(IncludeList(vec![Include::Document, Include::Metadata])),
+        )
+        .await
+        .with_context("getting records")?;
+    print_get("Get records", &get_response);
+
+    let query_response = collection
+        .query_records(QueryRecordsOptions {
+            query_texts: vec!["How do I use Chroma embeddings from Rust?".to_string()],
+            n_results: Some(3),
+            include: Some(IncludeList(vec![
+                Include::Document,
+                Include::Metadata,
+                Include::Distance,
+            ])),
+            r#where: None,
+            ids: None,
+        })
+        .await
+        .with_context("querying records")?;
+    print_query("Dense query_records from text", &query_response);
+
+    let search_response = collection
+        .search_records(SearchRecordsOptions {
+            query_texts: vec!["dense sparse hybrid search in Rust".to_string()],
+            sparse_key: Some(SPARSE_KEY.to_string()),
+            r#where: None,
+            ids: None,
+            limit: Some(3),
+            offset: 0,
+            rank_limit: Some(16),
+            dense_weight: Some(0.7),
+            sparse_weight: Some(0.3),
+            select: Some(vec![
+                Key::Score,
+                Key::Document,
+                Key::field("topic"),
+                Key::field("operation"),
+            ]),
+            read_level: ReadLevel::IndexAndWal,
+        })
+        .await
+        .with_context("searching records")?;
+    print_search("Hybrid search_records from text", &search_response);
+
+    client
+        .delete_collection(&collection_name)
+        .await
+        .with_context(format!("deleting collection {collection_name}"))?;
+    println!("\nDeleted example collection {collection_name}");
+
+    Ok(())
+}

--- a/rust/chroma/src/client/chroma_http_client.rs
+++ b/rust/chroma/src/client/chroma_http_client.rs
@@ -983,9 +983,10 @@ impl ChromaHttpClient {
                 configuration.get_or_insert_with(CollectionConfiguration::default);
             collection_configuration.embedding_function = Some(embedding_function.configuration());
             if collection_configuration.hnsw.is_none() && collection_configuration.spann.is_none() {
-                let mut hnsw = HnswConfiguration::default();
-                hnsw.space = Some(embedding_function.default_space());
-                collection_configuration.hnsw = Some(hnsw);
+                collection_configuration.hnsw = Some(HnswConfiguration {
+                    space: Some(embedding_function.default_space()),
+                    ..Default::default()
+                });
             }
         }
 
@@ -1435,24 +1436,26 @@ mod tests {
     #[test_log::test]
     async fn get_or_create_collection_compares_returned_embedding_function() {
         let server = MockServer::start_async().await;
-        let mut collection = Collection::default();
-        collection.name = "existing".to_string();
-        collection.tenant = "tenant".to_string();
-        collection.database = "database".to_string();
-        collection.config = CollectionConfiguration {
-            embedding_function: Some(
-                (
-                    "chroma-cloud-qwen",
-                    serde_json::json!({
-                        "model": "different-model"
-                    }),
-                )
-                    .into(),
-            ),
+        let collection = Collection {
+            name: "existing".to_string(),
+            tenant: "tenant".to_string(),
+            database: "database".to_string(),
+            config: CollectionConfiguration {
+                embedding_function: Some(
+                    (
+                        "chroma-cloud-qwen",
+                        serde_json::json!({
+                            "model": "different-model"
+                        }),
+                    )
+                        .into(),
+                ),
+                ..Default::default()
+            }
+            .try_into()
+            .unwrap(),
             ..Default::default()
-        }
-        .try_into()
-        .unwrap();
+        };
 
         let mock = server
             .mock_async(|when, then| {

--- a/rust/chroma/src/client/chroma_http_client.rs
+++ b/rust/chroma/src/client/chroma_http_client.rs
@@ -32,12 +32,12 @@ const USER_AGENT: &str = concat!(
 #[derive(Error, Debug)]
 pub enum ChromaHttpClientError {
     /// Network-level HTTP request failed.
-    #[error("Request error: {0:?}")]
+    #[error("Request error: {0}")]
     RequestError(#[from] reqwest::Error),
     /// Chroma API returned an error status with a structured error message.
     ///
     /// Contains the error message from the server and the HTTP status code that triggered the error.
-    #[error("API error: {0:?} ({1})")]
+    #[error("API error: {0} ({1})")]
     ApiError(String, reqwest::StatusCode),
     /// Client lacks access to a unique database or cannot determine which database to use.
     #[error("Could not resolve database ID: {0}")]
@@ -268,8 +268,9 @@ impl ChromaHttpClient {
 
     /// Constructs a client from environment variables.
     ///
-    /// Reads configuration from `CHROMA_ENDPOINT`, `CHROMA_TENANT`, and `CHROMA_DATABASE`.
-    /// Falls back to default local endpoint if `CHROMA_ENDPOINT` is not set.
+    /// Reads configuration from `CHROMA_ENDPOINT`, `CHROMA_HOST`, `CHROMA_TENANT`,
+    /// and `CHROMA_DATABASE`. Falls back to default local endpoint if neither
+    /// `CHROMA_ENDPOINT` nor `CHROMA_HOST` is set.
     ///
     /// # Errors
     ///
@@ -291,8 +292,9 @@ impl ChromaHttpClient {
 
     /// Constructs a client configured for Chroma Cloud from environment variables.
     ///
-    /// Reads `CHROMA_API_KEY` (required), `CHROMA_ENDPOINT` (defaults to Chroma Cloud),
-    /// `CHROMA_TENANT`, and `CHROMA_DATABASE` from the environment.
+    /// Reads `CHROMA_API_KEY` (required), `CHROMA_ENDPOINT` or `CHROMA_HOST`
+    /// (defaults to Chroma Cloud), `CHROMA_TENANT`, and `CHROMA_DATABASE` from
+    /// the environment.
     ///
     /// # Errors
     ///

--- a/rust/chroma/src/client/chroma_http_client.rs
+++ b/rust/chroma/src/client/chroma_http_client.rs
@@ -3,6 +3,9 @@ use backon::Retryable;
 use chroma_api_types::ErrorResponse;
 use chroma_error::ChromaValidationError;
 use chroma_types::Collection;
+use chroma_types::CollectionConfiguration;
+use chroma_types::CreateCollectionPayload;
+use chroma_types::HnswConfiguration;
 use chroma_types::Metadata;
 use chroma_types::Schema;
 use chroma_types::WhereError;
@@ -21,6 +24,7 @@ use chroma_api_types::{GetUserIdentityResponse, HeartbeatResponse};
 use crate::client::ChromaHttpClientOptions;
 use crate::client::ChromaHttpClientOptionsError;
 use crate::collection::ChromaCollection;
+use crate::embed::{dense_embedding_function_from_config, DenseEmbeddingFunction, EmbeddingError};
 
 const USER_AGENT: &str = concat!(
     "Chroma Rust Client v",
@@ -60,6 +64,9 @@ pub enum ChromaHttpClientError {
     /// validation error from the where clause parser.
     #[error("Invalid where clause")]
     InvalidWhere,
+    /// Client-side embedding failed before sending the Chroma request.
+    #[error("Embedding error: {0}")]
+    EmbeddingError(#[from] EmbeddingError),
 }
 
 impl From<WhereError> for ChromaHttpClientError {
@@ -121,7 +128,8 @@ impl FailurePredicate<ChromaHttpClientError> for BackendFailurePredicate {
             ChromaHttpClientError::CouldNotResolveDatabaseId(_)
             | ChromaHttpClientError::ValidationError(_)
             | ChromaHttpClientError::NoBackendAvailable
-            | ChromaHttpClientError::InvalidWhere => false,
+            | ChromaHttpClientError::InvalidWhere
+            | ChromaHttpClientError::EmbeddingError(_) => false,
         }
     }
 }
@@ -172,6 +180,7 @@ pub struct ChromaHttpClient {
     base_url: reqwest::Url,
     clients: Vec<Backend>,
     retry_policy: ExponentialBuilder,
+    chroma_cloud_api_key: Option<String>,
     tenant_id: Arc<Mutex<Option<String>>>,
     database_name: Arc<Mutex<Option<String>>>,
     resolve_tenant_or_database_lock: Arc<tokio::sync::Mutex<()>>,
@@ -189,11 +198,32 @@ impl Clone for ChromaHttpClient {
             base_url: self.base_url.clone(),
             clients: self.clients.clone(),
             retry_policy: self.retry_policy,
+            chroma_cloud_api_key: self.chroma_cloud_api_key.clone(),
             tenant_id: Arc::new(Mutex::new(self.tenant_id.lock().clone())),
             database_name: Arc::new(Mutex::new(self.database_name.lock().clone())),
             resolve_tenant_or_database_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
+}
+
+/// Options for collection creation APIs.
+#[derive(Clone, Default)]
+pub struct CreateCollectionOptions {
+    /// Optional schema to use when creating the collection.
+    pub schema: Option<Schema>,
+    /// Optional collection metadata.
+    pub metadata: Option<Metadata>,
+    /// Optional collection configuration.
+    pub configuration: Option<CollectionConfiguration>,
+    /// Optional dense embedding function to attach to the collection handle.
+    pub embedding_function: Option<Arc<dyn DenseEmbeddingFunction>>,
+}
+
+/// Options for collection retrieval APIs.
+#[derive(Clone, Default)]
+pub struct GetCollectionOptions {
+    /// Optional dense embedding function to attach to the returned collection handle.
+    pub embedding_function: Option<Arc<dyn DenseEmbeddingFunction>>,
 }
 
 /// Represents a database within a Chroma tenant.
@@ -233,6 +263,10 @@ impl ChromaHttpClient {
     /// ```
     pub fn new(options: ChromaHttpClientOptions) -> Self {
         let mut headers = options.headers();
+        let chroma_cloud_api_key = headers
+            .get("x-chroma-token")
+            .and_then(|value| value.to_str().ok())
+            .map(|value| value.to_string());
         headers.append("user-agent", USER_AGENT.try_into().unwrap());
 
         let client = reqwest::Client::builder()
@@ -260,10 +294,15 @@ impl ChromaHttpClient {
             base_url: options.endpoint.clone(),
             clients,
             retry_policy: options.retry_options.into(),
+            chroma_cloud_api_key,
             tenant_id: Arc::new(Mutex::new(options.tenant_id)),
             database_name: Arc::new(Mutex::new(options.database_name)),
             resolve_tenant_or_database_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
+    }
+
+    pub(crate) fn chroma_cloud_api_key(&self) -> Option<String> {
+        self.chroma_cloud_api_key.clone()
     }
 
     /// Constructs a client from environment variables.
@@ -594,8 +633,24 @@ impl ChromaHttpClient {
         schema: Option<Schema>,
         metadata: Option<Metadata>,
     ) -> Result<ChromaCollection, ChromaHttpClientError> {
-        self.common_create_collection(name, schema, metadata, true)
-            .await
+        self.get_or_create_collection_with_options(
+            name,
+            CreateCollectionOptions {
+                schema,
+                metadata,
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    /// Retrieves an existing collection or creates it with an options struct.
+    pub async fn get_or_create_collection_with_options(
+        &self,
+        name: impl AsRef<str>,
+        options: CreateCollectionOptions,
+    ) -> Result<ChromaCollection, ChromaHttpClientError> {
+        self.common_create_collection(name, options, true).await
     }
 
     /// Creates a new collection with the specified parameters.
@@ -630,14 +685,40 @@ impl ChromaHttpClient {
         schema: Option<Schema>,
         metadata: Option<Metadata>,
     ) -> Result<ChromaCollection, ChromaHttpClientError> {
-        self.common_create_collection(name, schema, metadata, false)
-            .await
+        self.create_collection_with_options(
+            name,
+            CreateCollectionOptions {
+                schema,
+                metadata,
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    /// Creates a new collection using an options struct.
+    pub async fn create_collection_with_options(
+        &self,
+        name: impl AsRef<str>,
+        options: CreateCollectionOptions,
+    ) -> Result<ChromaCollection, ChromaHttpClientError> {
+        self.common_create_collection(name, options, false).await
     }
 
     /// Retrieves an existing collection by name.
     pub async fn get_collection(
         &self,
         name: impl AsRef<str>,
+    ) -> Result<ChromaCollection, ChromaHttpClientError> {
+        self.get_collection_with_options(name, GetCollectionOptions::default())
+            .await
+    }
+
+    /// Retrieves an existing collection by name using an options struct.
+    pub async fn get_collection_with_options(
+        &self,
+        name: impl AsRef<str>,
+        options: GetCollectionOptions,
     ) -> Result<ChromaCollection, ChromaHttpClientError> {
         let tenant_id = self.get_tenant_id().await?;
         let database_name = self.get_database_name().await?;
@@ -657,10 +738,15 @@ impl ChromaHttpClient {
             )
             .await?;
 
-        Ok(ChromaCollection {
-            client: self.clone(),
-            collection: Arc::new(collection),
-        })
+        if let Some(embedding_function) = options.embedding_function.as_deref() {
+            self.compare_dense_embedding_function(&collection, embedding_function)?;
+        }
+
+        Ok(ChromaCollection::new(
+            self.clone(),
+            collection,
+            options.embedding_function,
+        ))
     }
 
     /// Retrieves an existing collection by its ID.
@@ -706,10 +792,7 @@ impl ChromaHttpClient {
             )
             .await?;
 
-        Ok(ChromaCollection {
-            client: self.clone(),
-            collection: Arc::new(collection),
-        })
+        Ok(ChromaCollection::new(self.clone(), collection, None))
     }
 
     /// Removes a collection and all its records from the database.
@@ -852,22 +935,59 @@ impl ChromaHttpClient {
 
         Ok(collections
             .into_iter()
-            .map(|collection| ChromaCollection {
-                client: self.clone(),
-                collection: Arc::new(collection),
-            })
+            .map(|collection| ChromaCollection::new(self.clone(), collection, None))
             .collect())
     }
 
     async fn common_create_collection(
         &self,
         name: impl AsRef<str>,
-        schema: Option<Schema>,
-        metadata: Option<Metadata>,
+        options: CreateCollectionOptions,
         get_or_create: bool,
     ) -> Result<ChromaCollection, ChromaHttpClientError> {
         let tenant_id = self.get_tenant_id().await?;
         let database_name = self.get_database_name().await?;
+        let CreateCollectionOptions {
+            schema,
+            metadata,
+            mut configuration,
+            embedding_function,
+        } = options;
+
+        if let Some(embedding_function) = embedding_function.as_deref() {
+            if configuration
+                .as_ref()
+                .and_then(|configuration| configuration.embedding_function.as_ref())
+                .is_some()
+            {
+                return Err(EmbeddingError::Configuration(
+                    "embedding function provided when already defined in collection configuration"
+                        .to_string(),
+                )
+                .into());
+            }
+
+            if schema
+                .as_ref()
+                .and_then(|schema| schema.dense_embedding_function())
+                .is_some()
+            {
+                return Err(EmbeddingError::Configuration(
+                    "embedding function provided when already defined in collection schema"
+                        .to_string(),
+                )
+                .into());
+            }
+
+            let collection_configuration =
+                configuration.get_or_insert_with(CollectionConfiguration::default);
+            collection_configuration.embedding_function = Some(embedding_function.configuration());
+            if collection_configuration.hnsw.is_none() && collection_configuration.spann.is_none() {
+                let mut hnsw = HnswConfiguration::default();
+                hnsw.space = Some(embedding_function.default_space());
+                collection_configuration.hnsw = Some(hnsw);
+            }
+        }
 
         let collection: chroma_types::Collection = self
             .send(
@@ -877,20 +997,49 @@ impl ChromaHttpClient {
                     "/api/v2/tenants/{}/databases/{}/collections",
                     tenant_id, database_name
                 ),
-                Some(serde_json::json!({
-                    "name": name.as_ref(),
-                    "schema": schema,
-                    "metadata": metadata,
-                    "get_or_create": get_or_create,
-                })),
+                Some(CreateCollectionPayload {
+                    name: name.as_ref().to_string(),
+                    schema,
+                    configuration,
+                    metadata,
+                    get_or_create,
+                }),
                 None::<()>,
             )
             .await?;
 
-        Ok(ChromaCollection {
-            client: self.clone(),
-            collection: Arc::new(collection),
-        })
+        if let Some(embedding_function) = embedding_function.as_deref() {
+            self.compare_dense_embedding_function(&collection, embedding_function)?;
+        }
+
+        Ok(ChromaCollection::new(
+            self.clone(),
+            collection,
+            embedding_function,
+        ))
+    }
+
+    fn compare_dense_embedding_function(
+        &self,
+        collection: &Collection,
+        provided: &dyn DenseEmbeddingFunction,
+    ) -> Result<(), EmbeddingError> {
+        let Some(persisted) = collection.dense_embedding_function() else {
+            return Ok(());
+        };
+        let persisted_configuration =
+            match dense_embedding_function_from_config(persisted, self.chroma_cloud_api_key()) {
+                Ok(persisted) => persisted.configuration(),
+                Err(EmbeddingError::UnsupportedEmbeddingFunction { .. }) => persisted.clone(),
+                Err(err) => return Err(err),
+            };
+        let provided_configuration = provided.configuration();
+        if provided_configuration != persisted_configuration {
+            return Err(EmbeddingError::Configuration(format!(
+                "embedding function conflict: provided: {provided_configuration:?} vs persisted: {persisted_configuration:?}"
+            )));
+        }
+        Ok(())
     }
 
     pub(crate) async fn send<
@@ -1145,6 +1294,7 @@ impl ChromaHttpClient {
 mod tests {
     use super::*;
     use crate::client::ChromaRetryOptions;
+    use crate::embed::chroma_cloud::{ChromaCloudQwenEmbeddingFunction, ChromaCloudQwenOptions};
     use crate::tests::{unique_collection_name, with_client};
     use chroma_types::{EmbeddingFunctionConfiguration, EmbeddingFunctionNewConfiguration};
     use httpmock::{HttpMockResponse, MockServer};
@@ -1279,6 +1429,66 @@ mod tests {
         let client = ChromaHttpClient::default();
         assert_eq!(client.clients.len(), 1);
         assert!(client.clients[0].breaker.is_none());
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn get_or_create_collection_compares_returned_embedding_function() {
+        let server = MockServer::start_async().await;
+        let mut collection = Collection::default();
+        collection.name = "existing".to_string();
+        collection.tenant = "tenant".to_string();
+        collection.database = "database".to_string();
+        collection.config = CollectionConfiguration {
+            embedding_function: Some(
+                (
+                    "chroma-cloud-qwen",
+                    serde_json::json!({
+                        "model": "different-model"
+                    }),
+                )
+                    .into(),
+            ),
+            ..Default::default()
+        }
+        .try_into()
+        .unwrap();
+
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST")
+                    .path("/api/v2/tenants/tenant/databases/database/collections");
+                then.status(200)
+                    .json_body(serde_json::to_value(&collection).unwrap());
+            })
+            .await;
+
+        let client = ChromaHttpClient::new(ChromaHttpClientOptions {
+            endpoint: server.base_url().parse().unwrap(),
+            tenant_id: Some("tenant".to_string()),
+            database_name: Some("database".to_string()),
+            ..Default::default()
+        });
+        let err = client
+            .get_or_create_collection_with_options(
+                "existing",
+                CreateCollectionOptions {
+                    embedding_function: Some(Arc::new(ChromaCloudQwenEmbeddingFunction::new(
+                        ChromaCloudQwenOptions::default(),
+                    ))),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+
+        match err {
+            ChromaHttpClientError::EmbeddingError(EmbeddingError::Configuration(message)) => {
+                assert!(message.contains("embedding function conflict"));
+            }
+            other => panic!("expected embedding function conflict, got {other:?}"),
+        }
+        assert_eq!(mock.calls(), 1);
     }
 
     #[tokio::test]

--- a/rust/chroma/src/client/options.rs
+++ b/rust/chroma/src/client/options.rs
@@ -110,6 +110,37 @@ pub enum ChromaHttpClientOptionsError {
 const DEFAULT_LOCAL_ENDPOINT: &str = "http://localhost:8000";
 const DEFAULT_CLOUD_ENDPOINT: &str = "https://api.trychroma.com";
 
+fn endpoint_from_env(default_endpoint: &str) -> Result<reqwest::Url, ChromaHttpClientOptionsError> {
+    let default_endpoint = default_endpoint.parse().expect("valid URL");
+
+    if let Ok(endpoint) = std::env::var("CHROMA_ENDPOINT") {
+        return endpoint
+            .parse::<reqwest::Url>()
+            .map_err(|err| ChromaHttpClientOptionsError::InvalidEndpoint(err.to_string()));
+    }
+
+    if let Ok(host) = std::env::var("CHROMA_HOST") {
+        return endpoint_from_host(&host, &default_endpoint);
+    }
+
+    Ok(default_endpoint)
+}
+
+fn endpoint_from_host(
+    host: &str,
+    default_endpoint: &reqwest::Url,
+) -> Result<reqwest::Url, ChromaHttpClientOptionsError> {
+    let endpoint = if host.contains("://") {
+        host.to_string()
+    } else {
+        format!("{}://{}", default_endpoint.scheme(), host)
+    };
+
+    endpoint
+        .parse::<reqwest::Url>()
+        .map_err(|err| ChromaHttpClientOptionsError::InvalidEndpoint(err.to_string()))
+}
+
 /// Configuration bundle for initializing a Chroma client.
 ///
 /// Aggregates connection parameters, authentication credentials, and operational policies
@@ -151,6 +182,7 @@ impl ChromaHttpClientOptions {
     ///
     /// Reads:
     /// - `CHROMA_ENDPOINT` (optional, defaults to `http://localhost:8000`)
+    /// - `CHROMA_HOST` (optional URL or bare host fallback when `CHROMA_ENDPOINT` is unset)
     /// - `CHROMA_TENANT` (optional, defaults to `"default_tenant"`)
     /// - `CHROMA_DATABASE` (optional, defaults to `"default_database"`)
     ///
@@ -158,7 +190,7 @@ impl ChromaHttpClientOptions {
     ///
     /// # Errors
     ///
-    /// Returns an error if `CHROMA_ENDPOINT` is set but cannot be parsed as a URL.
+    /// Returns an error if `CHROMA_ENDPOINT` or `CHROMA_HOST` is set but cannot be parsed as a URL.
     ///
     /// # Examples
     ///
@@ -171,10 +203,7 @@ impl ChromaHttpClientOptions {
     /// # }
     /// ```
     pub fn from_env() -> Result<Self, ChromaHttpClientOptionsError> {
-        let endpoint = std::env::var("CHROMA_ENDPOINT")
-            .map(|s| s.parse())
-            .unwrap_or(Ok(ChromaHttpClientOptions::default().endpoint))
-            .map_err(|err| ChromaHttpClientOptionsError::InvalidEndpoint(err.to_string()))?;
+        let endpoint = endpoint_from_env(DEFAULT_LOCAL_ENDPOINT)?;
 
         let tenant_id = std::env::var("CHROMA_TENANT").unwrap_or("default_tenant".to_string());
         let database_name =
@@ -193,6 +222,7 @@ impl ChromaHttpClientOptions {
     /// Reads:
     /// - `CHROMA_API_KEY` (required)
     /// - `CHROMA_ENDPOINT` (optional, defaults to `https://api.trychroma.com`)
+    /// - `CHROMA_HOST` (optional URL or bare host fallback when `CHROMA_ENDPOINT` is unset)
     /// - `CHROMA_TENANT` (optional, will be auto-resolved if not provided)
     /// - `CHROMA_DATABASE` (optional, will be auto-resolved if not provided)
     ///
@@ -200,7 +230,7 @@ impl ChromaHttpClientOptions {
     ///
     /// Returns an error if:
     /// - `CHROMA_API_KEY` is not set
-    /// - `CHROMA_ENDPOINT` is set but cannot be parsed as a URL
+    /// - `CHROMA_ENDPOINT` or `CHROMA_HOST` is set but cannot be parsed as a URL
     /// - The API key contains invalid header characters
     ///
     /// # Examples
@@ -214,10 +244,7 @@ impl ChromaHttpClientOptions {
     /// # }
     /// ```
     pub fn from_cloud_env() -> Result<Self, ChromaHttpClientOptionsError> {
-        let endpoint = std::env::var("CHROMA_ENDPOINT")
-            .map(|s| s.parse::<reqwest::Url>())
-            .unwrap_or(Ok(DEFAULT_CLOUD_ENDPOINT.parse().expect("valid URL")))
-            .map_err(|err| ChromaHttpClientOptionsError::InvalidEndpoint(err.to_string()))?;
+        let endpoint = endpoint_from_env(DEFAULT_CLOUD_ENDPOINT)?;
 
         let api_key = std::env::var("CHROMA_API_KEY").map_err(|_| {
             ChromaHttpClientOptionsError::MissingConfiguration("CHROMA_API_KEY".to_string())
@@ -321,5 +348,128 @@ impl ChromaHttpClientOptions {
             ChromaAuthMethod::None => {}
         }
         headers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    const ENV_KEYS: [&str; 5] = [
+        "CHROMA_API_KEY",
+        "CHROMA_DATABASE",
+        "CHROMA_ENDPOINT",
+        "CHROMA_HOST",
+        "CHROMA_TENANT",
+    ];
+
+    struct EnvSnapshot {
+        values: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvSnapshot {
+        fn capture() -> Self {
+            Self {
+                values: ENV_KEYS
+                    .into_iter()
+                    .map(|key| (key, std::env::var(key).ok()))
+                    .collect(),
+            }
+        }
+
+        fn clear() {
+            for key in ENV_KEYS {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (key, value) in &self.values {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    fn with_chroma_env<T>(vars: &[(&'static str, &'static str)], test: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _snapshot = EnvSnapshot::capture();
+        EnvSnapshot::clear();
+        for (key, value) in vars {
+            std::env::set_var(key, value);
+        }
+        test()
+    }
+
+    #[test]
+    fn from_env_uses_chroma_host_when_endpoint_is_unset() {
+        with_chroma_env(&[("CHROMA_HOST", "http://example.com:9000")], || {
+            let options = ChromaHttpClientOptions::from_env().unwrap();
+
+            assert_eq!(options.endpoint.as_str(), "http://example.com:9000/");
+        });
+    }
+
+    #[test]
+    fn from_env_uses_bare_chroma_host_with_local_scheme() {
+        with_chroma_env(&[("CHROMA_HOST", "localhost:9000")], || {
+            let options = ChromaHttpClientOptions::from_env().unwrap();
+
+            assert_eq!(options.endpoint.as_str(), "http://localhost:9000/");
+        });
+    }
+
+    #[test]
+    fn from_env_prefers_chroma_endpoint_over_chroma_host() {
+        with_chroma_env(
+            &[
+                ("CHROMA_ENDPOINT", "http://endpoint.example.com:9000"),
+                ("CHROMA_HOST", "http://host.example.com:9000"),
+            ],
+            || {
+                let options = ChromaHttpClientOptions::from_env().unwrap();
+
+                assert_eq!(
+                    options.endpoint.as_str(),
+                    "http://endpoint.example.com:9000/"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn from_cloud_env_uses_chroma_host_when_endpoint_is_unset() {
+        with_chroma_env(
+            &[
+                ("CHROMA_API_KEY", "test-key"),
+                ("CHROMA_HOST", "https://cloud.example.com"),
+            ],
+            || {
+                let options = ChromaHttpClientOptions::from_cloud_env().unwrap();
+
+                assert_eq!(options.endpoint.as_str(), "https://cloud.example.com/");
+            },
+        );
+    }
+
+    #[test]
+    fn from_cloud_env_uses_bare_chroma_host_with_cloud_scheme() {
+        with_chroma_env(
+            &[
+                ("CHROMA_API_KEY", "test-key"),
+                ("CHROMA_HOST", "api.devchroma.com"),
+            ],
+            || {
+                let options = ChromaHttpClientOptions::from_cloud_env().unwrap();
+
+                assert_eq!(options.endpoint.as_str(), "https://api.devchroma.com/");
+            },
+        );
     }
 }

--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -1381,7 +1381,8 @@ impl ChromaCollection {
 
         let mut sparse_keys = schema
             .sparse_vector_indices()
-            .filter_map(|(key, sparse_index)| sparse_index.enabled.then(|| key.to_string()));
+            .filter(|(_, sparse_index)| sparse_index.enabled)
+            .map(|(key, _)| key.to_string());
         let sparse_key = sparse_keys.next().ok_or_else(|| {
             EmbeddingError::InvalidInput(
                 "sparse_key is required because the collection has no sparse vector index"
@@ -1699,11 +1700,13 @@ mod tests {
         schema: Option<chroma_types::Schema>,
         dense_embedding_function: Option<Arc<dyn DenseEmbeddingFunction>>,
     ) -> ChromaCollection {
-        let mut collection = Collection::default();
-        collection.name = "test".to_string();
-        collection.tenant = "tenant".to_string();
-        collection.database = "database".to_string();
-        collection.schema = schema;
+        let collection = Collection {
+            name: "test".to_string(),
+            tenant: "tenant".to_string(),
+            database: "database".to_string(),
+            schema,
+            ..Default::default()
+        };
         let client = ChromaHttpClient::new(crate::client::ChromaHttpClientOptions {
             endpoint: server.base_url().parse().unwrap(),
             tenant_id: Some("tenant".to_string()),

--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -16,17 +16,27 @@ use std::sync::Arc;
 
 use chroma_api_types::ForkCollectionPayload;
 use chroma_types::{
+    operator::{Key, QueryVector, RankExpr},
     plan::{ReadLevel, SearchPayload},
     AddCollectionRecordsRequest, AddCollectionRecordsResponse, Collection, CollectionUuid,
     DeleteCollectionRecordsRequest, DeleteCollectionRecordsResponse, GetRequest, GetResponse,
-    IncludeList, IndexStatusResponse, Metadata, QueryRequest, QueryResponse, Schema, SearchRequest,
-    SearchResponse, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
-    UpdateMetadata, UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, Where,
+    IncludeList, IndexStatusResponse, Metadata, MetadataValue, QueryRequest, QueryResponse, Schema,
+    SearchRequest, SearchResponse, SparseVectorIndexConfig, UpdateCollectionConfiguration,
+    UpdateCollectionPayload, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
+    UpdateMetadata, UpdateMetadataValue, UpsertCollectionRecordsRequest,
+    UpsertCollectionRecordsResponse, Where, DOCUMENT_KEY,
 };
 use reqwest::Method;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use crate::{client::ChromaHttpClientError, ChromaHttpClient};
+use crate::{
+    client::ChromaHttpClientError,
+    embed::{
+        dense_embedding_function_from_config, sparse_embedding_function_from_config,
+        DenseEmbeddingFunction, EmbeddingError,
+    },
+    ChromaHttpClient,
+};
 
 #[derive(Deserialize)]
 struct ForkCountResponse {
@@ -63,6 +73,7 @@ struct ForkCountResponse {
 pub struct ChromaCollection {
     pub(crate) client: ChromaHttpClient,
     pub(crate) collection: Arc<Collection>,
+    pub(crate) dense_embedding_function: Option<Arc<dyn DenseEmbeddingFunction>>,
 }
 
 impl std::fmt::Debug for ChromaCollection {
@@ -77,7 +88,113 @@ impl std::fmt::Debug for ChromaCollection {
     }
 }
 
+/// Options for adding records with client-side embedding.
+#[derive(Clone)]
+pub struct AddRecordsOptions {
+    /// Record IDs.
+    pub ids: Vec<String>,
+    /// Documents to store and to use for client-side embedding.
+    pub documents: Vec<String>,
+    /// Optional URIs to store with records.
+    pub uris: Option<Vec<Option<String>>>,
+    /// Optional metadata to store with records.
+    pub metadatas: Option<Vec<Option<Metadata>>>,
+}
+
+/// Options for upserting records with client-side embedding.
+#[derive(Clone)]
+pub struct UpsertRecordsOptions {
+    /// Record IDs.
+    pub ids: Vec<String>,
+    /// Documents to store and to use for client-side embedding.
+    pub documents: Vec<String>,
+    /// Optional URIs to store with records.
+    pub uris: Option<Vec<Option<String>>>,
+    /// Optional metadata updates to store with records.
+    pub metadatas: Option<Vec<Option<UpdateMetadata>>>,
+}
+
+/// Options for updating records with optional client-side embedding.
+#[derive(Clone)]
+pub struct UpdateRecordsOptions {
+    /// Record IDs.
+    pub ids: Vec<String>,
+    /// Optional document updates. Present documents are embedded client-side.
+    pub documents: Option<Vec<Option<String>>>,
+    /// Optional URI updates.
+    pub uris: Option<Vec<Option<String>>>,
+    /// Optional metadata updates.
+    pub metadatas: Option<Vec<Option<UpdateMetadata>>>,
+}
+
+/// Options for querying records with client-side query text embedding.
+#[derive(Clone)]
+pub struct QueryRecordsOptions {
+    /// Query texts to embed client-side.
+    pub query_texts: Vec<String>,
+    /// Number of nearest neighbors to return per query.
+    pub n_results: Option<u32>,
+    /// Optional metadata filter.
+    pub r#where: Option<Where>,
+    /// Optional candidate ID restriction.
+    pub ids: Option<Vec<String>>,
+    /// Optional response include list.
+    pub include: Option<IncludeList>,
+}
+
+/// Options for hybrid search with client-side dense and sparse query embedding.
+#[derive(Clone)]
+pub struct SearchRecordsOptions {
+    /// Query texts used to embed dense and sparse query vectors.
+    pub query_texts: Vec<String>,
+    /// Metadata key that stores sparse vectors. When absent, the collection schema is used.
+    pub sparse_key: Option<String>,
+    /// Optional metadata filter.
+    pub r#where: Option<Where>,
+    /// Optional candidate ID restriction.
+    pub ids: Option<Vec<String>>,
+    /// Optional number of results to return per search payload.
+    pub limit: Option<u32>,
+    /// Number of results to skip per search payload.
+    pub offset: u32,
+    /// Optional KNN candidate limit. Defaults to `limit`, then the server KNN default.
+    pub rank_limit: Option<u32>,
+    /// Optional keys to return from each search payload.
+    pub select: Option<Vec<Key>>,
+    /// Optional dense KNN weight. Defaults to 1.0.
+    pub dense_weight: Option<f32>,
+    /// Optional sparse KNN weight. Defaults to 1.0.
+    pub sparse_weight: Option<f32>,
+    /// Controls whether to read from the write-ahead log.
+    pub read_level: ReadLevel,
+}
+
+/// Options for modifying a collection.
+#[derive(Clone, Default)]
+pub struct ModifyCollectionOptions {
+    /// Optional new collection name.
+    pub new_name: Option<String>,
+    /// Optional metadata update.
+    pub new_metadata: Option<UpdateMetadata>,
+    /// Optional collection configuration update.
+    pub new_configuration: Option<UpdateCollectionConfiguration>,
+    /// Optional dense embedding function to attach and persist in `new_configuration`.
+    pub embedding_function: Option<Arc<dyn DenseEmbeddingFunction>>,
+}
+
 impl ChromaCollection {
+    pub(crate) fn new(
+        client: ChromaHttpClient,
+        collection: Collection,
+        dense_embedding_function: Option<Arc<dyn DenseEmbeddingFunction>>,
+    ) -> Self {
+        Self {
+            client,
+            collection: Arc::new(collection),
+            dense_embedding_function,
+        }
+    }
+
     /// Returns the database ID that contains this collection.
     pub fn database(&self) -> &str {
         &self.collection.database
@@ -281,28 +398,100 @@ impl ChromaCollection {
         new_name: Option<impl AsRef<str>>,
         new_metadata: Option<Metadata>,
     ) -> Result<(), ChromaHttpClientError> {
+        let new_name = new_name.map(|name| name.as_ref().to_string());
+        let update_metadata = new_metadata.clone().map(|metadata| {
+            metadata
+                .into_iter()
+                .map(|(key, value)| (key, UpdateMetadataValue::from(value)))
+                .collect()
+        });
+        self.modify_with_options(ModifyCollectionOptions {
+            new_name: new_name.clone(),
+            new_metadata: update_metadata,
+            ..Default::default()
+        })
+        .await?;
+
+        if let Some(metadata) = new_metadata {
+            let mut updated_collection = (*self.collection).clone();
+            updated_collection.metadata = Some(metadata);
+            self.collection = Arc::new(updated_collection);
+        }
+
+        Ok(())
+    }
+
+    /// Modifies collection name, metadata, or configuration.
+    pub async fn modify_with_options(
+        &mut self,
+        options: ModifyCollectionOptions,
+    ) -> Result<(), ChromaHttpClientError> {
+        let ModifyCollectionOptions {
+            new_name,
+            new_metadata,
+            mut new_configuration,
+            embedding_function,
+        } = options;
+
+        if let Some(embedding_function) = embedding_function.as_ref() {
+            let embedding_configuration = embedding_function.configuration();
+            match new_configuration.as_mut() {
+                Some(configuration) if configuration.embedding_function.is_some() => {
+                    return Err(EmbeddingError::Configuration(
+                        "embedding function provided when already defined in collection configuration update"
+                            .to_string(),
+                    )
+                    .into());
+                }
+                Some(configuration) => {
+                    configuration.embedding_function = Some(embedding_configuration);
+                }
+                None => {
+                    new_configuration = Some(UpdateCollectionConfiguration {
+                        hnsw: None,
+                        spann: None,
+                        embedding_function: Some(embedding_configuration),
+                    });
+                }
+            }
+        }
+
         // Returns empty map ({})
         self.send::<_, serde_json::Value>(
             false,
             "modify",
             "",
             Method::PUT,
-            Some(serde_json::json!({
-                "new_name": new_name.as_ref().map(|s| s.as_ref()),
-                "new_metadata": new_metadata,
-            })),
+            Some(UpdateCollectionPayload {
+                new_name: new_name.clone(),
+                new_metadata: new_metadata.clone(),
+                new_configuration: new_configuration.clone(),
+            }),
         )
         .await?;
 
         let mut updated_collection = (*self.collection).clone();
-        if let Some(name) = new_name {
-            updated_collection.name = name.as_ref().to_string();
+        if let Some(name) = new_name.as_ref() {
+            updated_collection.name = name.clone();
         }
-        if let Some(metadata) = new_metadata {
+        if let Some(metadata_update) = new_metadata {
+            let mut metadata = updated_collection.metadata.take().unwrap_or_default();
+            for (key, value) in metadata_update {
+                if matches!(value, UpdateMetadataValue::None) {
+                    metadata.remove(&key);
+                } else {
+                    let value = MetadataValue::try_from(&value)
+                        .map_err(|err| EmbeddingError::InvalidInput(err.to_string()))?;
+                    metadata.insert(key, value);
+                }
+            }
             updated_collection.metadata = Some(metadata);
         }
 
         self.collection = Arc::new(updated_collection);
+        if let Some(embedding_function) = embedding_function {
+            self.dense_embedding_function = Some(embedding_function);
+        }
 
         Ok(())
     }
@@ -412,6 +601,126 @@ impl ChromaCollection {
         let request = request.into_payload()?;
         self.send(true, "query", "query", Method::POST, Some(request))
             .await
+    }
+
+    /// Performs similarity search with client-side query text embedding.
+    pub async fn query_records(
+        &self,
+        options: QueryRecordsOptions,
+    ) -> Result<QueryResponse, ChromaHttpClientError> {
+        let QueryRecordsOptions {
+            query_texts,
+            n_results,
+            r#where,
+            ids,
+            include,
+        } = options;
+
+        let query_embeddings = self.embed_query_texts(&query_texts).await?;
+
+        self.query(query_embeddings, n_results, r#where, ids, include)
+            .await
+    }
+
+    /// Performs hybrid search with client-side dense and sparse query embedding.
+    pub async fn search_records(
+        &self,
+        options: SearchRecordsOptions,
+    ) -> Result<SearchResponse, ChromaHttpClientError> {
+        let SearchRecordsOptions {
+            query_texts,
+            sparse_key,
+            r#where,
+            ids,
+            limit,
+            offset,
+            rank_limit,
+            select,
+            dense_weight,
+            sparse_weight,
+            read_level,
+        } = options;
+
+        let dense_embeddings = self.embed_query_texts(&query_texts).await?;
+        if dense_embeddings.is_empty() {
+            return Err(EmbeddingError::InvalidInput(
+                "search_records requires at least one query".to_string(),
+            )
+            .into());
+        }
+        let (sparse_key, sparse_config) =
+            self.sparse_query_embedding_target(sparse_key.as_deref())?;
+        let sparse_vectors = self
+            .sparse_embed(&sparse_config, &query_texts, true)
+            .await?;
+        ensure_len(
+            "sparse query vectors",
+            sparse_vectors.len(),
+            dense_embeddings.len(),
+        )?;
+
+        let dense_weight = dense_weight.unwrap_or(1.0);
+        if !dense_weight.is_finite() {
+            return Err(EmbeddingError::InvalidInput(
+                "dense_weight must be a finite number".to_string(),
+            )
+            .into());
+        }
+        let sparse_weight = sparse_weight.unwrap_or(1.0);
+        if !sparse_weight.is_finite() {
+            return Err(EmbeddingError::InvalidInput(
+                "sparse_weight must be a finite number".to_string(),
+            )
+            .into());
+        }
+        let rank_limit = rank_limit
+            .or(limit)
+            .unwrap_or_else(RankExpr::default_knn_limit);
+
+        let searches = dense_embeddings
+            .into_iter()
+            .zip(sparse_vectors)
+            .map(|(dense_embedding, sparse_vector)| {
+                let dense_knn = RankExpr::Knn {
+                    query: QueryVector::Dense(dense_embedding),
+                    key: Key::Embedding,
+                    limit: rank_limit,
+                    default: None,
+                    return_rank: false,
+                };
+                let sparse_knn = RankExpr::Knn {
+                    query: QueryVector::Sparse(sparse_vector),
+                    key: Key::field(sparse_key.clone()),
+                    limit: rank_limit,
+                    default: None,
+                    return_rank: false,
+                };
+                let dense_rank = if dense_weight == 1.0 {
+                    dense_knn
+                } else {
+                    dense_knn * dense_weight
+                };
+                let sparse_rank = if sparse_weight == 1.0 {
+                    sparse_knn
+                } else {
+                    sparse_knn * sparse_weight
+                };
+                let rank = dense_rank + sparse_rank;
+                let mut search = SearchPayload::default().rank(rank).limit(limit, offset);
+                if let Some(r#where) = r#where.clone() {
+                    search = search.r#where(r#where);
+                }
+                if let Some(ids) = ids.clone() {
+                    search.filter.query_ids = Some(ids);
+                }
+                if let Some(select) = select.clone() {
+                    search = search.select(select);
+                }
+                search
+            })
+            .collect();
+
+        self.search_with_options(searches, read_level).await
     }
 
     /// Performs hybrid search on the collection using the Search API.
@@ -664,6 +973,30 @@ impl ChromaCollection {
             .await
     }
 
+    /// Inserts records with client-side dense and sparse embedding.
+    pub async fn add_records(
+        &self,
+        options: AddRecordsOptions,
+    ) -> Result<AddCollectionRecordsResponse, ChromaHttpClientError> {
+        let AddRecordsOptions {
+            ids,
+            documents,
+            uris,
+            metadatas,
+        } = options;
+        let record_count = ids.len();
+        let documents = documents.into_iter().map(Some).collect::<Vec<_>>();
+        let embeddings = self
+            .embed_insert_documents(Some(&documents), record_count)
+            .await?;
+        let metadatas = self
+            .apply_sparse_embeddings_to_metadatas(metadatas, Some(&documents), record_count)
+            .await?;
+
+        self.add(ids, embeddings, Some(documents), uris, metadatas)
+            .await
+    }
+
     /// Modifies existing records in the collection.
     ///
     /// Updates only the specified fields for records matching the provided IDs. Fields set to
@@ -715,6 +1048,29 @@ impl ChromaCollection {
             .await
     }
 
+    /// Updates records with client-side dense and sparse embedding.
+    pub async fn update_records(
+        &self,
+        options: UpdateRecordsOptions,
+    ) -> Result<UpdateCollectionRecordsResponse, ChromaHttpClientError> {
+        let UpdateRecordsOptions {
+            ids,
+            documents,
+            uris,
+            metadatas,
+        } = options;
+        let record_count = ids.len();
+        let embeddings = self
+            .embed_update_documents(documents.as_deref(), record_count)
+            .await?;
+        let metadatas = self
+            .apply_sparse_embeddings_to_metadatas(metadatas, documents.as_deref(), record_count)
+            .await?;
+
+        self.update(ids, embeddings, documents, uris, metadatas)
+            .await
+    }
+
     /// Inserts new records or updates existing ones based on ID.
     ///
     /// For each ID: if the record exists, updates it; otherwise, inserts a new record.
@@ -763,6 +1119,30 @@ impl ChromaCollection {
         )?;
         let request = request.into_payload();
         self.send(false, "upsert", "upsert", Method::POST, Some(request))
+            .await
+    }
+
+    /// Inserts or updates records with client-side dense and sparse embedding.
+    pub async fn upsert_records(
+        &self,
+        options: UpsertRecordsOptions,
+    ) -> Result<UpsertCollectionRecordsResponse, ChromaHttpClientError> {
+        let UpsertRecordsOptions {
+            ids,
+            documents,
+            uris,
+            metadatas,
+        } = options;
+        let record_count = ids.len();
+        let documents = documents.into_iter().map(Some).collect::<Vec<_>>();
+        let embeddings = self
+            .embed_insert_documents(Some(&documents), record_count)
+            .await?;
+        let metadatas = self
+            .apply_sparse_embeddings_to_metadatas(metadatas, Some(&documents), record_count)
+            .await?;
+
+        self.upsert(ids, embeddings, Some(documents), uris, metadatas)
             .await
     }
 
@@ -844,10 +1224,11 @@ impl ChromaCollection {
         let collection: Collection = self
             .send(false, "fork", "fork", Method::POST, Some(request))
             .await?;
-        Ok(ChromaCollection {
-            client: self.client.clone(),
-            collection: Arc::new(collection),
-        })
+        Ok(ChromaCollection::new(
+            self.client.clone(),
+            collection,
+            self.dense_embedding_function.clone(),
+        ))
     }
 
     /// Returns the number of forks that exist for this collection.
@@ -874,6 +1255,283 @@ impl ChromaCollection {
             .send::<(), _>(true, "fork_count", "fork_count", Method::GET, None)
             .await?;
         Ok(response.count)
+    }
+
+    async fn embed_insert_documents(
+        &self,
+        documents: Option<&[Option<String>]>,
+        record_count: usize,
+    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let documents = documents.ok_or_else(|| {
+            EmbeddingError::InvalidInput(
+                "documents are required when embeddings are omitted".to_string(),
+            )
+        })?;
+        ensure_len("documents", documents.len(), record_count)?;
+
+        let mut texts = Vec::with_capacity(record_count);
+        for (index, document) in documents.iter().enumerate() {
+            let document = document.as_ref().ok_or_else(|| {
+                EmbeddingError::InvalidInput(format!(
+                    "documents[{index}] is required when embeddings are omitted"
+                ))
+            })?;
+            texts.push(document.clone());
+        }
+
+        self.embed_documents(&texts).await
+    }
+
+    async fn embed_update_documents(
+        &self,
+        documents: Option<&[Option<String>]>,
+        record_count: usize,
+    ) -> Result<Option<Vec<Option<Vec<f32>>>>, EmbeddingError> {
+        let Some(documents) = documents else {
+            return Ok(None);
+        };
+        ensure_len("documents", documents.len(), record_count)?;
+
+        let mut positions = Vec::new();
+        let mut texts = Vec::new();
+        for (index, document) in documents.iter().enumerate() {
+            if let Some(document) = document {
+                positions.push(index);
+                texts.push(document.clone());
+            }
+        }
+
+        if texts.is_empty() {
+            return Ok(None);
+        }
+
+        let embeddings = self.embed_documents(&texts).await?;
+        ensure_embedding_count(texts.len(), embeddings.len())?;
+
+        let mut result = vec![None; record_count];
+        for (position, embedding) in positions.into_iter().zip(embeddings) {
+            result[position] = Some(embedding);
+        }
+        Ok(Some(result))
+    }
+
+    async fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let embedder = self.dense_embedding_function()?;
+        let refs = texts.iter().map(String::as_str).collect::<Vec<_>>();
+        let embeddings = embedder.embed_documents(&refs).await?;
+        ensure_embedding_count(texts.len(), embeddings.len())?;
+        Ok(embeddings)
+    }
+
+    async fn embed_query_texts(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let embedder = self.dense_embedding_function()?;
+        let refs = texts.iter().map(String::as_str).collect::<Vec<_>>();
+        let embeddings = embedder.embed_query(&refs).await?;
+        ensure_embedding_count(texts.len(), embeddings.len())?;
+        Ok(embeddings)
+    }
+
+    fn dense_embedding_function(&self) -> Result<Arc<dyn DenseEmbeddingFunction>, EmbeddingError> {
+        if let Some(embedding_function) = self.dense_embedding_function.as_ref() {
+            return Ok(Arc::clone(embedding_function));
+        }
+
+        if let Some(configuration) = self.collection.dense_embedding_function() {
+            return dense_embedding_function_from_config(
+                configuration,
+                self.client.chroma_cloud_api_key(),
+            );
+        }
+
+        Err(EmbeddingError::InvalidInput(format!(
+            "no embedding function found for collection '{}'",
+            self.collection.name
+        )))
+    }
+
+    fn sparse_embedding_targets(&self) -> Vec<(String, SparseVectorIndexConfig)> {
+        let Some(schema) = self.collection.schema.as_ref() else {
+            return Vec::new();
+        };
+
+        schema
+            .sparse_vector_indices()
+            .filter_map(|(key, sparse_index)| {
+                if !sparse_index.enabled
+                    || sparse_index.config.embedding_function.is_none()
+                    || sparse_index.config.source_key.is_none()
+                {
+                    return None;
+                }
+                Some((key.to_string(), sparse_index.config.clone()))
+            })
+            .collect()
+    }
+
+    fn sparse_query_key(&self, sparse_key: Option<&str>) -> Result<String, EmbeddingError> {
+        if let Some(sparse_key) = sparse_key {
+            return Ok(sparse_key.to_string());
+        }
+
+        let schema = self.collection.schema.as_ref().ok_or_else(|| {
+            EmbeddingError::InvalidInput(
+                "sparse_key is required when the collection schema is unavailable".to_string(),
+            )
+        })?;
+
+        let mut sparse_keys = schema
+            .sparse_vector_indices()
+            .filter_map(|(key, sparse_index)| sparse_index.enabled.then(|| key.to_string()));
+        let sparse_key = sparse_keys.next().ok_or_else(|| {
+            EmbeddingError::InvalidInput(
+                "sparse_key is required because the collection has no sparse vector index"
+                    .to_string(),
+            )
+        })?;
+        if sparse_keys.next().is_some() {
+            return Err(EmbeddingError::InvalidInput(
+                "sparse_key is required because multiple sparse vector indexes are available"
+                    .to_string(),
+            ));
+        }
+        Ok(sparse_key)
+    }
+
+    fn sparse_query_embedding_target(
+        &self,
+        sparse_key: Option<&str>,
+    ) -> Result<(String, SparseVectorIndexConfig), EmbeddingError> {
+        let sparse_key = self.sparse_query_key(sparse_key)?;
+        let schema = self.collection.schema.as_ref().ok_or_else(|| {
+            EmbeddingError::InvalidInput(
+                "collection schema is required to embed sparse query text".to_string(),
+            )
+        })?;
+        let sparse_index = schema.sparse_vector_index(&sparse_key).ok_or_else(|| {
+            EmbeddingError::InvalidInput(format!(
+                "key '{sparse_key}' is not configured as a sparse vector index"
+            ))
+        })?;
+        if !sparse_index.enabled {
+            return Err(EmbeddingError::InvalidInput(format!(
+                "sparse vector index for key '{sparse_key}' is disabled"
+            )));
+        }
+        if sparse_index.config.embedding_function.is_none() {
+            return Err(EmbeddingError::InvalidInput(format!(
+                "sparse vector index for key '{sparse_key}' has no embedding function"
+            )));
+        }
+        Ok((sparse_key, sparse_index.config.clone()))
+    }
+
+    async fn apply_sparse_embeddings_to_metadatas<M>(
+        &self,
+        metadatas: Option<Vec<Option<M>>>,
+        documents: Option<&[Option<String>]>,
+        record_count: usize,
+    ) -> Result<Option<Vec<Option<M>>>, EmbeddingError>
+    where
+        M: SparseEmbeddingMetadata,
+    {
+        let targets = self.sparse_embedding_targets();
+        if targets.is_empty() {
+            return Ok(metadatas);
+        }
+        if let Some(metadatas) = metadatas.as_ref() {
+            ensure_len("metadatas", metadatas.len(), record_count)?;
+        }
+        if let Some(documents) = documents {
+            ensure_len("documents", documents.len(), record_count)?;
+        }
+
+        let Some(metadatas) = metadatas
+            .or_else(|| documents.map(|_| (0..record_count).map(|_| None).collect::<Vec<_>>()))
+        else {
+            return Ok(None);
+        };
+
+        let mut updated = metadatas
+            .into_iter()
+            .map(Option::unwrap_or_default)
+            .collect::<Vec<_>>();
+
+        for (target_key, config) in targets {
+            let source_key = config.source_key.as_deref().unwrap_or_default();
+            let mut inputs = Vec::new();
+            let mut positions = Vec::new();
+
+            if source_key == DOCUMENT_KEY {
+                let Some(documents) = documents else {
+                    continue;
+                };
+                for (index, metadata) in updated.iter().enumerate() {
+                    if metadata.has_key(&target_key) {
+                        continue;
+                    }
+                    if let Some(Some(document)) = documents.get(index) {
+                        inputs.push(document.clone());
+                        positions.push(index);
+                    }
+                }
+            } else {
+                for (index, metadata) in updated.iter().enumerate() {
+                    if metadata.has_key(&target_key) {
+                        continue;
+                    }
+                    if let Some(value) = metadata.get_str(source_key) {
+                        inputs.push(value.clone());
+                        positions.push(index);
+                    }
+                }
+            }
+
+            if inputs.is_empty() {
+                continue;
+            }
+
+            let sparse_embeddings = self.sparse_embed(&config, &inputs, false).await?;
+            ensure_embedding_count(positions.len(), sparse_embeddings.len())?;
+            for (position, sparse_embedding) in positions.into_iter().zip(sparse_embeddings) {
+                updated[position].insert_sparse(target_key.clone(), sparse_embedding);
+            }
+        }
+
+        Ok(Some(
+            updated
+                .into_iter()
+                .map(|metadata| {
+                    if metadata.is_empty_metadata() {
+                        None
+                    } else {
+                        Some(metadata)
+                    }
+                })
+                .collect(),
+        ))
+    }
+
+    async fn sparse_embed(
+        &self,
+        config: &SparseVectorIndexConfig,
+        inputs: &[String],
+        is_query: bool,
+    ) -> Result<Vec<chroma_types::SparseVector>, EmbeddingError> {
+        let embedding_function_config = config.embedding_function.as_ref().ok_or_else(|| {
+            EmbeddingError::Configuration(
+                "sparse embedding target has no embedding function".to_string(),
+            )
+        })?;
+        let embedding_function = sparse_embedding_function_from_config(
+            embedding_function_config,
+            self.client.chroma_cloud_api_key(),
+        )?;
+        let refs = inputs.iter().map(String::as_str).collect::<Vec<_>>();
+        if is_query {
+            embedding_function.embed_query(&refs).await
+        } else {
+            embedding_function.embed_documents(&refs).await
+        }
     }
 
     /// Internal transport method that constructs collection-specific API paths and delegates to the client.
@@ -924,15 +1582,475 @@ impl ChromaCollection {
     }
 }
 
+trait SparseEmbeddingMetadata: Default {
+    fn has_key(&self, key: &str) -> bool;
+    fn get_str(&self, key: &str) -> Option<&String>;
+    fn insert_sparse(&mut self, key: String, value: chroma_types::SparseVector);
+    fn is_empty_metadata(&self) -> bool;
+}
+
+impl SparseEmbeddingMetadata for Metadata {
+    fn has_key(&self, key: &str) -> bool {
+        self.contains_key(key)
+    }
+
+    fn get_str(&self, key: &str) -> Option<&String> {
+        match self.get(key) {
+            Some(MetadataValue::Str(value)) => Some(value),
+            _ => None,
+        }
+    }
+
+    fn insert_sparse(&mut self, key: String, value: chroma_types::SparseVector) {
+        self.insert(key, value.into());
+    }
+
+    fn is_empty_metadata(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+impl SparseEmbeddingMetadata for UpdateMetadata {
+    fn has_key(&self, key: &str) -> bool {
+        self.contains_key(key)
+    }
+
+    fn get_str(&self, key: &str) -> Option<&String> {
+        match self.get(key) {
+            Some(UpdateMetadataValue::Str(value)) => Some(value),
+            _ => None,
+        }
+    }
+
+    fn insert_sparse(&mut self, key: String, value: chroma_types::SparseVector) {
+        self.insert(key, value.into());
+    }
+
+    fn is_empty_metadata(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+fn ensure_len(name: &str, actual: usize, expected: usize) -> Result<(), EmbeddingError> {
+    if actual != expected {
+        return Err(EmbeddingError::InvalidInput(format!(
+            "{name} length {actual} does not match ids length {expected}"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_embedding_count(expected: usize, actual: usize) -> Result<(), EmbeddingError> {
+    if expected != actual {
+        return Err(EmbeddingError::LengthMismatch { expected, actual });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::embed::{DenseEmbeddingFunction, EmbeddingError};
     use crate::tests::{unique_collection_name, with_client};
     use chroma_types::operator::{Key, QueryVector, RankExpr};
     use chroma_types::plan::{ReadLevel, SearchPayload};
     use chroma_types::{
-        Include, IncludeList, Metadata, MetadataComparison, MetadataExpression, MetadataValue,
-        PrimitiveOperator, UpdateMetadata, UpdateMetadataValue, Where,
+        Collection, EmbeddingFunctionConfiguration, EmbeddingFunctionNewConfiguration, Include,
+        IncludeList, Metadata, MetadataComparison, MetadataExpression, MetadataValue,
+        PrimitiveOperator, SparseIndexAlgorithm, SparseVector, SparseVectorIndexConfig,
+        UpdateMetadata, UpdateMetadataValue, Where,
     };
+    use httpmock::prelude::HttpMockRequest;
+    use httpmock::MockServer;
+
+    struct MockDenseEmbeddingFunction {
+        wrong_length: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl DenseEmbeddingFunction for MockDenseEmbeddingFunction {
+        fn name(&self) -> &str {
+            "mock_dense"
+        }
+
+        async fn embed_documents(&self, input: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+            let mut embeddings = input
+                .iter()
+                .map(|text| vec![text.len() as f32])
+                .collect::<Vec<_>>();
+            if self.wrong_length {
+                embeddings.push(vec![999.0]);
+            }
+            Ok(embeddings)
+        }
+
+        async fn embed_query(&self, input: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+            Ok(input
+                .iter()
+                .map(|text| vec![100.0 + text.len() as f32])
+                .collect())
+        }
+    }
+
+    fn test_collection(
+        server: &MockServer,
+        schema: Option<chroma_types::Schema>,
+        dense_embedding_function: Option<Arc<dyn DenseEmbeddingFunction>>,
+    ) -> ChromaCollection {
+        let mut collection = Collection::default();
+        collection.name = "test".to_string();
+        collection.tenant = "tenant".to_string();
+        collection.database = "database".to_string();
+        collection.schema = schema;
+        let client = ChromaHttpClient::new(crate::client::ChromaHttpClientOptions {
+            endpoint: server.base_url().parse().unwrap(),
+            tenant_id: Some("tenant".to_string()),
+            database_name: Some("database".to_string()),
+            ..Default::default()
+        });
+        ChromaCollection::new(client, collection, dense_embedding_function)
+    }
+
+    fn body_json(req: &HttpMockRequest) -> serde_json::Value {
+        serde_json::from_slice(req.body_ref()).unwrap()
+    }
+
+    fn bm25_config() -> EmbeddingFunctionConfiguration {
+        EmbeddingFunctionConfiguration::Known(EmbeddingFunctionNewConfiguration {
+            name: "chroma_bm25".to_string(),
+            config: serde_json::json!({}),
+        })
+    }
+
+    fn sparse_schema(source_key: &str) -> chroma_types::Schema {
+        chroma_types::Schema::default()
+            .create_index(
+                Some("sparse"),
+                SparseVectorIndexConfig {
+                    embedding_function: Some(bm25_config()),
+                    source_key: Some(source_key.to_string()),
+                    bm25: Some(true),
+                    algorithm: SparseIndexAlgorithm::default(),
+                }
+                .into(),
+            )
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn add_records_embeds_documents() {
+        let server = MockServer::start_async().await;
+        let collection = test_collection(
+            &server,
+            None,
+            Some(Arc::new(MockDenseEmbeddingFunction {
+                wrong_length: false,
+            })),
+        );
+        let path = format!(
+            "/api/v2/tenants/tenant/databases/database/collections/{}/add",
+            collection.id()
+        );
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST").path(path).is_true(|req| {
+                    let body = body_json(req);
+                    body["ids"] == serde_json::json!(["id1", "id2"])
+                        && body["embeddings"] == serde_json::json!([[5.0], [6.0]])
+                        && body["documents"] == serde_json::json!(["alpha", "rocket"])
+                });
+                then.status(200).json_body(serde_json::json!({}));
+            })
+            .await;
+
+        collection
+            .add_records(AddRecordsOptions {
+                ids: vec!["id1".to_string(), "id2".to_string()],
+                documents: vec!["alpha".to_string(), "rocket".to_string()],
+                uris: None,
+                metadatas: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(mock.calls_async().await, 1);
+    }
+
+    #[tokio::test]
+    async fn query_records_uses_query_embedding_method() {
+        let server = MockServer::start_async().await;
+        let collection = test_collection(
+            &server,
+            None,
+            Some(Arc::new(MockDenseEmbeddingFunction {
+                wrong_length: false,
+            })),
+        );
+        let path = format!(
+            "/api/v2/tenants/tenant/databases/database/collections/{}/query",
+            collection.id()
+        );
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST").path(path).is_true(|req| {
+                    let body = body_json(req);
+                    body["query_embeddings"] == serde_json::json!([[103.0]])
+                        && body["n_results"] == serde_json::json!(3)
+                });
+                then.status(200).json_body(serde_json::json!({
+                    "ids": [[]],
+                    "embeddings": null,
+                    "documents": null,
+                    "uris": null,
+                    "metadatas": null,
+                    "distances": null,
+                    "include": []
+                }));
+            })
+            .await;
+
+        collection
+            .query_records(QueryRecordsOptions {
+                query_texts: vec!["abc".to_string()],
+                n_results: Some(3),
+                r#where: None,
+                ids: None,
+                include: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(mock.calls_async().await, 1);
+    }
+
+    #[tokio::test]
+    async fn search_records_embeds_dense_and_sparse_queries() {
+        let server = MockServer::start_async().await;
+        let collection = test_collection(
+            &server,
+            Some(sparse_schema(DOCUMENT_KEY)),
+            Some(Arc::new(MockDenseEmbeddingFunction {
+                wrong_length: false,
+            })),
+        );
+        let path = format!(
+            "/api/v2/tenants/tenant/databases/database/collections/{}/search",
+            collection.id()
+        );
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST").path(path).is_true(|req| {
+                    let body = body_json(req);
+                    let rank_terms = body["searches"][0]["rank"]["$sum"]
+                        .as_array()
+                        .expect("rank should be a sum of dense and sparse KNNs");
+                    let dense_knn = &rank_terms[0]["$knn"];
+                    let sparse_knn = &rank_terms[1]["$knn"];
+
+                    dense_knn["key"] == serde_json::json!("#embedding")
+                        && dense_knn["query"] == serde_json::json!([106.0])
+                        && sparse_knn["key"] == serde_json::json!("sparse")
+                        && sparse_knn["query"]["#type"] == serde_json::json!("sparse_vector")
+                        && sparse_knn["query"]["indices"]
+                            .as_array()
+                            .is_some_and(|indices| !indices.is_empty())
+                        && body["searches"][0]["limit"]["limit"] == serde_json::json!(5)
+                });
+                then.status(200).json_body(serde_json::json!({
+                    "ids": [[]],
+                    "documents": [null],
+                    "embeddings": [null],
+                    "metadatas": [null],
+                    "scores": [null],
+                    "select": [[]]
+                }));
+            })
+            .await;
+
+        let response = collection
+            .search_records(SearchRecordsOptions {
+                query_texts: vec!["hybrid".to_string()],
+                sparse_key: None,
+                r#where: None,
+                ids: None,
+                limit: Some(5),
+                offset: 0,
+                rank_limit: None,
+                select: Some(vec![Key::Document, Key::Score]),
+                dense_weight: None,
+                sparse_weight: None,
+                read_level: ReadLevel::default(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.ids.len(), 1);
+        assert_eq!(mock.calls_async().await, 1);
+    }
+
+    #[tokio::test]
+    async fn update_records_embeds_present_documents() {
+        let server = MockServer::start_async().await;
+        let collection = test_collection(
+            &server,
+            None,
+            Some(Arc::new(MockDenseEmbeddingFunction {
+                wrong_length: false,
+            })),
+        );
+        let path = format!(
+            "/api/v2/tenants/tenant/databases/database/collections/{}/update",
+            collection.id()
+        );
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST").path(path).is_true(|req| {
+                    let body = body_json(req);
+                    body["embeddings"] == serde_json::json!([null, [4.0]])
+                        && body["documents"] == serde_json::json!([null, "four"])
+                });
+                then.status(200).json_body(serde_json::json!({}));
+            })
+            .await;
+
+        collection
+            .update_records(UpdateRecordsOptions {
+                ids: vec!["id1".to_string(), "id2".to_string()],
+                documents: Some(vec![None, Some("four".to_string())]),
+                uris: None,
+                metadatas: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(mock.calls_async().await, 1);
+    }
+
+    #[tokio::test]
+    async fn sparse_metadata_embeds_document_source() {
+        let server = MockServer::start_async().await;
+        let collection = test_collection(
+            &server,
+            Some(sparse_schema(DOCUMENT_KEY)),
+            Some(Arc::new(MockDenseEmbeddingFunction {
+                wrong_length: false,
+            })),
+        );
+        let path = format!(
+            "/api/v2/tenants/tenant/databases/database/collections/{}/add",
+            collection.id()
+        );
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST").path(path).is_true(|req| {
+                    let body = body_json(req);
+                    let sparse = &body["metadatas"][0]["sparse"];
+                    body["metadatas"][0].is_object()
+                        && sparse["#type"] == serde_json::json!("sparse_vector")
+                        && sparse["indices"]
+                            .as_array()
+                            .is_some_and(|indices| !indices.is_empty())
+                });
+                then.status(200).json_body(serde_json::json!({}));
+            })
+            .await;
+
+        collection
+            .add_records(AddRecordsOptions {
+                ids: vec!["id1".to_string()],
+                documents: vec!["space text".to_string()],
+                uris: None,
+                metadatas: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(mock.calls_async().await, 1);
+    }
+
+    #[tokio::test]
+    async fn sparse_metadata_uses_metadata_source_and_skips_existing_target() {
+        let server = MockServer::start_async().await;
+        let collection = test_collection(
+            &server,
+            Some(sparse_schema("source")),
+            Some(Arc::new(MockDenseEmbeddingFunction {
+                wrong_length: false,
+            })),
+        );
+        let path = format!(
+            "/api/v2/tenants/tenant/databases/database/collections/{}/upsert",
+            collection.id()
+        );
+        let existing_sparse = SparseVector::new(vec![99], vec![1.0]).unwrap();
+        let mut first = UpdateMetadata::new();
+        first.insert("source".to_string(), "alpha".into());
+        let mut second = UpdateMetadata::new();
+        second.insert("source".to_string(), "beta".into());
+        second.insert("sparse".to_string(), existing_sparse.into());
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST").path(path).is_true(|req| {
+                    let body = body_json(req);
+                    let first_sparse = &body["metadatas"][0]["sparse"];
+                    let second_sparse = &body["metadatas"][1]["sparse"];
+                    first_sparse["#type"] == serde_json::json!("sparse_vector")
+                        && first_sparse["indices"]
+                            .as_array()
+                            .is_some_and(|indices| !indices.is_empty())
+                        && second_sparse["indices"] == serde_json::json!([99])
+                        && second_sparse["values"] == serde_json::json!([1.0])
+                });
+                then.status(200).json_body(serde_json::json!({}));
+            })
+            .await;
+
+        collection
+            .upsert_records(UpsertRecordsOptions {
+                ids: vec!["id1".to_string(), "id2".to_string()],
+                documents: vec!["alpha doc".to_string(), "beta doc".to_string()],
+                uris: None,
+                metadatas: Some(vec![Some(first), Some(second)]),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(mock.calls_async().await, 1);
+    }
+
+    #[tokio::test]
+    async fn embedding_length_mismatch_is_reported() {
+        let server = MockServer::start_async().await;
+        let collection = test_collection(
+            &server,
+            None,
+            Some(Arc::new(MockDenseEmbeddingFunction { wrong_length: true })),
+        );
+
+        let err = collection
+            .add_records(AddRecordsOptions {
+                ids: vec!["id1".to_string()],
+                documents: vec!["alpha".to_string()],
+                uris: None,
+                metadatas: None,
+            })
+            .await
+            .err()
+            .unwrap();
+
+        match err {
+            ChromaHttpClientError::EmbeddingError(EmbeddingError::LengthMismatch {
+                expected,
+                actual,
+            }) => {
+                assert_eq!(expected, 1);
+                assert_eq!(actual, 2);
+            }
+            other => panic!("expected length mismatch, got {other:?}"),
+        }
+    }
 
     #[tokio::test]
     #[test_log::test]

--- a/rust/chroma/src/embed/bm25.rs
+++ b/rust/chroma/src/embed/bm25.rs
@@ -1,9 +1,17 @@
 use chroma_types::SparseVector;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::embed::bm25_tokenizer::Bm25Tokenizer;
 use crate::embed::murmur3_abs_hasher::Murmur3AbsHasher;
-use crate::embed::{EmbeddingFunction, TokenHasher, Tokenizer};
+use crate::embed::{
+    EmbeddingError, EmbeddingFunction, SparseEmbeddingFunction, TokenHasher, Tokenizer,
+};
+
+const CHROMA_BM25_NAME: &str = "chroma_bm25";
+
+/// Default Chroma BM25 sparse embedding function.
+pub type ChromaBm25EmbeddingFunction = BM25SparseEmbeddingFunction<Bm25Tokenizer, Murmur3AbsHasher>;
 
 /// Error type for BM25 sparse embedding.
 ///
@@ -63,6 +71,68 @@ impl BM25SparseEmbeddingFunction<Bm25Tokenizer, Murmur3AbsHasher> {
             k: 1.2,
             b: 0.75,
             avg_len: 256.0,
+        }
+    }
+
+    /// Construct BM25 from a persisted Chroma BM25 configuration.
+    pub fn try_from_config(
+        configuration: &chroma_types::EmbeddingFunctionNewConfiguration,
+    ) -> Result<Self, EmbeddingError> {
+        let config: ChromaBm25Config = serde_json::from_value(configuration.config.clone())?;
+        Ok(Self::from_config(config))
+    }
+
+    fn from_config(config: ChromaBm25Config) -> Self {
+        let token_max_length = config.token_max_length.unwrap_or(40) as usize;
+        let tokenizer = match config.stopwords {
+            Some(stopwords) => Bm25Tokenizer::with_owned_stopwords(stopwords, token_max_length),
+            None => {
+                let mut tokenizer = Bm25Tokenizer::default();
+                tokenizer.token_max_length = token_max_length;
+                tokenizer
+            }
+        };
+
+        Self {
+            include_tokens: config.include_tokens.unwrap_or(true),
+            tokenizer,
+            hasher: Murmur3AbsHasher::default(),
+            k: config.k.unwrap_or(1.2),
+            b: config.b.unwrap_or(0.75),
+            avg_len: config.avg_doc_length.unwrap_or(256.0),
+        }
+    }
+}
+
+impl From<&BM25SparseEmbeddingFunction<Bm25Tokenizer, Murmur3AbsHasher>> for ChromaBm25Config {
+    fn from(value: &BM25SparseEmbeddingFunction<Bm25Tokenizer, Murmur3AbsHasher>) -> Self {
+        let default_stopwords = Bm25Tokenizer::default_stopwords();
+        let has_default_stopwords = value.tokenizer.stopwords.len() == default_stopwords.len()
+            && value
+                .tokenizer
+                .stopwords
+                .iter()
+                .all(|word| default_stopwords.contains(word.as_ref()));
+        let stopwords = if has_default_stopwords {
+            None
+        } else {
+            let mut stopwords = value
+                .tokenizer
+                .stopwords
+                .iter()
+                .map(|word| word.as_ref().to_string())
+                .collect::<Vec<_>>();
+            stopwords.sort();
+            Some(stopwords)
+        };
+
+        ChromaBm25Config {
+            k: Some(value.k),
+            b: Some(value.b),
+            avg_doc_length: Some(value.avg_len),
+            token_max_length: Some(value.tokenizer.token_max_length as u64),
+            stopwords,
+            include_tokens: Some(value.include_tokens),
         }
     }
 }
@@ -139,9 +209,45 @@ where
     }
 }
 
+#[async_trait::async_trait]
+impl SparseEmbeddingFunction for BM25SparseEmbeddingFunction<Bm25Tokenizer, Murmur3AbsHasher> {
+    fn name(&self) -> &str {
+        CHROMA_BM25_NAME
+    }
+
+    fn configuration(&self) -> chroma_types::EmbeddingFunctionConfiguration {
+        (
+            CHROMA_BM25_NAME,
+            serde_json::json!(ChromaBm25Config::from(self)),
+        )
+            .into()
+    }
+
+    async fn embed_documents(&self, batches: &[&str]) -> Result<Vec<SparseVector>, EmbeddingError> {
+        batches
+            .iter()
+            .map(|text| {
+                self.encode(text)
+                    .map_err(|err| EmbeddingError::InvalidInput(err.to_string()))
+            })
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct ChromaBm25Config {
+    k: Option<f32>,
+    b: Option<f32>,
+    avg_doc_length: Option<f32>,
+    token_max_length: Option<u64>,
+    stopwords: Option<Vec<String>>,
+    include_tokens: Option<bool>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chroma_types::{EmbeddingFunctionConfiguration, EmbeddingFunctionNewConfiguration};
 
     /// Tests comprehensive tokenization covering:
     /// - Possessive forms (Bolt's)
@@ -196,5 +302,36 @@ mod tests {
         for &value in &result.values {
             assert!((value - expected_value).abs() < 1e-5);
         }
+    }
+
+    #[test]
+    fn test_bm25_config_round_trip() {
+        let config = EmbeddingFunctionNewConfiguration {
+            name: "chroma-bm25".to_string(),
+            config: serde_json::json!({
+                "k": 1.5,
+                "b": 0.5,
+                "avg_doc_length": 128.0,
+                "token_max_length": 12,
+                "stopwords": ["and", "the"],
+                "include_tokens": false
+            }),
+        };
+        let bm25 = BM25SparseEmbeddingFunction::try_from_config(&config).unwrap();
+
+        assert_eq!(
+            bm25.configuration(),
+            EmbeddingFunctionConfiguration::Known(EmbeddingFunctionNewConfiguration {
+                name: "chroma_bm25".to_string(),
+                config: serde_json::json!({
+                    "k": 1.5,
+                    "b": 0.5,
+                    "avg_doc_length": 128.0,
+                    "token_max_length": 12,
+                    "stopwords": ["and", "the"],
+                    "include_tokens": false
+                }),
+            })
+        );
     }
 }

--- a/rust/chroma/src/embed/bm25.rs
+++ b/rust/chroma/src/embed/bm25.rs
@@ -86,11 +86,10 @@ impl BM25SparseEmbeddingFunction<Bm25Tokenizer, Murmur3AbsHasher> {
         let token_max_length = config.token_max_length.unwrap_or(40) as usize;
         let tokenizer = match config.stopwords {
             Some(stopwords) => Bm25Tokenizer::with_owned_stopwords(stopwords, token_max_length),
-            None => {
-                let mut tokenizer = Bm25Tokenizer::default();
-                tokenizer.token_max_length = token_max_length;
-                tokenizer
-            }
+            None => Bm25Tokenizer {
+                token_max_length,
+                ..Default::default()
+            },
         };
 
         Self {

--- a/rust/chroma/src/embed/bm25_tokenizer.rs
+++ b/rust/chroma/src/embed/bm25_tokenizer.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
@@ -8,7 +9,7 @@ use crate::embed::Tokenizer;
 /// Default English stopwords array for BM25 tokenization.
 ///
 /// This list is derived from NLTK's English stopwords. Total: 179 stopwords.
-const DEFAULT_ENGLISH_STOPWORDS_ARRAY: &[&str] = &[
+pub(crate) const DEFAULT_ENGLISH_STOPWORDS_ARRAY: &[&str] = &[
     "a",
     "about",
     "above",
@@ -209,7 +210,7 @@ pub struct Bm25Tokenizer {
     /// Snowball stemmer for reducing words to their root form.
     pub stemmer: Stemmer,
     /// Set of stopwords to filter out during tokenization.
-    pub stopwords: HashSet<&'static str>,
+    pub stopwords: HashSet<Cow<'static, str>>,
     /// Maximum token length; longer tokens are discarded.
     pub token_max_length: usize,
 }
@@ -218,13 +219,49 @@ impl Default for Bm25Tokenizer {
     fn default() -> Self {
         Self {
             stemmer: Stemmer::create(Algorithm::English),
-            stopwords: DEFAULT_ENGLISH_STOPWORDS.clone(),
+            stopwords: DEFAULT_ENGLISH_STOPWORDS
+                .iter()
+                .copied()
+                .map(Cow::Borrowed)
+                .collect(),
             token_max_length: 40,
         }
     }
 }
 
 impl Bm25Tokenizer {
+    /// Returns the default English stopword set.
+    pub fn default_stopwords() -> &'static HashSet<&'static str> {
+        &DEFAULT_ENGLISH_STOPWORDS
+    }
+
+    /// Create a tokenizer with a caller-provided lowercase stopword set.
+    pub fn with_stopwords(
+        stopwords: impl IntoIterator<Item = &'static str>,
+        token_max_length: usize,
+    ) -> Self {
+        Self {
+            stemmer: Stemmer::create(Algorithm::English),
+            stopwords: stopwords.into_iter().map(Cow::Borrowed).collect(),
+            token_max_length,
+        }
+    }
+
+    /// Create a tokenizer from owned stopwords read from persisted configuration.
+    pub(crate) fn with_owned_stopwords(
+        stopwords: impl IntoIterator<Item = String>,
+        token_max_length: usize,
+    ) -> Self {
+        Self {
+            stemmer: Stemmer::create(Algorithm::English),
+            stopwords: stopwords
+                .into_iter()
+                .map(|word| Cow::Owned(word.to_lowercase()))
+                .collect(),
+            token_max_length,
+        }
+    }
+
     /// Remove non-alphanumeric characters, replacing with spaces.
     ///
     /// Matches Python's: re.sub(r"[^\w\s]", " ", text, flags=re.UNICODE)

--- a/rust/chroma/src/embed/chroma_cloud.rs
+++ b/rust/chroma/src/embed/chroma_cloud.rs
@@ -536,17 +536,19 @@ mod tests {
             })
             .await;
 
-        let mut options = ChromaCloudQwenOptions::default();
-        options.api_key = Some("test-key".to_string());
-        options.url = server.base_url();
-        options.task = Some("task".to_string());
-        options.instructions = BTreeMap::from([(
-            "task".to_string(),
-            BTreeMap::from([
-                ("documents".to_string(), "document instruction".to_string()),
-                ("query".to_string(), "query instruction".to_string()),
-            ]),
-        )]);
+        let options = ChromaCloudQwenOptions {
+            api_key: Some("test-key".to_string()),
+            url: server.base_url(),
+            task: Some("task".to_string()),
+            instructions: BTreeMap::from([(
+                "task".to_string(),
+                BTreeMap::from([
+                    ("documents".to_string(), "document instruction".to_string()),
+                    ("query".to_string(), "query instruction".to_string()),
+                ]),
+            )]),
+            ..Default::default()
+        };
         let embedder = ChromaCloudQwenEmbeddingFunction::new(options);
 
         let embeddings = embedder.embed_query(&["hello"]).await.unwrap();
@@ -580,10 +582,12 @@ mod tests {
             })
             .await;
 
-        let mut options = ChromaCloudSpladeOptions::default();
-        options.api_key = Some("test-key".to_string());
-        options.url = format!("{}/embed_sparse", server.base_url());
-        options.include_tokens = true;
+        let options = ChromaCloudSpladeOptions {
+            api_key: Some("test-key".to_string()),
+            url: format!("{}/embed_sparse", server.base_url()),
+            include_tokens: true,
+            ..Default::default()
+        };
         let embedder = ChromaCloudSpladeEmbeddingFunction::new(options);
 
         let embeddings = embedder.embed_documents(&["hello"]).await.unwrap();

--- a/rust/chroma/src/embed/chroma_cloud.rs
+++ b/rust/chroma/src/embed/chroma_cloud.rs
@@ -1,0 +1,630 @@
+//! Chroma Cloud embedding function implementations.
+
+use std::collections::BTreeMap;
+
+use chroma_types::SparseVector;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use serde::{Deserialize, Serialize};
+
+use crate::embed::{
+    DenseEmbeddingFunction, EmbeddingError, EmbeddingStatus, SparseEmbeddingFunction,
+};
+
+const DEFAULT_CHROMA_EMBED_URL: &str = "https://embed.trychroma.com";
+const DEFAULT_API_KEY_ENV_VAR: &str = "CHROMA_API_KEY";
+const QWEN_NAME: &str = "chroma-cloud-qwen";
+const SPLADE_NAME: &str = "chroma-cloud-splade";
+const DEFAULT_QWEN_MODEL: &str = "Qwen/Qwen3-Embedding-0.6B";
+const DEFAULT_SPLADE_MODEL: &str = "prithivida/Splade_PP_en_v1";
+
+fn default_api_key_env_var() -> String {
+    DEFAULT_API_KEY_ENV_VAR.to_string()
+}
+
+fn default_chroma_embed_url() -> String {
+    std::env::var("CHROMA_EMBED_URL")
+        .unwrap_or_else(|_| DEFAULT_CHROMA_EMBED_URL.to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn default_qwen_instructions() -> BTreeMap<String, BTreeMap<String, String>> {
+    let mut targets = BTreeMap::new();
+    targets.insert("documents".to_string(), String::new());
+    targets.insert(
+        "query".to_string(),
+        "Given a question about coding, retrieval code or passage that can solve user's question"
+            .to_string(),
+    );
+
+    let mut instructions = BTreeMap::new();
+    instructions.insert("nl_to_code".to_string(), targets);
+    instructions
+}
+
+fn env_or_fallback_api_key(env_var: &str, fallback: Option<String>) -> Option<String> {
+    std::env::var(env_var).ok().or(fallback)
+}
+
+fn headers(api_key: Option<&str>, model: &str) -> Result<HeaderMap, EmbeddingError> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_static("content-type"),
+        HeaderValue::from_static("application/json"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-chroma-embedding-model"),
+        HeaderValue::from_str(model).map_err(|err| {
+            EmbeddingError::Configuration(format!("invalid embedding model header: {err}"))
+        })?,
+    );
+    headers.insert(
+        HeaderName::from_static("x-chroma-token"),
+        HeaderValue::from_str(api_key.unwrap_or_default()).map_err(|err| {
+            EmbeddingError::Configuration(format!("invalid Chroma API key header: {err}"))
+        })?,
+    );
+    Ok(headers)
+}
+
+/// Options for constructing a Chroma Cloud Qwen embedding function.
+#[derive(Clone, Debug)]
+pub struct ChromaCloudQwenOptions {
+    /// Qwen embedding model identifier.
+    pub model: String,
+    /// Optional task name used to select document and query instructions.
+    pub task: Option<String>,
+    /// Instruction map keyed by task and target (`documents` or `query`).
+    pub instructions: BTreeMap<String, BTreeMap<String, String>>,
+    /// Environment variable used to discover the Chroma API key.
+    pub api_key_env_var: String,
+    /// Optional API key fallback used when the environment variable is absent.
+    pub api_key: Option<String>,
+    /// Chroma embedding API URL.
+    pub url: String,
+}
+
+impl Default for ChromaCloudQwenOptions {
+    fn default() -> Self {
+        Self {
+            model: DEFAULT_QWEN_MODEL.to_string(),
+            task: None,
+            instructions: default_qwen_instructions(),
+            api_key_env_var: default_api_key_env_var(),
+            api_key: None,
+            url: default_chroma_embed_url(),
+        }
+    }
+}
+
+/// Dense embedding function backed by the Chroma Cloud Qwen embedding API.
+pub struct ChromaCloudQwenEmbeddingFunction {
+    client: reqwest::Client,
+    options: ChromaCloudQwenOptions,
+}
+
+impl ChromaCloudQwenEmbeddingFunction {
+    /// Construct a Qwen embedding function from options.
+    pub fn new(options: ChromaCloudQwenOptions) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            options,
+        }
+    }
+
+    /// Construct a Qwen embedding function from persisted configuration.
+    pub fn try_from_config(
+        configuration: &chroma_types::EmbeddingFunctionNewConfiguration,
+        chroma_cloud_api_key: Option<String>,
+    ) -> Result<Self, EmbeddingError> {
+        let config: ChromaCloudQwenConfig = serde_json::from_value(configuration.config.clone())?;
+        let api_key = env_or_fallback_api_key(&config.api_key_env_var, chroma_cloud_api_key);
+        Ok(Self::new(ChromaCloudQwenOptions {
+            model: config.model,
+            task: config.task,
+            instructions: config.instructions,
+            api_key_env_var: config.api_key_env_var,
+            api_key,
+            url: default_chroma_embed_url(),
+        }))
+    }
+
+    fn instruction(&self, target: &str) -> String {
+        self.options
+            .task
+            .as_ref()
+            .and_then(|task| self.options.instructions.get(task))
+            .and_then(|targets| targets.get(target))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    async fn embed_with_instruction(
+        &self,
+        input: &[&str],
+        instruction: String,
+    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        if input.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        #[derive(Serialize)]
+        struct Request<'a> {
+            texts: &'a [&'a str],
+            instructions: String,
+        }
+
+        #[derive(Deserialize)]
+        struct Response {
+            embeddings: Vec<Vec<f32>>,
+        }
+
+        let headers = headers(self.options.api_key.as_deref(), &self.options.model)?;
+        let response = self
+            .client
+            .post(&self.options.url)
+            .headers(headers)
+            .json(&Request {
+                texts: input,
+                instructions: instruction,
+            })
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(EmbeddingError::Provider {
+                status: EmbeddingStatus::some(status),
+                message,
+            });
+        }
+
+        let response = response.json::<Response>().await?;
+        Ok(response.embeddings)
+    }
+}
+
+#[async_trait::async_trait]
+impl DenseEmbeddingFunction for ChromaCloudQwenEmbeddingFunction {
+    fn name(&self) -> &str {
+        QWEN_NAME
+    }
+
+    fn configuration(&self) -> chroma_types::EmbeddingFunctionConfiguration {
+        (
+            QWEN_NAME,
+            serde_json::json!(ChromaCloudQwenConfig::from(&self.options)),
+        )
+            .into()
+    }
+
+    fn default_space(&self) -> chroma_types::Space {
+        chroma_types::Space::Cosine
+    }
+
+    fn supported_spaces(&self) -> Vec<chroma_types::Space> {
+        vec![
+            chroma_types::Space::Cosine,
+            chroma_types::Space::L2,
+            chroma_types::Space::Ip,
+        ]
+    }
+
+    async fn embed_documents(&self, input: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        self.embed_with_instruction(input, self.instruction("documents"))
+            .await
+    }
+
+    async fn embed_query(&self, input: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        self.embed_with_instruction(input, self.instruction("query"))
+            .await
+    }
+}
+
+/// Options for constructing a Chroma Cloud SPLADE embedding function.
+#[derive(Clone, Debug)]
+pub struct ChromaCloudSpladeOptions {
+    /// SPLADE embedding model identifier.
+    pub model: String,
+    /// Environment variable used to discover the Chroma API key.
+    pub api_key_env_var: String,
+    /// Optional API key fallback used when the environment variable is absent.
+    pub api_key: Option<String>,
+    /// Whether token labels should be retained in sparse vectors.
+    pub include_tokens: bool,
+    /// Chroma sparse embedding API URL.
+    pub url: String,
+}
+
+impl Default for ChromaCloudSpladeOptions {
+    fn default() -> Self {
+        Self {
+            model: DEFAULT_SPLADE_MODEL.to_string(),
+            api_key_env_var: default_api_key_env_var(),
+            api_key: None,
+            include_tokens: false,
+            url: format!("{}/embed_sparse", default_chroma_embed_url()),
+        }
+    }
+}
+
+/// Sparse embedding function backed by the Chroma Cloud SPLADE embedding API.
+pub struct ChromaCloudSpladeEmbeddingFunction {
+    client: reqwest::Client,
+    options: ChromaCloudSpladeOptions,
+}
+
+impl ChromaCloudSpladeEmbeddingFunction {
+    /// Construct a SPLADE embedding function from options.
+    pub fn new(options: ChromaCloudSpladeOptions) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            options,
+        }
+    }
+
+    /// Construct a SPLADE embedding function from persisted configuration.
+    pub fn try_from_config(
+        configuration: &chroma_types::EmbeddingFunctionNewConfiguration,
+        chroma_cloud_api_key: Option<String>,
+    ) -> Result<Self, EmbeddingError> {
+        let config: ChromaCloudSpladeConfig = serde_json::from_value(configuration.config.clone())?;
+        let api_key = env_or_fallback_api_key(&config.api_key_env_var, chroma_cloud_api_key);
+        Ok(Self::new(ChromaCloudSpladeOptions {
+            model: config.model,
+            api_key_env_var: config.api_key_env_var,
+            api_key,
+            include_tokens: config.include_tokens.unwrap_or(false),
+            url: format!("{}/embed_sparse", default_chroma_embed_url()),
+        }))
+    }
+
+    async fn embed(&self, input: &[&str]) -> Result<Vec<SparseVector>, EmbeddingError> {
+        if input.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        #[derive(Serialize)]
+        struct Request<'a> {
+            texts: &'a [&'a str],
+            task: &'static str,
+            target: &'static str,
+            fetch_tokens: &'static str,
+        }
+
+        #[derive(Deserialize)]
+        struct Response {
+            embeddings: Vec<CloudSparseVector>,
+        }
+
+        let headers = headers(self.options.api_key.as_deref(), &self.options.model)?;
+        let response = self
+            .client
+            .post(&self.options.url)
+            .headers(headers)
+            .json(&Request {
+                texts: input,
+                task: "",
+                target: "",
+                fetch_tokens: if self.options.include_tokens {
+                    "true"
+                } else {
+                    "false"
+                },
+            })
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(EmbeddingError::Provider {
+                status: EmbeddingStatus::some(status),
+                message,
+            });
+        }
+
+        response
+            .json::<Response>()
+            .await?
+            .embeddings
+            .into_iter()
+            .map(SparseVector::try_from)
+            .collect()
+    }
+}
+
+#[async_trait::async_trait]
+impl SparseEmbeddingFunction for ChromaCloudSpladeEmbeddingFunction {
+    fn name(&self) -> &str {
+        SPLADE_NAME
+    }
+
+    fn configuration(&self) -> chroma_types::EmbeddingFunctionConfiguration {
+        (
+            SPLADE_NAME,
+            serde_json::json!(ChromaCloudSpladeConfig::from(&self.options)),
+        )
+            .into()
+    }
+
+    async fn embed_documents(&self, input: &[&str]) -> Result<Vec<SparseVector>, EmbeddingError> {
+        self.embed(input).await
+    }
+
+    async fn embed_query(&self, input: &[&str]) -> Result<Vec<SparseVector>, EmbeddingError> {
+        self.embed(input).await
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ChromaCloudQwenConfig {
+    model: String,
+    task: Option<String>,
+    #[serde(default = "default_qwen_instructions")]
+    instructions: BTreeMap<String, BTreeMap<String, String>>,
+    #[serde(default = "default_api_key_env_var")]
+    api_key_env_var: String,
+}
+
+impl From<&ChromaCloudQwenOptions> for ChromaCloudQwenConfig {
+    fn from(value: &ChromaCloudQwenOptions) -> Self {
+        ChromaCloudQwenConfig {
+            model: value.model.clone(),
+            task: value.task.clone(),
+            instructions: value.instructions.clone(),
+            api_key_env_var: value.api_key_env_var.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ChromaCloudSpladeConfig {
+    model: String,
+    #[serde(default = "default_api_key_env_var")]
+    api_key_env_var: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    include_tokens: Option<bool>,
+}
+
+impl From<&ChromaCloudSpladeOptions> for ChromaCloudSpladeConfig {
+    fn from(value: &ChromaCloudSpladeOptions) -> Self {
+        ChromaCloudSpladeConfig {
+            model: value.model.clone(),
+            api_key_env_var: value.api_key_env_var.clone(),
+            include_tokens: Some(value.include_tokens),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CloudSparseVector {
+    indices: Vec<u32>,
+    values: Vec<f32>,
+    #[serde(alias = "labels")]
+    tokens: Option<Vec<String>>,
+}
+
+impl TryFrom<CloudSparseVector> for SparseVector {
+    type Error = EmbeddingError;
+
+    fn try_from(value: CloudSparseVector) -> Result<Self, Self::Error> {
+        let CloudSparseVector {
+            indices,
+            values,
+            tokens,
+        } = value;
+
+        if indices.len() != values.len() {
+            return Err(EmbeddingError::InvalidInput(
+                "sparse vector indices and values have different lengths".to_string(),
+            ));
+        }
+
+        if let Some(tokens) = tokens.as_ref() {
+            if tokens.len() != indices.len() {
+                return Err(EmbeddingError::InvalidInput(
+                    "sparse vector tokens and indices have different lengths".to_string(),
+                ));
+            }
+        }
+
+        let mut entries = indices
+            .into_iter()
+            .zip(values)
+            .enumerate()
+            .map(|(position, (index, score))| {
+                let token = tokens
+                    .as_ref()
+                    .and_then(|tokens| tokens.get(position).cloned());
+                (index, score, token)
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|(index, _, _)| *index);
+
+        let indices = entries
+            .iter()
+            .map(|(index, _, _)| *index)
+            .collect::<Vec<_>>();
+        let values = entries
+            .iter()
+            .map(|(_, value, _)| *value)
+            .collect::<Vec<_>>();
+        let tokens = tokens.map(|_| {
+            entries
+                .into_iter()
+                .map(|(_, _, token)| token.unwrap_or_default())
+                .collect()
+        });
+
+        let vector = match tokens {
+            Some(tokens) => SparseVector::new_with_tokens(indices, values, tokens),
+            None => SparseVector::new(indices, values),
+        }
+        .map_err(|err| EmbeddingError::InvalidInput(err.to_string()))?;
+        vector
+            .validate()
+            .map_err(|err| EmbeddingError::InvalidInput(err.to_string()))?;
+        Ok(vector)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embed::{DenseEmbeddingFunction, SparseEmbeddingFunction};
+    use chroma_types::{EmbeddingFunctionConfiguration, EmbeddingFunctionNewConfiguration};
+    use httpmock::MockServer;
+
+    #[test]
+    fn qwen_config_round_trip() {
+        let options = ChromaCloudQwenOptions {
+            task: Some("nl_to_code".to_string()),
+            ..Default::default()
+        };
+        let embedder = ChromaCloudQwenEmbeddingFunction::new(options);
+
+        assert_eq!(
+            embedder.configuration(),
+            EmbeddingFunctionConfiguration::Known(EmbeddingFunctionNewConfiguration {
+                name: QWEN_NAME.to_string(),
+                config: serde_json::json!({
+                    "model": DEFAULT_QWEN_MODEL,
+                    "task": "nl_to_code",
+                    "instructions": default_qwen_instructions(),
+                    "api_key_env_var": DEFAULT_API_KEY_ENV_VAR
+                }),
+            })
+        );
+    }
+
+    #[test]
+    fn splade_config_round_trip() {
+        let embedder = ChromaCloudSpladeEmbeddingFunction::new(ChromaCloudSpladeOptions::default());
+
+        assert_eq!(
+            embedder.configuration(),
+            EmbeddingFunctionConfiguration::Known(EmbeddingFunctionNewConfiguration {
+                name: SPLADE_NAME.to_string(),
+                config: serde_json::json!({
+                    "model": DEFAULT_SPLADE_MODEL,
+                    "api_key_env_var": DEFAULT_API_KEY_ENV_VAR,
+                    "include_tokens": false
+                }),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn qwen_sends_headers_and_query_instructions() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST")
+                    .path("/")
+                    .header("x-chroma-token", "test-key")
+                    .header("x-chroma-embedding-model", DEFAULT_QWEN_MODEL)
+                    .json_body(serde_json::json!({
+                        "texts": ["hello"],
+                        "instructions": "query instruction"
+                    }));
+                then.status(200).json_body(serde_json::json!({
+                    "embeddings": [[1.0, 2.0]],
+                    "num_tokens": 2
+                }));
+            })
+            .await;
+
+        let mut options = ChromaCloudQwenOptions::default();
+        options.api_key = Some("test-key".to_string());
+        options.url = server.base_url();
+        options.task = Some("task".to_string());
+        options.instructions = BTreeMap::from([(
+            "task".to_string(),
+            BTreeMap::from([
+                ("documents".to_string(), "document instruction".to_string()),
+                ("query".to_string(), "query instruction".to_string()),
+            ]),
+        )]);
+        let embedder = ChromaCloudQwenEmbeddingFunction::new(options);
+
+        let embeddings = embedder.embed_query(&["hello"]).await.unwrap();
+
+        assert_eq!(embeddings, vec![vec![1.0, 2.0]]);
+        assert_eq!(mock.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn splade_sorts_sparse_vectors() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST")
+                    .path("/embed_sparse")
+                    .header("x-chroma-token", "test-key")
+                    .header("x-chroma-embedding-model", DEFAULT_SPLADE_MODEL)
+                    .json_body(serde_json::json!({
+                        "texts": ["hello"],
+                        "task": "",
+                        "target": "",
+                        "fetch_tokens": "true"
+                    }));
+                then.status(200).json_body(serde_json::json!({
+                    "embeddings": [{
+                        "indices": [9, 1],
+                        "values": [0.9, 0.1],
+                        "labels": ["nine", "one"]
+                    }]
+                }));
+            })
+            .await;
+
+        let mut options = ChromaCloudSpladeOptions::default();
+        options.api_key = Some("test-key".to_string());
+        options.url = format!("{}/embed_sparse", server.base_url());
+        options.include_tokens = true;
+        let embedder = ChromaCloudSpladeEmbeddingFunction::new(options);
+
+        let embeddings = embedder.embed_documents(&["hello"]).await.unwrap();
+
+        assert_eq!(
+            embeddings,
+            vec![SparseVector::new_with_tokens(
+                vec![1, 9],
+                vec![0.1, 0.9],
+                vec!["one".to_string(), "nine".to_string()]
+            )
+            .unwrap()]
+        );
+        assert_eq!(mock.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn cloud_provider_http_errors_are_reported() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method("POST").path("/");
+                then.status(500).body("provider failed");
+            })
+            .await;
+
+        let options = ChromaCloudQwenOptions {
+            api_key: Some("test-key".to_string()),
+            url: server.base_url(),
+            ..Default::default()
+        };
+        let embedder = ChromaCloudQwenEmbeddingFunction::new(options);
+
+        let err = embedder.embed_documents(&["hello"]).await.unwrap_err();
+
+        match err {
+            EmbeddingError::Provider { status, message } => {
+                assert_eq!(status.0.unwrap().as_u16(), 500);
+                assert_eq!(message, "provider failed");
+            }
+            other => panic!("expected provider error, got {other:?}"),
+        }
+    }
+}

--- a/rust/chroma/src/embed/mod.rs
+++ b/rust/chroma/src/embed/mod.rs
@@ -7,16 +7,209 @@
 use std::{
     error::Error,
     fmt::{Debug, Display},
+    sync::Arc,
 };
+
+use chroma_types::{EmbeddingFunctionConfiguration, Space, SparseVector};
+use thiserror::Error;
 
 /// BM25 sparse embedding implementation.
 pub mod bm25;
 /// Text tokenization utilities for BM25.
 pub mod bm25_tokenizer;
+/// Chroma Cloud embedding function implementations.
+pub mod chroma_cloud;
 /// MurmurHash3 absolute value hasher for token hashing.
 pub mod murmur3_abs_hasher;
 #[cfg(feature = "ollama")]
 pub mod ollama;
+
+/// Error type shared by object-safe embedding functions.
+#[derive(Debug, Error)]
+pub enum EmbeddingError {
+    /// The named embedding function is known to Chroma but is not supported by this client.
+    #[error("embedding function '{name}' is not supported by this client")]
+    UnsupportedEmbeddingFunction {
+        /// Embedding function name from persisted configuration.
+        name: String,
+    },
+    /// The collection or request did not provide enough text to embed.
+    #[error("embedding input error: {0}")]
+    InvalidInput(String),
+    /// An embedding provider returned a different number of vectors than requested.
+    #[error("embedding function returned {actual} embeddings for {expected} inputs")]
+    LengthMismatch {
+        /// Number of input texts sent to the embedding function.
+        expected: usize,
+        /// Number of embeddings returned by the embedding function.
+        actual: usize,
+    },
+    /// The embedding function configuration could not be interpreted.
+    #[error("embedding configuration error: {0}")]
+    Configuration(String),
+    /// HTTP request to an embedding provider failed before a response was received.
+    #[error("embedding provider request failed: {0}")]
+    Request(#[from] reqwest::Error),
+    /// HTTP provider returned an error response or malformed provider payload.
+    #[error("embedding provider error{status}: {message}")]
+    Provider {
+        /// Optional HTTP status code.
+        status: EmbeddingStatus,
+        /// Provider error body or diagnostic message.
+        message: String,
+    },
+    /// JSON serialization or deserialization failed for an embedding provider.
+    #[error("embedding serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+/// Optional status code for embedding provider failures.
+#[derive(Debug, Clone, Copy)]
+pub struct EmbeddingStatus(Option<reqwest::StatusCode>);
+
+impl EmbeddingStatus {
+    /// Construct an empty embedding provider status.
+    pub fn none() -> Self {
+        Self(None)
+    }
+
+    /// Construct an embedding provider status from an HTTP status code.
+    pub fn some(status: reqwest::StatusCode) -> Self {
+        Self(Some(status))
+    }
+}
+
+impl Display for EmbeddingStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(status) => write!(f, " ({status})"),
+            None => Ok(()),
+        }
+    }
+}
+
+/// Object-safe dense embedding function interface.
+#[async_trait::async_trait]
+pub trait DenseEmbeddingFunction: Send + Sync + 'static {
+    /// Stable embedding function name used in persisted configuration.
+    fn name(&self) -> &str {
+        "legacy"
+    }
+
+    /// Persistable embedding function configuration.
+    fn configuration(&self) -> EmbeddingFunctionConfiguration {
+        EmbeddingFunctionConfiguration::Legacy
+    }
+
+    /// Default vector space for embeddings produced by this function.
+    fn default_space(&self) -> Space {
+        Space::L2
+    }
+
+    /// Vector spaces supported by this embedding function.
+    fn supported_spaces(&self) -> Vec<Space> {
+        vec![self.default_space()]
+    }
+
+    /// Embed documents for storage.
+    async fn embed_documents(&self, input: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError>;
+
+    /// Embed query text for search.
+    async fn embed_query(&self, input: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        self.embed_documents(input).await
+    }
+}
+
+/// Object-safe sparse embedding function interface.
+#[async_trait::async_trait]
+pub trait SparseEmbeddingFunction: Send + Sync + 'static {
+    /// Stable embedding function name used in persisted configuration.
+    fn name(&self) -> &str {
+        "legacy"
+    }
+
+    /// Persistable embedding function configuration.
+    fn configuration(&self) -> EmbeddingFunctionConfiguration {
+        EmbeddingFunctionConfiguration::Legacy
+    }
+
+    /// Embed documents for sparse-vector storage.
+    async fn embed_documents(&self, input: &[&str]) -> Result<Vec<SparseVector>, EmbeddingError>;
+
+    /// Embed query text for sparse-vector search.
+    async fn embed_query(&self, input: &[&str]) -> Result<Vec<SparseVector>, EmbeddingError> {
+        self.embed_documents(input).await
+    }
+}
+
+/// Build a supported dense embedding function from persisted configuration.
+pub fn dense_embedding_function_from_config(
+    configuration: &EmbeddingFunctionConfiguration,
+    chroma_cloud_api_key: Option<String>,
+) -> Result<Arc<dyn DenseEmbeddingFunction>, EmbeddingError> {
+    let EmbeddingFunctionConfiguration::Known(configuration) = configuration else {
+        return Err(EmbeddingError::UnsupportedEmbeddingFunction {
+            name: embedding_function_configuration_name(configuration).to_string(),
+        });
+    };
+
+    match configuration.name.as_str() {
+        #[cfg(feature = "ollama")]
+        "ollama" => Ok(Arc::new(ollama::OllamaEmbeddingFunction::try_from_config(
+            configuration,
+        )?)),
+        #[cfg(not(feature = "ollama"))]
+        "ollama" => Err(EmbeddingError::UnsupportedEmbeddingFunction {
+            name: configuration.name.clone(),
+        }),
+        "chroma-cloud-qwen" => Ok(Arc::new(
+            chroma_cloud::ChromaCloudQwenEmbeddingFunction::try_from_config(
+                configuration,
+                chroma_cloud_api_key,
+            )?,
+        )),
+        _ => Err(EmbeddingError::UnsupportedEmbeddingFunction {
+            name: configuration.name.clone(),
+        }),
+    }
+}
+
+/// Build a supported sparse embedding function from persisted configuration.
+pub fn sparse_embedding_function_from_config(
+    configuration: &EmbeddingFunctionConfiguration,
+    chroma_cloud_api_key: Option<String>,
+) -> Result<Arc<dyn SparseEmbeddingFunction>, EmbeddingError> {
+    let EmbeddingFunctionConfiguration::Known(configuration) = configuration else {
+        return Err(EmbeddingError::UnsupportedEmbeddingFunction {
+            name: embedding_function_configuration_name(configuration).to_string(),
+        });
+    };
+
+    match configuration.name.as_str() {
+        "chroma_bm25" | "chroma-bm25" => Ok(Arc::new(
+            bm25::ChromaBm25EmbeddingFunction::try_from_config(configuration)?,
+        )),
+        "chroma-cloud-splade" => Ok(Arc::new(
+            chroma_cloud::ChromaCloudSpladeEmbeddingFunction::try_from_config(
+                configuration,
+                chroma_cloud_api_key,
+            )?,
+        )),
+        _ => Err(EmbeddingError::UnsupportedEmbeddingFunction {
+            name: configuration.name.clone(),
+        }),
+    }
+}
+
+fn embedding_function_configuration_name(
+    configuration: &EmbeddingFunctionConfiguration,
+) -> &'static str {
+    match configuration {
+        EmbeddingFunctionConfiguration::Legacy => "legacy",
+        EmbeddingFunctionConfiguration::Known(_) => "known",
+        EmbeddingFunctionConfiguration::Unknown => "unknown",
+    }
+}
 
 /// Transforms text strings into embeddings.
 ///

--- a/rust/chroma/src/embed/ollama.rs
+++ b/rust/chroma/src/embed/ollama.rs
@@ -5,8 +5,11 @@
 //! Ollama enables privacy-preserving embeddings without sending data to external APIs.
 
 use reqwest::RequestBuilder;
+use serde::{Deserialize, Serialize};
 
-use super::EmbeddingFunction;
+use super::{DenseEmbeddingFunction, EmbeddingError, EmbeddingFunction};
+
+const OLLAMA_NAME: &str = "ollama";
 
 /////////////////////////////////////// OllamaEmbeddingError ///////////////////////////////////////
 
@@ -88,6 +91,37 @@ impl OllamaEmbeddingFunction {
         Ok(this)
     }
 
+    /// Constructs a new Ollama embedding function without a heartbeat request.
+    ///
+    /// This is used when restoring a persisted collection configuration. The Ollama
+    /// server is contacted lazily when text is actually embedded.
+    pub fn new_lazy(host: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            host: host.into(),
+            model: model.into(),
+        }
+    }
+
+    /// Construct Ollama from a persisted embedding function configuration.
+    pub fn try_from_config(
+        configuration: &chroma_types::EmbeddingFunctionNewConfiguration,
+    ) -> Result<Self, EmbeddingError> {
+        let config: OllamaConfig = serde_json::from_value(configuration.config.clone())?;
+        let client = if let Some(timeout) = config.timeout {
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(timeout))
+                .build()?
+        } else {
+            reqwest::Client::new()
+        };
+        Ok(Self {
+            client,
+            host: config.url,
+            model: config.model_name,
+        })
+    }
+
     /// Verifies that the Ollama server is responsive and the model is accessible.
     ///
     /// Sends a minimal embedding request to confirm the connection is healthy. This is
@@ -133,6 +167,39 @@ impl EmbeddingFunction for OllamaEmbeddingFunction {
     }
 }
 
+#[async_trait::async_trait]
+impl DenseEmbeddingFunction for OllamaEmbeddingFunction {
+    fn name(&self) -> &str {
+        OLLAMA_NAME
+    }
+
+    fn configuration(&self) -> chroma_types::EmbeddingFunctionConfiguration {
+        (
+            OLLAMA_NAME,
+            serde_json::json!(OllamaConfig {
+                url: self.host.clone(),
+                model_name: self.model.clone(),
+                timeout: None,
+            }),
+        )
+            .into()
+    }
+
+    async fn embed_documents(&self, batches: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        self.embed_strs(batches).await.map_err(|err| match err {
+            OllamaEmbeddingError::Reqwest(err) => EmbeddingError::Request(err),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct OllamaConfig {
+    url: String,
+    model_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout: Option<u64>,
+}
+
 /////////////////////////////////////////// EmbedRequest ///////////////////////////////////////////
 
 /// A request to embed multiple input documents.
@@ -166,4 +233,34 @@ pub struct EmbedResponse {
     pub load_duration: Option<f64>,
     /// The number of tokens counted in the prompt.
     pub prompt_eval_count: Option<f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_types::{EmbeddingFunctionConfiguration, EmbeddingFunctionNewConfiguration};
+
+    #[test]
+    fn test_ollama_config_round_trip() {
+        let config = EmbeddingFunctionNewConfiguration {
+            name: "ollama".to_string(),
+            config: serde_json::json!({
+                "url": "http://localhost:11434",
+                "model_name": "nomic-embed-text",
+                "timeout": 30
+            }),
+        };
+        let embedder = OllamaEmbeddingFunction::try_from_config(&config).unwrap();
+
+        assert_eq!(
+            embedder.configuration(),
+            EmbeddingFunctionConfiguration::Known(EmbeddingFunctionNewConfiguration {
+                name: "ollama".to_string(),
+                config: serde_json::json!({
+                    "url": "http://localhost:11434",
+                    "model_name": "nomic-embed-text"
+                }),
+            })
+        );
+    }
 }

--- a/rust/chroma/src/lib.rs
+++ b/rust/chroma/src/lib.rs
@@ -107,7 +107,12 @@ pub mod types;
 
 pub use client::ChromaHttpClient;
 pub use client::ChromaHttpClientOptions;
-pub use collection::ChromaCollection;
+pub use client::CreateCollectionOptions;
+pub use client::GetCollectionOptions;
+pub use collection::{
+    AddRecordsOptions, ChromaCollection, ModifyCollectionOptions, QueryRecordsOptions,
+    SearchRecordsOptions, UpdateRecordsOptions, UpsertRecordsOptions,
+};
 
 #[cfg(test)]
 mod tests {

--- a/rust/types/src/collection.rs
+++ b/rust/types/src/collection.rs
@@ -3,8 +3,9 @@ use std::time::{Duration, SystemTime};
 
 use super::{Metadata, MetadataValueConversionError};
 use crate::{
-    chroma_proto, test_segment, CollectionConfiguration, InternalCollectionConfiguration, Schema,
-    SchemaError, Segment, SegmentScope, UpdateCollectionConfiguration, UpdateMetadata,
+    chroma_proto, test_segment, CollectionConfiguration, EmbeddingFunctionConfiguration,
+    InternalCollectionConfiguration, Schema, SchemaError, Segment, SegmentScope,
+    UpdateCollectionConfiguration, UpdateMetadata,
 };
 use chroma_error::{ChromaError, ErrorCodes};
 use serde::{Deserialize, Serialize};
@@ -247,6 +248,13 @@ impl Collection {
         }
 
         Ok(())
+    }
+
+    pub fn dense_embedding_function(&self) -> Option<&EmbeddingFunctionConfiguration> {
+        self.schema
+            .as_ref()
+            .and_then(|schema| schema.dense_embedding_function())
+            .or(self.config.embedding_function.as_ref())
     }
 
     pub fn test_collection(dim: i32) -> Self {

--- a/rust/types/src/collection_configuration.rs
+++ b/rust/types/src/collection_configuration.rs
@@ -51,6 +51,24 @@ impl EmbeddingFunctionConfiguration {
     }
 }
 
+impl From<EmbeddingFunctionNewConfiguration> for EmbeddingFunctionConfiguration {
+    fn from(config: EmbeddingFunctionNewConfiguration) -> Self {
+        Self::Known(config)
+    }
+}
+
+impl From<(String, serde_json::Value)> for EmbeddingFunctionConfiguration {
+    fn from((name, config): (String, serde_json::Value)) -> Self {
+        EmbeddingFunctionNewConfiguration { name, config }.into()
+    }
+}
+
+impl From<(&str, serde_json::Value)> for EmbeddingFunctionConfiguration {
+    fn from((name, config): (&str, serde_json::Value)) -> Self {
+        (name.to_string(), config).into()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct EmbeddingFunctionNewConfiguration {

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -364,6 +364,38 @@ impl Schema {
             .and_then(|float_list| float_list.vector_index.as_mut())
     }
 
+    pub fn dense_embedding_function(&self) -> Option<&EmbeddingFunctionConfiguration> {
+        self.keys
+            .get(EMBEDDING_KEY)
+            .and_then(|value_types| value_types.float_list.as_ref())
+            .and_then(|float_list| float_list.vector_index.as_ref())
+            .and_then(|vector_index| vector_index.config.embedding_function.as_ref())
+            .or_else(|| {
+                self.defaults
+                    .float_list
+                    .as_ref()
+                    .and_then(|float_list| float_list.vector_index.as_ref())
+                    .and_then(|vector_index| vector_index.config.embedding_function.as_ref())
+            })
+    }
+
+    pub fn sparse_vector_index(&self, key: &str) -> Option<&SparseVectorIndexType> {
+        self.keys
+            .get(key)
+            .and_then(|value_types| value_types.sparse_vector.as_ref())
+            .and_then(|sparse_vector| sparse_vector.sparse_vector_index.as_ref())
+    }
+
+    pub fn sparse_vector_indices(&self) -> impl Iterator<Item = (&str, &SparseVectorIndexType)> {
+        self.keys.iter().filter_map(|(key, value_types)| {
+            value_types
+                .sparse_vector
+                .as_ref()
+                .and_then(|sparse_vector| sparse_vector.sparse_vector_index.as_ref())
+                .map(|sparse_vector_index| (key.as_str(), sparse_vector_index))
+        })
+    }
+
     fn apply_vector_index_update(
         vector_index: &mut VectorIndexType,
         update: &UpdateVectorIndexConfiguration,


### PR DESCRIPTION
## Description of changes

Introduce DenseEmbeddingFunction and SparseEmbeddingFunction traits with
object-safe async interfaces, and implement them for Chroma Cloud Qwen
(dense) and Splade (sparse) embedding providers as well as existing BM25.

Key changes:
- Add embed::chroma_cloud module with ChromaCloudQwenEmbeddingFunction and
  ChromaCloudSpladeEmbeddingFunction backed by the Chroma embed service
- Add EmbeddingError enum and EmbeddingStatus for unified error handling
- Extend ChromaCollection with high-level add, upsert, update, query, and
  search methods that perform client-side embedding transparently
- Wire dense_embedding_function through ChromaCollection so collections
  loaded from the server auto-resolve their embedding function config
- Add convenience constructors on EmbeddingFunctionConfiguration (From
  impls) and accessor helpers on Collection and Schema
- Extend ChromaHttpClient with chroma_cloud_api_key plumbing and create/
  get collection helpers that attach the resolved embedding function
- Re-export AddRecordsOptions, UpsertRecordsOptions, UpdateRecordsOptions,
  QueryRecordsOptions, SearchRecordsOptions, and ModifyCollectionOptions
- Add cloud-embeddings example demonstrating end-to-end usage

## Test plan

CI + I ran the example on staging.

## Migration plan

Backwards-compatible.

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
