### PR TITLE
docs(chroma): update README link to Chroma vectorstore integration docs

### DIFF
--- a/docs/mintlify/integrations/frameworks/langchain.mdx
+++ b/docs/mintlify/integrations/frameworks/langchain.mdx
@@ -15,4 +15,4 @@ title: Langchain
 
 ## Langchain - JS
 
-- [LangChainJS Chroma Documentation](https://js.langchain.com/docs/integrations/vectorstores/chroma/)
+- [LangChainJS Chroma Documentation](https://docs.langchain.com/oss/javascript/integrations/vectorstores/index#chroma)


### PR DESCRIPTION
## Description of changes

Updated the Chroma README link to point directly to the
`integration/vectorstores/index#chroma` section instead of the generic
LangChain overview page for improved navigation and discoverability.

## Type of change

- Documentation update

## Test plan

- Verified the updated link resolves correctly
- Confirmed the anchor navigates to the Chroma integration section

## Documentation Changes

- Updated README link reference only