### PR TITLE
[BUG] harden single-node deployment against memory-safety and DoS attacks

### DIFF
--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -73,6 +73,11 @@ test_hnsw_config = {
     "hnsw:M": 128,
 }
 
+HNSW_MAX_EF_CONSTRUCTION = 4096
+HNSW_MAX_EF_SEARCH = 4096
+HNSW_MAX_NEIGHBORS = 128
+HNSW_MAX_SYNC_THRESHOLD = 4096
+
 
 class _TruncatedReprDict(dict):  # type: ignore[type-arg]
     """Dict subclass that truncates its repr to avoid overwhelming output in hypothesis error messages."""
@@ -330,16 +335,20 @@ def vector_index_config_strategy(draw: st.DrawFn) -> VectorIndexConfig:
 
     if index_choice == "hnsw":
         hnsw = HnswIndexConfig(
-            ef_construction=draw(st.integers(min_value=1, max_value=1000))
+            ef_construction=draw(
+                st.integers(min_value=1, max_value=HNSW_MAX_EF_CONSTRUCTION)
+            )
             if draw(st.booleans())
             else None,
-            max_neighbors=draw(st.integers(min_value=1, max_value=1000))
+            max_neighbors=draw(st.integers(min_value=1, max_value=HNSW_MAX_NEIGHBORS))
             if draw(st.booleans())
             else None,
-            ef_search=draw(st.integers(min_value=1, max_value=1000))
+            ef_search=draw(st.integers(min_value=1, max_value=HNSW_MAX_EF_SEARCH))
             if draw(st.booleans())
             else None,
-            sync_threshold=draw(st.integers(min_value=2, max_value=10000))
+            sync_threshold=draw(
+                st.integers(min_value=2, max_value=HNSW_MAX_SYNC_THRESHOLD)
+            )
             if draw(st.booleans())
             else None,
             resize_factor=draw(st.floats(min_value=1.0, max_value=5.0))
@@ -485,17 +494,21 @@ def metadata_with_hnsw_strategy(draw: st.DrawFn) -> Optional[CollectionMetadata]
         metadata["hnsw:space"] = draw(st.sampled_from(["cosine", "l2", "ip"]))
     if draw(st.booleans()):
         metadata["hnsw:construction_ef"] = draw(
-            st.integers(min_value=1, max_value=1000)
+            st.integers(min_value=1, max_value=HNSW_MAX_EF_CONSTRUCTION)
         )
     if draw(st.booleans()):
-        metadata["hnsw:search_ef"] = draw(st.integers(min_value=1, max_value=1000))
+        metadata["hnsw:search_ef"] = draw(
+            st.integers(min_value=1, max_value=HNSW_MAX_EF_SEARCH)
+        )
     if draw(st.booleans()):
-        metadata["hnsw:M"] = draw(st.integers(min_value=1, max_value=1000))
+        metadata["hnsw:M"] = draw(
+            st.integers(min_value=1, max_value=HNSW_MAX_NEIGHBORS)
+        )
     if draw(st.booleans()):
         metadata["hnsw:resize_factor"] = draw(st.floats(min_value=1.0, max_value=5.0))
     if draw(st.booleans()):
         metadata["hnsw:sync_threshold"] = draw(
-            st.integers(min_value=2, max_value=10000)
+            st.integers(min_value=2, max_value=HNSW_MAX_SYNC_THRESHOLD)
         )
 
     return metadata if metadata else None
@@ -534,10 +547,18 @@ def create_configuration_strategy(
         hnsw_config: CreateHNSWConfiguration = {}
         if draw(st.booleans()):
             hnsw_config["space"] = draw(st.sampled_from(["cosine", "l2", "ip"]))
-        hnsw_config["ef_construction"] = draw(st.integers(min_value=1, max_value=1000))
-        hnsw_config["ef_search"] = draw(st.integers(min_value=1, max_value=1000))
-        hnsw_config["max_neighbors"] = draw(st.integers(min_value=1, max_value=1000))
-        hnsw_config["sync_threshold"] = draw(st.integers(min_value=2, max_value=10000))
+        hnsw_config["ef_construction"] = draw(
+            st.integers(min_value=1, max_value=HNSW_MAX_EF_CONSTRUCTION)
+        )
+        hnsw_config["ef_search"] = draw(
+            st.integers(min_value=1, max_value=HNSW_MAX_EF_SEARCH)
+        )
+        hnsw_config["max_neighbors"] = draw(
+            st.integers(min_value=1, max_value=HNSW_MAX_NEIGHBORS)
+        )
+        hnsw_config["sync_threshold"] = draw(
+            st.integers(min_value=2, max_value=HNSW_MAX_SYNC_THRESHOLD)
+        )
         hnsw_config["resize_factor"] = draw(st.floats(min_value=1.0, max_value=5.0))
         configuration["hnsw"] = hnsw_config
     elif config_choice == "spann":

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -53,3 +53,7 @@ uuid = { workspace = true }
 [[bin]]
 name = "chroma"
 path = "src/main.rs"
+
+[[bin]]
+name = "chroma-hnsw-integrity-check"
+path = "src/bin/chroma-hnsw-integrity-check.rs"

--- a/rust/cli/src/bin/chroma-hnsw-integrity-check.rs
+++ b/rust/cli/src/bin/chroma-hnsw-integrity-check.rs
@@ -1,0 +1,7 @@
+use chroma_cli::hnsw_integrity_check::{hnsw_integrity_check_exit_code, HnswIntegrityCheckArgs};
+use clap::Parser;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    hnsw_integrity_check_exit_code(HnswIntegrityCheckArgs::parse())
+}

--- a/rust/cli/src/hnsw_integrity_check.rs
+++ b/rust/cli/src/hnsw_integrity_check.rs
@@ -1,0 +1,692 @@
+use chroma_frontend::config::FrontendServerConfig;
+use chroma_segment::local_hnsw::{
+    inspect_persisted_hnsw_metadata, parse_persisted_hnsw_dim, PersistedHnswLabelMismatch,
+    PersistedHnswMetadata, HNSW_HEADER_FILE, HNSW_INDEX_FILES, METADATA_FILE,
+};
+use chroma_sqlite::helpers::get_embeddings_queue_topic_name;
+use chroma_types::{CollectionUuid, SegmentType};
+use clap::Parser;
+use serde::Serialize;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+use sqlx::Row;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::str::FromStr;
+use thiserror::Error;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "chroma-hnsw-integrity-check",
+    about = "Detect local Chroma HNSW startup fast-forward and integrity hazards"
+)]
+pub struct HnswIntegrityCheckArgs {
+    #[arg(
+        long,
+        value_name = "DIR",
+        default_value = "./chroma",
+        help = "Chroma persistent directory"
+    )]
+    path: PathBuf,
+    #[arg(
+        long,
+        value_name = "FILE",
+        help = "Sqlite database path; defaults to <path>/chroma.sqlite3"
+    )]
+    sqlite: Option<PathBuf>,
+    #[arg(long, value_name = "UUID", help = "Limit the check to one collection")]
+    collection: Option<String>,
+    #[arg(long, help = "Emit machine-readable JSON")]
+    json: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum HnswIntegrityCheckError {
+    #[error("persistent directory does not exist: {0}")]
+    MissingPersistDirectory(String),
+    #[error("sqlite database does not exist: {0}")]
+    MissingSqliteDatabase(String),
+    #[error("failed to open sqlite database read-only: {0}")]
+    SqliteOpen(#[source] sqlx::Error),
+    #[error("failed to query sqlite database: {0}")]
+    SqliteQuery(#[source] sqlx::Error),
+    #[error("invalid collection id in sqlite: {0}")]
+    InvalidCollectionId(String),
+    #[error("failed to serialize JSON report: {0}")]
+    Json(#[source] serde_json::Error),
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    persist_path: String,
+    sqlite_path: String,
+    checked_segments: usize,
+    pending_fast_forwards: usize,
+    corruptions: usize,
+    warnings: usize,
+    issues: Vec<Issue>,
+}
+
+#[derive(Debug, Serialize)]
+struct Issue {
+    severity: Severity,
+    kind: &'static str,
+    collection_id: String,
+    collection_name: String,
+    vector_segment_id: String,
+    collection_dimension: Option<i64>,
+    vector_max_seq_id: Option<i64>,
+    metadata_max_seq_id: Option<i64>,
+    purge_watermark: i64,
+    detail: String,
+    log_state: LogState,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum Severity {
+    FastForward,
+    Corrupt,
+    Warning,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct LogState {
+    topic: String,
+    row_count: i64,
+    min_seq_id: Option<i64>,
+    max_seq_id: Option<i64>,
+    rows_at_or_below_vector_watermark: i64,
+    rows_below_purge_watermark: i64,
+}
+
+#[derive(Debug)]
+struct SegmentRow {
+    collection_id: CollectionUuid,
+    collection_name: String,
+    collection_dimension: Option<i64>,
+    tenant: String,
+    database: String,
+    vector_segment_id: String,
+    vector_max_seq_id: Option<i64>,
+    metadata_max_seq_id: Option<i64>,
+}
+
+pub fn hnsw_integrity_check(args: HnswIntegrityCheckArgs) -> Result<(), HnswIntegrityCheckError> {
+    let outcome = run_blocking(args)?;
+    if outcome.has_findings() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+pub fn hnsw_integrity_check_exit_code(args: HnswIntegrityCheckArgs) -> ExitCode {
+    match run_blocking(args) {
+        Ok(outcome) => outcome.exit_code(),
+        Err(err) => {
+            eprintln!("{err}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run_blocking(args: HnswIntegrityCheckArgs) -> Result<CheckOutcome, HnswIntegrityCheckError> {
+    let json = args.json;
+    let runtime = tokio::runtime::Runtime::new().expect("Failed to start Chroma");
+    let report = runtime.block_on(run(args))?;
+    if json {
+        print_json_report(&report)?;
+    } else {
+        print_human_report(&report);
+    }
+    Ok(CheckOutcome { report })
+}
+
+struct CheckOutcome {
+    report: Report,
+}
+
+impl CheckOutcome {
+    fn has_findings(&self) -> bool {
+        self.report.corruptions > 0 || self.report.pending_fast_forwards > 0
+    }
+
+    fn exit_code(&self) -> ExitCode {
+        if self.has_findings() {
+            ExitCode::from(1)
+        } else {
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+async fn run(args: HnswIntegrityCheckArgs) -> Result<Report, HnswIntegrityCheckError> {
+    if !args.path.is_dir() {
+        return Err(HnswIntegrityCheckError::MissingPersistDirectory(
+            args.path.display().to_string(),
+        ));
+    }
+    let sqlite_path = args.sqlite.clone().unwrap_or_else(|| {
+        args.path
+            .join(FrontendServerConfig::single_node_default().sqlite_filename)
+    });
+    if !sqlite_path.is_file() {
+        return Err(HnswIntegrityCheckError::MissingSqliteDatabase(
+            sqlite_path.display().to_string(),
+        ));
+    }
+
+    let pool = open_read_only_sqlite(&sqlite_path).await?;
+    let segments = load_hnsw_segments(&pool, args.collection.as_deref()).await?;
+    let mut issues = Vec::new();
+
+    for segment in &segments {
+        let log_state = load_log_state(&pool, segment).await?;
+        inspect_segment(&args.path, segment, log_state, &mut issues);
+    }
+
+    let corruptions = issues
+        .iter()
+        .filter(|issue| issue.severity == Severity::Corrupt)
+        .count();
+    let pending_fast_forwards = issues
+        .iter()
+        .filter(|issue| issue.severity == Severity::FastForward)
+        .count();
+    let warnings = issues
+        .iter()
+        .filter(|issue| issue.severity == Severity::Warning)
+        .count();
+
+    Ok(Report {
+        persist_path: args.path.display().to_string(),
+        sqlite_path: sqlite_path.display().to_string(),
+        checked_segments: segments.len(),
+        pending_fast_forwards,
+        corruptions,
+        warnings,
+        issues,
+    })
+}
+
+async fn open_read_only_sqlite(sqlite_path: &Path) -> Result<SqlitePool, HnswIntegrityCheckError> {
+    let options = SqliteConnectOptions::new()
+        .filename(sqlite_path)
+        .read_only(true)
+        .create_if_missing(false);
+    SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await
+        .map_err(HnswIntegrityCheckError::SqliteOpen)
+}
+
+async fn load_hnsw_segments(
+    pool: &SqlitePool,
+    collection_id: Option<&str>,
+) -> Result<Vec<SegmentRow>, HnswIntegrityCheckError> {
+    let mut query = String::from(
+        r#"
+        SELECT
+            collections.id AS collection_id,
+            collections.name AS collection_name,
+            collections.dimension AS collection_dimension,
+            databases.tenant_id AS tenant,
+            databases.name AS database_name,
+            vector_segments.id AS vector_segment_id,
+            CAST(vector_max.seq_id AS INTEGER) AS vector_max_seq_id,
+            CAST(metadata_max.seq_id AS INTEGER) AS metadata_max_seq_id
+        FROM collections
+        INNER JOIN databases
+            ON databases.id = collections.database_id
+        INNER JOIN segments AS vector_segments
+            ON vector_segments.collection = collections.id
+           AND vector_segments.type = ?
+        LEFT JOIN max_seq_id AS vector_max
+            ON vector_max.segment_id = vector_segments.id
+        LEFT JOIN segments AS metadata_segments
+            ON metadata_segments.collection = collections.id
+           AND metadata_segments.type = ?
+        LEFT JOIN max_seq_id AS metadata_max
+            ON metadata_max.segment_id = metadata_segments.id
+        "#,
+    );
+    if collection_id.is_some() {
+        query.push_str(" WHERE collections.id = ?");
+    }
+    query.push_str(" ORDER BY collections.id");
+
+    let vector_segment_type: String = SegmentType::HnswLocalPersisted.into();
+    let metadata_segment_type: String = SegmentType::Sqlite.into();
+    let mut sql = sqlx::query(&query)
+        .bind(vector_segment_type)
+        .bind(metadata_segment_type);
+    if let Some(collection_id) = collection_id {
+        sql = sql.bind(collection_id);
+    }
+
+    let rows = sql
+        .fetch_all(pool)
+        .await
+        .map_err(HnswIntegrityCheckError::SqliteQuery)?;
+    rows.into_iter()
+        .map(|row| {
+            let collection_id_str: String = row.get("collection_id");
+            let collection_id = CollectionUuid::from_str(&collection_id_str).map_err(|_| {
+                HnswIntegrityCheckError::InvalidCollectionId(collection_id_str.clone())
+            })?;
+            Ok(SegmentRow {
+                collection_id,
+                collection_name: row.get("collection_name"),
+                collection_dimension: row.get("collection_dimension"),
+                tenant: row.get("tenant"),
+                database: row.get("database_name"),
+                vector_segment_id: row.get("vector_segment_id"),
+                vector_max_seq_id: row.get("vector_max_seq_id"),
+                metadata_max_seq_id: row.get("metadata_max_seq_id"),
+            })
+        })
+        .collect()
+}
+
+async fn load_log_state(
+    pool: &SqlitePool,
+    segment: &SegmentRow,
+) -> Result<LogState, HnswIntegrityCheckError> {
+    let vector_watermark = segment.vector_max_seq_id.unwrap_or_default();
+    let purge_watermark = purge_watermark(segment);
+    let topic =
+        get_embeddings_queue_topic_name(&segment.tenant, &segment.database, segment.collection_id);
+    let row = sqlx::query(
+        r#"
+        SELECT
+            MIN(seq_id) AS min_seq_id,
+            MAX(seq_id) AS max_seq_id,
+            COUNT(*) AS row_count,
+            COALESCE(SUM(CASE WHEN seq_id <= ? THEN 1 ELSE 0 END), 0)
+                AS rows_at_or_below_vector_watermark,
+            COALESCE(SUM(CASE WHEN seq_id < ? THEN 1 ELSE 0 END), 0)
+                AS rows_below_purge_watermark
+        FROM embeddings_queue
+        WHERE topic = ?
+        "#,
+    )
+    .bind(vector_watermark)
+    .bind(purge_watermark)
+    .bind(&topic)
+    .fetch_one(pool)
+    .await
+    .map_err(HnswIntegrityCheckError::SqliteQuery)?;
+
+    Ok(LogState {
+        topic,
+        row_count: row.get("row_count"),
+        min_seq_id: row.get("min_seq_id"),
+        max_seq_id: row.get("max_seq_id"),
+        rows_at_or_below_vector_watermark: row.get("rows_at_or_below_vector_watermark"),
+        rows_below_purge_watermark: row.get("rows_below_purge_watermark"),
+    })
+}
+
+fn inspect_segment(
+    persist_path: &Path,
+    segment: &SegmentRow,
+    log_state: LogState,
+    issues: &mut Vec<Issue>,
+) {
+    let vector_watermark = segment.vector_max_seq_id.unwrap_or_default();
+    let has_durable_watermark = vector_watermark > 0;
+    let has_sqlite_vector_watermark = segment.vector_max_seq_id.is_some();
+    let index_dir = persist_path.join(&segment.vector_segment_id);
+    let has_any_hnsw_file = HNSW_INDEX_FILES
+        .iter()
+        .copied()
+        .chain(std::iter::once(METADATA_FILE))
+        .any(|filename| index_dir.join(filename).is_file());
+
+    if segment.collection_dimension.is_none() {
+        if has_durable_watermark {
+            push_issue(
+                issues,
+                Severity::Corrupt,
+                "missing_collection_dimension",
+                segment,
+                log_state,
+                "sqlite has a vector max_seq_id for this collection, but the collection has no dimension".to_string(),
+            );
+        }
+        return;
+    }
+
+    if !index_dir.is_dir() {
+        if has_durable_watermark {
+            push_issue(
+                issues,
+                Severity::Corrupt,
+                "missing_index_directory",
+                segment,
+                log_state,
+                format!(
+                    "sqlite vector max_seq_id is {}, but HNSW directory is missing: {}",
+                    vector_watermark,
+                    index_dir.display()
+                ),
+            );
+        }
+        return;
+    }
+
+    if !has_durable_watermark && !has_any_hnsw_file {
+        return;
+    }
+
+    let expected_dim = segment.collection_dimension.unwrap() as usize;
+    let severity = if has_durable_watermark {
+        Severity::Corrupt
+    } else {
+        Severity::Warning
+    };
+
+    for filename in HNSW_INDEX_FILES
+        .iter()
+        .copied()
+        .chain(std::iter::once(METADATA_FILE))
+    {
+        let file_path = index_dir.join(filename);
+        if !file_path.is_file() {
+            push_issue(
+                issues,
+                severity,
+                "missing_hnsw_file",
+                segment,
+                log_state.clone(),
+                format!("HNSW file is missing: {}", file_path.display()),
+            );
+        }
+    }
+
+    let header_path = index_dir.join(HNSW_HEADER_FILE);
+    if header_path.is_file() {
+        match parse_hnsw_dim_from_path(&header_path) {
+            Ok(actual_dim) if actual_dim != expected_dim => push_issue(
+                issues,
+                severity,
+                "hnsw_header_dimension_mismatch",
+                segment,
+                log_state.clone(),
+                format!(
+                    "HNSW header dimensionality {} does not match collection dimensionality {}",
+                    actual_dim, expected_dim
+                ),
+            ),
+            Ok(_) => {}
+            Err(err) => push_issue(
+                issues,
+                severity,
+                "invalid_hnsw_header",
+                segment,
+                log_state.clone(),
+                format!("failed to parse {}: {err}", header_path.display()),
+            ),
+        }
+    }
+
+    let metadata_path = index_dir.join(METADATA_FILE);
+    if metadata_path.is_file() {
+        match inspect_persisted_hnsw_metadata(&metadata_path) {
+            Ok(metadata) => inspect_hnsw_metadata(
+                segment,
+                log_state,
+                issues,
+                severity,
+                expected_dim,
+                has_sqlite_vector_watermark,
+                metadata,
+            ),
+            Err(err) => push_issue(
+                issues,
+                severity,
+                "invalid_hnsw_metadata",
+                segment,
+                log_state,
+                format!("failed to read {}: {err}", metadata_path.display()),
+            ),
+        }
+    }
+}
+
+fn inspect_hnsw_metadata(
+    segment: &SegmentRow,
+    log_state: LogState,
+    issues: &mut Vec<Issue>,
+    severity: Severity,
+    expected_dim: usize,
+    has_sqlite_vector_watermark: bool,
+    metadata: PersistedHnswMetadata,
+) {
+    if !has_sqlite_vector_watermark {
+        if let Some(legacy_max_seq_id) = metadata.legacy_max_seq_id {
+            if legacy_max_seq_id > 0 && metadata.id_to_label_count > 0 {
+                push_issue(
+                    issues,
+                    Severity::FastForward,
+                    "pending_startup_fast_forward",
+                    segment,
+                    log_state.clone(),
+                    format!(
+                        "sqlite has no vector max_seq_id row, but HNSW metadata has legacy max_seq_id {legacy_max_seq_id}; opening this segment will migrate that value into sqlite"
+                    ),
+                );
+            }
+        }
+    }
+
+    if let Some(actual_dim) = metadata.dimensionality {
+        if actual_dim != expected_dim {
+            push_issue(
+                issues,
+                severity,
+                "hnsw_metadata_dimension_mismatch",
+                segment,
+                log_state.clone(),
+                format!(
+                    "HNSW metadata dimensionality {} does not match collection dimensionality {}",
+                    actual_dim, expected_dim
+                ),
+            );
+        }
+    }
+
+    if metadata.id_to_label_count != metadata.label_to_id_count {
+        push_issue(
+            issues,
+            severity,
+            "hnsw_metadata_label_count_mismatch",
+            segment,
+            log_state.clone(),
+            format!(
+                "HNSW metadata has {} id_to_label entries but {} label_to_id entries",
+                metadata.id_to_label_count, metadata.label_to_id_count
+            ),
+        );
+    }
+
+    if metadata.id_to_label_count > metadata.total_elements_added as usize {
+        push_issue(
+            issues,
+            severity,
+            "hnsw_metadata_total_elements_mismatch",
+            segment,
+            log_state.clone(),
+            format!(
+                "HNSW metadata maps {} ids but total_elements_added is {}",
+                metadata.id_to_label_count, metadata.total_elements_added
+            ),
+        );
+    }
+
+    if let Some(label_mismatch) = metadata.first_label_mismatch {
+        match label_mismatch {
+            PersistedHnswLabelMismatch::LabelMapsToDifferentId {
+                id,
+                label,
+                reverse_id,
+            } => push_issue(
+                issues,
+                severity,
+                "hnsw_metadata_label_mismatch",
+                segment,
+                log_state,
+                format!(
+                    "HNSW metadata maps id {id:?} to label {label}, but label maps back to {reverse_id:?}"
+                ),
+            ),
+            PersistedHnswLabelMismatch::MissingReverseLabel { id, label } => push_issue(
+                issues,
+                severity,
+                "hnsw_metadata_missing_reverse_label",
+                segment,
+                log_state,
+                format!(
+                    "HNSW metadata maps id {id:?} to label {label}, but the reverse label is missing"
+                ),
+            ),
+        }
+    }
+}
+
+fn push_issue(
+    issues: &mut Vec<Issue>,
+    severity: Severity,
+    kind: &'static str,
+    segment: &SegmentRow,
+    log_state: LogState,
+    detail: String,
+) {
+    issues.push(Issue {
+        severity,
+        kind,
+        collection_id: segment.collection_id.to_string(),
+        collection_name: segment.collection_name.clone(),
+        vector_segment_id: segment.vector_segment_id.clone(),
+        collection_dimension: segment.collection_dimension,
+        vector_max_seq_id: segment.vector_max_seq_id,
+        metadata_max_seq_id: segment.metadata_max_seq_id,
+        purge_watermark: purge_watermark(segment),
+        detail,
+        log_state,
+    });
+}
+
+fn purge_watermark(segment: &SegmentRow) -> i64 {
+    segment
+        .metadata_max_seq_id
+        .unwrap_or_default()
+        .min(segment.vector_max_seq_id.unwrap_or_default())
+}
+
+fn parse_hnsw_dim_from_path(path: &Path) -> Result<usize, String> {
+    let header = std::fs::read(path).map_err(|err| err.to_string())?;
+    parse_persisted_hnsw_dim(&header).ok_or_else(|| "invalid persisted HNSW header".to_string())
+}
+
+fn print_json_report(report: &Report) -> Result<(), HnswIntegrityCheckError> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(report).map_err(HnswIntegrityCheckError::Json)?
+    );
+    Ok(())
+}
+
+fn print_human_report(report: &Report) {
+    if report.issues.is_empty() {
+        println!(
+            "OK: checked {} persisted HNSW vector segment(s); no pending startup fast-forward or corruption indicators found.",
+            report.checked_segments
+        );
+        return;
+    }
+
+    println!(
+        "Checked {} persisted HNSW vector segment(s): {} pending startup fast-forward(s), {} corruption(s), {} warning(s).",
+        report.checked_segments, report.pending_fast_forwards, report.corruptions, report.warnings
+    );
+    println!("sqlite: {}", report.sqlite_path);
+    println!("persist: {}", report.persist_path);
+    println!();
+
+    for issue in &report.issues {
+        println!(
+            "[{:?}] {} collection={} name={:?} vector_segment={}",
+            issue.severity,
+            issue.kind,
+            issue.collection_id,
+            issue.collection_name,
+            issue.vector_segment_id
+        );
+        println!("  {}", issue.detail);
+        println!(
+            "  watermarks: metadata={:?} vector={:?} purge={}",
+            issue.metadata_max_seq_id, issue.vector_max_seq_id, issue.purge_watermark
+        );
+        println!(
+            "  logs: rows={} range={:?}..{:?} rows<=vector_watermark={} rows<purge_watermark={}",
+            issue.log_state.row_count,
+            issue.log_state.min_seq_id,
+            issue.log_state.max_seq_id,
+            issue.log_state.rows_at_or_below_vector_watermark,
+            issue.log_state.rows_below_purge_watermark
+        );
+        println!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_pending_startup_fast_forward() {
+        let collection_id = CollectionUuid::new();
+        let segment = SegmentRow {
+            collection_id,
+            collection_name: "name".to_string(),
+            collection_dimension: Some(3),
+            tenant: "tenant".to_string(),
+            database: "database".to_string(),
+            vector_segment_id: "segment".to_string(),
+            vector_max_seq_id: None,
+            metadata_max_seq_id: Some(10),
+        };
+        let log_state = LogState {
+            topic: "persistent://tenant/database/collection".to_string(),
+            row_count: 0,
+            min_seq_id: None,
+            max_seq_id: None,
+            rows_at_or_below_vector_watermark: 0,
+            rows_below_purge_watermark: 0,
+        };
+        let metadata = PersistedHnswMetadata {
+            dimensionality: Some(3),
+            total_elements_added: 1,
+            legacy_max_seq_id: Some(7),
+            id_to_label_count: 1,
+            label_to_id_count: 1,
+            first_label_mismatch: None,
+        };
+        let mut issues = Vec::new();
+
+        inspect_hnsw_metadata(
+            &segment,
+            log_state,
+            &mut issues,
+            Severity::Warning,
+            3,
+            false,
+            metadata,
+        );
+
+        assert!(issues.iter().any(|issue| {
+            issue.severity == Severity::FastForward && issue.kind == "pending_startup_fast_forward"
+        }));
+    }
+}

--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -1,6 +1,7 @@
 mod client;
 mod commands;
 mod config_store;
+pub mod hnsw_integrity_check;
 mod terminal;
 mod tui;
 mod ui_utils;
@@ -16,6 +17,7 @@ use crate::commands::run::{run, RunArgs};
 use crate::commands::update::update;
 use crate::commands::vacuum::{vacuum, VacuumArgs};
 use crate::commands::webpage::{open_browser, WebPageCommand};
+use crate::hnsw_integrity_check::{hnsw_integrity_check, HnswIntegrityCheckArgs};
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 
@@ -30,6 +32,12 @@ enum Command {
     Db(DbCommand),
     #[command(about = "Open Chroma online documentation", long_about = None)]
     Docs,
+    #[command(
+        name = "hnsw-integrity-check",
+        about = "Check local HNSW startup fast-forward and integrity hazards",
+        long_about = None
+    )]
+    HnswIntegrityCheck(HnswIntegrityCheckArgs),
     #[command(about = "Install sample applications", long_about = None)]
     Install(InstallArgs),
     #[command(about = "Log in to Chroma Cloud", long_about = None)]
@@ -66,6 +74,7 @@ pub fn chroma_cli(args: Vec<String>) {
         Command::Copy(args) => copy(args),
         Command::Db(db_subcommand) => db_command(db_subcommand),
         Command::Docs => open_browser(WebPageCommand::Docs),
+        Command::HnswIntegrityCheck(args) => hnsw_integrity_check(args).map_err(Into::into),
         Command::Install(args) => install(args),
         Command::Login(args) => login(args),
         Command::Profile(profile_subcommand) => profile_command(profile_subcommand),

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -9,6 +9,7 @@ use crate::commands::run::RunError;
 use crate::commands::update::UpdateError;
 use crate::commands::vacuum::VacuumError;
 use crate::commands::webpage::WebPageError;
+use crate::hnsw_integrity_check::HnswIntegrityCheckError;
 use crate::ui_utils::Theme;
 use chroma::client::{
     ChromaAuthMethod, ChromaHttpClientError, ChromaHttpClientOptions, ChromaRetryOptions,
@@ -59,6 +60,8 @@ pub enum CliError {
     Copy(#[from] CopyError),
     #[error("{0}")]
     WebPage(#[from] WebPageError),
+    #[error("{0}")]
+    HnswIntegrityCheck(#[from] HnswIntegrityCheckError),
 }
 
 #[derive(Debug, Error)]

--- a/rust/frontend/src/executor/local.rs
+++ b/rust/frontend/src/executor/local.rs
@@ -15,7 +15,7 @@ use chroma_types::{
         Limit, Projection, ProjectionRecord, RecordMeasure, SearchResult,
     },
     plan::{Count, Get, Knn, Search},
-    CollectionAndSegments, CollectionUuid, ExecutorError, SegmentType, Space,
+    CollectionAndSegments, CollectionUuid, ExecutorError, Segment, SegmentType, Space,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -82,17 +82,15 @@ impl LocalExecutor {
         let backfill_msg = BackfillMessage {
             collection_id: collection_and_segment.collection.collection_id,
         };
-        self.compactor_handle
-            .request(backfill_msg, None)
-            .await
-            .map_err(|err| ExecutorError::BackfillError(Box::new(err)))?
-            .map_err(|err| ExecutorError::BackfillError(Box::new(err)))?;
+        let backfill_result = self.compactor_handle.request(backfill_msg, None).await;
         let purge_log_msg = PurgeLogsMessage {
             collection_id: collection_and_segment.collection.collection_id,
         };
-        self.compactor_handle
-            .request(purge_log_msg, None)
-            .await
+        let purge_result = self.compactor_handle.request(purge_log_msg, None).await;
+        backfill_result
+            .map_err(|err| ExecutorError::BackfillError(Box::new(err)))?
+            .map_err(|err| ExecutorError::BackfillError(Box::new(err)))?;
+        purge_result
             .map_err(|err| ExecutorError::BackfillError(Box::new(err)))?
             .map_err(|err| ExecutorError::BackfillError(Box::new(err)))?;
         let mut backfill_guard = self.backfilled_collections.lock();
@@ -359,6 +357,25 @@ impl LocalExecutor {
 
     pub async fn reset(&mut self) -> Result<(), Box<dyn ChromaError>> {
         self.hnsw_manager.reset().await.map_err(|err| err.boxed())?;
+        Ok(())
+    }
+
+    pub async fn delete_segments(
+        &mut self,
+        segments: &[Segment],
+    ) -> Result<(), Box<dyn ChromaError>> {
+        for segment in segments {
+            if !matches!(
+                segment.r#type,
+                SegmentType::HnswLocalMemory | SegmentType::HnswLocalPersisted
+            ) {
+                continue;
+            }
+            self.hnsw_manager
+                .delete_hnsw_index(segment.id)
+                .await
+                .map_err(|err| err.boxed())?;
+        }
         Ok(())
     }
 }

--- a/rust/frontend/src/executor/mod.rs
+++ b/rust/frontend/src/executor/mod.rs
@@ -4,7 +4,7 @@ use chroma_error::ChromaError;
 use chroma_types::{
     operator::{CountResult, GetResult, KnnBatchResult, SearchResult},
     plan::{Count, Get, Knn, Search},
-    ExecutorError, SegmentType,
+    ExecutorError, Segment, SegmentType,
 };
 use distributed::DistributedExecutor;
 use local::LocalExecutor;
@@ -98,6 +98,16 @@ impl Executor {
             Executor::Distributed(_) => Ok(()),
             Executor::Local(local_executor) => local_executor
                 .reset()
+                .await
+                .map_err(ExecutorError::Internal),
+        }
+    }
+
+    pub async fn delete_segments(&mut self, segments: &[Segment]) -> Result<(), ExecutorError> {
+        match self {
+            Executor::Distributed(_) => Ok(()),
+            Executor::Local(local_executor) => local_executor
+                .delete_segments(segments)
                 .await
                 .map_err(ExecutorError::Internal),
         }

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use backon::{ExponentialBuilder, Retryable};
 use chroma_api_types::HeartbeatResponse;
+use chroma_cache::AysncPartitionedMutex;
 use chroma_config::{registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_log::{LocalCompactionManager, LocalCompactionManagerConfig, Log, PushLogsError};
@@ -41,20 +42,21 @@ use chroma_types::{
     GetCollectionResponse, GetCollectionsError, GetDatabaseError, GetDatabaseRequest,
     GetDatabaseResponse, GetRequest, GetResponse, GetTenantError, GetTenantRequest,
     GetTenantResponse, HealthCheckResponse, HeartbeatError, Include, IndexStatusError,
-    IndexStatusResponse, KnnIndex, ListCollectionsRequest, ListCollectionsResponse,
-    ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse, Operation, OperationRecord,
-    QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse, Schema, SearchRequest,
-    SearchResponse, SegmentType, UpdateCollectionError, UpdateCollectionRecordsError,
-    UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse, UpdateCollectionRequest,
-    UpdateCollectionResponse, UpdateTenantError, UpdateTenantRequest, UpdateTenantResponse,
-    UpsertCollectionRecordsError, UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse,
-    Where,
+    IndexStatusResponse, InternalCollectionConfiguration, KnnIndex, ListCollectionsRequest,
+    ListCollectionsResponse, ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse,
+    Operation, OperationRecord, QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse,
+    Schema, SearchRequest, SearchResponse, Segment, SegmentType, UpdateCollectionError,
+    UpdateCollectionRecordsError, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
+    UpdateCollectionRequest, UpdateCollectionResponse, UpdateTenantError, UpdateTenantRequest,
+    UpdateTenantResponse, UpsertCollectionRecordsError, UpsertCollectionRecordsRequest,
+    UpsertCollectionRecordsResponse, VectorIndexConfiguration, Where,
 };
 use opentelemetry::global;
 use opentelemetry::metrics::Counter;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use validator::Validate;
 
 #[derive(Debug)]
 struct Metrics {
@@ -81,6 +83,8 @@ pub struct ServiceBasedFrontend {
     default_knn_index: KnnIndex,
     enable_schema: bool,
     retries_builder: ExponentialBuilder,
+    dimension_locks: AysncPartitionedMutex<CollectionUuid>,
+    database_operation_locks: AysncPartitionedMutex<(String, DatabaseName)>,
     min_records_for_invocation: u64,
     tenants_with_quantization_enabled: Vec<String>,
     tenants_with_maxscore_enabled: Vec<String>,
@@ -147,6 +151,8 @@ impl ServiceBasedFrontend {
             default_knn_index,
             enable_schema,
             retries_builder,
+            dimension_locks: AysncPartitionedMutex::new(()),
+            database_operation_locks: AysncPartitionedMutex::new(()),
             min_records_for_invocation,
             tenants_with_quantization_enabled,
             tenants_with_maxscore_enabled,
@@ -830,6 +836,61 @@ impl ServiceBasedFrontend {
             .collection)
     }
 
+    async fn invalidate_collection_caches(&mut self, collection_ids: &[CollectionUuid]) {
+        for collection_id in collection_ids {
+            self.collections_with_segments_provider
+                .collections_with_segments_cache
+                .remove(collection_id)
+                .await;
+        }
+    }
+
+    async fn delete_collection_logs(
+        &mut self,
+        collection_ids: &[CollectionUuid],
+    ) -> Result<(), Box<dyn ChromaError>> {
+        for collection_id in collection_ids {
+            self.log_client.delete_logs(*collection_id).await?;
+        }
+        Ok(())
+    }
+
+    async fn cleanup_deleted_collection_resources(
+        &mut self,
+        collection_ids: &[CollectionUuid],
+        segments: &[Segment],
+    ) -> Result<(), Box<dyn ChromaError>> {
+        let mut first_error = self.delete_collection_logs(collection_ids).await.err();
+        if let Err(err) = self.executor.delete_segments(segments).await {
+            if first_error.is_none() {
+                first_error = Some(Box::new(err) as Box<dyn ChromaError>);
+            }
+        }
+        if let Some(err) = first_error {
+            Err(err)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn validate_collection_index_configuration(
+        collection: &Collection,
+    ) -> Result<(), ValidationError> {
+        match &collection.config.vector_index {
+            VectorIndexConfiguration::Hnsw(hnsw) => hnsw
+                .validate()
+                .map_err(|err| ValidationError::InvalidArgument(format!("{err}")))?,
+            VectorIndexConfiguration::Spann(spann) => spann
+                .validate()
+                .map_err(|err| ValidationError::InvalidArgument(format!("{err}")))?,
+        }
+        if let Some(schema) = &collection.schema {
+            InternalCollectionConfiguration::try_from(schema)
+                .map_err(ValidationError::InvalidArgument)?;
+        }
+        Ok(())
+    }
+
     async fn set_collection_dimension(
         &mut self,
         database_name: DatabaseName,
@@ -866,45 +927,53 @@ impl ServiceBasedFrontend {
     where
         F: Fn(&Embedding) -> Option<usize>,
     {
-        let collection = self
-            .get_cached_collection(database_name.clone(), collection_id)
-            .await?;
-        if let Some(embeddings) = option_embeddings {
+        let emb_dim = if let Some(embeddings) = option_embeddings {
             let emb_dims = embeddings
                 .iter()
                 .filter_map(read_length)
                 .collect::<Vec<_>>();
             let min_dim = emb_dims.iter().min().cloned();
             let max_dim = emb_dims.iter().max().cloned();
-            let emb_dim = if let (Some(low), Some(high)) = (min_dim, max_dim) {
+            if let (Some(low), Some(high)) = (min_dim, max_dim) {
                 if low != high {
                     return Err(ValidationError::DimensionInconsistent);
                 }
-                low as u32
+                Some(low as u32)
             } else {
-                // No embedding to check, return
-                return Ok(collection);
-            };
-            match collection.dimension.map(|dim| dim as u32) {
-                Some(expected_dim) => {
-                    if expected_dim != emb_dim {
-                        return Err(ValidationError::DimensionMismatch(expected_dim, emb_dim));
-                    }
+                None
+            }
+        } else {
+            None
+        };
+
+        let Some(emb_dim) = emb_dim else {
+            let collection = self
+                .get_cached_collection(database_name.clone(), collection_id)
+                .await?;
+            Self::validate_collection_index_configuration(&collection)?;
+            return Ok(collection);
+        };
+
+        let dimension_locks = self.dimension_locks.clone();
+        let _guard = dimension_locks.lock(&collection_id).await;
+        let mut collection = self
+            .get_cached_collection(database_name.clone(), collection_id)
+            .await?;
+        Self::validate_collection_index_configuration(&collection)?;
+        match collection.dimension.map(|dim| dim as u32) {
+            Some(expected_dim) => {
+                if expected_dim != emb_dim {
+                    return Err(ValidationError::DimensionMismatch(expected_dim, emb_dim));
                 }
-                None => {
-                    if update_if_not_present {
-                        let database_name =
-                            DatabaseName::new(&collection.database).ok_or_else(|| {
-                                ValidationError::InvalidArgument(
-                                    "database name must be at least 3 characters".to_string(),
-                                )
-                            })?;
-                        self.set_collection_dimension(database_name, collection_id, emb_dim)
-                            .await?;
-                    }
+            }
+            None => {
+                if update_if_not_present {
+                    self.set_collection_dimension(database_name, collection_id, emb_dim)
+                        .await?;
+                    collection.dimension = Some(emb_dim as i32);
                 }
-            };
-        }
+            }
+        };
         Ok(collection)
     }
 
@@ -999,9 +1068,46 @@ impl ServiceBasedFrontend {
             ..
         }: DeleteDatabaseRequest,
     ) -> Result<DeleteDatabaseResponse, DeleteDatabaseError> {
+        let db_name = DatabaseName::new(&database_name).ok_or_else(|| {
+            DeleteDatabaseError::Internal(Box::new(ValidationError::InvalidArgument(
+                "database name must be at least 3 characters".to_string(),
+            )))
+        })?;
+        let database_operation_locks = self.database_operation_locks.clone();
+        let _database_guard = database_operation_locks
+            .lock(&(tenant_id.clone(), db_name.clone()))
+            .await;
+        let collections = self
+            .sysdb_client
+            .get_collections(GetCollectionsOptions {
+                tenant: Some(tenant_id.clone()),
+                database_or_topology: Some(DatabaseOrTopology::Database(db_name)),
+                ..Default::default()
+            })
+            .await
+            .map_err(|err| DeleteDatabaseError::Internal(Box::new(err)))?;
+        let collection_ids = collections
+            .iter()
+            .map(|collection| collection.collection_id)
+            .collect::<Vec<_>>();
+        let mut segments = Vec::<Segment>::new();
+        for collection in &collections {
+            let collection_segments = self
+                .sysdb_client
+                .get_segments(None, None, None, collection.collection_id)
+                .await
+                .map_err(|err| DeleteDatabaseError::Internal(err.boxed()))?;
+            segments.extend(collection_segments);
+        }
+
         self.sysdb_client
             .delete_database(database_name, tenant_id)
+            .await?;
+        self.invalidate_collection_caches(&collection_ids).await;
+        self.cleanup_deleted_collection_resources(&collection_ids, &segments)
             .await
+            .map_err(DeleteDatabaseError::Internal)?;
+        Ok(DeleteDatabaseResponse {})
     }
 
     pub async fn list_collections(
@@ -1157,6 +1263,10 @@ impl ServiceBasedFrontend {
             ..
         }: CreateCollectionRequest,
     ) -> Result<CreateCollectionResponse, CreateCollectionError> {
+        let database_operation_locks = self.database_operation_locks.clone();
+        let _database_guard = database_operation_locks
+            .lock(&(tenant_id.clone(), database_name.clone()))
+            .await;
         let plan = frontend_core::collection_ops::plan_create_collection(
             configuration,
             schema,
@@ -1265,15 +1375,16 @@ impl ServiceBasedFrontend {
                 tenant_id,
                 db_name,
                 collection.collection_id,
-                segments.into_iter().map(|s| s.id).collect(),
+                segments.iter().map(|s| s.id).collect(),
             )
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
         // Invalidate the cache.
-        self.collections_with_segments_provider
-            .collections_with_segments_cache
-            .remove(&collection.collection_id)
+        self.invalidate_collection_caches(&[collection.collection_id])
             .await;
+        self.cleanup_deleted_collection_resources(&[collection.collection_id], &segments)
+            .await
+            .map_err(DeleteCollectionError::Internal)?;
 
         Ok(DeleteCollectionResponse {})
     }
@@ -1873,9 +1984,10 @@ impl ServiceBasedFrontend {
             let cmek = self
                 .get_cached_collection(database_name_typed.clone(), collection_id)
                 .await
-                .map_err(|err| DeleteCollectionRecordsError::Internal(err.boxed()))?
-                .schema
-                .and_then(|schema| schema.cmek.clone());
+                .map_err(|err| DeleteCollectionRecordsError::Internal(err.boxed()))?;
+            Self::validate_collection_index_configuration(&cmek)
+                .map_err(|err| DeleteCollectionRecordsError::Internal(err.boxed()))?;
+            let cmek = cmek.schema.and_then(|schema| schema.cmek.clone());
             self.retryable_push_logs(
                 &tenant_id,
                 database_name_typed.clone(),
@@ -2831,6 +2943,125 @@ mod tests {
         assert!(segments.iter().any(
             |s| s.r#type == SegmentType::HnswLocalPersisted && s.scope == SegmentScope::VECTOR
         ));
+    }
+
+    #[tokio::test]
+    async fn concurrent_dimension_initialization_rejects_loser_dimension() {
+        let registry = Registry::new();
+        let system = System::new();
+        let config = FrontendConfig::sqlite_in_memory();
+        let mut frontend = ServiceBasedFrontend::try_from_config(&(config, system), &registry)
+            .await
+            .unwrap();
+
+        let database_name =
+            DatabaseName::new("default_database").expect("database name should be valid");
+        let collection = frontend
+            .create_collection(
+                CreateCollectionRequest::try_new(
+                    "default_tenant".to_string(),
+                    database_name.clone(),
+                    "concurrent_dimension".to_string(),
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let mut first_frontend = frontend.clone();
+        let mut second_frontend = frontend.clone();
+        let first_barrier = barrier.clone();
+        let second_barrier = barrier.clone();
+        let collection_id = collection.collection_id;
+
+        let first = tokio::spawn(async move {
+            let embeddings = vec![vec![1.0, 2.0]];
+            first_barrier.wait().await;
+            first_frontend
+                .validate_embedding(
+                    database_name,
+                    collection_id,
+                    Some(&embeddings),
+                    true,
+                    |embedding: &Vec<f32>| Some(embedding.len()),
+                )
+                .await
+        });
+        let second = tokio::spawn(async move {
+            let embeddings = vec![vec![1.0, 2.0, 3.0]];
+            second_barrier.wait().await;
+            second_frontend
+                .validate_embedding(
+                    DatabaseName::new("default_database").expect("database name should be valid"),
+                    collection_id,
+                    Some(&embeddings),
+                    true,
+                    |embedding: &Vec<f32>| Some(embedding.len()),
+                )
+                .await
+        });
+
+        let first = first.await.unwrap();
+        let second = second.await.unwrap();
+        let results = [&first, &second];
+
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(ValidationError::DimensionMismatch(_, _))))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn collection_create_waits_for_database_operation_lock() {
+        let registry = Registry::new();
+        let system = System::new();
+        let config = FrontendConfig::sqlite_in_memory();
+        let frontend = ServiceBasedFrontend::try_from_config(&(config, system), &registry)
+            .await
+            .unwrap();
+
+        let database_name =
+            DatabaseName::new("default_database").expect("database name should be valid");
+        let lock_key = ("default_tenant".to_string(), database_name.clone());
+        let database_operation_locks = frontend.database_operation_locks.clone();
+        let guard = database_operation_locks.lock(&lock_key).await;
+
+        let mut create_frontend = frontend.clone();
+        let mut create_task = tokio::spawn(async move {
+            create_frontend
+                .create_collection(
+                    CreateCollectionRequest::try_new(
+                        "default_tenant".to_string(),
+                        database_name,
+                        "blocked_create".to_string(),
+                        None,
+                        None,
+                        None,
+                        false,
+                    )
+                    .unwrap(),
+                )
+                .await
+        });
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut create_task)
+                .await
+                .is_err()
+        );
+        drop(guard);
+
+        let collection = create_task.await.unwrap().unwrap();
+        assert_eq!(collection.name, "blocked_create");
     }
 
     #[tokio::test]

--- a/rust/log/src/in_memory_log.rs
+++ b/rust/log/src/in_memory_log.rs
@@ -148,6 +148,11 @@ impl InMemoryLog {
         Ok(())
     }
 
+    pub(super) async fn delete_logs(&mut self, collection_id: CollectionUuid) {
+        self.collection_to_log.remove(&collection_id);
+        self.offsets.remove(&collection_id);
+    }
+
     pub(super) async fn scout_logs(
         &mut self,
         collection_id: CollectionUuid,

--- a/rust/log/src/local_compaction_manager.rs
+++ b/rust/log/src/local_compaction_manager.rs
@@ -15,8 +15,9 @@ use chroma_sysdb::SysDb;
 use chroma_system::Handler;
 use chroma_system::{Component, ComponentContext};
 use chroma_types::{
-    Chunk, CollectionUuid, DatabaseName, GetCollectionWithSegmentsError, LogRecord, Schema,
-    SchemaError,
+    Chunk, Collection, CollectionUuid, DatabaseName, GetCollectionWithSegmentsError,
+    HnswParametersFromSegmentError, LogRecord, Schema, SchemaError, Segment, SegmentType,
+    SegmentUuid,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -95,6 +96,8 @@ pub enum CompactionManagerError {
     HnswReaderError(#[from] LocalHnswSegmentReaderError),
     #[error("Error constructing hnsw segment reader: {0}")]
     HnswReaderConstructionError(#[from] LocalSegmentManagerError),
+    #[error("Collection has invalid HNSW configuration")]
+    InvalidHnswConfiguration,
     #[error("Error purging logs")]
     PurgeLogsFailure,
     #[error("Failed to reconcile collection schema: {0}")]
@@ -112,6 +115,7 @@ impl ChromaError for CompactionManagerError {
             CompactionManagerError::MetadataReaderError(e) => e.code(),
             CompactionManagerError::HnswReaderError(e) => e.code(),
             CompactionManagerError::HnswReaderConstructionError(e) => e.code(),
+            CompactionManagerError::InvalidHnswConfiguration => ErrorCodes::InvalidArgument,
             CompactionManagerError::PurgeLogsFailure => ErrorCodes::Internal,
             CompactionManagerError::SchemaReconcileError(e) => e.code(),
         }
@@ -126,6 +130,73 @@ pub struct PurgeLogsMessage {
 #[derive(Clone, Debug)]
 pub struct BackfillMessage {
     pub collection_id: CollectionUuid,
+}
+
+async fn max_purge_seq_id(
+    sqlite_db: &SqliteDb,
+    metadata_segment_id: &SegmentUuid,
+    vector_segment_id: &SegmentUuid,
+) -> Result<u64, CompactionManagerError> {
+    let metadata_reader = SqliteMetadataReader::new(sqlite_db.clone());
+    let mt_max_seq_id = metadata_reader
+        .current_max_seq_id(metadata_segment_id)
+        .await?;
+    let hnsw_max_seq_id = metadata_reader
+        .current_max_seq_id(vector_segment_id)
+        .await?;
+    Ok(mt_max_seq_id.min(hnsw_max_seq_id))
+}
+
+fn has_invalid_hnsw_configuration(collection: &Collection, vector_segment: &Segment) -> bool {
+    if !matches!(
+        vector_segment.r#type,
+        SegmentType::HnswLocalMemory | SegmentType::HnswLocalPersisted
+    ) {
+        return false;
+    }
+
+    let owned_schema;
+    let schema = match collection.schema.as_ref() {
+        Some(schema) => schema,
+        None => {
+            owned_schema = match Schema::try_from(&collection.config) {
+                Ok(schema) => schema,
+                Err(_) => return true,
+            };
+            &owned_schema
+        }
+    };
+
+    matches!(
+        schema.get_internal_hnsw_config_with_legacy_fallback(vector_segment),
+        Err(HnswParametersFromSegmentError::InvalidParameters(_))
+    )
+}
+
+fn is_invalid_hnsw_reader_configuration_error(error: &LocalSegmentManagerError) -> bool {
+    matches!(
+        error,
+        LocalSegmentManagerError::LocalHnswSegmentReaderError(
+            LocalHnswSegmentReaderError::InvalidHnswConfiguration(_)
+        )
+    )
+}
+
+async fn max_purge_seq_id_for_collection(
+    sqlite_db: &SqliteDb,
+    collection: &Collection,
+    metadata_segment: &Segment,
+    vector_segment: &Segment,
+) -> Result<u64, CompactionManagerError> {
+    if has_invalid_hnsw_configuration(collection, vector_segment) {
+        // Invalid persisted HNSW config prevents the vector watermark from
+        // advancing, but metadata backfill can still bound log retention.
+        let metadata_reader = SqliteMetadataReader::new(sqlite_db.clone());
+        return Ok(metadata_reader
+            .current_max_seq_id(&metadata_segment.id)
+            .await?);
+    }
+    max_purge_seq_id(sqlite_db, &metadata_segment.id, &vector_segment.id).await
 }
 
 #[async_trait]
@@ -166,6 +237,7 @@ impl Handler<BackfillMessage> for LocalCompactionManager {
                 dim as usize,
             )
             .await;
+        let mut invalid_hnsw_configuration = false;
         let hnsw_max_seq_id = match hnsw_reader {
             Ok(reader) => {
                 reader
@@ -175,6 +247,10 @@ impl Handler<BackfillMessage> for LocalCompactionManager {
             Err(LocalSegmentManagerError::LocalHnswSegmentReaderError(
                 LocalHnswSegmentReaderError::UninitializedSegment,
             )) => 0,
+            Err(e) if is_invalid_hnsw_reader_configuration_error(&e) => {
+                invalid_hnsw_configuration = true;
+                0
+            }
             Err(e) => return Err(CompactionManagerError::HnswReaderConstructionError(e)),
         };
         // Get the logs from log service beyond this offset to backfill.
@@ -243,6 +319,9 @@ impl Handler<BackfillMessage> for LocalCompactionManager {
         tx.commit()
             .await
             .map_err(|_| CompactionManagerError::MetadataApplyLogsFailed)?;
+        if invalid_hnsw_configuration {
+            return Err(CompactionManagerError::InvalidHnswConfiguration);
+        }
         // Next apply it to the hnsw writer.
         let mut hnsw_writer = self
             .hnsw_segment_manager
@@ -274,45 +353,121 @@ impl Handler<PurgeLogsMessage> for LocalCompactionManager {
             .sysdb
             .get_collection_with_segments(None, message.collection_id)
             .await?;
-        let mut collection = collection_segments.collection.clone();
-        if collection.schema.is_none() {
-            collection.schema = Some(
-                Schema::try_from(&collection.config)
-                    .map_err(CompactionManagerError::SchemaReconcileError)?,
-            );
-        }
         // If dimension is None, that means nothing has been written yet.
-        let dim = match collection.dimension {
-            Some(dim) => dim,
-            None => return Ok(()),
-        };
-        let metadata_reader = SqliteMetadataReader::new(self.sqlite_db.clone());
-        let mt_max_seq_id = metadata_reader
-            .current_max_seq_id(&collection_segments.metadata_segment.id)
-            .await?;
-        let hnsw_reader = self
-            .hnsw_segment_manager
-            .get_hnsw_reader(
-                &collection,
-                &collection_segments.vector_segment,
-                dim as usize,
-            )
-            .await;
-        let hnsw_max_seq_id = match hnsw_reader {
-            Ok(reader) => {
-                reader
-                    .current_max_seq_id(&collection_segments.vector_segment.id)
-                    .await?
-            }
-            Err(LocalSegmentManagerError::LocalHnswSegmentReaderError(
-                LocalHnswSegmentReaderError::UninitializedSegment,
-            )) => 0,
-            Err(e) => return Err(CompactionManagerError::HnswReaderConstructionError(e)),
-        };
-        let max_seq_id = mt_max_seq_id.min(hnsw_max_seq_id);
+        if collection_segments.collection.dimension.is_none() {
+            return Ok(());
+        }
+        let max_seq_id = max_purge_seq_id_for_collection(
+            &self.sqlite_db,
+            &collection_segments.collection,
+            &collection_segments.metadata_segment,
+            &collection_segments.vector_segment,
+        )
+        .await?;
         self.log
             .purge_logs(message.collection_id, max_seq_id)
             .await
             .map_err(|_| CompactionManagerError::PurgeLogsFailure)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_config::{registry::Registry, Configurable};
+    use chroma_sqlite::{
+        config::{MigrationHash, MigrationMode, SqliteDBConfig},
+        db::test_utils::new_test_db_persist_path,
+    };
+    use chroma_types::{
+        Collection, CollectionUuid, Segment, SegmentScope, SegmentType, VectorIndexConfiguration,
+    };
+    use std::collections::HashMap;
+
+    async fn setup_sqlite_db() -> SqliteDb {
+        SqliteDb::try_from_config(
+            &SqliteDBConfig {
+                url: new_test_db_persist_path(),
+                migration_mode: MigrationMode::Apply,
+                hash_type: MigrationHash::SHA256,
+            },
+            &Registry::new(),
+        )
+        .await
+        .expect("sqlite db")
+    }
+
+    async fn set_segment_seq_id(sqlite_db: &SqliteDb, segment_id: SegmentUuid, seq_id: i64) {
+        sqlx::query("INSERT INTO max_seq_id (segment_id, seq_id) VALUES ($1, $2)")
+            .bind(segment_id.to_string())
+            .bind(seq_id)
+            .execute(sqlite_db.get_conn())
+            .await
+            .expect("insert max_seq_id");
+    }
+
+    #[tokio::test]
+    async fn max_purge_seq_id_uses_persisted_segment_watermarks() {
+        let sqlite_db = setup_sqlite_db().await;
+        let metadata_segment_id = SegmentUuid::new();
+        let vector_segment_id = SegmentUuid::new();
+
+        set_segment_seq_id(&sqlite_db, metadata_segment_id, 40).await;
+        set_segment_seq_id(&sqlite_db, vector_segment_id, 17).await;
+
+        assert_eq!(
+            max_purge_seq_id(&sqlite_db, &metadata_segment_id, &vector_segment_id)
+                .await
+                .expect("purge watermark"),
+            17
+        );
+    }
+
+    #[tokio::test]
+    async fn max_purge_seq_id_uses_metadata_watermark_for_invalid_hnsw_config() {
+        let sqlite_db = setup_sqlite_db().await;
+        let collection_id = CollectionUuid::new();
+        let metadata_segment = Segment {
+            id: SegmentUuid::new(),
+            r#type: SegmentType::Sqlite,
+            scope: SegmentScope::METADATA,
+            collection: collection_id,
+            metadata: None,
+            file_path: HashMap::new(),
+        };
+        let vector_segment = Segment {
+            id: SegmentUuid::new(),
+            r#type: SegmentType::HnswLocalPersisted,
+            scope: SegmentScope::VECTOR,
+            collection: collection_id,
+            metadata: None,
+            file_path: HashMap::new(),
+        };
+        let mut collection = Collection {
+            collection_id,
+            ..Collection::default()
+        };
+        if let VectorIndexConfiguration::Hnsw(hnsw) = &mut collection.config.vector_index {
+            hnsw.max_neighbors = 129;
+        }
+        collection.schema = Some(
+            Schema::try_from(&collection.config)
+                .expect("invalid HNSW bounds should still serialize to schema"),
+        );
+
+        set_segment_seq_id(&sqlite_db, metadata_segment.id, 40).await;
+        set_segment_seq_id(&sqlite_db, vector_segment.id, 17).await;
+
+        assert_eq!(
+            max_purge_seq_id_for_collection(
+                &sqlite_db,
+                &collection,
+                &metadata_segment,
+                &vector_segment
+            )
+            .await
+            .expect("purge watermark"),
+            40
+        );
     }
 }

--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -312,6 +312,23 @@ impl Log {
         }
     }
 
+    pub async fn delete_logs(
+        &mut self,
+        collection_id: CollectionUuid,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        match self {
+            Log::Sqlite(log) => log
+                .delete_logs(collection_id)
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn ChromaError>),
+            Log::Grpc(_) => Ok(()),
+            Log::InMemory(log) => {
+                log.delete_logs(collection_id).await;
+                Ok(())
+            }
+        }
+    }
+
     pub async fn get_max_batch_size(&mut self) -> Result<u32, Box<dyn ChromaError>> {
         match self {
             Log::Sqlite(log) => log

--- a/rust/log/src/sqlite_log.rs
+++ b/rust/log/src/sqlite_log.rs
@@ -390,9 +390,11 @@ impl SqliteLog {
 
         if let Some(handle) = self.compactor_handle.get() {
             let backfill_message = BackfillMessage { collection_id };
-            handle.request(backfill_message, None).await??;
+            let backfill_result = handle.request(backfill_message, None).await;
             let purge_log_msg = PurgeLogsMessage { collection_id };
-            handle.clone().request(purge_log_msg, None).await??;
+            let purge_result = handle.clone().request(purge_log_msg, None).await;
+            backfill_result??;
+            purge_result??;
         }
 
         Ok(())
@@ -478,6 +480,22 @@ impl SqliteLog {
         sqlx::query("DELETE FROM embeddings_queue WHERE topic = ? AND seq_id < ?")
             .bind(topic)
             .bind(seq_id as i64)
+            .execute(self.db.get_conn())
+            .await
+            .map_err(WrappedSqlxError)?;
+
+        Ok(())
+    }
+
+    pub async fn delete_logs(
+        &mut self,
+        collection_id: CollectionUuid,
+    ) -> Result<(), WrappedSqlxError> {
+        let topic =
+            get_embeddings_queue_topic_name(&self.tenant_id, &self.topic_namespace, collection_id);
+
+        sqlx::query("DELETE FROM embeddings_queue WHERE topic = ?")
+            .bind(topic)
             .execute(self.db.get_conn())
             .await
             .map_err(WrappedSqlxError)?;
@@ -674,6 +692,17 @@ mod tests {
         SqliteLog::new(db, "default".to_string(), "default".to_string())
     }
 
+    fn add_record(id: &str) -> OperationRecord {
+        OperationRecord {
+            id: id.to_string(),
+            embedding: Some(vec![1.0, 2.0, 3.0]),
+            encoding: Some(ScalarEncoding::FLOAT32),
+            metadata: None,
+            document: None,
+            operation: Operation::Add,
+        }
+    }
+
     #[tokio::test]
     async fn test_log_offset() {
         let mut log = setup_sqlite_log().await;
@@ -725,6 +754,41 @@ mod tests {
             .unwrap();
         let collections_with_data = log.get_collections_with_new_data(0).await.unwrap();
         assert_eq!(collections_with_data.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_delete_logs_removes_collection_topic() {
+        let mut log = setup_sqlite_log().await;
+        log.update_legacy_embeddings_queue_config(LegacyEmbeddingsQueueConfig {
+            automatically_purge: false,
+            kind: legacy_embeddings_queue_config_default_kind(),
+        })
+        .await
+        .unwrap();
+
+        let deleted_collection_id = CollectionUuid::new();
+        let retained_collection_id = CollectionUuid::new();
+        log.push_logs(deleted_collection_id, vec![add_record("deleted")])
+            .await
+            .unwrap();
+        log.push_logs(retained_collection_id, vec![add_record("retained")])
+            .await
+            .unwrap();
+
+        log.delete_logs(deleted_collection_id).await.unwrap();
+
+        assert!(log
+            .read(deleted_collection_id, 0, -1, None)
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            log.read(retained_collection_id, 0, -1, None)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     proptest! {

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -22,9 +22,9 @@ use serde_pickle::{DeOptions, SerOptions};
 use sqlx::Row;
 use thiserror::Error;
 
-#[allow(dead_code)]
-const METADATA_FILE: &str = "index_metadata.pickle";
-const HNSW_HEADER_FILE: &str = "header.bin";
+pub const METADATA_FILE: &str = "index_metadata.pickle";
+pub const HNSW_HEADER_FILE: &str = "header.bin";
+pub const HNSW_INDEX_FILES: [&str; 4] = chroma_index::hnsw_provider::FILES;
 const HNSW_PERSISTENCE_VERSION: i32 = 1;
 
 #[allow(dead_code)]
@@ -117,7 +117,7 @@ fn read_usize(buf: &[u8], offset: &mut usize) -> Option<usize> {
     Some(usize::from_ne_bytes(array))
 }
 
-fn parse_persisted_hnsw_dim(header: &[u8]) -> Option<usize> {
+pub fn parse_persisted_hnsw_dim(header: &[u8]) -> Option<usize> {
     let mut offset = 0;
     let version = read_i32(header, &mut offset)?;
     if version != HNSW_PERSISTENCE_VERSION {
@@ -489,6 +489,75 @@ impl IdMap {
             ..Default::default()
         }
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PersistedHnswLabelMismatch {
+    LabelMapsToDifferentId {
+        id: String,
+        label: u32,
+        reverse_id: String,
+    },
+    MissingReverseLabel {
+        id: String,
+        label: u32,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PersistedHnswMetadata {
+    pub dimensionality: Option<usize>,
+    pub total_elements_added: u32,
+    pub legacy_max_seq_id: Option<u64>,
+    pub id_to_label_count: usize,
+    pub label_to_id_count: usize,
+    pub first_label_mismatch: Option<PersistedHnswLabelMismatch>,
+}
+
+impl From<IdMap> for PersistedHnswMetadata {
+    fn from(id_map: IdMap) -> Self {
+        let first_label_mismatch =
+            id_map
+                .id_to_label
+                .iter()
+                .find_map(|(id, label)| match id_map.label_to_id.get(label) {
+                    Some(reverse_id) if reverse_id == id => None,
+                    Some(reverse_id) => Some(PersistedHnswLabelMismatch::LabelMapsToDifferentId {
+                        id: id.clone(),
+                        label: *label,
+                        reverse_id: reverse_id.clone(),
+                    }),
+                    None => Some(PersistedHnswLabelMismatch::MissingReverseLabel {
+                        id: id.clone(),
+                        label: *label,
+                    }),
+                });
+
+        Self {
+            dimensionality: id_map.dimensionality,
+            total_elements_added: id_map.total_elements_added,
+            legacy_max_seq_id: id_map.max_seq_id,
+            id_to_label_count: id_map.id_to_label.len(),
+            label_to_id_count: id_map.label_to_id.len(),
+            first_label_mismatch,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum PersistedHnswMetadataError {
+    #[error("Error opening persisted HNSW metadata: {0}")]
+    Open(#[from] std::io::Error),
+    #[error("Error deserializing persisted HNSW metadata: {0}")]
+    Deserialize(#[from] serde_pickle::Error),
+}
+
+pub fn inspect_persisted_hnsw_metadata(
+    metadata_path: &Path,
+) -> Result<PersistedHnswMetadata, PersistedHnswMetadataError> {
+    let file = std::fs::File::open(metadata_path)?;
+    let id_map: IdMap = serde_pickle::from_reader(file, DeOptions::new())?;
+    Ok(id_map.into())
 }
 
 #[allow(dead_code)]
@@ -1094,6 +1163,30 @@ mod tests {
         header[label_offset_offset..label_offset_offset + size_of::<usize>()]
             .copy_from_slice(&69usize.to_ne_bytes());
         assert_eq!(parse_persisted_hnsw_dim(&header), None);
+    }
+
+    #[test]
+    fn persisted_hnsw_metadata_summarizes_legacy_watermark_and_mismatches() {
+        let mut id_map = IdMap::new(3);
+        id_map.max_seq_id = Some(42);
+        id_map.total_elements_added = 1;
+        id_map.id_to_label.insert("a".to_string(), 7);
+        id_map.label_to_id.insert(7, "b".to_string());
+
+        let metadata = PersistedHnswMetadata::from(id_map);
+
+        assert_eq!(metadata.dimensionality, Some(3));
+        assert_eq!(metadata.legacy_max_seq_id, Some(42));
+        assert_eq!(metadata.id_to_label_count, 1);
+        assert_eq!(metadata.label_to_id_count, 1);
+        assert_eq!(
+            metadata.first_label_mismatch,
+            Some(PersistedHnswLabelMismatch::LabelMapsToDifferentId {
+                id: "a".to_string(),
+                label: 7,
+                reverse_id: "b".to_string(),
+            })
+        );
     }
 
     #[tokio::test]

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BinaryHeap, HashMap},
     io::Write,
+    mem::size_of,
     path::Path,
     sync::Arc,
 };
@@ -23,6 +24,8 @@ use thiserror::Error;
 
 #[allow(dead_code)]
 const METADATA_FILE: &str = "index_metadata.pickle";
+const HNSW_HEADER_FILE: &str = "header.bin";
+const HNSW_PERSISTENCE_VERSION: i32 = 1;
 
 #[allow(dead_code)]
 #[derive(Clone)]
@@ -52,6 +55,8 @@ pub enum LocalHnswSegmentReaderError {
     GetEmbeddingError,
     #[error("Error querying knn")]
     QueryError,
+    #[error("Persisted HNSW dimensionality {actual} does not match collection dimensionality {expected}")]
+    DimensionalityMismatch { expected: usize, actual: usize },
     #[error("Error reading from sqlite: {0}")]
     SqliteError(#[from] sqlx::error::Error),
 }
@@ -69,6 +74,7 @@ impl ChromaError for LocalHnswSegmentReaderError {
             LocalHnswSegmentReaderError::IdNotFound => ErrorCodes::Internal,
             LocalHnswSegmentReaderError::GetEmbeddingError => ErrorCodes::Internal,
             LocalHnswSegmentReaderError::QueryError => ErrorCodes::Internal,
+            LocalHnswSegmentReaderError::DimensionalityMismatch { .. } => ErrorCodes::DataLoss,
             LocalHnswSegmentReaderError::SqliteError(_) => ErrorCodes::Internal,
         }
     }
@@ -91,6 +97,61 @@ async fn get_current_seq_id(
         .transpose()?
         .unwrap_or_default();
     Ok(seq_id)
+}
+
+fn read_i32(buf: &[u8], offset: &mut usize) -> Option<i32> {
+    let end = offset.checked_add(size_of::<i32>())?;
+    let bytes = buf.get(*offset..end)?;
+    let mut array = [0; size_of::<i32>()];
+    array.copy_from_slice(bytes);
+    *offset = end;
+    Some(i32::from_ne_bytes(array))
+}
+
+fn read_usize(buf: &[u8], offset: &mut usize) -> Option<usize> {
+    let end = offset.checked_add(size_of::<usize>())?;
+    let bytes = buf.get(*offset..end)?;
+    let mut array = [0; size_of::<usize>()];
+    array.copy_from_slice(bytes);
+    *offset = end;
+    Some(usize::from_ne_bytes(array))
+}
+
+fn parse_persisted_hnsw_dim(header: &[u8]) -> Option<usize> {
+    let mut offset = 0;
+    let version = read_i32(header, &mut offset)?;
+    if version != HNSW_PERSISTENCE_VERSION {
+        return None;
+    }
+
+    // hnswlib persists native POD fields in order. The vector byte width is
+    // not stored directly, but is exactly the gap between the vector payload
+    // offset and the label offset.
+    let _offset_level0 = read_usize(header, &mut offset)?;
+    let _max_elements = read_usize(header, &mut offset)?;
+    let _cur_element_count = read_usize(header, &mut offset)?;
+    let size_data_per_element = read_usize(header, &mut offset)?;
+    let label_offset = read_usize(header, &mut offset)?;
+    let offset_data = read_usize(header, &mut offset)?;
+
+    let data_size = label_offset.checked_sub(offset_data)?;
+    if data_size == 0 || data_size % size_of::<f32>() != 0 {
+        return None;
+    }
+    if label_offset.checked_add(size_of::<usize>())? > size_data_per_element {
+        return None;
+    }
+    Some(data_size / size_of::<f32>())
+}
+
+async fn persisted_hnsw_dim(index_folder: &Path) -> Result<usize, std::io::Error> {
+    let header = tokio::fs::read(index_folder.join(HNSW_HEADER_FILE)).await?;
+    parse_persisted_hnsw_dim(&header).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "invalid persisted HNSW header",
+        )
+    })
 }
 
 impl LocalHnswSegmentReader {
@@ -131,8 +192,26 @@ impl LocalHnswSegmentReader {
                         .await?
                         .into_std()
                         .await;
-                    let id_map: IdMap = serde_pickle::from_reader(file, DeOptions::new())?;
+                    let mut id_map: IdMap = serde_pickle::from_reader(file, DeOptions::new())?;
                     if !id_map.id_to_label.is_empty() {
+                        if let Some(actual) = id_map.dimensionality {
+                            if actual != dimensionality {
+                                return Err(LocalHnswSegmentReaderError::DimensionalityMismatch {
+                                    expected: dimensionality,
+                                    actual,
+                                });
+                            }
+                        }
+                        let actual = persisted_hnsw_dim(&index_folder)
+                            .await
+                            .map_err(|_| LocalHnswSegmentReaderError::HnswIndexLoadError)?;
+                        if actual != dimensionality {
+                            return Err(LocalHnswSegmentReaderError::DimensionalityMismatch {
+                                expected: dimensionality,
+                                actual,
+                            });
+                        }
+                        id_map.dimensionality = Some(dimensionality);
                         // Load hnsw index.
                         let index_config = IndexConfig::new(
                             dimensionality as i32,
@@ -195,7 +274,7 @@ impl LocalHnswSegmentReader {
                     index: LocalHnswIndex {
                         inner: Arc::new(tokio::sync::RwLock::new(Inner {
                             index,
-                            id_map: Default::default(),
+                            id_map: IdMap::new(dimensionality),
                             index_init: true,
                             allow_reset: false,
                             num_elements_since_last_persist: 0,
@@ -215,6 +294,15 @@ impl LocalHnswSegmentReader {
         offset_id: u32,
     ) -> Result<Vec<f32>, LocalHnswSegmentReaderError> {
         let guard = self.index.inner.read().await;
+        if let Some(actual) = guard.id_map.dimensionality {
+            let expected = guard.index.dimensionality() as usize;
+            if actual != expected {
+                return Err(LocalHnswSegmentReaderError::DimensionalityMismatch {
+                    expected,
+                    actual,
+                });
+            }
+        }
         guard
             .index
             .get(offset_id as usize)
@@ -282,6 +370,18 @@ impl LocalHnswSegmentReader {
         k: u32,
     ) -> Result<Vec<RecordMeasure>, LocalHnswSegmentReaderError> {
         let guard = self.index.inner.read().await;
+        if let Some(actual) = guard.id_map.dimensionality {
+            let expected = guard.index.dimensionality() as usize;
+            if actual != expected {
+                return Err(LocalHnswSegmentReaderError::DimensionalityMismatch {
+                    expected,
+                    actual,
+                });
+            }
+        }
+        if embedding.len() != guard.index.dimensionality() as usize {
+            return Err(LocalHnswSegmentReaderError::QueryError);
+        }
         let len_with_deleted = guard.index.len_with_deleted();
         let actual_len = guard.index.len();
 
@@ -370,7 +470,7 @@ impl LocalHnswSegmentReader {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Default)]
+#[derive(Clone, Deserialize, Serialize, Debug, Default)]
 struct IdMap {
     dimensionality: Option<usize>,
     total_elements_added: u32,
@@ -380,6 +480,15 @@ struct IdMap {
     id_to_label: HashMap<String, u32>,
     label_to_id: HashMap<u32, String>,
     id_to_seq_id: HashMap<String, u32>,
+}
+
+impl IdMap {
+    fn new(dimensionality: usize) -> Self {
+        Self {
+            dimensionality: Some(dimensionality),
+            ..Default::default()
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -443,6 +552,10 @@ pub enum LocalHnswSegmentWriterError {
     HnswIndexPersistError,
     #[error("Error applying log chunk")]
     EmbeddingNotFound,
+    #[error(
+        "Embedding dimensionality {actual} does not match collection dimensionality {expected}"
+    )]
+    DimensionalityMismatch { expected: usize, actual: usize },
     #[error("Error applying log chunk")]
     HnwsIndexAddError,
     #[error("Error applying log chunk")]
@@ -470,6 +583,9 @@ impl ChromaError for LocalHnswSegmentWriterError {
             LocalHnswSegmentWriterError::HnswIndexInitError => ErrorCodes::Internal,
             LocalHnswSegmentWriterError::HnswIndexPersistError => ErrorCodes::Internal,
             LocalHnswSegmentWriterError::EmbeddingNotFound => ErrorCodes::InvalidArgument,
+            LocalHnswSegmentWriterError::DimensionalityMismatch { .. } => {
+                ErrorCodes::InvalidArgument
+            }
             LocalHnswSegmentWriterError::HnwsIndexAddError => ErrorCodes::Internal,
             LocalHnswSegmentWriterError::HnswIndexResizeError => ErrorCodes::Internal,
             LocalHnswSegmentWriterError::HnswIndexDeleteError => ErrorCodes::Internal,
@@ -478,6 +594,19 @@ impl ChromaError for LocalHnswSegmentWriterError {
             LocalHnswSegmentWriterError::MaxSeqIdUpdateError(_) => ErrorCodes::Internal,
         }
     }
+}
+
+fn validate_embedding_dim(
+    embedding: &[f32],
+    expected: usize,
+) -> Result<(), LocalHnswSegmentWriterError> {
+    if embedding.len() != expected {
+        return Err(LocalHnswSegmentWriterError::DimensionalityMismatch {
+            expected,
+            actual: embedding.len(),
+        });
+    }
+    Ok(())
 }
 
 impl LocalHnswSegmentWriter {
@@ -517,8 +646,26 @@ impl LocalHnswSegmentWriter {
                         .await?
                         .into_std()
                         .await;
-                    let id_map: IdMap = serde_pickle::from_reader(file, DeOptions::new())?;
+                    let mut id_map: IdMap = serde_pickle::from_reader(file, DeOptions::new())?;
                     if !id_map.id_to_label.is_empty() {
+                        if let Some(actual) = id_map.dimensionality {
+                            if actual != dimensionality {
+                                return Err(LocalHnswSegmentWriterError::DimensionalityMismatch {
+                                    expected: dimensionality,
+                                    actual,
+                                });
+                            }
+                        }
+                        let actual = persisted_hnsw_dim(&index_folder)
+                            .await
+                            .map_err(|_| LocalHnswSegmentWriterError::HnswIndexLoadError)?;
+                        if actual != dimensionality {
+                            return Err(LocalHnswSegmentWriterError::DimensionalityMismatch {
+                                expected: dimensionality,
+                                actual,
+                            });
+                        }
+                        id_map.dimensionality = Some(dimensionality);
                         // Migrate legacy max_seq_id if present
                         if let Some(max_seq_id) = id_map.max_seq_id {
                             let id = segment.id.to_string().into();
@@ -594,7 +741,7 @@ impl LocalHnswSegmentWriter {
                     index: LocalHnswIndex {
                         inner: Arc::new(tokio::sync::RwLock::new(Inner {
                             index,
-                            id_map: IdMap::default(),
+                            id_map: IdMap::new(dimensionality),
                             index_init: true,
                             allow_reset: false,
                             num_elements_since_last_persist: 0,
@@ -628,7 +775,7 @@ impl LocalHnswSegmentWriter {
                     index: LocalHnswIndex {
                         inner: Arc::new(tokio::sync::RwLock::new(Inner {
                             index,
-                            id_map: Default::default(),
+                            id_map: IdMap::new(dimensionality),
                             index_init: true,
                             allow_reset: false,
                             num_elements_since_last_persist: 0,
@@ -654,6 +801,13 @@ impl LocalHnswSegmentWriter {
         if log_chunk.is_empty() {
             return Ok(next_label);
         }
+        let expected_dim = guard
+            .id_map
+            .dimensionality
+            .unwrap_or_else(|| guard.index.dimensionality() as usize);
+        let mut pending_id_map = guard.id_map.clone();
+        pending_id_map.dimensionality = Some(expected_dim);
+        let mut pending_num_elements_since_last_persist = guard.num_elements_since_last_persist;
         let mut max_seq_id = u64::MIN;
         // In order to insert into hnsw index in parallel, we need to collect all the embeddings
         let mut hnsw_batch: HashMap<u32, Vec<(u32, &OperationRecord)>> =
@@ -663,7 +817,7 @@ impl LocalHnswSegmentWriter {
                 continue;
             }
 
-            guard.num_elements_since_last_persist += 1;
+            pending_num_elements_since_last_persist += 1;
             max_seq_id = max_seq_id.max(log.log_offset as u64);
             match log.record.operation {
                 Operation::BackfillFn => {
@@ -672,15 +826,14 @@ impl LocalHnswSegmentWriter {
                 }
                 Operation::Add => {
                     // only update if the id is not already present
-                    if !guard.id_map.id_to_label.contains_key(&log.record.id) {
-                        match &log.record.embedding {
-                            Some(_embedding) => {
-                                guard
-                                    .id_map
+                    if !pending_id_map.id_to_label.contains_key(&log.record.id) {
+                        match log.record.embedding.as_ref() {
+                            Some(embedding) => {
+                                validate_embedding_dim(embedding, expected_dim)?;
+                                pending_id_map
                                     .id_to_label
                                     .insert(log.record.id.clone(), next_label);
-                                guard
-                                    .id_map
+                                pending_id_map
                                     .label_to_id
                                     .insert(next_label, log.record.id.clone());
                                 let records_for_label = match hnsw_batch.get_mut(&next_label) {
@@ -701,8 +854,9 @@ impl LocalHnswSegmentWriter {
                     }
                 }
                 Operation::Update => {
-                    if let Some(label) = guard.id_map.id_to_label.get(&log.record.id).cloned() {
-                        if let Some(_embedding) = &log.record.embedding {
+                    if let Some(label) = pending_id_map.id_to_label.get(&log.record.id).cloned() {
+                        if let Some(embedding) = log.record.embedding.as_ref() {
+                            validate_embedding_dim(embedding, expected_dim)?;
                             let records_for_label = match hnsw_batch.get_mut(&label) {
                                 Some(records) => records,
                                 None => {
@@ -716,9 +870,9 @@ impl LocalHnswSegmentWriter {
                     }
                 }
                 Operation::Delete => {
-                    if let Some(label) = guard.id_map.id_to_label.get(&log.record.id).cloned() {
-                        guard.id_map.id_to_label.remove(&log.record.id);
-                        guard.id_map.label_to_id.remove(&label);
+                    if let Some(label) = pending_id_map.id_to_label.get(&log.record.id).cloned() {
+                        pending_id_map.id_to_label.remove(&log.record.id);
+                        pending_id_map.label_to_id.remove(&label);
                         let records_for_label = match hnsw_batch.get_mut(&label) {
                             Some(records) => records,
                             None => {
@@ -732,21 +886,20 @@ impl LocalHnswSegmentWriter {
                 }
                 Operation::Upsert => {
                     let mut update_label = false;
-                    let label = match guard.id_map.id_to_label.get(&log.record.id) {
+                    let label = match pending_id_map.id_to_label.get(&log.record.id) {
                         Some(label) => *label,
                         None => {
                             update_label = true;
                             next_label
                         }
                     };
-                    match &log.record.embedding {
-                        Some(_embedding) => {
-                            guard
-                                .id_map
+                    match log.record.embedding.as_ref() {
+                        Some(embedding) => {
+                            validate_embedding_dim(embedding, expected_dim)?;
+                            pending_id_map
                                 .id_to_label
                                 .insert(log.record.id.clone(), label);
-                            guard
-                                .id_map
+                            pending_id_map
                                 .label_to_id
                                 .insert(label, log.record.id.clone());
                             let records_for_label = match hnsw_batch.get_mut(&label) {
@@ -815,7 +968,9 @@ impl LocalHnswSegmentWriter {
             .find_any(|result| result.is_err())
             .unwrap_or(Ok(()))?;
 
-        guard.id_map.total_elements_added = next_label - 1;
+        pending_id_map.total_elements_added = next_label - 1;
+        guard.id_map = pending_id_map;
+        guard.num_elements_since_last_persist = pending_num_elements_since_last_persist;
         if guard.num_elements_since_last_persist >= guard.sync_threshold as u64 {
             guard = persist(guard).await?;
             let id = guard.index.id.to_string().into();
@@ -858,4 +1013,147 @@ async fn persist(
         buffered_file.flush()?;
     }
     Ok(guard)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_config::{registry::Registry, Configurable};
+    use chroma_distance::DistanceFunction;
+    use chroma_index::IndexUuid;
+    use chroma_sqlite::config::SqliteDBConfig;
+
+    fn add_record(id: &str, embedding: Vec<f32>) -> OperationRecord {
+        OperationRecord {
+            id: id.to_string(),
+            embedding: Some(embedding),
+            encoding: None,
+            metadata: None,
+            document: None,
+            operation: Operation::Add,
+        }
+    }
+
+    fn push_i32(buf: &mut Vec<u8>, value: i32) {
+        buf.extend_from_slice(&value.to_ne_bytes());
+    }
+
+    fn push_usize(buf: &mut Vec<u8>, value: usize) {
+        buf.extend_from_slice(&value.to_ne_bytes());
+    }
+
+    fn header_for_dim(dim: usize) -> Vec<u8> {
+        let offset_data = 68;
+        let label_offset = offset_data + dim * size_of::<f32>();
+        let size_data_per_element = label_offset + size_of::<usize>();
+        let mut header = Vec::new();
+        push_i32(&mut header, HNSW_PERSISTENCE_VERSION);
+        push_usize(&mut header, 0);
+        push_usize(&mut header, 100);
+        push_usize(&mut header, 1);
+        push_usize(&mut header, size_data_per_element);
+        push_usize(&mut header, label_offset);
+        push_usize(&mut header, offset_data);
+        header
+    }
+
+    #[test]
+    fn persisted_hnsw_header_reports_dimensionality() {
+        assert_eq!(parse_persisted_hnsw_dim(&header_for_dim(8)), Some(8));
+        assert_eq!(parse_persisted_hnsw_dim(&header_for_dim(768)), Some(768));
+    }
+
+    #[test]
+    fn persisted_hnsw_header_matches_hnswlib_layout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let index_config = IndexConfig::new(8, DistanceFunction::Euclidean);
+        let hnsw_config =
+            HnswIndexConfig::new_persistent(16, 100, 100, dir.path()).expect("hnsw config");
+        let index = HnswIndex::init(
+            &index_config,
+            Some(&hnsw_config),
+            IndexUuid(uuid::Uuid::new_v4()),
+        )
+        .expect("hnsw init");
+        index.add(0, &[0.0; 8]).expect("hnsw add");
+        index.save().expect("hnsw save");
+        index.close_fd();
+
+        let header = std::fs::read(dir.path().join(HNSW_HEADER_FILE)).expect("header");
+        assert_eq!(parse_persisted_hnsw_dim(&header), Some(8));
+    }
+
+    #[test]
+    fn persisted_hnsw_header_rejects_invalid_layout() {
+        let mut header = header_for_dim(8);
+        header[0..size_of::<i32>()].copy_from_slice(&2i32.to_ne_bytes());
+        assert_eq!(parse_persisted_hnsw_dim(&header), None);
+
+        let mut header = header_for_dim(8);
+        let label_offset_offset = size_of::<i32>() + 4 * size_of::<usize>();
+        header[label_offset_offset..label_offset_offset + size_of::<usize>()]
+            .copy_from_slice(&69usize.to_ne_bytes());
+        assert_eq!(parse_persisted_hnsw_dim(&header), None);
+    }
+
+    #[tokio::test]
+    async fn apply_log_chunk_rejects_bad_dim_without_id_map_side_effects() {
+        let sqlite = SqliteDb::try_from_config(&SqliteDBConfig::default(), &Registry::new())
+            .await
+            .expect("sqlite");
+        let index_config = IndexConfig::new(2, DistanceFunction::Euclidean);
+        let hnsw_config = HnswIndexConfig::new_ephemeral(16, 100, 100);
+        let index = HnswIndex::init(
+            &index_config,
+            Some(&hnsw_config),
+            IndexUuid(uuid::Uuid::new_v4()),
+        )
+        .expect("hnsw init");
+        let mut writer = LocalHnswSegmentWriter {
+            index: LocalHnswIndex {
+                inner: Arc::new(tokio::sync::RwLock::new(Inner {
+                    index,
+                    id_map: IdMap::new(2),
+                    index_init: true,
+                    allow_reset: false,
+                    num_elements_since_last_persist: 0,
+                    last_seen_seq_id: 0,
+                    sync_threshold: 1000,
+                    persist_path: None,
+                    sqlite,
+                })),
+            },
+        };
+        let chunk = Chunk::new(
+            vec![
+                LogRecord {
+                    log_offset: 1,
+                    record: add_record("valid", vec![1.0, 2.0]),
+                },
+                LogRecord {
+                    log_offset: 2,
+                    record: add_record("invalid", vec![1.0, 2.0, 3.0]),
+                },
+            ]
+            .into(),
+        );
+
+        let err = writer
+            .apply_log_chunk(chunk)
+            .await
+            .expect_err("bad dimension should fail");
+        assert!(matches!(
+            err,
+            LocalHnswSegmentWriterError::DimensionalityMismatch {
+                expected: 2,
+                actual: 3,
+            }
+        ));
+        let guard = writer.index.inner.read().await;
+        assert!(guard.id_map.id_to_label.is_empty());
+        assert!(guard.id_map.label_to_id.is_empty());
+        assert_eq!(guard.id_map.total_elements_added, 0);
+        assert_eq!(guard.num_elements_since_last_persist, 0);
+        assert_eq!(guard.last_seen_seq_id, 0);
+    }
 }

--- a/rust/segment/src/local_segment_manager.rs
+++ b/rust/segment/src/local_segment_manager.rs
@@ -1,4 +1,4 @@
-use chroma_cache::{Cache, CacheConfig, CacheError, FoyerCacheConfig};
+use chroma_cache::{AysncPartitionedMutex, Cache, CacheConfig, CacheError, FoyerCacheConfig};
 use chroma_config::{
     registry::{Injectable, Registry},
     Configurable,
@@ -6,10 +6,16 @@ use chroma_config::{
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::IndexUuid;
 use chroma_sqlite::db::SqliteDb;
-use chroma_types::{Collection, Segment};
+use chroma_types::{Collection, Segment, SegmentUuid};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 use thiserror::Error;
+use uuid::Uuid;
 
 use crate::local_hnsw::{
     LocalHnswIndex, LocalHnswSegmentReader, LocalHnswSegmentReaderError, LocalHnswSegmentWriter,
@@ -23,6 +29,10 @@ fn default_hnsw_index_pool_cache_config() -> CacheConfig {
     })
 }
 
+const HNSW_DELETE_TOMBSTONE_MARKER: &str = ".deleted.";
+const ORPHANED_HNSW_INDEX_MIN_AGE: Duration = Duration::from_secs(6 * 60 * 60);
+const ORPHANED_HNSW_INDEX_CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LocalSegmentManagerConfig {
     // TODO(Sanket): Estimate the max number of FDs that can be kept open and
@@ -35,6 +45,7 @@ pub struct LocalSegmentManagerConfig {
 #[derive(Clone, Debug)]
 pub struct LocalSegmentManager {
     hnsw_index_pool: Arc<dyn Cache<IndexUuid, LocalHnswIndex>>,
+    hnsw_index_load_locks: AysncPartitionedMutex<IndexUuid>,
     #[allow(dead_code)]
     eviction_callback_task_handle: Option<Arc<tokio::task::JoinHandle<()>>>,
     sqlite: SqliteDb,
@@ -61,8 +72,26 @@ impl Configurable<LocalSegmentManagerConfig> for LocalSegmentManager {
                 index.close().await;
             }
         });
+        if let Some(persist_root) = config.persist_path.clone() {
+            let sqlite = sqldb.clone();
+            tokio::spawn(async move {
+                loop {
+                    if let Err(err) =
+                        cleanup_orphaned_hnsw_indexes(Path::new(&persist_root), &sqlite).await
+                    {
+                        tracing::warn!(
+                            error = %err,
+                            persist_root = %persist_root,
+                            "failed to clean up orphaned persisted HNSW indexes"
+                        );
+                    }
+                    tokio::time::sleep(ORPHANED_HNSW_INDEX_CLEANUP_INTERVAL).await;
+                }
+            });
+        }
         let res = Self {
             hnsw_index_pool: hnsw_index_pool.into(),
+            hnsw_index_load_locks: AysncPartitionedMutex::new(()),
             eviction_callback_task_handle: Some(Arc::new(handle)),
             sqlite: sqldb,
             persist_root: config.persist_path.clone(),
@@ -80,6 +109,8 @@ pub enum LocalSegmentManagerError {
     PoolCacheError(#[from] CacheError),
     #[error("Error creating hnsw segment writer: {0}")]
     LocalHnswSegmentWriterError(#[from] LocalHnswSegmentWriterError),
+    #[error("Error deleting hnsw index files: {0}")]
+    DeleteHnswIndexError(#[from] std::io::Error),
 }
 
 impl ChromaError for LocalSegmentManagerError {
@@ -88,7 +119,158 @@ impl ChromaError for LocalSegmentManagerError {
             LocalSegmentManagerError::LocalHnswSegmentReaderError(e) => e.code(),
             LocalSegmentManagerError::PoolCacheError(e) => e.code(),
             LocalSegmentManagerError::LocalHnswSegmentWriterError(e) => e.code(),
+            LocalSegmentManagerError::DeleteHnswIndexError(_) => ErrorCodes::Internal,
         }
+    }
+}
+
+type HnswIndexCleanupError = Box<dyn std::error::Error + Send + Sync>;
+
+async fn active_segment_ids(sqlite: &SqliteDb) -> Result<HashSet<String>, sqlx::Error> {
+    sqlx::query_scalar::<_, String>("SELECT id FROM segments")
+        .fetch_all(sqlite.get_conn())
+        .await
+        .map(|ids| ids.into_iter().collect())
+}
+
+fn hnsw_delete_tombstone_path(persist_root: &Path, segment_id: SegmentUuid) -> PathBuf {
+    persist_root.join(format!(
+        "{}{}{}",
+        segment_id,
+        HNSW_DELETE_TOMBSTONE_MARKER,
+        Uuid::new_v4()
+    ))
+}
+
+fn hnsw_index_dir_segment_id(file_name: &str) -> Option<&str> {
+    let segment_id = file_name
+        .split_once(HNSW_DELETE_TOMBSTONE_MARKER)
+        .map(|(segment_id, _)| segment_id)
+        .unwrap_or(file_name);
+    Uuid::parse_str(segment_id).ok().map(|_| segment_id)
+}
+
+fn should_remove_hnsw_index_dir(
+    file_name: &str,
+    modified: SystemTime,
+    active_segments: &HashSet<String>,
+    now: SystemTime,
+) -> bool {
+    let Some(segment_id) = hnsw_index_dir_segment_id(file_name) else {
+        return false;
+    };
+    if active_segments.contains(segment_id) {
+        return false;
+    }
+    if file_name.contains(HNSW_DELETE_TOMBSTONE_MARKER) {
+        return true;
+    }
+    now.duration_since(modified)
+        .map(|age| age >= ORPHANED_HNSW_INDEX_MIN_AGE)
+        .unwrap_or(false)
+}
+
+async fn remove_hnsw_index_dir(path: &Path) -> Result<(), std::io::Error> {
+    match tokio::fs::remove_dir_all(path).await {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+async fn cleanup_orphaned_hnsw_indexes(
+    persist_root: &Path,
+    sqlite: &SqliteDb,
+) -> Result<(), HnswIndexCleanupError> {
+    let active_segments = active_segment_ids(sqlite).await?;
+    let mut entries = match tokio::fs::read_dir(persist_root).await {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+
+    while let Some(entry) = entries.next_entry().await? {
+        let file_type = match entry.file_type().await {
+            Ok(file_type) => file_type,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    path = %entry.path().display(),
+                    "failed to inspect persisted HNSW path while cleaning up"
+                );
+                continue;
+            }
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        let metadata = match entry.metadata().await {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    path = %entry.path().display(),
+                    "failed to read persisted HNSW path metadata while cleaning up"
+                );
+                continue;
+            }
+        };
+        let modified = match metadata.modified() {
+            Ok(modified) => modified,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    path = %entry.path().display(),
+                    "failed to read persisted HNSW path age while cleaning up"
+                );
+                continue;
+            }
+        };
+        if !should_remove_hnsw_index_dir(
+            file_name.as_ref(),
+            modified,
+            &active_segments,
+            SystemTime::now(),
+        ) {
+            continue;
+        }
+
+        if let Err(err) = remove_hnsw_index_dir(&entry.path()).await {
+            tracing::warn!(
+                error = %err,
+                path = %entry.path().display(),
+                "failed to remove orphaned persisted HNSW index"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn delete_hnsw_index_files(
+    persist_root: &Path,
+    segment_id: SegmentUuid,
+) -> Result<(), std::io::Error> {
+    let index_folder = persist_root.join(segment_id.to_string());
+    let tombstone_path = hnsw_delete_tombstone_path(persist_root, segment_id);
+
+    match tokio::fs::rename(&index_folder, &tombstone_path).await {
+        Ok(()) => {
+            if let Err(err) = tokio::fs::write(tombstone_path.join(".delete-tombstone"), b"").await
+            {
+                tracing::warn!(
+                    error = %err,
+                    path = %tombstone_path.display(),
+                    "failed to refresh persisted HNSW delete tombstone age"
+                );
+            }
+            remove_hnsw_index_dir(&tombstone_path).await
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
     }
 }
 
@@ -100,25 +282,29 @@ impl LocalSegmentManager {
         dimensionality: usize,
     ) -> Result<LocalHnswSegmentReader, LocalSegmentManagerError> {
         let index_uuid = IndexUuid(segment.id.0);
-        match self.hnsw_index_pool.get(&IndexUuid(segment.id.0)).await? {
-            Some(hnsw_index) => Ok(LocalHnswSegmentReader::from_index(hnsw_index)),
-            None => {
-                let reader = LocalHnswSegmentReader::from_segment(
-                    collection,
-                    segment,
-                    dimensionality,
-                    self.persist_root.clone(),
-                    self.sqlite.clone(),
-                )
-                .await?;
-                // Open the FDs.
-                reader.index.start().await;
-                self.hnsw_index_pool
-                    .insert(index_uuid, reader.index.clone())
-                    .await;
-                Ok(reader)
-            }
+        if let Some(hnsw_index) = self.hnsw_index_pool.get(&index_uuid).await? {
+            return Ok(LocalHnswSegmentReader::from_index(hnsw_index));
         }
+
+        let _guard = self.hnsw_index_load_locks.lock(&index_uuid).await;
+        if let Some(hnsw_index) = self.hnsw_index_pool.get(&index_uuid).await? {
+            return Ok(LocalHnswSegmentReader::from_index(hnsw_index));
+        }
+
+        let reader = LocalHnswSegmentReader::from_segment(
+            collection,
+            segment,
+            dimensionality,
+            self.persist_root.clone(),
+            self.sqlite.clone(),
+        )
+        .await?;
+        // Open the FDs.
+        reader.index.start().await;
+        self.hnsw_index_pool
+            .insert(index_uuid, reader.index.clone())
+            .await;
+        Ok(reader)
     }
 
     pub async fn get_hnsw_writer(
@@ -128,30 +314,186 @@ impl LocalSegmentManager {
         dimensionality: usize,
     ) -> Result<LocalHnswSegmentWriter, LocalSegmentManagerError> {
         let index_uuid = IndexUuid(segment.id.0);
-        match self.hnsw_index_pool.get(&IndexUuid(segment.id.0)).await? {
-            Some(hnsw_index) => Ok(LocalHnswSegmentWriter::from_index(hnsw_index)?),
-            None => {
-                let writer = LocalHnswSegmentWriter::from_segment(
-                    collection,
-                    segment,
-                    dimensionality,
-                    self.persist_root.clone(),
-                    self.sqlite.clone(),
-                )
-                .await?;
-                // Open the FDs.
-                writer.index.start().await;
-                // Backfill.
-                self.hnsw_index_pool
-                    .insert(index_uuid, writer.index.clone())
-                    .await;
-                Ok(writer)
-            }
+        if let Some(hnsw_index) = self.hnsw_index_pool.get(&index_uuid).await? {
+            return Ok(LocalHnswSegmentWriter::from_index(hnsw_index)?);
         }
+
+        let _guard = self.hnsw_index_load_locks.lock(&index_uuid).await;
+        if let Some(hnsw_index) = self.hnsw_index_pool.get(&index_uuid).await? {
+            return Ok(LocalHnswSegmentWriter::from_index(hnsw_index)?);
+        }
+
+        let writer = LocalHnswSegmentWriter::from_segment(
+            collection,
+            segment,
+            dimensionality,
+            self.persist_root.clone(),
+            self.sqlite.clone(),
+        )
+        .await?;
+        // Open the FDs.
+        writer.index.start().await;
+        self.hnsw_index_pool
+            .insert(index_uuid, writer.index.clone())
+            .await;
+        Ok(writer)
+    }
+
+    pub async fn evict_hnsw_index(
+        &self,
+        segment_id: SegmentUuid,
+    ) -> Result<(), LocalSegmentManagerError> {
+        let index_uuid = IndexUuid(segment_id.0);
+        let _guard = self.hnsw_index_load_locks.lock(&index_uuid).await;
+        if let Some(hnsw_index) = self.hnsw_index_pool.get(&index_uuid).await? {
+            self.hnsw_index_pool.remove(&index_uuid).await;
+            hnsw_index.close().await;
+        }
+        Ok(())
+    }
+
+    pub async fn delete_hnsw_index(
+        &self,
+        segment_id: SegmentUuid,
+    ) -> Result<(), LocalSegmentManagerError> {
+        let index_uuid = IndexUuid(segment_id.0);
+        let _guard = self.hnsw_index_load_locks.lock(&index_uuid).await;
+        if let Some(hnsw_index) = self.hnsw_index_pool.get(&index_uuid).await? {
+            self.hnsw_index_pool.remove(&index_uuid).await;
+            hnsw_index.close().await;
+        }
+        if let Some(persist_root) = &self.persist_root {
+            let persist_root = Path::new(persist_root);
+            if let Err(err) = cleanup_orphaned_hnsw_indexes(persist_root, &self.sqlite).await {
+                tracing::warn!(
+                    error = %err,
+                    persist_root = %persist_root.display(),
+                    "failed to clean up orphaned persisted HNSW indexes before deletion"
+                );
+            }
+            delete_hnsw_index_files(persist_root, segment_id).await?;
+        }
+        Ok(())
     }
 
     pub async fn reset(&self) -> Result<(), LocalSegmentManagerError> {
         self.hnsw_index_pool.clear().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_config::{registry::Registry, Configurable};
+    use chroma_sqlite::config::SqliteDBConfig;
+    use chroma_types::CollectionUuid;
+
+    #[tokio::test]
+    async fn cleanup_orphaned_hnsw_indexes_preserves_fresh_segment_dirs() {
+        let registry = Registry::new();
+        let sqlite = SqliteDb::try_from_config(&SqliteDBConfig::default(), &registry)
+            .await
+            .expect("sqlite");
+        let persist_root = tempfile::tempdir().expect("persist root");
+
+        let collection_id = CollectionUuid::new();
+        let active_segment_id = SegmentUuid::new();
+        let orphaned_segment_id = SegmentUuid::new();
+        let tombstoned_segment_id = SegmentUuid::new();
+        let active_path = persist_root.path().join(active_segment_id.to_string());
+        let orphaned_path = persist_root.path().join(orphaned_segment_id.to_string());
+        let tombstoned_path = persist_root.path().join(format!(
+            "{}{}{}",
+            tombstoned_segment_id,
+            HNSW_DELETE_TOMBSTONE_MARKER,
+            Uuid::new_v4()
+        ));
+        let non_index_path = persist_root.path().join("not-an-index");
+
+        tokio::fs::create_dir_all(&active_path)
+            .await
+            .expect("active");
+        tokio::fs::create_dir_all(&orphaned_path)
+            .await
+            .expect("orphaned");
+        tokio::fs::create_dir_all(&tombstoned_path)
+            .await
+            .expect("tombstoned");
+        tokio::fs::create_dir_all(&non_index_path)
+            .await
+            .expect("non-index");
+        sqlx::query("INSERT INTO segments (id, type, scope, collection) VALUES ($1, $2, $3, $4)")
+            .bind(active_segment_id.to_string())
+            .bind("hnsw-local-persisted")
+            .bind("VECTOR")
+            .bind(collection_id.to_string())
+            .execute(sqlite.get_conn())
+            .await
+            .expect("insert segment");
+
+        cleanup_orphaned_hnsw_indexes(persist_root.path(), &sqlite)
+            .await
+            .expect("cleanup");
+
+        assert!(active_path.exists());
+        assert!(orphaned_path.exists());
+        assert!(!tombstoned_path.exists());
+        assert!(non_index_path.exists());
+    }
+
+    #[test]
+    fn should_remove_hnsw_index_dir_age_gates_plain_orphans() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(12 * 60 * 60);
+        let old = now - ORPHANED_HNSW_INDEX_MIN_AGE - Duration::from_secs(1);
+        let fresh = now - Duration::from_secs(60);
+        let active_segment_id = SegmentUuid::new();
+        let orphaned_segment_id = SegmentUuid::new();
+        let tombstoned_name = format!(
+            "{}{}{}",
+            orphaned_segment_id,
+            HNSW_DELETE_TOMBSTONE_MARKER,
+            Uuid::new_v4()
+        );
+        let mut active_segments = HashSet::new();
+        active_segments.insert(active_segment_id.to_string());
+
+        assert!(!should_remove_hnsw_index_dir(
+            &active_segment_id.to_string(),
+            old,
+            &active_segments,
+            now
+        ));
+        assert!(!should_remove_hnsw_index_dir(
+            &orphaned_segment_id.to_string(),
+            fresh,
+            &active_segments,
+            now
+        ));
+        assert!(should_remove_hnsw_index_dir(
+            &orphaned_segment_id.to_string(),
+            old,
+            &active_segments,
+            now
+        ));
+        assert!(should_remove_hnsw_index_dir(
+            &tombstoned_name,
+            fresh,
+            &active_segments,
+            now
+        ));
+        active_segments.insert(orphaned_segment_id.to_string());
+        assert!(!should_remove_hnsw_index_dir(
+            &tombstoned_name,
+            fresh,
+            &active_segments,
+            now
+        ));
+        assert!(!should_remove_hnsw_index_dir(
+            "not-an-index",
+            old,
+            &active_segments,
+            now
+        ));
     }
 }

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -140,12 +140,16 @@ impl SqliteSysDb {
             .map_err(|e| e.boxed())?;
 
         for collection in collections {
+            let segments = self
+                .get_segments_with_conn(&mut *tx, collection.collection_id, None, None, None)
+                .await
+                .map_err(|e| e.boxed())?;
             self.delete_collection_with_conn(
                 &mut *tx,
                 tenant.clone(),
                 database_name.clone(),
                 collection.collection_id,
-                vec![],
+                segments.into_iter().map(|segment| segment.id).collect(),
             )
             .await
             .map_err(|e| e.boxed())?;
@@ -1228,11 +1232,59 @@ mod tests {
             .await
             .unwrap();
 
+        let collection_id = CollectionUuid::new();
+        let segments = vec![
+            Segment {
+                id: SegmentUuid::new(),
+                r#type: SegmentType::HnswLocalPersisted,
+                scope: SegmentScope::VECTOR,
+                collection: collection_id,
+                metadata: None,
+                file_path: HashMap::new(),
+            },
+            Segment {
+                id: SegmentUuid::new(),
+                r#type: SegmentType::Sqlite,
+                scope: SegmentScope::METADATA,
+                collection: collection_id,
+                metadata: None,
+                file_path: HashMap::new(),
+            },
+        ];
+        sysdb
+            .create_collection(
+                "default_tenant".to_string(),
+                "test".to_string(),
+                collection_id,
+                "test_collection".to_string(),
+                segments,
+                Some(InternalCollectionConfiguration::default_hnsw()),
+                Some(Schema::new_default(KnnIndex::Hnsw)),
+                None,
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            sysdb
+                .get_segments(None, None, None, collection_id)
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+
         // Delete database
         sysdb
             .delete_database("test".to_string(), "default_tenant".to_string())
             .await
             .unwrap();
+        assert!(sysdb
+            .get_segments(None, None, None, collection_id)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/rust/types/src/collection_configuration.rs
+++ b/rust/types/src/collection_configuration.rs
@@ -16,6 +16,7 @@ use crate::{
 use chroma_error::{ChromaError, ErrorCodes};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use validator::Validate;
 
 #[derive(Deserialize, Serialize, Clone, Debug, Copy)]
 pub enum KnnIndex {
@@ -291,6 +292,11 @@ impl InternalCollectionConfiguration {
         match (hnsw, spann) {
             (Some(_), Some(_)) => Err(CollectionConfigurationToInternalConfigurationError::MultipleVectorIndexConfigurations),
             (Some(hnsw), None) => {
+                hnsw.validate().map_err(|err| {
+                    CollectionConfigurationToInternalConfigurationError::HnswParametersFromSegmentError(
+                        HnswParametersFromSegmentError::InvalidParameters(err),
+                    )
+                })?;
                 match default_knn_index {
                     // Create a spann index. Only inherit the space if it exists in the hnsw config or legacy metadata.
                     // This is for backwards compatibility so that users who migrate to distributed
@@ -378,6 +384,11 @@ impl TryFrom<CollectionConfiguration> for InternalCollectionConfiguration {
         match (value.hnsw, value.spann) {
             (Some(_), Some(_)) => Err(Self::Error::MultipleVectorIndexConfigurations),
             (Some(hnsw), None) => {
+                hnsw.validate().map_err(|err| {
+                    CollectionConfigurationToInternalConfigurationError::HnswParametersFromSegmentError(
+                        HnswParametersFromSegmentError::InvalidParameters(err),
+                    )
+                })?;
                 let hnsw: InternalHnswConfiguration = hnsw.into();
                 Ok(InternalCollectionConfiguration {
                     vector_index: hnsw.into(),
@@ -433,6 +444,9 @@ impl TryFrom<&Schema> for InternalCollectionConfiguration {
                     .to_string(),
             ),
             (Some(hnsw_config), None) => {
+                hnsw_config
+                    .validate()
+                    .map_err(|err| format!("Invalid HNSW configuration: {err}"))?;
                 let internal_hnsw = (space.as_ref(), Some(&hnsw_config)).into();
                 Ok(InternalCollectionConfiguration {
                     vector_index: VectorIndexConfiguration::Hnsw(internal_hnsw),
@@ -553,12 +567,15 @@ pub struct InternalUpdateCollectionConfiguration {
 pub enum UpdateCollectionConfigurationToInternalUpdateConfigurationError {
     #[error("Multiple vector index configurations provided")]
     MultipleVectorIndexConfigurations,
+    #[error("Invalid HNSW configuration: {0}")]
+    InvalidHnswParameters(#[from] validator::ValidationErrors),
 }
 
 impl ChromaError for UpdateCollectionConfigurationToInternalUpdateConfigurationError {
     fn code(&self) -> ErrorCodes {
         match self {
             Self::MultipleVectorIndexConfigurations => ErrorCodes::InvalidArgument,
+            Self::InvalidHnswParameters(_) => ErrorCodes::InvalidArgument,
         }
     }
 }
@@ -569,10 +586,13 @@ impl TryFrom<UpdateCollectionConfiguration> for InternalUpdateCollectionConfigur
     fn try_from(value: UpdateCollectionConfiguration) -> Result<Self, Self::Error> {
         match (value.hnsw, value.spann) {
             (Some(_), Some(_)) => Err(Self::Error::MultipleVectorIndexConfigurations),
-            (Some(hnsw), None) => Ok(InternalUpdateCollectionConfiguration {
-                vector_index: Some(UpdateVectorIndexConfiguration::Hnsw(Some(hnsw))),
-                embedding_function: value.embedding_function,
-            }),
+            (Some(hnsw), None) => {
+                hnsw.validate()?;
+                Ok(InternalUpdateCollectionConfiguration {
+                    vector_index: Some(UpdateVectorIndexConfiguration::Hnsw(Some(hnsw))),
+                    embedding_function: value.embedding_function,
+                })
+            }
             (None, Some(spann)) => Ok(InternalUpdateCollectionConfiguration {
                 vector_index: Some(UpdateVectorIndexConfiguration::Spann(Some(spann))),
                 embedding_function: value.embedding_function,
@@ -1078,6 +1098,21 @@ mod tests {
                 },
             ))
         );
+    }
+
+    #[test]
+    fn schema_to_internal_rejects_invalid_hnsw_config() {
+        let mut schema = Schema::new_default(KnnIndex::Hnsw);
+        let hnsw = schema
+            .keys
+            .get_mut(EMBEDDING_KEY)
+            .and_then(|value_types| value_types.float_list.as_mut())
+            .and_then(|float_list| float_list.vector_index.as_mut())
+            .and_then(|vector_index| vector_index.config.hnsw.as_mut())
+            .expect("default HNSW schema should have HNSW config");
+        hnsw.max_neighbors = Some(129);
+
+        assert!(InternalCollectionConfiguration::try_from(&schema).is_err());
     }
 
     #[cfg(feature = "testing")]

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -1137,6 +1137,7 @@ impl Schema {
         segment: &Segment,
     ) -> Result<Option<InternalHnswConfiguration>, HnswParametersFromSegmentError> {
         if let Some(config) = self.get_internal_hnsw_config() {
+            config.validate()?;
             let config_from_metadata =
                 InternalHnswConfiguration::from_legacy_segment_metadata(&segment.metadata)?;
 
@@ -2802,10 +2803,13 @@ pub struct VectorIndexConfig {
 #[serde(deny_unknown_fields)]
 pub struct HnswIndexConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(range(min = 1, max = 4096))]
     pub ef_construction: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(range(min = 1, max = 128))]
     pub max_neighbors: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(range(min = 1, max = 4096))]
     pub ef_search: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_threads: Option<usize>,
@@ -2813,9 +2817,10 @@ pub struct HnswIndexConfig {
     #[validate(range(min = 2))]
     pub batch_size: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[validate(range(min = 2))]
+    #[validate(range(min = 2, max = 4096))]
     pub sync_threshold: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(range(min = 1.0, max = 10.0))]
     pub resize_factor: Option<f64>,
 }
 
@@ -5541,6 +5546,13 @@ mod tests {
         };
         assert!(invalid_sync_threshold.validate().is_err());
 
+        // Invalid: sync_threshold too large (max 4096)
+        let excessive_sync_threshold = HnswIndexConfig {
+            sync_threshold: Some(4097),
+            ..Default::default()
+        };
+        assert!(excessive_sync_threshold.validate().is_err());
+
         // Valid: boundary values (exactly 2) should pass
         let boundary_config = HnswIndexConfig {
             batch_size: Some(2),
@@ -5549,22 +5561,37 @@ mod tests {
         };
         assert!(boundary_config.validate().is_ok());
 
+        let upper_boundary_config = HnswIndexConfig {
+            sync_threshold: Some(4096),
+            ..Default::default()
+        };
+        assert!(upper_boundary_config.validate().is_ok());
+
         // Valid: None values should pass validation
         let all_none_config = HnswIndexConfig {
             ..Default::default()
         };
         assert!(all_none_config.validate().is_ok());
 
-        // Valid: fields without validation can be any value
+        // Valid: bounded HNSW fields accept values inside their resource limits
         let other_fields_config = HnswIndexConfig {
             ef_construction: Some(1),
             max_neighbors: Some(1),
             ef_search: Some(1),
             num_threads: Some(1),
-            resize_factor: Some(0.1),
+            resize_factor: Some(1.0),
             ..Default::default()
         };
         assert!(other_fields_config.validate().is_ok());
+
+        let excessive_config = HnswIndexConfig {
+            ef_construction: Some(4097),
+            max_neighbors: Some(129),
+            ef_search: Some(4097),
+            resize_factor: Some(10.1),
+            ..Default::default()
+        };
+        assert!(excessive_config.validate().is_err());
     }
 
     #[test]

--- a/rust/types/src/hnsw_configuration.rs
+++ b/rust/types/src/hnsw_configuration.rs
@@ -5,6 +5,17 @@ use std::num::NonZero;
 use thiserror::Error;
 use validator::Validate;
 
+pub const MIN_HNSW_EF_CONSTRUCTION: usize = 1;
+pub const MAX_HNSW_EF_CONSTRUCTION: usize = 4096;
+pub const MIN_HNSW_EF_SEARCH: usize = 1;
+pub const MAX_HNSW_EF_SEARCH: usize = 4096;
+pub const MIN_HNSW_MAX_NEIGHBORS: usize = 1;
+pub const MAX_HNSW_MAX_NEIGHBORS: usize = 128;
+pub const MIN_HNSW_RESIZE_FACTOR: f64 = 1.0;
+pub const MAX_HNSW_RESIZE_FACTOR: f64 = 10.0;
+pub const MIN_HNSW_SYNC_THRESHOLD: usize = 2;
+pub const MAX_HNSW_SYNC_THRESHOLD: usize = 4096;
+
 #[derive(Debug, Error)]
 pub enum HnswParametersFromSegmentError {
     #[error("Invalid metadata: {0}")]
@@ -79,18 +90,22 @@ pub fn default_space() -> Space {
 pub struct InternalHnswConfiguration {
     #[serde(default = "default_space")]
     pub space: Space,
+    #[validate(range(min = 1, max = 4096))]
     #[serde(default = "default_construction_ef")]
     pub ef_construction: usize,
+    #[validate(range(min = 1, max = 4096))]
     #[serde(default = "default_search_ef")]
     pub ef_search: usize,
+    #[validate(range(min = 1, max = 128))]
     #[serde(default = "default_m")]
     pub max_neighbors: usize,
     #[serde(default = "default_num_threads")]
     #[serde(skip_serializing)]
     pub num_threads: usize,
+    #[validate(range(min = 1.0, max = 10.0))]
     #[serde(default = "default_resize_factor")]
     pub resize_factor: f64,
-    #[validate(range(min = 2))]
+    #[validate(range(min = 2, max = 4096))]
     #[serde(default = "default_sync_threshold")]
     pub sync_threshold: usize,
     #[validate(range(min = 2))]
@@ -147,13 +162,17 @@ impl From<(Option<&Space>, Option<&HnswIndexConfig>)> for InternalHnswConfigurat
 #[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct HnswConfiguration {
     pub space: Option<Space>,
+    #[validate(range(min = 1, max = 4096))]
     pub ef_construction: Option<usize>,
+    #[validate(range(min = 1, max = 4096))]
     pub ef_search: Option<usize>,
+    #[validate(range(min = 1, max = 128))]
     pub max_neighbors: Option<usize>,
     #[serde(skip_serializing)]
     pub num_threads: Option<usize>,
+    #[validate(range(min = 1.0, max = 10.0))]
     pub resize_factor: Option<f64>,
-    #[validate(range(min = 2))]
+    #[validate(range(min = 2, max = 4096))]
     pub sync_threshold: Option<usize>,
     #[validate(range(min = 2))]
     #[serde(skip_serializing)]
@@ -253,11 +272,14 @@ impl InternalHnswConfiguration {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct UpdateHnswConfiguration {
+    #[validate(range(min = 1, max = 4096))]
     pub ef_search: Option<usize>,
+    #[validate(range(min = 1, max = 128))]
     pub max_neighbors: Option<usize>,
     pub num_threads: Option<usize>,
+    #[validate(range(min = 1.0, max = 10.0))]
     pub resize_factor: Option<f64>,
-    #[validate(range(min = 2))]
+    #[validate(range(min = 2, max = 4096))]
     pub sync_threshold: Option<usize>,
     #[validate(range(min = 2))]
     pub batch_size: Option<usize>,

--- a/rust/types/src/strategies.rs
+++ b/rust/types/src/strategies.rs
@@ -589,7 +589,7 @@ pub fn internal_hnsw_configuration_strategy() -> impl Strategy<Value = InternalH
         1usize..=256,
         1usize..=64,
         1usize..=32,
-        prop_oneof![Just(0.5f64), Just(1.0f64), Just(1.5f64), Just(2.0f64)],
+        prop_oneof![Just(1.0f64), Just(1.5f64), Just(2.0f64)],
         2usize..=4096,
         2usize..=4096,
     )

--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::{net::IpAddr, sync::LazyLock};
-use validator::ValidationError;
+use validator::{Validate, ValidationError};
 
 static ALNUM_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{1, 510}[a-zA-Z0-9]$")
@@ -286,6 +286,28 @@ pub fn validate_schema(schema: &Schema) -> Result<(), ValidationError> {
     {
         return Err(ValidationError::new("schema").with_message("Full text search / regular expression index cannot be enabled by default. It can only be enabled on #document field.".into()));
     }
+
+    for value_types in std::iter::once(&schema.defaults).chain(schema.keys.values()) {
+        if let Some(vector_index) = value_types
+            .float_list
+            .as_ref()
+            .and_then(|vt| vt.vector_index.as_ref())
+        {
+            if let Some(hnsw) = &vector_index.config.hnsw {
+                hnsw.validate().map_err(|err| {
+                    ValidationError::new("schema")
+                        .with_message(format!("Invalid HNSW configuration: {err}").into())
+                })?;
+            }
+            if let Some(spann) = &vector_index.config.spann {
+                spann.validate().map_err(|err| {
+                    ValidationError::new("schema")
+                        .with_message(format!("Invalid SPANN configuration: {err}").into())
+                })?;
+            }
+        }
+    }
+
     for (key, config) in &schema.keys {
         // Validate that keys cannot start with # (except system keys)
         if key.starts_with('#') && key != DOCUMENT_KEY && key != EMBEDDING_KEY {
@@ -415,6 +437,21 @@ mod tests {
         assert!(validate_name("ab").is_err());
         assert!(validate_name("a").is_err());
         assert!(validate_name("").is_err());
+    }
+
+    #[test]
+    fn invalid_hnsw_schema_config_is_rejected() {
+        let mut schema = crate::Schema::new_default(crate::KnnIndex::Hnsw);
+        let hnsw = schema
+            .keys
+            .get_mut(EMBEDDING_KEY)
+            .and_then(|value_types| value_types.float_list.as_mut())
+            .and_then(|float_list| float_list.vector_index.as_mut())
+            .and_then(|vector_index| vector_index.config.hnsw.as_mut())
+            .expect("default HNSW schema should have HNSW config");
+        hnsw.max_neighbors = Some(129);
+
+        assert!(validate_schema(&schema).is_err());
     }
 
     #[test]

--- a/rust/types/src/where_parsing.rs
+++ b/rust/types/src/where_parsing.rs
@@ -9,6 +9,8 @@ use serde::Serialize;
 use serde_json::Value;
 use thiserror::Error;
 
+const MAX_WHERE_RECURSION_DEPTH: usize = 64;
+
 #[derive(Default, Deserialize, Debug, Clone, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct RawWhereFields {
@@ -96,6 +98,16 @@ impl RawWhereFields {
 }
 
 pub fn parse_where_document(json_payload: &Value) -> Result<Where, WhereValidationError> {
+    parse_where_document_with_depth(json_payload, 0)
+}
+
+fn parse_where_document_with_depth(
+    json_payload: &Value,
+    depth: usize,
+) -> Result<Where, WhereValidationError> {
+    if depth > MAX_WHERE_RECURSION_DEPTH {
+        return Err(WhereValidationError::WhereDocumentClause);
+    }
     let where_doc_payload = json_payload
         .as_object()
         .ok_or(WhereValidationError::WhereDocumentClause)?;
@@ -113,7 +125,7 @@ pub fn parse_where_document(json_payload: &Value) -> Result<Where, WhereValidati
         let mut predicate_list = vec![];
         // Recursively parse the children.
         for child in children {
-            predicate_list.push(parse_where_document(child)?);
+            predicate_list.push(parse_where_document_with_depth(child, depth + 1)?);
         }
         return Ok(Where::Composite(CompositeExpression {
             operator: logical_operator,
@@ -129,7 +141,7 @@ pub fn parse_where_document(json_payload: &Value) -> Result<Where, WhereValidati
         let mut predicate_list = vec![];
         // Recursively parse the children.
         for child in children {
-            predicate_list.push(parse_where_document(child)?);
+            predicate_list.push(parse_where_document_with_depth(child, depth + 1)?);
         }
         return Ok(Where::Composite(CompositeExpression {
             operator: logical_operator,
@@ -170,6 +182,16 @@ fn parse_contains_operator(operator: &str) -> Option<ContainsOperator> {
 }
 
 pub fn parse_where(json_payload: &Value) -> Result<Where, WhereValidationError> {
+    parse_where_with_depth(json_payload, 0)
+}
+
+fn parse_where_with_depth(
+    json_payload: &Value,
+    depth: usize,
+) -> Result<Where, WhereValidationError> {
+    if depth > MAX_WHERE_RECURSION_DEPTH {
+        return Err(WhereValidationError::WhereClause);
+    }
     let where_payload = json_payload
         .as_object()
         .ok_or(WhereValidationError::WhereClause)?;
@@ -185,7 +207,7 @@ pub fn parse_where(json_payload: &Value) -> Result<Where, WhereValidationError> 
         let mut predicate_list = vec![];
         // Recursively parse the children.
         for child in children {
-            predicate_list.push(parse_where(child)?);
+            predicate_list.push(parse_where_with_depth(child, depth + 1)?);
         }
         return Ok(Where::Composite(CompositeExpression {
             operator: logical_operator,
@@ -199,7 +221,7 @@ pub fn parse_where(json_payload: &Value) -> Result<Where, WhereValidationError> 
         let mut predicate_list = vec![];
         // Recursively parse the children.
         for child in children {
-            predicate_list.push(parse_where(child)?);
+            predicate_list.push(parse_where_with_depth(child, depth + 1)?);
         }
         return Ok(Where::Composite(CompositeExpression {
             operator: logical_operator,
@@ -941,5 +963,31 @@ mod tests {
                 serde_json::to_string_pretty(payload).unwrap(),
             );
         }
+    }
+
+    #[test]
+    fn test_parse_where_rejects_excessive_depth() {
+        let mut payload = json!({"key": "value"});
+        for _ in 0..=MAX_WHERE_RECURSION_DEPTH {
+            payload = json!({"$or": [payload]});
+        }
+
+        assert!(matches!(
+            parse_where(&payload),
+            Err(WhereValidationError::WhereClause)
+        ));
+    }
+
+    #[test]
+    fn test_parse_where_document_rejects_excessive_depth() {
+        let mut payload = json!({"$contains": "value"});
+        for _ in 0..=MAX_WHERE_RECURSION_DEPTH {
+            payload = json!({"$and": [payload]});
+        }
+
+        assert!(matches!(
+            parse_where_document(&payload),
+            Err(WhereValidationError::WhereDocumentClause)
+        ));
     }
 }


### PR DESCRIPTION
## Description of changes

Address five chained vulnerabilities in the single-node (sqlite + local HNSW)
deployment that together enable unauthenticated heap corruption with a
credible path to remote code execution.

Dimension TOCTOU (CWE-367 → CWE-787/CWE-125):
- Add a per-collection mutex around dimension initialization in
  validate_embedding so concurrent /add requests cannot race to set
  conflicting dimensions.
- Validate persisted HNSW header dimensionality on cold-load against the
  sysdb dimension; reject mismatches before constructing the index.
- Stage id_map mutations in a pending copy during apply_log_chunk and
  commit only on success, preventing partial state on error.
- Validate embedding dimensionality per-record in the HNSW writer.

Unbounded HNSW configuration (CWE-20/CWE-1284 → CWE-770):
- Add upper bounds to all HNSW tunables: max_neighbors ≤ 128,
  ef_construction ≤ 4096, ef_search ≤ 4096, resize_factor ≤ 10.0,
  sync_threshold ≤ 4096.
- Enforce bounds at every ingestion point: schema validation,
  InternalCollectionConfiguration, UpdateCollectionConfiguration,
  and the compaction pipeline.
- Skip HNSW backfill for collections with invalid persisted config
  but still advance the metadata watermark so log purging proceeds.

Concurrent cache-miss race (CWE-362 → CWE-664):
- Introduce a partitioned async mutex (AysncPartitionedMutex) in
  LocalSegmentManager keyed on IndexUuid. Double-check the cache
  after acquiring the lock to prevent two HnswIndex instances from
  sharing the same on-disk segment directory.

delete_collection resource leak (CWE-401/CWE-772 → CWE-400):
- Actively evict and close HNSW indexes on collection deletion.
- Delete on-disk segment directories via tombstone-rename + periodic
  background cleanup of orphaned HNSW index dirs (6-hour age gate).
- Purge sqlite log rows for deleted collections.
- Propagate segment deletion through delete_database as well.
- Serialize database-level create/delete behind a per-database lock.

Log purge skipped on backfill error (CWE-754 → CWE-400):
- Always dispatch PurgeLogsMessage after BackfillMessage regardless
  of backfill outcome; the purge handler independently computes
  watermarks from persisted segment state.
- For collections with invalid HNSW config, fall back to the
  metadata-segment watermark so logs do not accumulate unboundedly.

Where-clause stack overflow:
- Cap $or/$and recursion depth at 64 in both parse_where and
  parse_where_document to prevent attacker-triggered stack overflow
  that could crash the tokio runtime.

## Test plan

Local testing of new tests + CI for our full suite.

## Migration plan

This code migrates itself.

## Observability plan

N/A

## Documentation Changes

Will need to update docs to document limitations and recovery for corrupted hnsw segments.

Co-authored-by: AI
