### PR TITLE
[CHORE](foundation-api): Use CONFIG_PATH env var like other binaries

### DIFF
--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -18,7 +18,7 @@ pub use frontend_core::{ac, auth, errors, middleware as server_middleware, trace
 use config::FoundationApiConfig;
 use server::FoundationApiServer;
 
-pub const CONFIG_PATH_ENV_VAR: &str = "FOUNDATION_API_CONFIG_PATH";
+pub const CONFIG_PATH_ENV_VAR: &str = "CONFIG_PATH";
 
 pub async fn foundation_service_entrypoint(
     auth: Arc<dyn auth::AuthenticateAndAuthorize>,


### PR DESCRIPTION
## Summary

Every other Rust binary in this workspace reads its config path from the `CONFIG_PATH` env var:

```
rust/frontend/src/lib.rs:31:            "CONFIG_PATH"
rust/worker/src/lib.rs:23:              "CONFIG_PATH"
rust/rust-sysdb/src/lib.rs:11:          "CONFIG_PATH"
rust/garbage_collector/src/lib.rs:36:   "CONFIG_PATH"
rust/log-service/src/lib.rs:223:        "CONFIG_PATH"
rust/s3heap-service/src/lib.rs:208:     "CONFIG_PATH"
rust/spanner-migrations/src/config.rs:10:"CONFIG_PATH"
rust/worker/src/work_queue/server.rs:9: "CONFIG_PATH"
rust/worker/src/fn_consumer/server.rs:14:"CONFIG_PATH"
```

`foundation-api` was the lone outlier reading `FOUNDATION_API_CONFIG_PATH`, which broke the staging deploy:

1. The k8s Deployment template (matching the rest of the fleet's convention) sets `CONFIG_PATH=/config/config.yaml`.
2. The `foundation_service` binary called `std::env::var("FOUNDATION_API_CONFIG_PATH")`, which returned `Err`.
3. So it fell back to `HostedFoundationConfig::default()` instead of loading the ConfigMap.
4. `AuthConfig::default()` is `Cloud { ... }` (not `Noop`), so the binary then panicked on missing `CHROMA_AUTHN_CONFIG_API_HOST` — even though `foundation-configuration.yaml` says `auth: noop`.

Aligning with the convention makes the existing k8s template Just Work, and avoids cementing a one-off env var name into the manifest.

## Changes

- `rust/foundation-api/src/lib.rs:21`: `CONFIG_PATH_ENV_VAR` string value `FOUNDATION_API_CONFIG_PATH` → `CONFIG_PATH`.

## Companion PRs

- chroma-core/hosted-chroma — updates `tilt/foundation-service.yaml` so local Tilt dev gets the matching env var name. Needs to merge in lock-step with this one.

## Test plan

- [ ] CI passes (cargo build/test/clippy for the foundation-api crate).
- [ ] After this merges + a new image build lands + k8s staging picks up the new tag (via the foundationServer bumper added in chroma-core/k8s#2933), the `foundation-server-deployment` pod reaches Ready instead of CrashLoopBackOff.
- [ ] Pod logs show "Authentication is disabled" warning (the `AuthConfig::Noop` arm), confirming the ConfigMap was actually loaded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1zRm3bD3poBkPkZanK4uS)_