### PR TITLE
fix: copy include list before mutating in get/query

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -279,7 +279,7 @@ class CollectionCommon(Generic[ClientT]):
             )
 
         # Prepare
-        request_include = include
+        request_include = list(include)
         # We need to include uris in the result from the API to load datas
         if "data" in include and "uris" not in include:
             request_include.append("uris")
@@ -343,7 +343,7 @@ class CollectionCommon(Generic[ClientT]):
         request_where_document = filters["where_document"]
 
         # We need to manually include uris in the result from the API to load datas
-        request_include = include
+        request_include = list(include)
         if "data" in request_include and "uris" not in request_include:
             request_include.append("uris")
 


### PR DESCRIPTION
If you pass the same `include` list to multiple `collection.query()` or `collection.get()` calls, the list gets `"uris"` appended to it on the first call and stays mutated for all subsequent calls. Depending on how many times you call it you can end up with duplicate entries which then fails validation.

Root cause: `_validate_and_prepare_get_request` and `_validate_and_prepare_query_request` both do `request_include = include` (a reference, not a copy) before calling `request_include.append("uris")`.

Fix is `request_include = list(include)` in both places — one line each.

Fixes #5857