### PR TITLE
fix: add explicit encoding="utf-8" to text-mode open() calls

### DIFF
--- a/chromadb/auth/__init__.py
+++ b/chromadb/auth/__init__.py
@@ -121,7 +121,7 @@ class ServerAuthenticationProvider(Component):
         if _creds:
             return [c for c in _creds.split("\n") if c]
         elif _creds_file:
-            with open(_creds_file, "r") as f:
+            with open(_creds_file, "r", encoding="utf-8") as f:
                 return f.readlines()
         raise ValueError("Should never happen")
 
@@ -232,6 +232,6 @@ class ServerAuthorizationProvider(Component):
         if _config:
             return [c for c in _config.split("\n") if c]
         elif _config_file:
-            with open(_config_file, "r") as f:
+            with open(_config_file, "r", encoding="utf-8") as f:
                 return f.readlines()
         raise ValueError("Should never happen")

--- a/chromadb/cli/utils.py
+++ b/chromadb/cli/utils.py
@@ -9,7 +9,7 @@ def set_log_file_path(
 ) -> Dict[str, Any]:
     """This works with the standard log_config.yml file.
     It will not work with custom log configs that may use different handlers"""
-    with open(f"{log_config_path}", "r") as file:
+    with open(f"{log_config_path}", "r", encoding="utf-8") as file:
         log_config = yaml.safe_load(file)
     for handler in log_config["handlers"].values():
         if handler.get("class") == "logging.handlers.RotatingFileHandler":

--- a/chromadb/telemetry/product/__init__.py
+++ b/chromadb/telemetry/product/__init__.py
@@ -85,12 +85,12 @@ class ProductTelemetryClient(Component):
         try:
             if not os.path.exists(self.USER_ID_PATH):
                 os.makedirs(os.path.dirname(self.USER_ID_PATH), exist_ok=True)
-                with open(self.USER_ID_PATH, "w") as f:
+                with open(self.USER_ID_PATH, "w", encoding="utf-8") as f:
                     new_user_id = str(uuid.uuid4())
                     f.write(new_user_id)
                 self._curr_user_id = new_user_id
             else:
-                with open(self.USER_ID_PATH, "r") as f:
+                with open(self.USER_ID_PATH, "r", encoding="utf-8") as f:
                     self._curr_user_id = f.read()
         except Exception:
             self._curr_user_id = self.UNKNOWN_USER_ID

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -35,7 +35,7 @@ def get_schema_info() -> Dict[str, Dict[str, str]]:
     schema_info = {}
     for schema_name in get_available_schemas():
         schema_path = os.path.join(SCHEMAS_DIR, f"{schema_name}.json")
-        with open(schema_path, "r") as f:
+        with open(schema_path, "r", encoding="utf-8") as f:
             schema = json.load(f)
             schema_info[schema_name] = {
                 "version": schema.get("version", "1.0.0"),

--- a/chromadb/utils/embedding_functions/schemas/schema_utils.py
+++ b/chromadb/utils/embedding_functions/schemas/schema_utils.py
@@ -33,7 +33,7 @@ def load_schema(schema_name: str) -> Dict[str, Any]:
     if schema_name in cached_schemas:
         return cached_schemas[schema_name]
     schema_path = os.path.join(SCHEMAS_DIR, f"{schema_name}.json")
-    with open(schema_path, "r") as f:
+    with open(schema_path, "r", encoding="utf-8") as f:
         schema = cast(Dict[str, Any], json.load(f))
         cached_schemas[schema_name] = schema
         return schema


### PR DESCRIPTION
## What

Several text-mode `open()` calls in `chromadb` load or persist user-facing configuration and credential files without an explicit `encoding=` argument. Python falls back to `locale.getpreferredencoding()`, which is `cp1252` on Windows and `utf-8` on Linux/macOS — so a file written on one platform can become unreadable on another, and any non-ASCII content in user-supplied paths or values can fail to round-trip.

## Why

- Reliability across Windows / Linux / macOS / Docker — credential and config files are frequently round-tripped between developer machines.
- PEP 597 recommends always specifying `encoding=` for text-mode opens.
- Eliminates `EncodingWarning` under `PYTHONWARNDEFAULTENCODING=1` (Python 3.10+).
- No behavior change on systems where the default is already utf-8.

## Changes

Added `encoding="utf-8"` to 7 text-mode `open()` call sites across 5 files:

- `chromadb/telemetry/product/__init__.py` — 2 sites in `TelemetryClient` user-id read/write
- `chromadb/auth/__init__.py` — 2 sites in credential and config file loaders
- `chromadb/cli/utils.py` — 1 site in log-config loader
- `chromadb/utils/embedding_functions/schemas/registry.py` — 1 site loading embedding-function JSON schemas
- `chromadb/utils/embedding_functions/schemas/schema_utils.py` — 1 site loading embedding-function JSON schemas

Total: 5 files, +7/-7 lines.

## Testing

Pure keyword-argument addition to existing `open()` calls; no logic touched. Verified all 5 files parse cleanly with `python -m py_compile`. The files were already being read/written as utf-8 in practice on Linux/macOS CI — this just makes it explicit and portable to Windows.