### PR TITLE
Fix get_collection/create_collection Raises docstring (#5492)

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -438,7 +438,7 @@ class ClientAPI(BaseAPI, ABC):
             Collection: The newly created collection.
 
         Raises:
-            ValueError: If the collection already exists and get_or_create is False.
+            UniqueConstraintError: If the collection already exists and get_or_create is False.
             ValueError: If the collection name is invalid.
 
         Examples:
@@ -472,7 +472,7 @@ class ClientAPI(BaseAPI, ABC):
             Collection: The collection
 
         Raises:
-            ValueError: If the collection does not exist
+            NotFoundError: If the collection does not exist
 
         Examples:
             ```python

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -390,7 +390,7 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
             Collection: The newly created collection.
 
         Raises:
-            ValueError: If the collection already exists and get_or_create is False.
+            UniqueConstraintError: If the collection already exists and get_or_create is False.
             ValueError: If the collection name is invalid.
 
         Examples:
@@ -424,7 +424,7 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
             Collection: The collection
 
         Raises:
-            ValueError: If the collection does not exist
+            NotFoundError: If the collection does not exist
 
         Examples:
             ```python

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -203,6 +203,7 @@ class Client(SharedSystemClient, ClientAPI):
             Collection: The created collection.
 
         Raises:
+            UniqueConstraintError: If the collection already exists and get_or_create is False.
             ValueError: If the embedding function conflicts with configuration.
         """
         if configuration is None:
@@ -255,6 +256,7 @@ class Client(SharedSystemClient, ClientAPI):
             Collection: The requested collection.
 
         Raises:
+            NotFoundError: If the collection does not exist.
             ValueError: If the embedding function conflicts with configuration.
         """
         model = self._server.get_collection(


### PR DESCRIPTION
## Description of changes

The `Raises` section on `ClientAPI.get_collection` says `ValueError`, but the implementation in `chromadb/api/segment.py` actually raises `NotFoundError`. The same mismatch shows up on `create_collection`, whose `Raises` lists `ValueError` for duplicate names while the SysDB / gRPC path raises `UniqueConstraintError`. The async client and the concrete `Client` wrapper have the same drift, so callers consulting any of the three files get the wrong exception type to catch.

This PR updates the docstrings in `chromadb/api/__init__.py`, `chromadb/api/async_api.py`, and `chromadb/api/client.py` so the sync and async clients describe the exceptions that are actually raised:

- `get_collection`: `ValueError` becomes `NotFoundError`.
- `create_collection`: the duplicate-name entry becomes `UniqueConstraintError`; the existing `ValueError: If the collection name is invalid.` entry is kept since name validation does raise `ValueError`.
- `Client.get_collection` and `Client.create_collection`: add the missing `NotFoundError` / `UniqueConstraintError` entries alongside the existing embedding-function `ValueError` entry, which is still raised by `validate_embedding_function_conflict_on_create` / `_on_get`.

Both `NotFoundError` and `UniqueConstraintError` are already exported from `chromadb/errors.py`, so users can `from chromadb.errors import NotFoundError, UniqueConstraintError` and catch them today.

Fixes #5492.

This also supersedes the Python portion of #6369, which has been idle for roughly three months and bundles unrelated `.github/workflows/_rust-tests.yml` GCS credential changes that aren't appropriate for a docs fix.

## Test plan

Docstring-only change with no runtime behavior. Verified by reading `chromadb/api/segment.py` (`raise NotFoundError(...)` at line 338 for `get_collection`) and `chromadb/db/impl/grpc/client.py` (`raise UniqueConstraintError()` for duplicate-collection paths), and confirming the existing `ValueError` raises in `chromadb/api/client.py` come from `validate_embedding_function_conflict_on_create` / `_on_get` in `chromadb/api/collection_configuration.py`.

## Documentation Changes

This PR is itself the documentation change. No updates needed in the docs repo.