### PR TITLE
[BUG] prevent integer overflow in HNSW index resize

### DIFF
--- a/rust/index/src/hnsw.rs
+++ b/rust/index/src/hnsw.rs
@@ -77,6 +77,63 @@ impl HnswIndexConfig {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HnswCapacityGrowth {
+    NextPowerOfTwo,
+    Double,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum HnswCapacityError {
+    #[error("HNSW capacity overflow")]
+    Overflow,
+}
+
+impl ChromaError for HnswCapacityError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
+}
+
+pub fn required_hnsw_capacity(
+    len_with_deleted: usize,
+    additional: usize,
+    capacity: usize,
+    resize_at_capacity: bool,
+    growth: HnswCapacityGrowth,
+) -> Result<Option<usize>, HnswCapacityError> {
+    let required = len_with_deleted
+        .checked_add(additional)
+        .ok_or(HnswCapacityError::Overflow)?;
+    let has_capacity = if resize_at_capacity {
+        required < capacity
+    } else {
+        required <= capacity
+    };
+
+    if has_capacity {
+        return Ok(None);
+    }
+
+    let new_capacity = match growth {
+        HnswCapacityGrowth::NextPowerOfTwo => required
+            .checked_next_power_of_two()
+            .ok_or(HnswCapacityError::Overflow)?,
+        HnswCapacityGrowth::Double => {
+            let doubled = capacity.checked_mul(2).ok_or(HnswCapacityError::Overflow)?;
+            if doubled >= required {
+                doubled
+            } else {
+                required
+                    .checked_next_power_of_two()
+                    .ok_or(HnswCapacityError::Overflow)?
+            }
+        }
+    };
+
+    Ok(Some(new_capacity))
+}
+
 pub struct HnswIndex {
     index: hnswlib::HnswIndex,
     pub id: IndexUuid,
@@ -277,5 +334,73 @@ fn map_distance_function(distance_function: DistanceFunction) -> hnswlib::HnswDi
         DistanceFunction::Cosine => hnswlib::HnswDistanceFunction::Cosine,
         DistanceFunction::Euclidean => hnswlib::HnswDistanceFunction::Euclidean,
         DistanceFunction::InnerProduct => hnswlib::HnswDistanceFunction::InnerProduct,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        required_hnsw_capacity, HnswCapacityError, HnswCapacityGrowth::Double,
+        HnswCapacityGrowth::NextPowerOfTwo,
+    };
+
+    #[test]
+    fn required_capacity_below_limit_does_not_resize() {
+        assert_eq!(
+            Ok(None),
+            required_hnsw_capacity(98, 1, 100, true, NextPowerOfTwo)
+        );
+    }
+
+    #[test]
+    fn required_capacity_at_limit_resizes_when_requested() {
+        assert_eq!(
+            Ok(Some(128)),
+            required_hnsw_capacity(99, 1, 100, true, NextPowerOfTwo)
+        );
+    }
+
+    #[test]
+    fn required_capacity_at_limit_does_not_resize_when_allowed() {
+        assert_eq!(Ok(None), required_hnsw_capacity(99, 1, 100, false, Double));
+    }
+
+    #[test]
+    fn required_capacity_double_growth_uses_doubled_capacity() {
+        assert_eq!(
+            Ok(Some(200)),
+            required_hnsw_capacity(100, 1, 100, false, Double)
+        );
+    }
+
+    #[test]
+    fn required_capacity_double_growth_handles_zero_capacity() {
+        assert_eq!(Ok(Some(1)), required_hnsw_capacity(0, 1, 0, false, Double));
+    }
+
+    #[test]
+    fn required_capacity_rejects_len_overflow() {
+        assert_eq!(
+            Err(HnswCapacityError::Overflow),
+            required_hnsw_capacity(usize::MAX, 1, usize::MAX, false, Double)
+        );
+    }
+
+    #[test]
+    fn required_capacity_rejects_next_power_overflow() {
+        assert_eq!(
+            Err(HnswCapacityError::Overflow),
+            required_hnsw_capacity(usize::MAX, 0, usize::MAX, true, NextPowerOfTwo)
+        );
+    }
+
+    #[test]
+    fn required_capacity_rejects_double_growth_overflow() {
+        let capacity = usize::MAX / 2 + 1;
+
+        assert_eq!(
+            Err(HnswCapacityError::Overflow),
+            required_hnsw_capacity(capacity, 1, capacity, false, Double)
+        );
     }
 }

--- a/rust/index/src/spann/fast_writer.rs
+++ b/rust/index/src/spann/fast_writer.rs
@@ -12,6 +12,7 @@ use chroma_blockstore::{
     BlockfileWriter, BlockfileWriterOptions,
 };
 use chroma_distance::{normalize, DistanceFunction};
