### PR TITLE
[ENH](ef): Add Azure OpenAI deployment alias

### DIFF
--- a/chromadb/test/ef/test_openai_ef.py
+++ b/chromadb/test/ef/test_openai_ef.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -36,3 +37,55 @@ def test_with_incorrect_api_key() -> None:
     ef = OpenAIEmbeddingFunction(api_key="incorrect_api_key", dimensions=64)
     with pytest.raises(Exception, match="Incorrect API key provided"):
         ef(["hello world"])
+
+
+def test_azure_openai_accepts_azure_deployment_alias() -> None:
+    """Matches Azure OpenAI SDK naming; see chroma-core/chroma#1770."""
+    pytest.importorskip("openai", reason="openai not installed")
+    with patch("openai.OpenAI"), patch("openai.AzureOpenAI") as mock_azure_cls:
+        mock_azure_cls.return_value = MagicMock()
+        ef = OpenAIEmbeddingFunction(
+            api_key="fake-key",
+            model_name="text-embedding-ada-002",
+            api_type="azure",
+            api_version="2023-05-15",
+            api_base="https://example.openai.azure.com",
+            azure_deployment="my-deployment",
+        )
+    mock_azure_cls.assert_called_once()
+    _, kwargs = mock_azure_cls.call_args
+    assert kwargs["azure_deployment"] == "my-deployment"
+    assert ef.get_config()["deployment_id"] == "my-deployment"
+    assert "azure_deployment" not in ef.get_config()
+
+
+def test_azure_deployment_and_deployment_id_must_agree() -> None:
+    pytest.importorskip("openai", reason="openai not installed")
+    with pytest.raises(ValueError, match="cannot both be set"):
+        OpenAIEmbeddingFunction(
+            api_key="fake-key",
+            model_name="text-embedding-ada-002",
+            api_type="azure",
+            api_version="2023-05-15",
+            api_base="https://example.openai.azure.com",
+            deployment_id="dep-a",
+            azure_deployment="dep-b",
+        )
+
+
+def test_azure_openai_accepts_matching_deployment_names() -> None:
+    pytest.importorskip("openai", reason="openai not installed")
+    with patch("openai.OpenAI"), patch("openai.AzureOpenAI") as mock_azure_cls:
+        mock_azure_cls.return_value = MagicMock()
+        OpenAIEmbeddingFunction(
+            api_key="fake-key",
+            model_name="text-embedding-ada-002",
+            api_type="azure",
+            api_version="2023-05-15",
+            api_base="https://example.openai.azure.com",
+            deployment_id="my-deployment",
+            azure_deployment="my-deployment",
+        )
+    mock_azure_cls.assert_called_once()
+    _, kwargs = mock_azure_cls.call_args
+    assert kwargs["azure_deployment"] == "my-deployment"

--- a/chromadb/utils/embedding_functions/openai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/openai_embedding_function.py
@@ -16,6 +16,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
         api_type: Optional[str] = None,
         api_version: Optional[str] = None,
         deployment_id: Optional[str] = None,
+        azure_deployment: Optional[str] = None,
         default_headers: Optional[Dict[str, str]] = None,
         dimensions: Optional[int] = None,
         api_key_env_var: str = "CHROMA_OPENAI_API_KEY",
@@ -37,7 +38,10 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
             api_version (str, optional): The api version for the API. If not provided,
                 it will use the api version for the OpenAI API. This can be used to
                 point to a different deployment, such as an Azure deployment.
-            deployment_id (str, optional): Deployment ID for Azure OpenAI.
+            deployment_id (str, optional): Deployment ID for Azure OpenAI (passed to the
+                SDK as ``azure_deployment``).
+            azure_deployment (str, optional): Alias for ``deployment_id`` for Azure OpenAI,
+                matching the parameter name used in the official ``openai`` SDK.
             default_headers (Dict[str, str], optional): A mapping of default headers to be sent with each API request.
             dimensions (int, optional): The number of dimensions for the embeddings.
                 Only supported for `text-embedding-3` or later models from OpenAI.
@@ -68,12 +72,26 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 f"The {self.api_key_env_var} environment variable is not set."
             )
 
+        if (
+            deployment_id is not None
+            and azure_deployment is not None
+            and deployment_id != azure_deployment
+        ):
+            raise ValueError(
+                "deployment_id and azure_deployment cannot both be set to different values; "
+                "they refer to the same Azure deployment name."
+            )
+
         self.model_name = model_name
         self.organization_id = organization_id
         self.api_base = api_base
         self.api_type = api_type
         self.api_version = api_version
-        self.deployment_id = deployment_id
+        # Accept Azure's SDK parameter name while keeping deployment_id as
+        # Chroma's canonical persisted config key.
+        self.deployment_id = (
+            deployment_id if deployment_id is not None else azure_deployment
+        )
         self.default_headers = default_headers
         self.dimensions = dimensions
 
@@ -94,7 +112,9 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
             if self.api_version is None:
                 raise ValueError("api_version must be specified for Azure OpenAI")
             if self.deployment_id is None:
-                raise ValueError("deployment_id must be specified for Azure OpenAI")
+                raise ValueError(
+                    "deployment_id or azure_deployment must be specified for Azure OpenAI"
+                )
             if self.api_base is None:
                 raise ValueError("api_base must be specified for Azure OpenAI")
 


### PR DESCRIPTION
Accept azure_deployment as a constructor alias for deployment_id so Azure OpenAI users can use the same parameter name as the OpenAI SDK without changing Chroma's persisted embedding function config.

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
