### PR TITLE
[BUG]: Fn consumer manager keys its job scheduler on output collection id

### DIFF
--- a/go/pkg/sysdb/coordinator/async_attached_function_simple_test.go
+++ b/go/pkg/sysdb/coordinator/async_attached_function_simple_test.go
@@ -69,7 +69,7 @@ func TestAsyncFunctionRepairFlowSimple(t *testing.T) {
 
 	// Mock all the DB calls
 	mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(mockAttachedFunctionDb)
-	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), true).
+	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), []uuid.UUID(nil), true).
 		Return([]*dbmodel.AttachedFunction{attachedFunction}, nil)
 
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)
@@ -187,7 +187,7 @@ func TestAsyncFunctionNoRepairSimple(t *testing.T) {
 
 	// Mock all the DB calls
 	mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(mockAttachedFunctionDb)
-	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), true).
+	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), []uuid.UUID(nil), true).
 		Return([]*dbmodel.AttachedFunction{attachedFunction}, nil)
 
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)
@@ -274,7 +274,7 @@ func TestAsyncFunctionTryFinishIdempotent(t *testing.T) {
 
 	// Mock all the DB calls
 	mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(mockAttachedFunctionDb)
-	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), true).
+	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), []uuid.UUID(nil), true).
 		Return([]*dbmodel.AttachedFunction{attachedFunction}, nil)
 
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)
@@ -411,7 +411,7 @@ func TestAsyncFunctionOffsetOnlyMovesForward(t *testing.T) {
 
 	// Mock all the DB calls
 	mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(mockAttachedFunctionDb)
-	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), true).
+	mockAttachedFunctionDb.On("GetAttachedFunctions", &attachedFunctionID, (*string)(nil), (*string)(nil), (*string)(nil), []uuid.UUID(nil), true).
 		Return([]*dbmodel.AttachedFunction{attachedFunction}, nil)
 
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)

--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -69,7 +69,7 @@ func (suite *AttachFunctionTestSuite) setupAttachFunctionMocks(ctx context.Conte
 	// Phase 1: Create attached function in transaction
 	// Check if any attached function exists for this collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, (*string)(nil), false).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, (*string)(nil), []uuid.UUID(nil), false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
@@ -165,7 +165,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_SuccessfulCreation() {
 	// Setup mocks that will be called within the transaction (using mock.Anything for context)
 	// Check if any attached function exists for this collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, (*string)(nil), false).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, (*string)(nil), []uuid.UUID(nil), false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	// Look up database
@@ -186,7 +186,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_SuccessfulCreation() {
 
 	// Check if input collection is being used as an output collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), (*string)(nil), &inputCollectionID, false).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), (*string)(nil), &inputCollectionID, []uuid.UUID(nil), false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	// Check if output collection already exists
@@ -296,7 +296,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Alrea
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
 			inputCollID := inputCollectionID
-			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), false).
+			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), []uuid.UUID(nil), false).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup),
@@ -365,7 +365,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 
 	// Phase 1: Create attached function in transaction
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, (*string)(nil), false).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, (*string)(nil), []uuid.UUID(nil), false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
@@ -383,7 +383,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 
 	// Check if input collection is being used as an output collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), (*string)(nil), &inputCollectionID, false).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), (*string)(nil), &inputCollectionID, []uuid.UUID(nil), false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	// Check if output collection already exists
@@ -434,7 +434,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
 			inputCollID := inputCollectionID
-			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), false).
+			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), []uuid.UUID(nil), false).
 				Return([]*dbmodel.AttachedFunction{incompleteAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup),
@@ -525,7 +525,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
 			inputCollID := inputCollectionID
-			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), false).
+			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), []uuid.UUID(nil), false).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup)

