### PR TITLE
[ENH]: Allow multiple functions to use the same output collection

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -268,7 +268,7 @@ def test_functions_one_attached_function_per_collection(
 def test_attach_function_output_collection_already_exists(
     basic_http_client: System,
 ) -> None:
-    """Test that attach_function fails when output collection name already exists"""
+    """Test that attach_function can reuse any existing collection as output collection"""
     client = ClientCreator.from_system(basic_http_client)
     client.reset()
 
@@ -279,17 +279,64 @@ def test_attach_function_output_collection_already_exists(
     # Create another collection with the name we want to use for output
     client.create_collection(name="existing_output_collection")
 
-    # Attempt to create task with output collection name that already exists
-    with pytest.raises(
-        ChromaError,
-        match=r"Output collection \[existing_output_collection\] already exists",
-    ):
-        input_collection.attach_function(
-            name="my_task",
-            function=RECORD_COUNTER_FUNCTION,
-            output_collection="existing_output_collection",
-            params=None,
-        )
+    # Attempt to create task with output collection name that already exists - should succeed
+    attached_fn, created = input_collection.attach_function(
+        name="my_task",
+        function=RECORD_COUNTER_FUNCTION,
+        output_collection="existing_output_collection",
+        params=None,
+    )
+    assert attached_fn is not None
+    assert created is True  # We can now reuse any existing collection
+
+
+def test_multiple_functions_can_share_output_collection(
+    basic_http_client: System,
+) -> None:
+    """Test that multiple functions can share an output collection, including different function types"""
+    client = ClientCreator.from_system(basic_http_client)
+    client.reset()
+
+    # Create three input collections
+    input_collection1 = client.create_collection(name="input_collection_1")
+    input_collection1.add(ids=["id1", "id2"], documents=["doc1", "doc2"])
+
+    input_collection2 = client.create_collection(name="input_collection_2")
+    input_collection2.add(ids=["id3", "id4"], documents=["doc3", "doc4"])
+
+    input_collection3 = client.create_collection(name="input_collection_3")
+    input_collection3.add(ids=["id5", "id6"], documents=["doc5", "doc6"])
+
+    # Attach first record_counter function
+    attached_fn1, created1 = input_collection1.attach_function(
+        name="counter_1",
+        function=RECORD_COUNTER_FUNCTION,
+        output_collection="shared_counter_output",
+        params=None,
+    )
+    assert attached_fn1 is not None
+    assert created1 is True
+
+    # Attach second record_counter function to the same output collection - should succeed
+    attached_fn2, created2 = input_collection2.attach_function(
+        name="counter_2",
+        function=RECORD_COUNTER_FUNCTION,
+        output_collection="shared_counter_output",
+        params=None,
+    )
+    assert attached_fn2 is not None
+    assert created2 is True
+
+    # Now try to attach a different function type to the same output collection - should succeed
+    # The validation has been removed, so different function types can share output collections
+    attached_fn3, created3 = input_collection3.attach_function(
+        name="statistics_1",
+        function=STATISTICS_FUNCTION,
+        output_collection="shared_counter_output",
+        params=None,
+    )
+    assert attached_fn3 is not None
+    assert created3 is True
 
 
 def test_function_remove_nonexistent(basic_http_client: System) -> None:
@@ -362,7 +409,7 @@ def test_delete_output_collection_detaches_function(basic_http_client: System) -
     # Delete the output collection directly
     client.delete_collection("output_collection")
 
-    # The attached function should now be gone - trying to get it should raise NotFoundError
+    # The attached function should be deleted due to cascade delete (database query finds all functions using this output collection)
     with pytest.raises(NotFoundError):
         input_collection.get_attached_function("my_function")
 
@@ -428,22 +475,26 @@ def test_partial_attach_function_repair(
     )
 
     # Create a task that counts records in the collection
-    # This should fail
-    with pytest.raises(
-        ChromaError, match=r"Output collection \[my_documents_counts\] already exists"
-    ):
-        attached_fn, _ = collection2.attach_function(
-            name="count_my_docs",
-            function=RECORD_COUNTER_FUNCTION,
-            output_collection="my_documents_counts",
-            params=None,
-        )
+    # This should succeed since both are record_counter functions
+    attached_fn2, created2 = collection2.attach_function(
+        name="count_my_docs2",
+        function=RECORD_COUNTER_FUNCTION,
+        output_collection="my_documents_counts",
+        params=None,
+    )
+    assert attached_fn2 is not None
+    assert created2 is True  # Both functions can share the same output collection
 
-    # Detach the function
+    # Detach the function with delete_output_collection=True
+    # This will delete the output collection and cascade delete ALL attached functions
     assert (
         collection.detach_function(attached_fn.name, delete_output_collection=True)
         is True
     )
+
+    # The second function should be deleted due to cascade delete
+    with pytest.raises(NotFoundError):
+        collection2.get_attached_function(attached_fn2.name)
 
     # Create a task that counts records in the collection
     attached_fn, created = collection2.attach_function(
@@ -454,37 +505,6 @@ def test_partial_attach_function_repair(
     )
     assert attached_fn is not None
     assert created is True
-
-
-def test_output_collection_created_with_schema(basic_http_client: System) -> None:
-    """Test that output collections are created with the source_attached_function_id in the schema"""
-    client = ClientCreator.from_system(basic_http_client)
-    client.reset()
-
-    # Create input collection and attach a function
-    input_collection = client.create_collection(name="input_collection")
-    input_collection.add(ids=["id1"], documents=["test"])
-
-    attached_fn, created = input_collection.attach_function(
-        name="my_function",
-        function=RECORD_COUNTER_FUNCTION,
-        output_collection="output_collection",
-        params=None,
-    )
-    assert attached_fn is not None
-    assert created is True
-
-    # Get the output collection - it should exist
-    output_collection = client.get_collection(name="output_collection")
-    assert output_collection is not None
-
-    # The source_attached_function_id is stored in the schema (not metadata)
-    # We can't directly access the schema from the client, but we verify the collection exists
-    # and the attached function orchestrator will use this field internally
-    assert "source_attached_function_id" in output_collection._model.pretty_schema()
-
-    # Clean up
-    input_collection.detach_function(attached_fn.name, delete_output_collection=True)
 
 
 def test_count_function_attach_and_detach_attach_attach(

--- a/clients/new-js/packages/chromadb/src/api/types.gen.ts
+++ b/clients/new-js/packages/chromadb/src/api/types.gen.ts
@@ -503,10 +503,6 @@ export type Schema = {
     keys: {
         [key: string]: ValueTypes;
     };
-    /**
-     * ID of the attached function that created this output collection (if applicable)
-     */
-    source_attached_function_id?: string | null;
 };
 
 export type SearchPayload = {

--- a/go/pkg/sysdb/coordinator/async_attached_function_simple_test.go
+++ b/go/pkg/sysdb/coordinator/async_attached_function_simple_test.go
@@ -69,7 +69,7 @@ func TestAsyncFunctionRepairFlowSimple(t *testing.T) {
 
 	// Mock all the DB calls
 	mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(mockAttachedFunctionDb)
-	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), true).
+	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), true).
 		Return([]*dbmodel.AttachedFunction{attachedFunction}, nil)
 
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)
@@ -187,7 +187,7 @@ func TestAsyncFunctionNoRepairSimple(t *testing.T) {
 
 	// Mock all the DB calls
 	mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(mockAttachedFunctionDb)
-	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), true).
+	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), true).
 		Return([]*dbmodel.AttachedFunction{attachedFunction}, nil)
 
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)
@@ -274,7 +274,7 @@ func TestAsyncFunctionTryFinishIdempotent(t *testing.T) {
 
 	// Mock all the DB calls
 	mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(mockAttachedFunctionDb)
-	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), true).
+	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), true).
 		Return([]*dbmodel.AttachedFunction{attachedFunction}, nil)
 
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)
@@ -411,7 +411,7 @@ func TestAsyncFunctionOffsetOnlyMovesForward(t *testing.T) {
 
 	// Mock all the DB calls
 	mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(mockAttachedFunctionDb)
-	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), true).
+	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), true).
 		Return([]*dbmodel.AttachedFunction{attachedFunction}, nil)
 
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)

