### PR TITLE
[BUG](embedding-functions): compare values in validate_config_update

### DIFF
--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -120,3 +120,135 @@ def test_validation_context_with_custom_ef() -> None:
     expected_msg = f"{original_msg} in custom_ef_call."
     assert str(excinfo.value) == expected_msg
     assert excinfo.value.args == (expected_msg,)
+
+
+def _construct_ef(name: str, monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
+    """Construct one of the affected EFs, skipping if its SDK is unavailable."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("COHERE_API_KEY", "test")
+    monkeypatch.setenv("MORPH_API_KEY", "test")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test")
+    monkeypatch.setenv("TOGETHER_API_KEY", "test")
+    monkeypatch.setenv("VOYAGE_API_KEY", "test")
+    monkeypatch.setenv("JINA_API_KEY", "test")
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "test")
+    monkeypatch.setenv("CLOUDFLARE_API_KEY", "test")
+    monkeypatch.setenv("CHROMA_CLOUDFLARE_ACCOUNT_ID", "test")
+
+    if name == "openai":
+        from chromadb.utils.embedding_functions.openai_embedding_function import (
+            OpenAIEmbeddingFunction,
+        )
+
+        return OpenAIEmbeddingFunction(model_name="text-embedding-3-small")
+    if name == "cohere":
+        from chromadb.utils.embedding_functions.cohere_embedding_function import (
+            CohereEmbeddingFunction,
+        )
+
+        return CohereEmbeddingFunction()
+    if name == "morph":
+        from chromadb.utils.embedding_functions.morph_embedding_function import (
+            MorphEmbeddingFunction,
+        )
+
+        return MorphEmbeddingFunction()
+    if name == "perplexity":
+        from chromadb.utils.embedding_functions.perplexity_embedding_function import (
+            PerplexityEmbeddingFunction,
+        )
+
+        return PerplexityEmbeddingFunction()
+    if name == "together_ai":
+        from chromadb.utils.embedding_functions.together_ai_embedding_function import (
+            TogetherAIEmbeddingFunction,
+        )
+
+        monkeypatch.setenv("CHROMA_TOGETHER_AI_API_KEY", "test")
+        return TogetherAIEmbeddingFunction(model_name="togethercomputer/m2-bert-80M-8k-retrieval")
+    if name == "voyageai":
+        from chromadb.utils.embedding_functions.voyageai_embedding_function import (
+            VoyageAIEmbeddingFunction,
+        )
+
+        return VoyageAIEmbeddingFunction()
+    if name == "jina":
+        from chromadb.utils.embedding_functions.jina_embedding_function import (
+            JinaEmbeddingFunction,
+        )
+
+        return JinaEmbeddingFunction()
+    if name == "huggingface":
+        from chromadb.utils.embedding_functions.huggingface_embedding_function import (
+            HuggingFaceEmbeddingFunction,
+        )
+
+        return HuggingFaceEmbeddingFunction()
+    if name == "cloudflare_workers_ai":
+        from chromadb.utils.embedding_functions.cloudflare_workers_ai_embedding_function import (  # noqa: E501
+            CloudflareWorkersAIEmbeddingFunction,
+        )
+
+        monkeypatch.setenv("CHROMA_CLOUDFLARE_API_KEY", "test")
+        return CloudflareWorkersAIEmbeddingFunction(
+            model_name="@cf/baai/bge-base-en-v1.5", account_id="test"
+        )
+    raise AssertionError(f"unknown EF name {name}")
+
+
+# Builtin EFs that historically rejected any update whose new config contained
+# model_name, even when the value was unchanged. Tracked by name to keep the
+# test parametrization stable when an SDK is missing locally.
+_EF_NAMES = [
+    "openai",
+    "cohere",
+    "morph",
+    "perplexity",
+    "together_ai",
+    "voyageai",
+    "jina",
+    "huggingface",
+    "cloudflare_workers_ai",
+]
+
+
+@pytest.mark.parametrize("name", _EF_NAMES)
+def test_validate_config_update_accepts_unchanged_model_name(
+    name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Updating an EF with the same model_name must not raise.
+
+    Regression test: previously these EFs raised
+    "The model name cannot be changed after the embedding function has been
+    initialized." whenever the new config contained model_name at all, even
+    when it matched the existing value. That made it impossible to update any
+    other field through `overwrite_embedding_function`, since `get_config()`
+    always includes model_name.
+    """
+    try:
+        ef = _construct_ef(name, monkeypatch)
+    except (ImportError, ValueError) as exc:
+        # ValueError covers EFs that re-raise ImportError as ValueError when
+        # an optional SDK is missing.
+        pytest.skip(f"{name} SDK not available: {exc}")
+
+    cfg = ef.get_config()
+    ef.validate_config_update(cfg, cfg)
+
+
+@pytest.mark.parametrize("name", _EF_NAMES)
+def test_validate_config_update_rejects_changed_model_name(
+    name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Changing the model_name must still raise."""
+    try:
+        ef = _construct_ef(name, monkeypatch)
+    except (ImportError, ValueError) as exc:
+        pytest.skip(f"{name} SDK not available: {exc}")
+
+    old_cfg = ef.get_config()
+    new_cfg = dict(old_cfg)
+    key = "model_name" if "model_name" in new_cfg else "model"
+    new_cfg[key] = "definitely-a-different-model"
+    with pytest.raises(ValueError, match="cannot be changed"):
+        ef.validate_config_update(old_cfg, new_cfg)

--- a/chromadb/utils/embedding_functions/amazon_bedrock_embedding_function.py
+++ b/chromadb/utils/embedding_functions/amazon_bedrock_embedding_function.py
@@ -119,7 +119,10 @@ class AmazonBedrockEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
+++ b/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
@@ -205,15 +205,18 @@ class ChromaCloudQwenEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model" in new_config:
+        if "model" in new_config and new_config["model"] != old_config.get("model"):
             raise ValueError(
                 "The model cannot be changed after the embedding function has been initialized."
             )
-        elif "task" in new_config:
+        if "task" in new_config and new_config["task"] != old_config.get("task"):
             raise ValueError(
                 "The task cannot be changed after the embedding function has been initialized."
             )
-        elif "instructions" in new_config:
+        if (
+            "instructions" in new_config
+            and new_config["instructions"] != old_config.get("instructions")
+        ):
             raise ValueError(
                 "The instructions cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/cloudflare_workers_ai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/cloudflare_workers_ai_embedding_function.py
@@ -140,7 +140,10 @@ class CloudflareWorkersAIEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/cohere_embedding_function.py
+++ b/chromadb/utils/embedding_functions/cohere_embedding_function.py
@@ -163,7 +163,10 @@ class CohereEmbeddingFunction(EmbeddingFunction[Embeddable]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/google_embedding_function.py
+++ b/chromadb/utils/embedding_functions/google_embedding_function.py
@@ -171,23 +171,38 @@ class GoogleGeminiEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )
-        if "dimension" in new_config:
+        if (
+            "dimension" in new_config
+            and new_config["dimension"] != old_config.get("dimension")
+        ):
             raise ValueError(
                 "The dimension cannot be changed after the embedding function has been initialized."
             )
-        if "vertexai" in new_config:
+        if (
+            "vertexai" in new_config
+            and new_config["vertexai"] != old_config.get("vertexai")
+        ):
             raise ValueError(
                 "The vertexai cannot be changed after the embedding function has been initialized."
             )
-        if "project" in new_config:
+        if (
+            "project" in new_config
+            and new_config["project"] != old_config.get("project")
+        ):
             raise ValueError(
                 "The project cannot be changed after the embedding function has been initialized."
             )
-        if "location" in new_config:
+        if (
+            "location" in new_config
+            and new_config["location"] != old_config.get("location")
+        ):
             raise ValueError(
                 "The location cannot be changed after the embedding function has been initialized."
             )
@@ -340,15 +355,24 @@ class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )
-        if "task_type" in new_config:
+        if (
+            "task_type" in new_config
+            and new_config["task_type"] != old_config.get("task_type")
+        ):
             raise ValueError(
                 "The task type cannot be changed after the embedding function has been initialized."
             )
-        if "dimension" in new_config:
+        if (
+            "dimension" in new_config
+            and new_config["dimension"] != old_config.get("dimension")
+        ):
             raise ValueError(
                 "The dimension cannot be changed after the embedding function has been initialized."
             )
@@ -469,7 +493,10 @@ class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )
@@ -615,15 +642,24 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )
-        if "project_id" in new_config:
+        if (
+            "project_id" in new_config
+            and new_config["project_id"] != old_config.get("project_id")
+        ):
             raise ValueError(
                 "The project ID cannot be changed after the embedding function has been initialized."
             )
-        if "region" in new_config:
+        if (
+            "region" in new_config
+            and new_config["region"] != old_config.get("region")
+        ):
             raise ValueError(
                 "The region cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/huggingface_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_embedding_function.py
@@ -109,7 +109,10 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/jina_embedding_function.py
+++ b/chromadb/utils/embedding_functions/jina_embedding_function.py
@@ -264,7 +264,10 @@ class JinaEmbeddingFunction(EmbeddingFunction[Embeddable]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/mistral_embedding_function.py
+++ b/chromadb/utils/embedding_functions/mistral_embedding_function.py
@@ -76,7 +76,7 @@ class MistralEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model" in new_config:
+        if "model" in new_config and new_config["model"] != old_config.get("model"):
             raise ValueError(
                 "The model cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/morph_embedding_function.py
+++ b/chromadb/utils/embedding_functions/morph_embedding_function.py
@@ -128,7 +128,10 @@ class MorphEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/nomic_embedding_function.py
+++ b/chromadb/utils/embedding_functions/nomic_embedding_function.py
@@ -113,7 +113,7 @@ class NomicEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model" in new_config:
+        if "model" in new_config and new_config["model"] != old_config.get("model"):
             raise ValueError(
                 "The model cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/ollama_embedding_function.py
+++ b/chromadb/utils/embedding_functions/ollama_embedding_function.py
@@ -98,7 +98,10 @@ class OllamaEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/open_clip_embedding_function.py
+++ b/chromadb/utils/embedding_functions/open_clip_embedding_function.py
@@ -164,11 +164,17 @@ class OpenCLIPEmbeddingFunction(EmbeddingFunction[Embeddable]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )
-        if "checkpoint" in new_config:
+        if (
+            "checkpoint" in new_config
+            and new_config["checkpoint"] != old_config.get("checkpoint")
+        ):
             raise ValueError(
                 "The checkpoint cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/openai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/openai_embedding_function.py
@@ -191,7 +191,10 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/perplexity_embedding_function.py
+++ b/chromadb/utils/embedding_functions/perplexity_embedding_function.py
@@ -117,7 +117,10 @@ class PerplexityEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/together_ai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/together_ai_embedding_function.py
@@ -130,7 +130,10 @@ class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )

--- a/chromadb/utils/embedding_functions/voyageai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/voyageai_embedding_function.py
@@ -123,7 +123,10 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
+        if (
+            "model_name" in new_config
+            and new_config["model_name"] != old_config.get("model_name")
+        ):
             raise ValueError(
                 "The model name cannot be changed after the embedding function has been initialized."
             )


### PR DESCRIPTION
Several builtin embedding functions reject any config update whose new config contains a key such as `model_name`, even when the value matches the existing one. The check inside `validate_config_update` is `if "model_name" in new_config:` and `overwrite_embedding_function` passes `update_embedding_function.get_config()` as `new_config`, which always includes `model_name`. The result is that you cannot change any other persisted field, e.g. `api_base`, `dimensions`, `organization_id`, `project_id`, without also changing the model name, and the resulting error message claims the model name changed even when it did not.

This PR changes the check to compare values against `old_config`, matching the existing pattern in `HuggingFaceEmbeddingServer` and `ChromaCloudSpladeEmbeddingFunction`. The same shape is applied to every immutability guard in `amazon_bedrock`, `cloudflare_workers_ai`, `chroma_cloud_qwen`, `cohere`, `google` (Generative AI, Genai, Palm, Vertex), `huggingface`, `jina`, `mistral`, `morph`, `nomic`, `ollama`, `open_clip`, `openai`, `perplexity`, `together_ai`, and `voyageai`. Same-name updates now succeed, and changed values still raise the original error.

Adds parametrized regression tests in `chromadb/test/ef/test_ef.py` that construct each affected EF with a dummy API key, then assert that `validate_config_update(cfg, cfg)` does not raise and that swapping in a different `model_name` (or `model`) still raises. EFs whose third-party SDK is not installed locally are skipped rather than failing.