### PR TITLE
[BUG] Use camelCase constructor args on MorphEmbeddingFunction for parity

### DIFF
--- a/clients/new-js/packages/ai-embeddings/morph/README.md
+++ b/clients/new-js/packages/ai-embeddings/morph/README.md
@@ -11,20 +11,20 @@ npm install @chroma-core/morph
 ## Usage
 
 ```typescript
-import { MorphEmbeddingFunction } from '@chroma-core/morph';
+import { MorphEmbeddingFunction } from "@chroma-core/morph";
 
 // Initialize the embedding function
 const morphEmbedding = new MorphEmbeddingFunction({
-  api_key: 'your-morph-api-key', // or set MORPH_API_KEY env var
-  model_name: 'morph-embedding-v2', // default
-  api_base: 'https://api.morphllm.com/v1', // default
-  encoding_format: 'float' // default
+  apiKey: "your-morph-api-key", // or set MORPH_API_KEY env var
+  modelName: "morph-embedding-v2", // default
+  apiBase: "https://api.morphllm.com/v1", // default
+  encodingFormat: "float", // default
 });
 
 // Generate embeddings for code snippets
 const codeSnippets = [
-  'function calculateSum(a, b) { return a + b; }',
-  'class User { constructor(name) { this.name = name; } }'
+  "function calculateSum(a, b) { return a + b; }",
+  "class User { constructor(name) { this.name = name; } }",
 ];
 
 const embeddings = await morphEmbedding.generate(codeSnippets);
@@ -35,11 +35,11 @@ console.log(embeddings);
 
 The `MorphEmbeddingFunction` constructor accepts the following options:
 
-- `api_key` (optional): Your Morph API key. If not provided, it will read from the environment variable specified by `api_key_env_var`.
-- `model_name` (optional): The Morph model to use. Defaults to `'morph-embedding-v2'`.
-- `api_base` (optional): The base URL for the Morph API. Defaults to `'https://api.morphllm.com/v1'`.
-- `encoding_format` (optional): The format for embeddings ('float' or 'base64'). Defaults to `'float'`.
-- `api_key_env_var` (optional): The environment variable name for the API key. Defaults to `'MORPH_API_KEY'`.
+- `apiKey` (optional): Your Morph API key. If not provided, it will read from the environment variable specified by `apiKeyEnvVar`.
+- `modelName` (optional): The Morph model to use. Defaults to `'morph-embedding-v2'`.
+- `apiBase` (optional): The base URL for the Morph API. Defaults to `'https://api.morphllm.com/v1'`.
+- `encodingFormat` (optional): The format for embeddings ('float' or 'base64'). Defaults to `'float'`.
+- `apiKeyEnvVar` (optional): The environment variable name for the API key. Defaults to `'MORPH_API_KEY'`.
 
 ## Environment Variables
 
@@ -59,5 +59,6 @@ export MORPH_API_KEY="your-morph-api-key"
 ## API Reference
 
 For more information about Morph's embedding models and API, visit:
+
 - [Morph Embedding API Documentation](https://docs.morphllm.com/api-reference/endpoint/embedding)
 - [Morph Website](https://morphllm.com/)

--- a/clients/new-js/packages/ai-embeddings/morph/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/morph/src/index.test.ts
@@ -10,7 +10,7 @@ describe("MorphEmbeddingFunction", () => {
 
   const defaultParametersTest = "should initialize with default parameters";
   if (!process.env.MORPH_API_KEY) {
-    it.skip(defaultParametersTest, () => { });
+    it.skip(defaultParametersTest, () => {});
   } else {
     it(defaultParametersTest, () => {
       const embedder = new MorphEmbeddingFunction();
@@ -26,14 +26,14 @@ describe("MorphEmbeddingFunction", () => {
 
   const customParametersTest = "should initialize with custom parameters";
   if (!process.env.MORPH_API_KEY) {
-    it.skip(customParametersTest, () => { });
+    it.skip(customParametersTest, () => {});
   } else {
     it(customParametersTest, () => {
       const embedder = new MorphEmbeddingFunction({
-        model_name: "custom-model",
-        api_base: "https://custom-api.com/v1",
-        encoding_format: "base64",
-        api_key_env_var: "MORPH_API_KEY",
+        modelName: "custom-model",
+        apiBase: "https://custom-api.com/v1",
+        encodingFormat: "base64",
+        apiKeyEnvVar: "MORPH_API_KEY",
       });
 
       const config = embedder.getConfig();
@@ -64,12 +64,10 @@ describe("MorphEmbeddingFunction", () => {
 
     try {
       const embedder = new MorphEmbeddingFunction({
-        api_key_env_var: "CUSTOM_MORPH_API_KEY",
+        apiKeyEnvVar: "CUSTOM_MORPH_API_KEY",
       });
 
-      expect(embedder.getConfig().api_key_env_var).toBe(
-        "CUSTOM_MORPH_API_KEY",
-      );
+      expect(embedder.getConfig().api_key_env_var).toBe("CUSTOM_MORPH_API_KEY");
     } finally {
       delete process.env.CUSTOM_MORPH_API_KEY;
     }
@@ -77,7 +75,7 @@ describe("MorphEmbeddingFunction", () => {
 
   const buildFromConfigTest = "should build from config";
   if (!process.env.MORPH_API_KEY) {
-    it.skip(buildFromConfigTest, () => { });
+    it.skip(buildFromConfigTest, () => {});
   } else {
     it(buildFromConfigTest, () => {
       const config = {
@@ -95,7 +93,7 @@ describe("MorphEmbeddingFunction", () => {
 
   const generateEmbeddingsTest = "should generate embeddings";
   if (!process.env.MORPH_API_KEY) {
-    it.skip(generateEmbeddingsTest, () => { });
+    it.skip(generateEmbeddingsTest, () => {});
   } else {
     it(generateEmbeddingsTest, async () => {
       const embedder = new MorphEmbeddingFunction();

--- a/clients/new-js/packages/ai-embeddings/morph/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/morph/src/index.ts
@@ -13,48 +13,48 @@ export interface MorphConfig {
   api_key_env_var: string;
   model_name: string;
   api_base?: string;
-  encoding_format?: 'float' | 'base64';
+  encoding_format?: "float" | "base64";
 }
 
-export interface MorphEmbeddingFunctionConfig {
-  api_key?: string;
-  model_name?: string;
-  api_base?: string;
-  encoding_format?: 'float' | 'base64';
-  api_key_env_var?: string;
+export interface MorphArgs {
+  apiKey?: string;
+  apiKeyEnvVar?: string;
+  modelName?: string;
+  apiBase?: string;
+  encodingFormat?: "float" | "base64";
 }
 
 export class MorphEmbeddingFunction implements EmbeddingFunction {
   public readonly name = NAME;
   private readonly apiKeyEnvVar: string;
   private readonly modelName: string;
-  private readonly encodingFormat: 'float' | 'base64';
+  private readonly encodingFormat: "float" | "base64";
   private readonly apiBase: string;
   private client: OpenAI;
 
-  constructor(config: MorphEmbeddingFunctionConfig = {}) {
+  constructor(args: MorphArgs = {}) {
     const {
-      api_key,
-      model_name = 'morph-embedding-v2',
-      api_base = 'https://api.morphllm.com/v1',
-      encoding_format = 'float',
-      api_key_env_var = 'MORPH_API_KEY'
-    } = config;
+      apiKeyEnvVar = "MORPH_API_KEY",
+      modelName = "morph-embedding-v2",
+      apiBase = "https://api.morphllm.com/v1",
+      encodingFormat = "float",
+    } = args;
 
-    // Get API key from config or environment
-    const apiKey = api_key || process.env[api_key_env_var];
+    const apiKey = args.apiKey || process.env[apiKeyEnvVar];
     if (!apiKey) {
-      throw new Error(`API key not found. Please set ${api_key_env_var} environment variable or provide api_key in config.`);
+      throw new Error(
+        `API key not found. Please set ${apiKeyEnvVar} environment variable or provide apiKey in args.`,
+      );
     }
 
-    this.modelName = model_name;
-    this.encodingFormat = encoding_format;
-    this.apiKeyEnvVar = api_key_env_var;
-    this.apiBase = api_base;
+    this.modelName = modelName;
+    this.encodingFormat = encodingFormat;
+    this.apiKeyEnvVar = apiKeyEnvVar;
+    this.apiBase = apiBase;
 
     this.client = new OpenAI({
       apiKey,
-      baseURL: api_base,
+      baseURL: apiBase,
     });
   }
 
@@ -65,7 +65,7 @@ export class MorphEmbeddingFunction implements EmbeddingFunction {
       encoding_format: this.encodingFormat,
     });
 
-    return response.data.map(item => item.embedding);
+    return response.data.map((item) => item.embedding);
   }
 
   public defaultSpace(): EmbeddingFunctionSpace {
@@ -78,10 +78,10 @@ export class MorphEmbeddingFunction implements EmbeddingFunction {
 
   public static buildFromConfig(config: MorphConfig): MorphEmbeddingFunction {
     return new MorphEmbeddingFunction({
-      model_name: config.model_name,
-      api_key_env_var: config.api_key_env_var,
-      api_base: config.api_base,
-      encoding_format: config.encoding_format,
+      modelName: config.model_name,
+      apiKeyEnvVar: config.api_key_env_var,
+      apiBase: config.api_base,
+      encodingFormat: config.encoding_format,
     });
   }
 


### PR DESCRIPTION
## Description of changes

The Morph embedding function exposed snake_case constructor args (`api_key`, `api_key_env_var`, `model_name`, `api_base`, `encoding_format`), diverging from the camelCase contract used by every other TS embedding function (`OpenAIArgs`, `CohereArgs`, ...). This forced TS callers to special-case Morph.

This change renames `MorphEmbeddingFunctionConfig` to `MorphArgs` with camelCase fields, mirroring `OpenAIArgs`/`CohereArgs` exactly. The snake_case `MorphConfig` interface used by `buildFromConfig`/`getConfig` is kept unchanged for parity with siblings (its shape is also what the JSON schema validates against).

Before:

```ts
new MorphEmbeddingFunction({
  api_key: "...",
  model_name: "morph-embedding-v2",
  api_base: "https://api.morphllm.com/v1",
  encoding_format: "float",
  api_key_env_var: "MORPH_API_KEY",
});
```

After:

```ts
new MorphEmbeddingFunction({
  apiKey: "...",
  modelName: "morph-embedding-v2",
  apiBase: "https://api.morphllm.com/v1",
  encodingFormat: "float",
  apiKeyEnvVar: "MORPH_API_KEY",
});
```

`MorphConfig` (snake_case) is unchanged, so persisted collection configs and `buildFromConfig`/`getConfig` continue to work without migration. The `morph.json` schema is unchanged.

Fixes #6201

## Test plan

- `pnpm test` in `clients/new-js/packages/ai-embeddings/morph` passes (the offline tests; API key gated tests stay skipped without `MORPH_API_KEY`).
- `pnpm build` in the morph package emits clean d.ts: exported surface is `MorphArgs`, `MorphConfig`, `MorphEmbeddingFunction`, matching `OpenAIArgs`/`OpenAIConfig` and `CohereArgs`/`CohereConfig`.
- Updated tests use the new camelCase constructor args; assertions on `getConfig()` still use snake_case since `MorphConfig` is unchanged.
- README updated to document the camelCase args.

## Documentation Changes

`clients/new-js/packages/ai-embeddings/morph/README.md` updated to use `apiKey` / `modelName` / `apiBase` / `encodingFormat` / `apiKeyEnvVar` in the usage example and configuration table.