--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -1994,67 +1994,6 @@ func (suite *APIsTestSuite) TestDeleteCollectionWithAttachedFunction() {
 	suite.Equal(int64(1), count)
 }
 
-func (suite *APIsTestSuite) TestCannotAttachToOutputCollection() {
-	ctx := context.Background()
-
-	// Create a test collection (input)
-	inputCollectionID := types.NewUniqueID()
-	inputCollectionName := "test_input_collection"
-	createInputCollection := &model.CreateCollection{
-		ID:           inputCollectionID,
-		Name:         inputCollectionName,
-		TenantID:     suite.tenantName,
-		DatabaseName: suite.databaseName,
-	}
-	_, _, err := suite.coordinator.CreateCollection(ctx, createInputCollection)
-	suite.NoError(err)
-
-	// Create a collection that simulates an output collection (has source_attached_function_id in schema)
-	outputCollectionID := types.NewUniqueID()
-	outputCollectionName := "simulated_output_collection"
-	outputSchemaStr := `{"defaults":{},"keys":{},"source_attached_function_id":"some-function-id"}`
-	createOutputCollection := &model.CreateCollection{
-		ID:           outputCollectionID,
-		Name:         outputCollectionName,
-		TenantID:     suite.tenantName,
-		DatabaseName: suite.databaseName,
-		SchemaStr:    &outputSchemaStr,
-	}
-	_, _, err = suite.coordinator.CreateCollection(ctx, createOutputCollection)
-	suite.NoError(err)
-
-	// Create a dummy function
-	functionID := uuid.New()
-	functionName := "test_function_for_output_test"
-	err = suite.db.Create(&dbmodel.Function{
-		ID:            functionID,
-		Name:          functionName,
-		IsIncremental: false,
-		ReturnType:    "{}",
-	}).Error
-	suite.NoError(err)
-
-	// Try to attach function to the output collection - should fail
-	attachReq := &coordinatorpb.AttachFunctionRequest{
-		Name:                    "test_attached_fn",
-		InputCollectionId:       outputCollectionID.String(),
-		OutputCollectionName:    "another_output_collection",
-		FunctionName:            functionName,
-		TenantId:                suite.tenantName,
-		Database:                suite.databaseName,
-		MinRecordsForInvocation: 100,
-		Params:                  &structpb.Struct{Fields: map[string]*structpb.Value{}},
-	}
-	_, err = suite.coordinator.AttachFunction(ctx, attachReq)
-	suite.Error(err)
-	suite.True(errors.Is(err, common.ErrCannotAttachToOutputCollection))
-
-	// Attaching to input collection should succeed
-	attachReq.InputCollectionId = inputCollectionID.String()
-	_, err = suite.coordinator.AttachFunction(ctx, attachReq)
-	suite.NoError(err)
-}
-
 func (suite *APIsTestSuite) TestDeleteOutputCollectionDeletesAttachedFunction() {
 	ctx := context.Background()
 
@@ -2104,14 +2043,12 @@ func (suite *APIsTestSuite) TestDeleteOutputCollectionDeletesAttachedFunction() 
 	}).Error
 	suite.NoError(err)
 
-	// Create an output collection with schema pointing to the attached function
-	outputSchemaStr := fmt.Sprintf(`{"defaults":{},"keys":{},"source_attached_function_id":"%s"}`, attachedFunctionID.String())
+	// Create an output collection
 	createOutputCollection := &model.CreateCollection{
 		ID:           outputCollectionID,
 		Name:         "test_output_for_delete",
 		TenantID:     suite.tenantName,
 		DatabaseName: suite.databaseName,
-		SchemaStr:    &outputSchemaStr,
 	}
 	_, _, err = suite.coordinator.CreateCollection(ctx, createOutputCollection)
 	suite.NoError(err)