--- a/go/pkg/sysdb/coordinator/list_attached_functions_test.go
+++ b/go/pkg/sysdb/coordinator/list_attached_functions_test.go
@@ -86,7 +86,7 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_Success()
 	}
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), true).Return(attachedFunctions, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), []uuid.UUID(nil), true).Return(attachedFunctions, nil).Once()
 
 	functionOne := &dbmodel.Function{ID: functionID1, Name: "function-one", IsAsync: false}
 	functionTwo := &dbmodel.Function{ID: functionID2, Name: "function-two", IsAsync: true}
@@ -132,7 +132,7 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_EmptyResu
 	collectionID := "test-collection"
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), true).Return([]*dbmodel.AttachedFunction{}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), []uuid.UUID(nil), true).Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	req := &coordinatorpb.GetAttachedFunctionsRequest{InputCollectionId: &collectionID}
 	resp, err := suite.coordinator.GetAttachedFunctions(ctx, req)
@@ -165,7 +165,7 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_FunctionD
 	}
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), true).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), []uuid.UUID(nil), true).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
 
 	suite.mockMetaDomain.On("FunctionDb", ctx).Return(suite.mockFunctionDb).Once()
 	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{functionID}).Return(nil, errors.New("db error")).Once()
@@ -200,7 +200,7 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_InvalidPa
 	}
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), true).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, (*string)(nil), []uuid.UUID(nil), true).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
 
 	functionModel := &dbmodel.Function{ID: functionID, Name: "function", IsAsync: false}
 

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -720,7 +720,7 @@ func (tc *Catalog) softDeleteCollection(ctx context.Context, deleteCollection *m
 
 		// List attached functions for this collection (as input) and soft delete them
 		deleteCollectionIDStr := deleteCollection.ID.String()
-		attachedFunctions, err := tc.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &deleteCollectionIDStr, nil, true)
+		attachedFunctions, err := tc.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &deleteCollectionIDStr, nil, nil, true)
 		if err != nil {
 			return err
 		}