+use chroma_error::ChromaError;
 use chroma_tracing::util::Stopwatch;
 use chroma_types::{Cmek, CollectionUuid, InternalSpannConfiguration, SpannPostingList};
 use dashmap::DashMap;
@@ -21,11 +22,12 @@ use uuid::Uuid;
 
 use crate::{
     hnsw_provider::{HnswIndexFlusher, HnswIndexProvider, HnswIndexRef},
+    required_hnsw_capacity,
     spann::types::{
         GarbageCollectionContext, HnswGarbageCollectionPolicy, PlGarbageCollectionPolicy,
         SpannIndexFlusher, SpannIndexFlusherMetrics, SpannIndexWriterError,
     },
-    IndexUuid,
+    HnswCapacityGrowth, IndexUuid,
 };
 
 use super::utils::{cluster, KMeansAlgorithmInput, KMeansError};
@@ -1459,14 +1461,24 @@ impl FastSpannIndexWriter {
                 let mut hnsw_write_guard = self.hnsw_index.inner.write();
                 let hnsw_len = hnsw_write_guard.hnsw_index.len_with_deleted();
                 let hnsw_capacity = hnsw_write_guard.hnsw_index.capacity();
-                if hnsw_len + 1 > hnsw_capacity {
+                if let Some(needed_capacity) = required_hnsw_capacity(
+                    hnsw_len,
+                    1,
+                    hnsw_capacity,
+                    false,
+                    HnswCapacityGrowth::Double,
+                )
+                .map_err(|e| {
+                    tracing::error!("Error calculating hnsw index resize during split: {}", e);
+                    SpannIndexWriterError::HnswIndexResizeError(e.boxed())
+                })? {
                     hnsw_write_guard
                         .hnsw_index
-                        .resize(hnsw_capacity * 2)
+                        .resize(needed_capacity)
                         .map_err(|e| {
                             tracing::error!(
                                 "Error resizing hnsw index during split to {}: {}",
-                                hnsw_capacity * 2,
+                                needed_capacity,
                                 e
                             );
                             SpannIndexWriterError::HnswIndexResizeError(e)
@@ -1547,14 +1559,24 @@ impl FastSpannIndexWriter {
                 let mut write_guard = self.hnsw_index.inner.write();
                 let hnsw_len = write_guard.hnsw_index.len_with_deleted();
                 let hnsw_capacity = write_guard.hnsw_index.capacity();
-                if hnsw_len + 1 > hnsw_capacity {
+                if let Some(needed_capacity) = required_hnsw_capacity(
+                    hnsw_len,
+                    1,
+                    hnsw_capacity,
+                    false,
+                    HnswCapacityGrowth::Double,
+                )
+                .map_err(|e| {
+                    tracing::error!("Error calculating hnsw index resize during append: {}", e);
+                    SpannIndexWriterError::HnswIndexResizeError(e.boxed())
+                })? {
                     write_guard
                         .hnsw_index
-                        .resize(hnsw_capacity * 2)
+                        .resize(needed_capacity)
                         .map_err(|e| {
                             tracing::error!(
                                 "Error resizing hnsw index during append to {}: {}",
-                                hnsw_capacity * 2,
+                                needed_capacity,
                                 e
                             );
                             SpannIndexWriterError::HnswIndexResizeError(e)
@@ -1745,14 +1767,24 @@ impl FastSpannIndexWriter {
                     .ok_or(SpannIndexWriterError::HeadNotFound)?;
                 let hnsw_len = clean_hnsw_write_guard.hnsw_index.len_with_deleted();
                 let hnsw_capacity = clean_hnsw_write_guard.hnsw_index.capacity();
-                if hnsw_len + 1 > hnsw_capacity {
+                if let Some(needed_capacity) = required_hnsw_capacity(
+                    hnsw_len,
+                    1,
+                    hnsw_capacity,
+                    false,
+                    HnswCapacityGrowth::Double,
+                )
+                .map_err(|e| {
+                    tracing::error!("Error calculating hnsw index resize during gc: {}", e);
+                    SpannIndexWriterError::HnswIndexResizeError(e.boxed())
+                })? {
                     clean_hnsw_write_guard
                         .hnsw_index
-                        .resize(hnsw_capacity * 2)
+                        .resize(needed_capacity)
                         .map_err(|e| {
                             tracing::error!(
                                 "Error resizing hnsw index during gc to {}: {}",
-                                hnsw_capacity * 2,
+                                needed_capacity,
                                 e
                             );
                             SpannIndexWriterError::HnswIndexResizeError(e)

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -34,8 +34,9 @@ use crate::{
         HnswIndexProviderFlushError, HnswIndexProviderForkError, HnswIndexProviderOpenError,
         HnswIndexRef,
     },
+    required_hnsw_capacity,
     spann::utils::cluster,
-    IndexUuid,
+    HnswCapacityGrowth, IndexUuid,
 };
 
 use super::utils::{rng_query, KMeansAlgorithmInput, KMeansError, RngQueryError};
@@ -1422,14 +1423,27 @@ impl SpannIndexWriter {
                         let mut hnsw_write_guard = self.hnsw_index.inner.write();
                         let hnsw_len = hnsw_write_guard.hnsw_index.len_with_deleted();
                         let hnsw_capacity = hnsw_write_guard.hnsw_index.capacity();
-                        if hnsw_len + 1 > hnsw_capacity {
+                        if let Some(needed_capacity) = required_hnsw_capacity(
+                            hnsw_len,
+                            1,
+                            hnsw_capacity,
+                            false,
+                            HnswCapacityGrowth::Double,
+                        )
+                        .map_err(|e| {
+                            tracing::error!(
+                                "Error calculating hnsw index resize during append: {}",
+                                e
+                            );
+                            SpannIndexWriterError::HnswIndexResizeError(e.boxed())
+                        })? {
                             hnsw_write_guard
                                 .hnsw_index
-                                .resize(hnsw_capacity * 2)
+                                .resize(needed_capacity)
                                 .map_err(|e| {
                                     tracing::error!(
                                         "Error resizing hnsw index during append to {}: {}",
-                                        hnsw_capacity * 2,
+                                        needed_capacity,
                                         e
                                     );
                                     SpannIndexWriterError::HnswIndexResizeError(e)
@@ -1542,14 +1556,24 @@ impl SpannIndexWriter {
                 let mut write_guard = self.hnsw_index.inner.write();
                 let hnsw_len = write_guard.hnsw_index.len_with_deleted();
                 let hnsw_capacity = write_guard.hnsw_index.capacity();
-                if hnsw_len + 1 > hnsw_capacity {
+                if let Some(needed_capacity) = required_hnsw_capacity(
+                    hnsw_len,
+                    1,
+                    hnsw_capacity,
+                    false,
+                    HnswCapacityGrowth::Double,
+                )
+                .map_err(|e| {
+                    tracing::error!("Error calculating hnsw index resize during append: {}", e);
+                    SpannIndexWriterError::HnswIndexResizeError(e.boxed())
+                })? {
                     write_guard
                         .hnsw_index
-                        .resize(hnsw_capacity * 2)
+                        .resize(needed_capacity)
                         .map_err(|e| {
                             tracing::error!(
                                 "Error resizing hnsw index during append to {}: {}",
-                                hnsw_capacity * 2,
+                                needed_capacity,
                                 e
                             );
                             SpannIndexWriterError::HnswIndexResizeError(e)
@@ -2087,14 +2111,24 @@ impl SpannIndexWriter {
                     .ok_or(SpannIndexWriterError::HeadNotFound)?;
                 let hnsw_len = clean_hnsw_write_guard.hnsw_index.len_with_deleted();
                 let hnsw_capacity = clean_hnsw_write_guard.hnsw_index.capacity();
-                if hnsw_len + 1 > hnsw_capacity {
+                if let Some(needed_capacity) = required_hnsw_capacity(
+                    hnsw_len,
+                    1,
+                    hnsw_capacity,
+                    false,
+                    HnswCapacityGrowth::Double,
+                )
+                .map_err(|e| {
+                    tracing::error!("Error calculating hnsw index resize during gc: {}", e);
+                    SpannIndexWriterError::HnswIndexResizeError(e.boxed())
+                })? {
                     clean_hnsw_write_guard
                         .hnsw_index
-                        .resize(hnsw_capacity * 2)
+                        .resize(needed_capacity)
                         .map_err(|e| {
                             tracing::error!(
                                 "Error resizing hnsw index during gc to {}: {}",
-                                hnsw_capacity * 2,
+                                needed_capacity,
                                 e
                             );
                             SpannIndexWriterError::HnswIndexResizeError(e)

--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -7,7 +7,7 @@ use chroma_index::hnsw_provider::{
     HnswIndexProvider, HnswIndexProviderCreateError, HnswIndexProviderForkError,
     HnswIndexProviderOpenError, HnswIndexRef,
 };
-use chroma_index::IndexUuid;
+use chroma_index::{required_hnsw_capacity, HnswCapacityGrowth, IndexUuid};
 use chroma_types::{
     Cmek, Collection, HnswParametersFromSegmentError, MaterializedLogOperation, Schema,
     SchemaError, Segment, SegmentUuid,
@@ -217,17 +217,20 @@ impl DistributedHNSWSegmentWriter {
                         .map_err(ApplyMaterializedLogError::Materialization)?;
                     let embedding = record.merged_embeddings_ref();
 
-                    let mut index = self.index.inner.upgradable_read();
+                    let mut index = self.index.inner.write();
                     let index_len = index.hnsw_index.len_with_deleted();
                     let index_capacity = index.hnsw_index.capacity();
-                    if index_len + 1 > index_capacity {
-                        index.with_upgraded(|index| {
-                            // Bump allocation by 2x
-                            index
-                                .hnsw_index
-                                .resize(index_capacity * 2)
-                                .map(|_| ApplyMaterializedLogError::Allocation)
-                        })?;
+                    if let Some(needed_capacity) = required_hnsw_capacity(
+                        index_len,
+                        1,
+                        index_capacity,
+                        false,
+                        HnswCapacityGrowth::Double,
+                    )
+                    .map_err(|_| ApplyMaterializedLogError::Allocation)?
+                    {
+                        // Bump allocation by 2x
+                        index.hnsw_index.resize(needed_capacity)?;
                     }
 
                     match index
@@ -248,7 +251,7 @@ impl DistributedHNSWSegmentWriter {
                     match self
                         .index
                         .inner
-                        .read()
+                        .write()
                         .hnsw_index
                         .delete(record.get_offset_id() as usize)
                     {

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -7,7 +7,9 @@ use std::{
 
 use chroma_cache::Weighted;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_index::{HnswIndex, HnswIndexConfig, IndexConfig};
+use chroma_index::{
+    required_hnsw_capacity, HnswCapacityGrowth, HnswIndex, HnswIndexConfig, IndexConfig,
+};
 use chroma_sqlite::{db::SqliteDb, table::MaxSeqId};
 use chroma_types::{
     operator::RecordMeasure, Chunk, Collection, HnswParametersFromSegmentError, LogRecord,
@@ -774,8 +776,15 @@ impl LocalHnswSegmentWriter {
         // Resize the index if needed
         let index_len = guard.index.len_with_deleted();
         let index_capacity = guard.index.capacity();
-        if index_len + hnsw_batch.len() >= index_capacity {
-            let needed_capacity = (index_len + hnsw_batch.len()).next_power_of_two();
+        if let Some(needed_capacity) = required_hnsw_capacity(
+            index_len,
+            hnsw_batch.len(),
+            index_capacity,
+            true,
+            HnswCapacityGrowth::NextPowerOfTwo,
+        )
+        .map_err(|_| LocalHnswSegmentWriterError::HnswIndexResizeError)?
+        {
             guard
                 .index
                 .resize(needed_capacity)

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -2816,6 +2816,7 @@ pub struct HnswIndexConfig {
     #[validate(range(min = 2))]
     pub sync_threshold: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(range(min = 1.0, max = 5.0))]
     pub resize_factor: Option<f64>,
 }
 
@@ -5555,16 +5556,30 @@ mod tests {
         };
         assert!(all_none_config.validate().is_ok());
 
-        // Valid: fields without validation can be any value
+        // Valid: boundary values for the remaining fields should pass.
         let other_fields_config = HnswIndexConfig {
             ef_construction: Some(1),
             max_neighbors: Some(1),
             ef_search: Some(1),
             num_threads: Some(1),
-            resize_factor: Some(0.1),
+            resize_factor: Some(1.0),
             ..Default::default()
         };
         assert!(other_fields_config.validate().is_ok());
+
+        // Invalid: resize_factor too small (min 1.0)
+        let invalid_resize_factor_low = HnswIndexConfig {
+            resize_factor: Some(0.1),
+            ..Default::default()
+        };
+        assert!(invalid_resize_factor_low.validate().is_err());
+
+        // Invalid: resize_factor too large (max 5.0)
+        let invalid_resize_factor_high = HnswIndexConfig {
+            resize_factor: Some(5.1),
+            ..Default::default()
+        };
+        assert!(invalid_resize_factor_high.validate().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

Replace unchecked arithmetic (capacity * 2, len + additional) with a
central required_hnsw_capacity function that uses checked_add,
checked_mul, and checked_next_power_of_two, returning a typed
HnswCapacityError::Overflow on overflow instead of silently wrapping.

All six callsites in fast_writer, spann/types, distributed_hnsw, and
local_hnsw now route through this function, which encodes two growth
strategies (Double and NextPowerOfTwo) and an optional resize-at-
capacity flag to preserve each callsite's existing semantics.

Also constrain resize_factor to [1.0, 5.0] on the Rust
HnswIndexConfig via a validate(range) annotation, with tests for
both boundary rejection and overflow at usize::MAX.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