--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -69,7 +69,7 @@ func (suite *AttachFunctionTestSuite) setupAttachFunctionMocks(ctx context.Conte
 	// Phase 1: Create attached function in transaction
 	// Check if any attached function exists for this collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, false).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, (*string)(nil), false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
@@ -165,7 +165,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_SuccessfulCreation() {
 	// Setup mocks that will be called within the transaction (using mock.Anything for context)
 	// Check if any attached function exists for this collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, false).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, (*string)(nil), false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	// Look up database
@@ -183,6 +183,17 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_SuccessfulCreation() {
 	suite.mockCollectionDb.On("GetCollections",
 		[]string{inputCollectionID}, (*string)(nil), tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
 		Return([]*dbmodel.CollectionAndMetadata{{Collection: &dbmodel.Collection{ID: inputCollectionID}}}, nil).Once()
+
+	// Check if input collection is being used as an output collection
+	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), (*string)(nil), &inputCollectionID, false).
+		Return([]*dbmodel.AttachedFunction{}, nil).Once()
+
+	// Check if output collection already exists
+	suite.mockMetaDomain.On("CollectionDb", mock.Anything).Return(suite.mockCollectionDb).Once()
+	suite.mockCollectionDb.On("GetCollections",
+		[]string(nil), &outputCollectionName, tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
+		Return([]*dbmodel.CollectionAndMetadata{}, nil).Once()
 
 	// Insert attached function with lowest_live_nonce = NULL
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
@@ -285,7 +296,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Alrea
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
 			inputCollID := inputCollectionID
-			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, false).
+			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), false).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup),
@@ -354,7 +365,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 
 	// Phase 1: Create attached function in transaction
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, false).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, (*string)(nil), false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
@@ -369,6 +380,17 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 	suite.mockCollectionDb.On("GetCollections",
 		[]string{inputCollectionID}, (*string)(nil), tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
 		Return([]*dbmodel.CollectionAndMetadata{{Collection: &dbmodel.Collection{ID: inputCollectionID}}}, nil).Once()
+
+	// Check if input collection is being used as an output collection
+	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), (*string)(nil), &inputCollectionID, false).
+		Return([]*dbmodel.AttachedFunction{}, nil).Once()
+
+	// Check if output collection already exists
+	suite.mockMetaDomain.On("CollectionDb", mock.Anything).Return(suite.mockCollectionDb).Once()
+	suite.mockCollectionDb.On("GetCollections",
+		[]string(nil), &outputCollectionName, tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
+		Return([]*dbmodel.CollectionAndMetadata{}, nil).Once()
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
 	suite.mockAttachedFunctionDb.On("Insert", mock.Anything).Return(nil).Once()
@@ -412,7 +434,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
 			inputCollID := inputCollectionID
-			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, false).
+			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), false).
 				Return([]*dbmodel.AttachedFunction{incompleteAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup),
@@ -503,7 +525,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
 			inputCollID := inputCollectionID
-			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, false).
+			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), false).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup)

--- a/go/pkg/sysdb/coordinator/list_attached_functions_test.go
+++ b/go/pkg/sysdb/coordinator/list_attached_functions_test.go
@@ -86,7 +86,7 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_Success()
 	}
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, true).Return(attachedFunctions, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), true).Return(attachedFunctions, nil).Once()
 
 	functionOne := &dbmodel.Function{ID: functionID1, Name: "function-one", IsAsync: false}
 	functionTwo := &dbmodel.Function{ID: functionID2, Name: "function-two", IsAsync: true}
@@ -132,7 +132,7 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_EmptyResu
 	collectionID := "test-collection"
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, true).Return([]*dbmodel.AttachedFunction{}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), true).Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	req := &coordinatorpb.GetAttachedFunctionsRequest{InputCollectionId: &collectionID}
 	resp, err := suite.coordinator.GetAttachedFunctions(ctx, req)
@@ -165,7 +165,7 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_FunctionD
 	}
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, true).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), true).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
 
 	suite.mockMetaDomain.On("FunctionDb", ctx).Return(suite.mockFunctionDb).Once()
 	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{functionID}).Return(nil, errors.New("db error")).Once()
@@ -200,7 +200,7 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_InvalidPa
 	}
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, true).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), true).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
 
 	functionModel := &dbmodel.Function{ID: functionID, Name: "function", IsAsync: false}
 

--- a/go/pkg/sysdb/coordinator/model/collection_configuration.go
+++ b/go/pkg/sysdb/coordinator/model/collection_configuration.go
@@ -261,22 +261,9 @@ type Cmek struct {
 }
 
 type Schema struct {
-	Defaults                 ValueTypes            `json:"defaults"`
-	Keys                     map[string]ValueTypes `json:"keys"`
-	Cmek                     *Cmek                 `json:"cmek,omitempty"`
-	SourceAttachedFunctionID *string               `json:"source_attached_function_id,omitempty"`
-}
-
-// GetSourceAttachedFunctionIDFromSchema parses a schema string and returns the source attached function ID if present
-func GetSourceAttachedFunctionIDFromSchema(schemaStr *string) *string {
-	if schemaStr == nil || *schemaStr == "" || *schemaStr == "{}" {
-		return nil
-	}
-	var schema Schema
-	if err := json.Unmarshal([]byte(*schemaStr), &schema); err != nil {
-		return nil
-	}
-	return schema.SourceAttachedFunctionID
+	Defaults ValueTypes            `json:"defaults"`
+	Keys     map[string]ValueTypes `json:"keys"`
+	Cmek     *Cmek                 `json:"cmek,omitempty"`
 }
 
 // UpdateSchemaFromConfig merges an InternalCollectionConfiguration into a Schema

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -720,7 +720,7 @@ func (tc *Catalog) softDeleteCollection(ctx context.Context, deleteCollection *m
 
 		// List attached functions for this collection (as input) and soft delete them
 		deleteCollectionIDStr := deleteCollection.ID.String()
-		attachedFunctions, err := tc.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &deleteCollectionIDStr, true)
+		attachedFunctions, err := tc.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &deleteCollectionIDStr, nil, true)
 		if err != nil {
 			return err
 		}
@@ -731,32 +731,37 @@ func (tc *Catalog) softDeleteCollection(ctx context.Context, deleteCollection *m
 			}
 		}
 