@@ -735,7 +735,7 @@ func (tc *Catalog) softDeleteCollection(ctx context.Context, deleteCollection *m
 		// This is done transactionally - either all functions are deleted or none are
 		// Query for all attached functions that have this collection as their output
 		outputCollectionIDStr := deleteCollection.ID.String()
-		attachedFunctionsWithOutput, err := tc.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, nil, &outputCollectionIDStr, false)
+		attachedFunctionsWithOutput, err := tc.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, nil, &outputCollectionIDStr, nil, false)
 		if err != nil {
 			log.Error("Failed to query attached functions by output collection", zap.Error(err))
 			return fmt.Errorf("failed to query attached functions for output collection: %w", err)

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -101,7 +101,7 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 	err := s.catalog.txImpl.Transaction(ctx, func(txCtx context.Context) error {
 		// Check if there's any active (ready, non-deleted) attached function for this collection
 		// We only allow one active attached function per collection
-		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &req.InputCollectionId, nil, false)
+		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &req.InputCollectionId, nil, nil, false)
 		if err != nil {
 			log.Error("AttachFunction: failed to check for existing attached function", zap.Error(err))
 			return err
@@ -168,7 +168,7 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 
 		// Check if input collection is being used as an output collection by any attached function
 		inputCollectionIDStr := req.InputCollectionId
-		attachedFunctionsUsingAsOutput, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, nil, &inputCollectionIDStr, false)
+		attachedFunctionsUsingAsOutput, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, nil, &inputCollectionIDStr, nil, false)
 		if err != nil {
 			log.Error("AttachFunction: failed to check if input collection is used as output", zap.Error(err))
 			return err
@@ -303,6 +303,12 @@ func attachedFunctionToProto(attachedFunction *dbmodel.AttachedFunction, functio
 // GetAttachedFunctions retrieves attached functions using flexible query parameters
 // All parameters are optional - nil means don't filter on that field
 func (s *Coordinator) GetAttachedFunctions(ctx context.Context, req *coordinatorpb.GetAttachedFunctionsRequest) (*coordinatorpb.GetAttachedFunctionsResponse, error) {
+	// Validate that both id and ids are not provided together
+	if req.Id != nil && len(req.Ids) > 0 {
+		log.Error("GetAttachedFunctions: cannot provide both 'id' and 'ids' parameters")
+		return nil, status.Errorf(codes.InvalidArgument, "cannot provide both 'id' and 'ids' parameters")
+	}
+
 	// Parse optional ID parameter
 	var idPtr *uuid.UUID
 	if req.Id != nil {
@@ -314,13 +320,34 @@ func (s *Coordinator) GetAttachedFunctions(ctx context.Context, req *coordinator
 		idPtr = &parsed
 	}
 
+	// Parse multiple IDs if provided
+	var ids []uuid.UUID
+	if len(req.Ids) > 0 {
+		// Enforce a reasonable limit on the number of IDs to prevent overly large queries
+		const maxIDs = 100
+		if len(req.Ids) > maxIDs {
+			log.Error("GetAttachedFunctions: too many IDs provided", zap.Int("count", len(req.Ids)), zap.Int("max", maxIDs))
+			return nil, status.Errorf(codes.InvalidArgument, "too many IDs provided: %d (maximum: %d)", len(req.Ids), maxIDs)
+		}
+
+		ids = make([]uuid.UUID, 0, len(req.Ids))
+		for _, idStr := range req.Ids {
+			parsed, err := uuid.Parse(idStr)
+			if err != nil {
+				log.Error("GetAttachedFunctions: invalid id in ids array", zap.String("id", idStr), zap.Error(err))
+				return nil, status.Errorf(codes.InvalidArgument, "invalid id in ids array: %v", err)
+			}
+			ids = append(ids, parsed)
+		}
+	}
+
 	// Default onlyReady to true if not specified
 	onlyReady := true
 	if req.OnlyReady != nil {
 		onlyReady = *req.OnlyReady
 	}
 
-	attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).GetAttachedFunctions(idPtr, req.Name, req.InputCollectionId, nil, onlyReady)
+	attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).GetAttachedFunctions(idPtr, req.Name, req.InputCollectionId, nil, ids, onlyReady)
 	if err != nil {
 		log.Error("GetAttachedFunctions: failed to get attached functions", zap.Error(err))
 		return nil, err
@@ -389,7 +416,7 @@ func (s *Coordinator) GetAttachedFunctions(ctx context.Context, req *coordinator
 // DetachFunction soft deletes an attached function by name
 func (s *Coordinator) DetachFunction(ctx context.Context, req *coordinatorpb.DetachFunctionRequest) (*coordinatorpb.DetachFunctionResponse, error) {
 	// First get the attached function to check if we need to delete the output collection
-	attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).GetAttachedFunctions(nil, &req.Name, &req.InputCollectionId, nil, true)
+	attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).GetAttachedFunctions(nil, &req.Name, &req.InputCollectionId, nil, nil, true)
 	if err != nil {
 		log.Error("DetachFunction: failed to get attached function", zap.Error(err))
 		return nil, err
@@ -491,7 +518,7 @@ func (s *Coordinator) FinishCreateAttachedFunction(ctx context.Context, req *coo
 	// Execute all operations in a transaction for atomicity
 	err = s.catalog.txImpl.Transaction(ctx, func(txCtx context.Context) error {
 		// 1. Get the attached function to retrieve metadata
-		attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, false)
+		attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, nil, false)
 		if err != nil {
 			log.Error("FinishCreateAttachedFunction: failed to get attached function", zap.Error(err))
 			return err
@@ -606,7 +633,7 @@ func (s *Coordinator) FinishCreateAttachedFunction(ctx context.Context, req *coo
 		}
 
 		// 7. Validate that there is only one ready attached function for this collection
-		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &attachedFunction.InputCollectionID, nil, true)
+		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &attachedFunction.InputCollectionID, nil, nil, true)
 		if err != nil {
 			log.Error("FinishCreateAttachedFunction: failed to get attached functions", zap.Error(err))
 			return err
@@ -755,7 +782,7 @@ func (s *Coordinator) TryFinishAsyncAttachedFunctionInvocation(ctx context.Conte
 	var witnessedLogOffset int64
 
 	err = s.catalog.txImpl.Transaction(ctx, func(txCtx context.Context) error {
-		attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, true)
+		attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, nil, true)
 		if err != nil {
 			log.Error("Failed to get attached function", zap.Error(err))
 			return err

--- a/go/pkg/sysdb/metastore/db/dao/attached_function_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/attached_function_test.go
@@ -150,7 +150,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByName() {
 	// Retrieve by name
 	inputColID := "input_col_id"
 	attachedFunctionName := "test-get-attachedFunction"
-	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunctionName, &inputColID, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunctionName, &inputColID, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 1)
 	retrieved := retrievedList[0]
@@ -186,7 +186,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByName_NotRe
 	// Retrieve by name with onlyReady=true should not return it
 	inputColID := "input_col_id"
 	attachedFunctionName := "test-get-attachedFunction"
-	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunctionName, &inputColID, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunctionName, &inputColID, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 
@@ -198,7 +198,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByName_NotFo
 	// Try to get non-existent attached function
 	inputColID := "input_col_id"
 	nonexistentName := "nonexistent-attachedFunction"
-	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &nonexistentName, &inputColID, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &nonexistentName, &inputColID, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 }
@@ -231,7 +231,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByName_Ignor
 	// GetByName should not return it
 	inputColID := "input1"
 	deletedName := "test-deleted-attachedFunction"
-	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &deletedName, &inputColID, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(nil, &deletedName, &inputColID, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 
@@ -334,7 +334,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_DeleteAll() {
 
 	// Verify all attached functions are deleted
 	for _, attachedFunction := range attachedFunctions {
-		retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunction.Name, &attachedFunction.InputCollectionID, nil, true)
+		retrievedList, err := suite.Db.GetAttachedFunctions(nil, &attachedFunction.Name, &attachedFunction.InputCollectionID, nil, nil, true)
 		suite.Require().NoError(err)
 		suite.Require().Len(retrievedList, 0)
 	}
@@ -365,7 +365,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByID() {
 	err := suite.Db.Insert(attachedFunction)
 	suite.Require().NoError(err)
 
-	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 1)
 	retrieved := retrievedList[0]
@@ -396,7 +396,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByID_NoReady
 	err := suite.Db.Insert(attachedFunction)
 	suite.Require().NoError(err)
 
-	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 
@@ -405,7 +405,7 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByID_NoReady
 
 func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByID_NotFound() {
 	nonexistentID := uuid.New()
-	retrievedList, err := suite.Db.GetAttachedFunctions(&nonexistentID, nil, nil, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(&nonexistentID, nil, nil, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 }
@@ -433,11 +433,56 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetByID_Ignores
 	err = suite.Db.SoftDelete("input1", "test-get-by-id-deleted")
 	suite.Require().NoError(err)
 
-	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, true)
+	retrievedList, err := suite.Db.GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(retrievedList, 0)
 
 	suite.db.Unscoped().Delete(&dbmodel.AttachedFunction{}, "id = ?", attachedFunction.ID)
+}
+
+func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_GetAttachedFunctions_ErrorWhenBothIdAndIdsProvided() {
+	// Create two test attached functions
+	attachedFunction1 := &dbmodel.AttachedFunction{
+		ID:                      uuid.New(),
+		Name:                    "test-both-params-1",
+		FunctionID:              dbmodel.FunctionRecordCounter,
+		InputCollectionID:       "input1",
+		OutputCollectionName:    "output1",
+		FunctionParams:          "{}",
+		TenantID:                "tenant1",
+		DatabaseID:              "db1",
+		MinRecordsForInvocation: 100,
+		IsReady:                 true,
+	}
+	attachedFunction2 := &dbmodel.AttachedFunction{
+		ID:                      uuid.New(),
+		Name:                    "test-both-params-2",
+		FunctionID:              dbmodel.FunctionRecordCounter,
+		InputCollectionID:       "input1",
+		OutputCollectionName:    "output2",
+		FunctionParams:          "{}",
+		TenantID:                "tenant1",
+		DatabaseID:              "db1",
+		MinRecordsForInvocation: 100,
+		IsReady:                 true,
+	}
+
+	err := suite.Db.Insert(attachedFunction1)
+	suite.Require().NoError(err)
+	err = suite.Db.Insert(attachedFunction2)
+	suite.Require().NoError(err)
+
+	// Test that providing both id and ids returns an error
+	singleID := attachedFunction1.ID
+	multipleIDs := []uuid.UUID{attachedFunction1.ID, attachedFunction2.ID}
+
+	_, err = suite.Db.GetAttachedFunctions(&singleID, nil, nil, nil, multipleIDs, true)
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "cannot provide both 'id' and 'ids' parameters")
+
+	// Clean up
+	suite.db.Unscoped().Delete(&dbmodel.AttachedFunction{}, "id = ?", attachedFunction1.ID)
+	suite.db.Unscoped().Delete(&dbmodel.AttachedFunction{}, "id = ?", attachedFunction2.ID)
 }
 
 // TestFunctionConstantsMatchSeededDatabase verifies that function constants in

--- a/go/pkg/sysdb/metastore/db/dao/task.go
+++ b/go/pkg/sysdb/metastore/db/dao/task.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/chroma-core/chroma/go/pkg/common"
@@ -131,17 +132,26 @@ func (s *attachedFunctionDb) UpdateHeapEntryPending(id uuid.UUID, heapEntryPendi
 
 // GetAttachedFunctions is a consolidated getter that supports various query patterns
 // Parameters can be nil to indicate they should not be filtered on
-// - id: Filter by attached function ID
+// - id: DEPRECATED - Use ids instead. Filter by attached function ID
 // - name: Filter by attached function name
 // - inputCollectionID: Filter by input collection ID
 // - outputCollectionID: Filter by output collection ID
+// - ids: Filter by multiple attached function IDs (cannot be used together with id)
 // - onlyReady: If true, only returns attached functions where is_ready = true
-func (s *attachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
+func (s *attachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, ids []uuid.UUID, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
 	var attachedFunctions []*dbmodel.AttachedFunction
+
+	// Validate that both id and ids are not provided together
+	if id != nil && len(ids) > 0 {
+		return nil, fmt.Errorf("cannot provide both 'id' and 'ids' parameters")
+	}
 
 	query := s.db.Where("is_deleted = ?", false)
 
-	if id != nil {
+	// Handle ID filtering
+	if len(ids) > 0 {
+		query = query.Where("id IN ?", ids)
+	} else if id != nil {
 		query = query.Where("id = ?", *id)
 	}
 

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
@@ -112,9 +112,9 @@ func (_m *IAttachedFunctionDb) Finish(id uuid.UUID) error {
 	return r0
 }
 
-// GetAttachedFunctions provides a mock function with given fields: id, name, inputCollectionID, outputCollectionID, onlyReady
-func (_m *IAttachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
-	ret := _m.Called(id, name, inputCollectionID, outputCollectionID, onlyReady)
+// GetAttachedFunctions provides a mock function with given fields: id, name, inputCollectionID, outputCollectionID, ids, onlyReady
+func (_m *IAttachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, ids []uuid.UUID, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
+	ret := _m.Called(id, name, inputCollectionID, outputCollectionID, ids, onlyReady)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAttachedFunctions")
@@ -122,19 +122,19 @@ func (_m *IAttachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string,
 
 	var r0 []*dbmodel.AttachedFunction
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*uuid.UUID, *string, *string, *string, bool) ([]*dbmodel.AttachedFunction, error)); ok {
-		return rf(id, name, inputCollectionID, outputCollectionID, onlyReady)
+	if rf, ok := ret.Get(0).(func(*uuid.UUID, *string, *string, *string, []uuid.UUID, bool) ([]*dbmodel.AttachedFunction, error)); ok {
+		return rf(id, name, inputCollectionID, outputCollectionID, ids, onlyReady)
 	}
-	if rf, ok := ret.Get(0).(func(*uuid.UUID, *string, *string, *string, bool) []*dbmodel.AttachedFunction); ok {
-		r0 = rf(id, name, inputCollectionID, outputCollectionID, onlyReady)
+	if rf, ok := ret.Get(0).(func(*uuid.UUID, *string, *string, *string, []uuid.UUID, bool) []*dbmodel.AttachedFunction); ok {
+		r0 = rf(id, name, inputCollectionID, outputCollectionID, ids, onlyReady)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*dbmodel.AttachedFunction)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*uuid.UUID, *string, *string, *string, bool) error); ok {
-		r1 = rf(id, name, inputCollectionID, outputCollectionID, onlyReady)
+	if rf, ok := ret.Get(1).(func(*uuid.UUID, *string, *string, *string, []uuid.UUID, bool) error); ok {
+		r1 = rf(id, name, inputCollectionID, outputCollectionID, ids, onlyReady)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/go/pkg/sysdb/metastore/db/dbmodel/task.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/task.go
@@ -39,12 +39,13 @@ type IAttachedFunctionDb interface {
 	Insert(attachedFunction *AttachedFunction) error
 	// GetAttachedFunctions is a consolidated getter that supports various query patterns
 	// Parameters can be nil to indicate they should not be filtered on
-	// - id: Filter by attached function ID
+	// - id: DEPRECATED - Use ids instead. Filter by attached function ID
 	// - name: Filter by attached function name
 	// - inputCollectionID: Filter by input collection ID
 	// - outputCollectionID: Filter by output collection ID
+	// - ids: Filter by multiple attached function IDs (cannot be used together with id)
 	// - onlyReady: If true, only returns attached functions where is_ready = true
-	GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, onlyReady bool) ([]*AttachedFunction, error)
+	GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, ids []uuid.UUID, onlyReady bool) ([]*AttachedFunction, error)
 	Update(attachedFunction *AttachedFunction) error
 	UpdateCompletionOffsetAndHeapEntry(id uuid.UUID, collectionID string, newOffset int64) error
 	UpdateHeapEntryPending(id uuid.UUID, heapEntryPending bool) error

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -580,14 +580,17 @@ message AttachFunctionResponse {
 
 message GetAttachedFunctionsRequest {
   // All parameters are optional - nil means don't filter on that field
-  // - id: Filter by attached function ID (UUID string)
+  // - id: DEPRECATED - Use ids field instead. Filter by attached function ID (UUID string)
   // - name: Filter by attached function name
   // - input_collection_id: Filter by input collection ID
   // - only_ready: If true, only returns attached functions where is_ready = true (default: true)
-  optional string id = 1;
+  // - ids: Filter by multiple attached function IDs. Pass a single-element array to filter by one ID.
+  //        Maximum 100 IDs can be queried at once.
+  optional string id = 1 [deprecated = true];
   optional string name = 2;
   optional string input_collection_id = 3;
   optional bool only_ready = 4;
+  repeated string ids = 5;
 }
 
 message GetAttachedFunctionsResponse {

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -2645,9 +2645,9 @@ impl ServiceBasedFrontend {
         let attached_functions = self
             .sysdb_client
             .get_attached_functions(
-                None,
                 Some(function_name.clone()),
                 Some(collection_uuid),
+                vec![],
                 true,
             )
             .await?;

--- a/rust/sysdb/src/bin/chroma-task-manager.rs
+++ b/rust/sysdb/src/bin/chroma-task-manager.rs
@@ -139,9 +139,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             name,
         } => {
             let request = chroma_proto::GetAttachedFunctionsRequest {
+                #[allow(deprecated)]
                 id: None,
                 name: Some(name),
                 input_collection_id: Some(input_collection_id),
+                ids: vec![],
                 only_ready: Some(true),
             };
 

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -1620,9 +1620,11 @@ impl GrpcSysDb {
         let res = self
             .client
             .get_attached_functions(chroma_proto::GetAttachedFunctionsRequest {
+                #[allow(deprecated)]
                 id: None,
                 name: None,
                 input_collection_id: Some(collection_id.0.to_string()),
+                ids: vec![],
                 only_ready: Some(true),
             })
             .await
@@ -2379,18 +2381,41 @@ impl GrpcSysDb {
 
     /// Get attached functions using flexible query parameters
     /// All parameters are optional - None means don't filter on that field
+    /// Maximum 100 IDs can be queried at once
     pub async fn get_attached_functions(
         &mut self,
-        id: Option<chroma_types::AttachedFunctionUuid>,
         name: Option<String>,
         input_collection_id: Option<chroma_types::CollectionUuid>,
+        ids: Vec<chroma_types::AttachedFunctionUuid>,
         only_ready: bool,
     ) -> Result<Vec<chroma_types::AttachedFunction>, GetAttachedFunctionError> {
+        // Enforce a reasonable limit on the number of IDs to prevent overly large queries
+        const MAX_IDS: usize = 100;
+        if ids.len() > MAX_IDS {
+            return Err(GetAttachedFunctionError::InvalidArgument(format!(
+                "Too many IDs provided: {} (maximum: {})",
+                ids.len(),
+                MAX_IDS
+            )));
+        }
+
+        // Convert ids to strings for the proto request
+        let ids_as_strings: Vec<String> = ids.into_iter().map(|id| id.0.to_string()).collect();
+
+        // If we have exactly one ID, also set the deprecated id field for backward compatibility
+        let single_id = if ids_as_strings.len() == 1 {
+            Some(ids_as_strings[0].clone())
+        } else {
+            None
+        };
+
         let req = chroma_proto::GetAttachedFunctionsRequest {
-            id: id.map(|id| id.0.to_string()),
+            #[allow(deprecated)]
+            id: single_id,
             name,
             input_collection_id: input_collection_id.map(|id| id.to_string()),
             only_ready: Some(only_ready),
+            ids: ids_as_strings,
         };
 
         let response = match self.client.get_attached_functions(req).await {
@@ -2688,16 +2713,27 @@ impl SysDb {
 
     /// Get attached functions using flexible query parameters
     /// All parameters are optional - None means don't filter on that field
+    /// Maximum 100 IDs can be queried at once
     pub async fn get_attached_functions(
         &mut self,
-        id: Option<chroma_types::AttachedFunctionUuid>,
         name: Option<String>,
         input_collection_id: Option<chroma_types::CollectionUuid>,
+        ids: Vec<chroma_types::AttachedFunctionUuid>,
         only_ready: bool,
     ) -> Result<Vec<chroma_types::AttachedFunction>, GetAttachedFunctionError> {
+        // Enforce the same limit here as in GrpcSysDb
+        const MAX_IDS: usize = 100;
+        if ids.len() > MAX_IDS {
+            return Err(GetAttachedFunctionError::InvalidArgument(format!(
+                "Too many IDs provided: {} (maximum: {})",
+                ids.len(),
+                MAX_IDS
+            )));
+        }
+
         match self {
             SysDb::Grpc(grpc) => {
-                grpc.get_attached_functions(id, name, input_collection_id, only_ready)
+                grpc.get_attached_functions(name, input_collection_id, ids, only_ready)
                     .await
             }
             SysDb::Sqlite(_) => {
@@ -2879,6 +2915,8 @@ pub enum GetAttachedFunctionError {
     FailedToGetAttachedFunction(tonic::Status),
     #[error("Server returned invalid data")]
     ServerReturnedInvalidData,
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
 }
 
 impl ChromaError for GetAttachedFunctionError {
@@ -2888,6 +2926,7 @@ impl ChromaError for GetAttachedFunctionError {
             GetAttachedFunctionError::NotReady => ErrorCodes::FailedPrecondition,
             GetAttachedFunctionError::FailedToGetAttachedFunction(e) => e.code().into(),
             GetAttachedFunctionError::ServerReturnedInvalidData => ErrorCodes::Internal,
+            GetAttachedFunctionError::InvalidArgument(_) => ErrorCodes::InvalidArgument,
         }
     }
 }

--- a/rust/worker/src/execution/functions/statistics.rs
+++ b/rust/worker/src/execution/functions/statistics.rs
@@ -1416,9 +1416,9 @@ mod tests {
         // Verify statistics were generated
         let attached_functions = sysdb
             .get_attached_functions(
-                None,
                 Some(attached_function_name.clone()),
                 Some(collection_id),
+                vec![],
                 true,
             )
             .await

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -4085,9 +4085,9 @@ mod tests {
         // Verify the attached function was executed
         let attached_functions = sysdb
             .get_attached_functions(
-                None,
                 Some(attached_function_name.clone()),
                 Some(collection_id),
+                vec![],
                 true,
             )
             .await
@@ -4175,9 +4175,9 @@ mod tests {
         // Verify the attached function was NOT executed (completion_offset should still be 9)
         let attached_functions = sysdb
             .get_attached_functions(
-                None,
                 Some(attached_function_name.clone()),
                 Some(collection_id),
+                vec![],
                 true,
             )
             .await
@@ -5108,9 +5108,9 @@ mod tests {
         // Verify the attached function was found
         let attached_functions = sysdb
             .get_attached_functions(
-                None,
                 Some(attached_function_name.clone()),
                 Some(collection_id),
+                vec![],
                 true,
             )
             .await

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -340,12 +340,6 @@ impl FnConsumerManager {
 #[derive(Clone, Debug)]
 pub struct ScheduledPollMessage;
 
-#[derive(Clone, Debug)]
-pub struct RemoveInProgressMessage {
-    pub fn_id: AttachedFunctionUuid,
-    pub input_coll_id: CollectionUuid,
-}
-
 #[async_trait]
 impl Component for FnConsumerManager {
     fn get_name() -> &'static str {
@@ -379,14 +373,5 @@ impl Handler<ScheduledPollMessage> for FnConsumerManager {
             ctx,
             || Some(span!(parent: None, tracing::Level::INFO, "Scheduled fn-consumer poll")),
         );
-    }
-}
-
-#[async_trait]
-impl Handler<RemoveInProgressMessage> for FnConsumerManager {
-    type Result = ();
-
-    async fn handle(&mut self, msg: RemoveInProgressMessage, _ctx: &ComponentContext<Self>) {
-        self.in_progress.remove(&(msg.fn_id, msg.input_coll_id));
     }
 }


### PR DESCRIPTION
## Description of changes

The `FnConsumerManager` was keying its "in-progress" job scheduler on `(fn_id, input_coll_id)` — a `FnJobKey`. The bug: multiple different attached functions could share the same output collection, and the old key didn't prevent two jobs from writing to the same output collection concurrently. The fix re-keys the in-progress map on `output_coll_id` (`CollectionUuid`), which is the actual resource that must be serialized.

To support this, `GetAttachedFunctions` gains a batch `ids` parameter so the manager can look up all output collection IDs in a single sysdb call rather than one per work item.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_