-		// If this collection is an output collection, soft delete the attached function that created it
-		// Check schema for source_attached_function_id
-		if sourceAttachedFunctionIDStr := model.GetSourceAttachedFunctionIDFromSchema(collections[0].Collection.SchemaStr); sourceAttachedFunctionIDStr != nil {
-			attachedFunctionID, parseErr := uuid.Parse(*sourceAttachedFunctionIDStr)
-			if parseErr != nil {
-				log.Error("Failed to parse attached function ID from schema", zap.Error(parseErr), zap.String("value", *sourceAttachedFunctionIDStr))
-				return parseErr
-			}
-			attachedFunction, err := tc.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, true)
-			if err != nil {
-				log.Error("Failed to get attached function by ID", zap.Error(err), zap.String("attached_function_id", attachedFunctionID.String()))
-				return err
-			}
-			if len(attachedFunction) == 0 {
-				log.Info("Attached function not found, may have been deleted already", zap.String("attached_function_id", attachedFunctionID.String()))
-			} else {
-				inputCollectionID, parseErr := uuid.Parse(attachedFunction[0].InputCollectionID)
-				if parseErr != nil {
-					log.Error("Failed to parse input collection ID", zap.Error(parseErr), zap.String("input_collection_id", attachedFunction[0].InputCollectionID))
-					return parseErr
+		// If this collection is an output collection, cascade delete all attached functions
+		// This is done transactionally - either all functions are deleted or none are
+		// Query for all attached functions that have this collection as their output
+		outputCollectionIDStr := deleteCollection.ID.String()
+		attachedFunctionsWithOutput, err := tc.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, nil, &outputCollectionIDStr, false)
+		if err != nil {
+			log.Error("Failed to query attached functions by output collection", zap.Error(err))
+			return fmt.Errorf("failed to query attached functions for output collection: %w", err)
+		}
+
+		if len(attachedFunctionsWithOutput) > 0 {
+			log.Info("Deleting output collection with attached functions - cascade deleting functions",
+				zap.String("collection_id", deleteCollection.ID.String()),
+				zap.String("collection_name", *collections[0].Collection.Name),
+				zap.Int("num_attached_functions", len(attachedFunctionsWithOutput)))
+
+			// Delete each function that writes to this output collection (all in same transaction)
+			for _, af := range attachedFunctionsWithOutput {
+				inputCollectionID, err := uuid.Parse(af.InputCollectionID)
+				if err != nil {
+					log.Error("Failed to parse input collection ID", zap.Error(err), zap.String("input_collection_id", af.InputCollectionID))
+					return fmt.Errorf("invalid input collection ID for function %s: %s", af.ID.String(), af.InputCollectionID)
 				}
-				log.Info("Soft deleting attached function for output collection",
-					zap.String("attached_function_id", attachedFunctionID.String()),
+
+				log.Info("Cascade deleting attached function",
+					zap.String("attached_function_id", af.ID.String()),
 					zap.String("output_collection_id", deleteCollection.ID.String()))
-				if err := tc.metaDomain.AttachedFunctionDb(txCtx).SoftDeleteByID(attachedFunctionID, inputCollectionID); err != nil {
-					return err
+
+				if err := tc.metaDomain.AttachedFunctionDb(txCtx).SoftDeleteByID(af.ID, inputCollectionID); err != nil {
+					log.Error("Failed to soft delete attached function", zap.Error(err), zap.String("attached_function_id", af.ID.String()))
+					return fmt.Errorf("failed to delete attached function %s: %w", af.ID.String(), err)
 				}
 			}
 		}

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -101,7 +101,7 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 	err := s.catalog.txImpl.Transaction(ctx, func(txCtx context.Context) error {
 		// Check if there's any active (ready, non-deleted) attached function for this collection
 		// We only allow one active attached function per collection
-		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &req.InputCollectionId, false)
+		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &req.InputCollectionId, nil, false)
 		if err != nil {
 			log.Error("AttachFunction: failed to check for existing attached function", zap.Error(err))
 			return err
@@ -166,12 +166,30 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 			return common.ErrCollectionNotFound
 		}
 
-		// Check if input collection is an output collection (prevent chaining)
-		inputCollection := collections[0]
-		if model.GetSourceAttachedFunctionIDFromSchema(inputCollection.Collection.SchemaStr) != nil {
-			log.Error("AttachFunction: cannot attach function to an output collection",
-				zap.String("input_collection_id", req.InputCollectionId))
+		// Check if input collection is being used as an output collection by any attached function
+		inputCollectionIDStr := req.InputCollectionId
+		attachedFunctionsUsingAsOutput, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, nil, &inputCollectionIDStr, false)
+		if err != nil {
+			log.Error("AttachFunction: failed to check if input collection is used as output", zap.Error(err))
+			return err
+		}
+		if len(attachedFunctionsUsingAsOutput) > 0 {
+			log.Error("AttachFunction: cannot attach function to a collection that is already an output collection",
+				zap.String("collection_id", req.InputCollectionId))
 			return common.ErrCannotAttachToOutputCollection
+		}
+
+		// Check if output collection already exists
+		existingOutputCollections, err := s.catalog.metaDomain.CollectionDb(txCtx).GetCollections(nil, &req.OutputCollectionName, req.TenantId, req.Database, nil, nil, false)
+		if err != nil {
+			log.Error("AttachFunction: failed to check for existing output collection", zap.Error(err))
+			return err
+		}
+
+		if len(existingOutputCollections) > 0 {
+			// Output collection exists - we now allow reusing any existing collection
+			log.Info("AttachFunction: output collection already exists, will reuse it",
+				zap.String("output_collection_name", req.OutputCollectionName))
 		}
 
 		// Serialize params
@@ -302,7 +320,7 @@ func (s *Coordinator) GetAttachedFunctions(ctx context.Context, req *coordinator
 		onlyReady = *req.OnlyReady
 	}
 
-	attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).GetAttachedFunctions(idPtr, req.Name, req.InputCollectionId, onlyReady)
+	attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).GetAttachedFunctions(idPtr, req.Name, req.InputCollectionId, nil, onlyReady)
 	if err != nil {
 		log.Error("GetAttachedFunctions: failed to get attached functions", zap.Error(err))
 		return nil, err
@@ -371,7 +389,7 @@ func (s *Coordinator) GetAttachedFunctions(ctx context.Context, req *coordinator
 // DetachFunction soft deletes an attached function by name
 func (s *Coordinator) DetachFunction(ctx context.Context, req *coordinatorpb.DetachFunctionRequest) (*coordinatorpb.DetachFunctionResponse, error) {
 	// First get the attached function to check if we need to delete the output collection
-	attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).GetAttachedFunctions(nil, &req.Name, &req.InputCollectionId, true)
+	attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).GetAttachedFunctions(nil, &req.Name, &req.InputCollectionId, nil, true)
 	if err != nil {
 		log.Error("DetachFunction: failed to get attached function", zap.Error(err))
 		return nil, err
@@ -473,7 +491,7 @@ func (s *Coordinator) FinishCreateAttachedFunction(ctx context.Context, req *coo
 	// Execute all operations in a transaction for atomicity
 	err = s.catalog.txImpl.Transaction(ctx, func(txCtx context.Context) error {
 		// 1. Get the attached function to retrieve metadata
-		attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, false)
+		attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, false)
 		if err != nil {
 			log.Error("FinishCreateAttachedFunction: failed to get attached function", zap.Error(err))
 			return err
@@ -502,54 +520,74 @@ func (s *Coordinator) FinishCreateAttachedFunction(ctx context.Context, req *coo
 			return common.ErrDatabaseNotFound
 		}
 
-		// 4. Generate new collection UUID
-		collectionID := types.NewUniqueID()
-
-		// 5. Create the output collection with segments
-		dimension := int32(1) // Default dimension for attached function output collections
-
-		// Use the schema string passed from Rust (contains default schema + source_attached_function_id)
-		schemaStr := req.OutputCollectionSchemaStr
-
-		collection := &model.CreateCollection{
-			ID:                   collectionID,
-			Name:                 attachedFunction.OutputCollectionName,
-			ConfigurationJsonStr: "{}", // Empty JSON object for default config
-			SchemaStr:            &schemaStr,
-			TenantID:             attachedFunction.TenantID,
-			DatabaseName:         database.Name,
-			Dimension:            &dimension,
-		}
-
-		// Create segments for the collection (distributed setup with HNSW)
-		segments := []*model.Segment{
-			{
-				ID:           types.NewUniqueID(),
-				Type:         "urn:chroma:segment/vector/hnsw-distributed",
-				Scope:        "VECTOR",
-				CollectionID: collectionID,
-			},
-			{
-				ID:           types.NewUniqueID(),
-				Type:         "urn:chroma:segment/metadata/blockfile",
-				Scope:        "METADATA",
-				CollectionID: collectionID,
-			},
-			{
-				ID:           types.NewUniqueID(),
-				Type:         "urn:chroma:segment/record/blockfile",
-				Scope:        "RECORD",
-				CollectionID: collectionID,
-			},
-		}
-
-		_, _, err = s.catalog.CreateCollectionAndSegments(txCtx, collection, segments, 0)
+		// 4. Check if output collection already exists
+		existingCollections, err := s.catalog.metaDomain.CollectionDb(txCtx).GetCollections(nil, &attachedFunction.OutputCollectionName, attachedFunction.TenantID, database.Name, nil, nil, false)
 		if err != nil {
-			log.Error("FinishCreateAttachedFunction: failed to create output collection", zap.Error(err))
-			if err == common.ErrCollectionUniqueConstraintViolation {
-				return grpcutils.BuildAlreadyExistsGrpcError(fmt.Sprintf("output collection '%s' already exists", collection.Name))
-			}
+			log.Error("FinishCreateAttachedFunction: failed to check for existing output collection", zap.Error(err))
 			return err
+		}
+
+		var collectionID types.UniqueID
+		if len(existingCollections) > 0 {
+			// Output collection exists - reuse it
+			existingCollection := existingCollections[0]
+			log.Info("FinishCreateAttachedFunction: reusing existing output collection",
+				zap.String("output_collection_name", attachedFunction.OutputCollectionName))
+
+			collectionID, err = types.Parse(existingCollection.Collection.ID)
+			if err != nil {
+				log.Error("FinishCreateAttachedFunction: failed to parse existing collection ID", zap.Error(err))
+				return grpcutils.BuildInternalGrpcError("invalid collection ID")
+			}
+			created = false // Collection already existed
+		} else {
+			// 5. Create new output collection with segments
+			collectionID = types.NewUniqueID()
+			dimension := int32(1) // Default dimension for attached function output collections
+
+			// Use the schema string passed from Rust (contains default schema)
+			schemaStr := req.OutputCollectionSchemaStr
+
+			collection := &model.CreateCollection{
+				ID:                   collectionID,
+				Name:                 attachedFunction.OutputCollectionName,
+				ConfigurationJsonStr: "{}", // Empty JSON object for default config
+				SchemaStr:            &schemaStr,
+				TenantID:             attachedFunction.TenantID,
+				DatabaseName:         database.Name,
+				Dimension:            &dimension,
+			}
+
+			// Create segments for the collection (distributed setup with HNSW)
+			segments := []*model.Segment{
+				{
+					ID:           types.NewUniqueID(),
+					Type:         "urn:chroma:segment/vector/hnsw-distributed",
+					Scope:        "VECTOR",
+					CollectionID: collectionID,
+				},
+				{
+					ID:           types.NewUniqueID(),
+					Type:         "urn:chroma:segment/metadata/blockfile",
+					Scope:        "METADATA",
+					CollectionID: collectionID,
+				},
+				{
+					ID:           types.NewUniqueID(),
+					Type:         "urn:chroma:segment/record/blockfile",
+					Scope:        "RECORD",
+					CollectionID: collectionID,
+				},
+			}
+
+			_, _, err = s.catalog.CreateCollectionAndSegments(txCtx, collection, segments, 0)
+			if err != nil {
+				log.Error("FinishCreateAttachedFunction: failed to create output collection", zap.Error(err))
+				if err == common.ErrCollectionUniqueConstraintViolation {
+					return grpcutils.BuildAlreadyExistsGrpcError(fmt.Sprintf("output collection '%s' already exists", collection.Name))
+				}
+				return err
+			}
 		}
 
 		// 6. Update attached function with output_collection_id and set is_ready to true
@@ -568,7 +606,7 @@ func (s *Coordinator) FinishCreateAttachedFunction(ctx context.Context, req *coo
 		}
 
 		// 7. Validate that there is only one ready attached function for this collection
-		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &attachedFunction.InputCollectionID, true)
+		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &attachedFunction.InputCollectionID, nil, true)
 		if err != nil {
 			log.Error("FinishCreateAttachedFunction: failed to get attached functions", zap.Error(err))
 			return err
@@ -717,7 +755,7 @@ func (s *Coordinator) TryFinishAsyncAttachedFunctionInvocation(ctx context.Conte
 	var witnessedLogOffset int64
 
 	err = s.catalog.txImpl.Transaction(ctx, func(txCtx context.Context) error {
-		attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, true)
+		attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, true)
 		if err != nil {
 			log.Error("Failed to get attached function", zap.Error(err))
 			return err

--- a/go/pkg/sysdb/metastore/db/dao/attached_function_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/attached_function_test.go
@@ -150,7 +150,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByName() {
 	// Retrieve by name
 	inputColID := "input_col_id"
 	attachedFunctionName := "test-get-attachedFunction"
-	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunctionName, &inputColID, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunctionName, &inputColID, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 1)
 	retrieved := retrievedList[0]
@@ -186,7 +186,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByName_NotRe
 	// Retrieve by name with onlyReady=true should not return it
 	inputColID := "input_col_id"
 	attachedFunctionName := "test-get-attachedFunction"
-	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunctionName, &inputColID, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunctionName, &inputColID, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 
@@ -198,7 +198,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByName_NotFo
 	// Try to get non-existent attached function
 	inputColID := "input_col_id"
 	nonexistentName := "nonexistent-attachedFunction"
-	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &nonexistentName, &inputColID, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &nonexistentName, &inputColID, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 }
@@ -231,7 +231,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByName_Ignor
 	// GetByName should not return it
 	inputColID := "input1"
 	deletedName := "test-deleted-attachedFunction"
-	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &deletedName, &inputColID, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &deletedName, &inputColID, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 
@@ -334,7 +334,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_DeleteAll() {
 
 	// Verify all attached functions are deleted
 	for _, attachedFunction := range attachedFunctions {
-		retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunction.Name, &attachedFunction.InputCollectionID, true)
+		retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunction.Name, &attachedFunction.InputCollectionID, nil, true)
 		suite.Require().NoError(err)
 		suite.Require().Len(retrievedList, 0)
 	}
@@ -365,7 +365,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByID() {
 	err := suite.Db.Insert(attachedFunction)
 	suite.Require().NoError(err)
 
-	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 1)
 	retrieved := retrievedList[0]
@@ -396,7 +396,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByID_NoReady
 	err := suite.Db.Insert(attachedFunction)
 	suite.Require().NoError(err)
 
-	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 
@@ -405,7 +405,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByID_NoReady
 
 func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByID_NotFound() {
 	nonexistentID := uuid.New()
-	retrievedList, err := suite.Db.GetAttachedFunctions(&nonexistentID, nil, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(&nonexistentID, nil, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 }
@@ -433,7 +433,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByID_Ignores
 	err = suite.Db.SoftDelete("input1", "test-get-by-id-deleted")
 	suite.Require().NoError(err)
 
-	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 

--- a/go/pkg/sysdb/metastore/db/dao/task.go
+++ b/go/pkg/sysdb/metastore/db/dao/task.go
@@ -134,8 +134,9 @@ func (s *attachedFunctionDb) UpdateHeapEntryPending(id uuid.UUID, heapEntryPendi
 // - id: Filter by attached function ID
 // - name: Filter by attached function name
 // - inputCollectionID: Filter by input collection ID
+// - outputCollectionID: Filter by output collection ID
 // - onlyReady: If true, only returns attached functions where is_ready = true
-func (s *attachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
+func (s *attachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
 	var attachedFunctions []*dbmodel.AttachedFunction
 
 	query := s.db.Where("is_deleted = ?", false)
@@ -150,6 +151,10 @@ func (s *attachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, i
 
 	if inputCollectionID != nil {
 		query = query.Where("input_collection_id = ?", *inputCollectionID)
+	}
+
+	if outputCollectionID != nil {
+		query = query.Where("output_collection_id = ?", *outputCollectionID)
 	}
 
 	if onlyReady {

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
@@ -112,9 +112,9 @@ func (_m *IAttachedFunctionDb) Finish(id uuid.UUID) error {
 	return r0
 }
 
-// GetAttachedFunctions provides a mock function with given fields: id, name, inputCollectionID, onlyReady
-func (_m *IAttachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
-	ret := _m.Called(id, name, inputCollectionID, onlyReady)
+// GetAttachedFunctions provides a mock function with given fields: id, name, inputCollectionID, outputCollectionID, onlyReady
+func (_m *IAttachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
+	ret := _m.Called(id, name, inputCollectionID, outputCollectionID, onlyReady)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAttachedFunctions")
@@ -122,19 +122,19 @@ func (_m *IAttachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string,
 
 	var r0 []*dbmodel.AttachedFunction
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*uuid.UUID, *string, *string, bool) ([]*dbmodel.AttachedFunction, error)); ok {
-		return rf(id, name, inputCollectionID, onlyReady)
+	if rf, ok := ret.Get(0).(func(*uuid.UUID, *string, *string, *string, bool) ([]*dbmodel.AttachedFunction, error)); ok {
+		return rf(id, name, inputCollectionID, outputCollectionID, onlyReady)
 	}
-	if rf, ok := ret.Get(0).(func(*uuid.UUID, *string, *string, bool) []*dbmodel.AttachedFunction); ok {
-		r0 = rf(id, name, inputCollectionID, onlyReady)
+	if rf, ok := ret.Get(0).(func(*uuid.UUID, *string, *string, *string, bool) []*dbmodel.AttachedFunction); ok {
+		r0 = rf(id, name, inputCollectionID, outputCollectionID, onlyReady)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*dbmodel.AttachedFunction)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*uuid.UUID, *string, *string, bool) error); ok {
-		r1 = rf(id, name, inputCollectionID, onlyReady)
+	if rf, ok := ret.Get(1).(func(*uuid.UUID, *string, *string, *string, bool) error); ok {
+		r1 = rf(id, name, inputCollectionID, outputCollectionID, onlyReady)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/go/pkg/sysdb/metastore/db/dbmodel/task.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/task.go
@@ -42,8 +42,9 @@ type IAttachedFunctionDb interface {
 	// - id: Filter by attached function ID
 	// - name: Filter by attached function name
 	// - inputCollectionID: Filter by input collection ID
+	// - outputCollectionID: Filter by output collection ID
 	// - onlyReady: If true, only returns attached functions where is_ready = true
-	GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, onlyReady bool) ([]*AttachedFunction, error)
+	GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, onlyReady bool) ([]*AttachedFunction, error)
 	Update(attachedFunction *AttachedFunction) error
 	UpdateCompletionOffsetAndHeapEntry(id uuid.UUID, collectionID string, newOffset int64) error
 	UpdateHeapEntryPending(id uuid.UUID, heapEntryPending bool) error

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -2548,9 +2548,8 @@ impl ServiceBasedFrontend {
         .await?;
 
         // Step 3: Create output collection and set is_ready = true
-        // Generate a default HNSW schema for the output collection with the attached function ID
-        let mut output_schema = Schema::new_default(KnnIndex::Hnsw);
-        output_schema.source_attached_function_id = Some(attached_function_id.0.to_string());
+        // Generate a default HNSW schema for the output collection
+        let output_schema = Schema::new_default(KnnIndex::Hnsw);
         let output_schema_str = serde_json::to_string(&output_schema).map_err(|e| {
             chroma_types::AttachFunctionError::Internal(Box::new(chroma_error::TonicError(
                 tonic::Status::internal(format!(
@@ -2566,14 +2565,7 @@ impl ServiceBasedFrontend {
             .sysdb_client
             .finish_create_attached_function(attached_function_id, output_schema_str)
             .await
-            .map_err(|e| match e {
-                chroma_types::FinishCreateAttachedFunctionError::OutputCollectionExists => {
-                    chroma_types::AttachFunctionError::OutputCollectionExists(
-                        output_collection.clone(),
-                    )
-                }
-                other => chroma_types::AttachFunctionError::from(other),
-            })?;
+            .map_err(chroma_types::AttachFunctionError::from)?;
 
         Ok(AttachFunctionResponse {
             attached_function: chroma_types::AttachedFunctionInfo {

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -1864,10 +1864,9 @@ impl GrpcSysDb {
         let collection_id_to_path = res.into_inner().collection_id_to_version_file_path;
         let mut result = HashMap::new();
         for (key, value) in collection_id_to_path {
-            let collection_id = CollectionUuid(
-                Uuid::try_parse(&key)
-                    .map_err(|err| BatchGetCollectionVersionFilePathsError::Uuid(err, key))?,
-            );
+            let collection_id = CollectionUuid(Uuid::try_parse(&key).map_err(|err| {
+                BatchGetCollectionVersionFilePathsError::Uuid(err, key.to_string())
+            })?);
             result.insert(collection_id, value);
         }
         Ok(result)
@@ -1900,10 +1899,9 @@ impl GrpcSysDb {
         );
         let mut result = HashMap::new();
         for (key, value) in collection_id_to_status {
-            let collection_id = CollectionUuid(
-                Uuid::try_parse(&key)
-                    .map_err(|err| BatchGetCollectionSoftDeleteStatusError::Uuid(err, key))?,
-            );
+            let collection_id = CollectionUuid(Uuid::try_parse(&key).map_err(|err| {
+                BatchGetCollectionSoftDeleteStatusError::Uuid(err, key.to_string())
+            })?);
             tracing::debug!("Collection {} is soft deleted: {}", collection_id, value);
             result.insert(collection_id, value);
         }
@@ -2212,7 +2210,6 @@ impl GrpcSysDb {
             .await
             .map_err(|e| match e.code() {
                 Code::NotFound => FinishCreateAttachedFunctionError::AttachedFunctionNotFound,
-                Code::AlreadyExists => FinishCreateAttachedFunctionError::OutputCollectionExists,
                 _ => FinishCreateAttachedFunctionError::FailedToFinishCreateAttachedFunction(e),
             })?;
         Ok(response.into_inner().created)

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -243,9 +243,6 @@ pub struct Schema {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<Object>))]
     pub cmek: Option<Cmek>,
-    /// ID of the attached function that created this output collection (if applicable)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_attached_function_id: Option<String>,
 }
 
 impl Schema {
@@ -588,7 +585,6 @@ impl Default for Schema {
             defaults,
             keys,
             cmek: None,
-            source_attached_function_id: None,
         }
     }
 }
@@ -973,7 +969,6 @@ impl Schema {
             defaults,
             keys,
             cmek: None,
-            source_attached_function_id: None,
         }
     }
 
@@ -1189,10 +1184,6 @@ impl Schema {
                     defaults: merged_defaults,
                     keys: merged_keys,
                     cmek: user.cmek.clone().or(default_schema.cmek.clone()),
-                    source_attached_function_id: user
-                        .source_attached_function_id
-                        .clone()
-                        .or(default_schema.source_attached_function_id.clone()),
                 })
             }
             None => Ok(default_schema),
@@ -1220,10 +1211,6 @@ impl Schema {
             defaults: self.defaults.clone(),
             keys,
             cmek: other.cmek.clone().or(self.cmek.clone()),
-            source_attached_function_id: other
-                .source_attached_function_id
-                .clone()
-                .or(self.source_attached_function_id.clone()),
         })
     }
 
@@ -3267,7 +3254,6 @@ mod tests {
             defaults: ValueTypes::default(),
             keys: HashMap::new(),
             cmek: None,
-            source_attached_function_id: None,
         };
 
         let result = Schema::reconcile_with_defaults(Some(&user_schema), KnnIndex::Spann).unwrap();
@@ -3282,7 +3268,6 @@ mod tests {
             defaults: ValueTypes::default(),
             keys: HashMap::new(),
             cmek: None,
-            source_attached_function_id: None,
         };
 
         user_schema.defaults.string = Some(StringValueType {
@@ -3319,7 +3304,6 @@ mod tests {
             defaults: ValueTypes::default(),
             keys: HashMap::new(),
             cmek: None,
-            source_attached_function_id: None,
         };
 
         user_schema.defaults.float_list = Some(FloatListValueType {
@@ -3370,7 +3354,6 @@ mod tests {
                 defaults: merged_defaults,
                 keys: merged_keys,
                 cmek: None,
-                source_attached_function_id: None,
             }
         };
 
@@ -3408,7 +3391,6 @@ mod tests {
             defaults: ValueTypes::default(),
             keys: HashMap::new(),
             cmek: None,
-            source_attached_function_id: None,
         };
 
         // Add a custom key override
@@ -3457,7 +3439,6 @@ mod tests {
             defaults: ValueTypes::default(),
             keys: HashMap::new(),
             cmek: None,
-            source_attached_function_id: None,
         };
 
         // Override the #embedding key with custom settings
@@ -4174,7 +4155,6 @@ mod tests {
             defaults: ValueTypes::default(),
             keys: HashMap::new(),
             cmek: None,
-            source_attached_function_id: None,
         };
 
         // Set up complex user defaults
@@ -4252,7 +4232,6 @@ mod tests {
                 defaults: merged_defaults,
                 keys: merged_keys,
                 cmek: None,
-                source_attached_function_id: None,
             }
         };
 
@@ -6204,7 +6183,6 @@ mod tests {
             defaults: ValueTypes::default(),
             keys: HashMap::new(),
             cmek: None,
-            source_attached_function_id: None,
         };
         assert!(empty_schema.is_fts_enabled());
     }
@@ -7078,7 +7056,6 @@ mod tests {
                             defaults,
                             keys: extra_keys,
                             cmek: None,
-                            source_attached_function_id: None,
                         }
                     },
                 )

--- a/rust/types/src/flush.rs
+++ b/rust/types/src/flush.rs
@@ -56,8 +56,6 @@ pub enum FinishCreateAttachedFunctionError {
     FailedToFinishCreateAttachedFunction(#[from] tonic::Status),
     #[error("Attached function not found")]
     AttachedFunctionNotFound,
-    #[error("Output collection already exists")]
-    OutputCollectionExists,
 }
 
 impl ChromaError for FinishCreateAttachedFunctionError {
@@ -67,7 +65,6 @@ impl ChromaError for FinishCreateAttachedFunctionError {
                 ErrorCodes::Internal
             }
             FinishCreateAttachedFunctionError::AttachedFunctionNotFound => ErrorCodes::NotFound,
-            FinishCreateAttachedFunctionError::OutputCollectionExists => ErrorCodes::AlreadyExists,
         }
     }
 }

--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -245,13 +245,6 @@ pub fn validate_search_payload(payload: &SearchPayload) -> Result<(), Validation
 
 /// Validate schema
 pub fn validate_schema(schema: &Schema) -> Result<(), ValidationError> {
-    // Prevent users from setting source_attached_function_id - only the system can set this
-    if schema.source_attached_function_id.is_some() {
-        return Err(ValidationError::new("schema").with_message(
-            "Cannot set source_attached_function_id. This field is reserved for system use.".into(),
-        ));
-    }
-
     let mut sparse_index_keys = Vec::new();
     if schema
         .defaults

--- a/rust/worker/src/execution/functions/statistics.rs
+++ b/rust/worker/src/execution/functions/statistics.rs
@@ -1379,8 +1379,7 @@ mod tests {
             )
             .await
             .expect("Attached function creation should succeed");
-        let mut output_schema = chroma_types::Schema::new_default(chroma_types::KnnIndex::Hnsw);
-        output_schema.source_attached_function_id = Some(attached_function_id.0.to_string());
+        let output_schema = chroma_types::Schema::new_default(chroma_types::KnnIndex::Hnsw);
         let output_schema_str = serde_json::to_string(&output_schema).unwrap();
         sysdb
             .finish_create_attached_function(attached_function_id, output_schema_str)

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -4042,8 +4042,7 @@ mod tests {
             )
             .await
             .expect("Attached function creation should succeed");
-        let mut output_schema = chroma_types::Schema::new_default(chroma_types::KnnIndex::Hnsw);
-        output_schema.source_attached_function_id = Some(attached_function_id.0.to_string());
+        let output_schema = chroma_types::Schema::new_default(chroma_types::KnnIndex::Hnsw);
         let output_schema_str = serde_json::to_string(&output_schema).unwrap();
         sysdb
             .finish_create_attached_function(attached_function_id, output_schema_str)
@@ -5032,8 +5031,7 @@ mod tests {
             .await
             .expect("Attached function creation should succeed");
 
-        let mut output_schema = chroma_types::Schema::new_default(chroma_types::KnnIndex::Hnsw);
-        output_schema.source_attached_function_id = Some(attached_function_id.0.to_string());
+        let output_schema = chroma_types::Schema::new_default(chroma_types::KnnIndex::Hnsw);
         let output_schema_str = serde_json::to_string(&output_schema).unwrap();
         sysdb
             .finish_create_attached_function(attached_function_id, output_schema_str)


### PR DESCRIPTION
## Description of changes

This PR changes how output collections work for attached functions. Previously, each output collection was tied to exactly one attached function via a `source_attached_function_id` field. Now, multiple functions of the same type can share a single output collection. The condition of whether a collection as an output collection was encoded in the collection schema before this change. The schema of an output collection encoded the functionid  that led to its creation. We remove that from the schema and make all former uses of this field extract incoming functions via a filtered call to the `attached_functions` table in the sysdb instead.



The change touches four layers:

1. **Rust types** — remove the field from `Schema` and related error variants
2. **Go sysdb DAO** — add `outputCollectionID` filter to `GetAttachedFunctions`
3. **Go coordinator** — rewrite `softDeleteCollection` and `FinishCreateAttachedFunction` to use DB queries instead of schema inspection
4. **Python integration tests** — update expectations to match new semantics

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

Tests were added to test_task_api.py

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?__a