### PR TITLE
[ENH] Chunk bitmap for FTS index

### DIFF
--- a/rust/index/src/fulltext/README.md
+++ b/rust/index/src/fulltext/README.md
@@ -12,15 +12,19 @@ Word-based full-text substring search using hashed token buckets with roaring bi
 
 ## Blockfile Layout
 
-A single blockfile typed as `(prefix: &str, key: u32) → RoaringBitmap` with three logical partitions:
+A single blockfile typed as `(prefix: &str, key: u32) → RoaringBitmap`. The key layout uses the top 2 bits as flags, the middle 24 bits for the hash/bucket ID, and the bottom 6 bits for the chunk index: `[flags:2][id:24][chunk:6]`.
 
-1. **Token buckets** — `prefix=""`, `key ∈ [0, 2^24)`. Each token is hashed to a bucket ID. The bitmap stores doc IDs containing tokens in that bucket.
+Doc-ID bitmaps are chunked into 2^24 (16M) doc-ID ranges, supporting up to 1B doc IDs. Each chunk's bitmap stays under ~4 MB.
 
-2. **Transitions** — `prefix=""`, `key ∈ [2^24, 2^26)`. For each adjacent token pair, the boundary characters are hashed. Two entries per transition: `key = hash | (1 << 24)` for doc-ID bitmap, `key = hash | (1 << 25)` for bucket-ID bitmap.
+1. **Token buckets** — `prefix=""`, flags `00`. `key = (bucket_id << 6) | chunk_index`. Each token is hashed to a 24-bit bucket ID. Doc-ID bitmaps are chunked.
 
-3. **Trigrams** — `prefix="{trigram}"`, `key ∈ {0, 1, 2}`. Maps character trigrams to bucket IDs with disjoint positional keys: 0 = prefix (first trigram of token), 1 = infix, 2 = suffix (last trigram). Single-trigram tokens (3 chars) are stored under both key=0 and key=2.
+2. **Transition doc bitmaps** — `prefix=""`, flags `01`. `key = (1 << 30) | (hash << 6) | chunk_index`. Chunked like token buckets.
 
-Entries are written in `(prefix, key)` sorted order: all token buckets, then transitions, then trigrams.
+3. **Transition bucket bitmaps** — `prefix=""`, flags `10`. `key = (1 << 31) | hash`. Not chunked (stores bucket IDs, not doc IDs).
+
+4. **Trigrams** — `prefix="{trigram}"`, `key ∈ {0, 1, 2}`. Maps character trigrams to bucket IDs with disjoint positional keys: 0 = prefix (first trigram of token), 1 = infix, 2 = suffix (last trigram). Single-trigram tokens (3 chars) are stored under both key=0 and key=2.
+
+Entries are written in `(prefix, key)` sorted order: token buckets (flags `00`), then transition docs (flags `01`), then transition buckets (flags `10`), then trigrams.
 
 ## Query Pipeline
 

--- a/rust/index/src/fulltext/README.md
+++ b/rust/index/src/fulltext/README.md
@@ -12,19 +12,19 @@ Word-based full-text substring search using hashed token buckets with roaring bi
 
 ## Blockfile Layout
 
-A single blockfile typed as `(prefix: &str, key: u32) → RoaringBitmap`. The key layout uses the top 2 bits as flags, the middle 24 bits for the hash/bucket ID, and the bottom 6 bits for the chunk index: `[flags:2][id:24][chunk:6]`.
+A single blockfile typed as `(prefix: &str, key: u32) → RoaringBitmap`. The 32-bit key is laid out as `[partition:2][id:24][chunk:6]`. The top 2 bits select the partition, the middle 24 bits hold the hash/bucket ID, and the bottom 6 bits hold the chunk index.
 
 Doc-ID bitmaps are chunked into 2^24 (16M) doc-ID ranges, supporting up to 1B doc IDs. Each chunk's bitmap stays under ~4 MB.
 
-1. **Token buckets** — `prefix=""`, flags `00`. `key = (bucket_id << 6) | chunk_index`. Each token is hashed to a 24-bit bucket ID. Doc-ID bitmaps are chunked.
+1. **Token buckets** — `prefix=""`, keys `[0, 2^30)`. `key = (bucket_id << 6) | chunk_index`. Each token is hashed to a 24-bit bucket ID. Doc-ID bitmaps are chunked.
 
-2. **Transition doc bitmaps** — `prefix=""`, flags `01`. `key = (1 << 30) | (hash << 6) | chunk_index`. Chunked like token buckets.
+2. **Transition doc bitmaps** — `prefix=""`, keys `[2^30, 2^31)`. `key = (1 << 30) | (hash << 6) | chunk_index`. Chunked like token buckets.
 
-3. **Transition bucket bitmaps** — `prefix=""`, flags `10`. `key = (1 << 31) | hash`. Not chunked (stores bucket IDs, not doc IDs).
+3. **Transition bucket bitmaps** — `prefix=""`, keys `[2^31, 2^31 + 2^24)`. `key = (1 << 31) | hash`. Not chunked (stores bucket IDs, not doc IDs).
 
 4. **Trigrams** — `prefix="{trigram}"`, `key ∈ {0, 1, 2}`. Maps character trigrams to bucket IDs with disjoint positional keys: 0 = prefix (first trigram of token), 1 = infix, 2 = suffix (last trigram). Single-trigram tokens (3 chars) are stored under both key=0 and key=2.
 
-Entries are written in `(prefix, key)` sorted order: token buckets (flags `00`), then transition docs (flags `01`), then transition buckets (flags `10`), then trigrams.
+Entries are written in `(prefix, key)` sorted order: token buckets, then transition docs, then transition buckets, then trigrams.
 
 ## Query Pipeline
 

--- a/rust/index/src/fulltext/bitmap_index.rs
+++ b/rust/index/src/fulltext/bitmap_index.rs
@@ -9,10 +9,19 @@ use uuid::Uuid;
 
 use super::tokenizer::{DocumentTokens, QueryPlan, TokenLookup};
 
-/// Transition doc-ID keys: `key = hash | (1 << 24)`, range `[2^24, 2^25)`.
-const TRANSITION_DOC_FLAG: u32 = 1 << 24;
-/// Transition bucket-ID keys: `key = hash | (1 << 25)`, range `[2^25, 2^25 + 2^24)`.
-const TRANSITION_BUCKET_FLAG: u32 = 1 << 25;
+/// Key layout (32 bits): `[flags:2][id:24][chunk:6]`.
+///
+/// Doc-ID bitmaps (token buckets and transition docs) are chunked into
+/// 2^CHUNK_BITS (16M) doc-ID ranges, bounding per-entry bitmap size.
+/// Flags in the top 2 bits distinguish the partition:
+///   00 = token bucket doc-ID bitmap
+///   01 = transition doc-ID bitmap
+///   10 = transition bucket-ID bitmap (not chunked, chunk bits unused)
+const CHUNK_BITS: u32 = 24;
+const CHUNK_SHIFT: u32 = 6;
+const MAX_CHUNK: u32 = (1 << CHUNK_SHIFT) - 1;
+const TRANSITION_DOC_FLAG: u32 = 1 << 30;
+const TRANSITION_BUCKET_FLAG: u32 = 1 << 31;
 
 // ---------------------------------------------------------------------------
 // Error
@@ -66,17 +75,17 @@ struct TrigramDelta {
 ///
 /// # Blockfile layout
 ///
-/// A single blockfile with three logical partitions, distinguished by
-/// prefix and key range. The blockfile writer requires `(prefix, key)`
-/// pairs in globally sorted order, so entries are written as:
+/// A single blockfile with four logical partitions under `prefix=""`,
+/// plus trigram entries under `prefix="{trigram}"`. The top 2 bits of
+/// the key distinguish the partition:
 ///
-/// 1. `prefix=""`, token bucket keys `[0, 2^24)` — doc-ID bitmaps
-/// 2. `prefix=""`, transition keys `[2^24, 2^26)` — doc-ID and bucket-ID bitmaps
-/// 3. `prefix="{trigram}"`, keys 0/1/2 — bucket-ID bitmaps (positional)
-///
-/// This ordering ensures all `prefix=""` entries (partitions 1–2) are
-/// written first in ascending key order, followed by trigram entries
-/// sorted by `(prefix, key)`.
+/// 1. `prefix=""`, flags `00` — token bucket doc-ID bitmaps (chunked).
+///    `key = (bucket_id << CHUNK_SHIFT) | chunk_index`.
+/// 2. `prefix=""`, flags `01` — transition doc-ID bitmaps (chunked).
+///    `key = TRANSITION_DOC_FLAG | (hash << CHUNK_SHIFT) | chunk_index`.
+/// 3. `prefix=""`, flags `10` — transition bucket-ID bitmaps (not chunked).
+///    `key = TRANSITION_BUCKET_FLAG | hash`.
+/// 4. `prefix="{trigram}"`, keys 0/1/2 — positional bucket-ID bitmaps.
 #[derive(Clone)]
 pub struct FullTextBitmapWriter {
     bitmap_writer: BlockfileWriter,
@@ -144,12 +153,14 @@ impl FullTextBitmapWriter {
     /// Merge accumulated deltas into the blockfile.
     ///
     /// Writes in `(prefix, key)` sorted order as required by the blockfile:
-    /// 1. Token buckets: `prefix=""`, keys `[0, 2^24)`
-    /// 2. Transitions: `prefix=""`, keys `[2^24, 2^26)`
-    /// 3. Trigrams: `prefix="{trigram}"`, keys `0/1/2`
+    /// 1. Token buckets (flags `00`)
+    /// 2. Transition doc bitmaps (flags `01`)
+    /// 3. Transition bucket bitmaps (flags `10`)
+    /// 4. Trigrams (`prefix="{trigram}"`)
     pub async fn write_to_blockfiles(&self) -> Result<(), FullTextBitmapError> {
         self.write_token_buckets().await?;
-        self.write_transitions().await?;
+        self.write_transition_docs().await?;
+        self.write_transition_buckets().await?;
         self.write_trigrams().await?;
         Ok(())
     }
@@ -159,41 +170,37 @@ impl FullTextBitmapWriter {
         Ok(FullTextBitmapFlusher { flusher })
     }
 
-    // --- Phases ---
+    // --- Write phases (one per partition, in sorted key order) ---
 
+    /// Partition 1: token bucket doc-ID bitmaps (flags `00`, chunked).
     async fn write_token_buckets(&self) -> Result<(), FullTextBitmapError> {
-        let mut keys: Vec<u32> = self.token_deltas.iter().map(|e| *e.key()).collect();
-        keys.sort_unstable();
+        let mut bucket_ids: Vec<u32> = self.token_deltas.iter().map(|e| *e.key()).collect();
+        bucket_ids.sort_unstable();
 
-        // Preload blocks for all delta keys so point reads hit cache.
         if let Some(reader) = &self.old_reader {
             reader
-                .load_keys(keys.iter().map(|k| (String::new(), *k)))
+                .load_keys(bucket_ids.iter().flat_map(|&b| {
+                    (0u32..=MAX_CHUNK).map(move |c| (String::new(), (b << CHUNK_SHIFT) | c))
+                }))
                 .await;
         }
 
-        for key in keys {
-            let Some((_, delta)) = self.token_deltas.remove(&key) else {
+        for bucket_id in bucket_ids {
+            let Some((_, delta)) = self.token_deltas.remove(&bucket_id) else {
                 continue;
             };
             let mut bitmap = match &self.old_reader {
-                Some(r) => r.get_bucket(key).await?,
+                Some(r) => r.get_doc_bitmap(0, bucket_id).await?,
                 None => RoaringBitmap::new(),
             };
             bitmap |= &delta.adds;
             bitmap -= &delta.deletes;
-
-            if bitmap.is_empty() {
-                self.bitmap_writer
-                    .delete::<u32, RoaringBitmap>("", key)
-                    .await?;
-            } else {
-                self.bitmap_writer.set("", key, bitmap).await?;
-            }
+            self.write_doc_bitmap(0, bucket_id, &bitmap).await?;
         }
         Ok(())
     }
 
+    /// Partition 4: trigram positional bucket-ID bitmaps (not chunked).
     async fn write_trigrams(&self) -> Result<(), FullTextBitmapError> {
         let mut keys: Vec<String> = self
             .trigram_deltas
@@ -221,7 +228,11 @@ impl FullTextBitmapWriter {
                     continue;
                 }
                 let mut bitmap = match &self.old_reader {
-                    Some(r) => r.get_trigram(&trigram, key).await?,
+                    Some(r) => r
+                        .bitmap_reader
+                        .get(&trigram, key)
+                        .await?
+                        .unwrap_or_default(),
                     None => RoaringBitmap::new(),
                 };
                 bitmap |= &new_buckets;
@@ -233,58 +244,100 @@ impl FullTextBitmapWriter {
         Ok(())
     }
 
-    async fn write_transitions(&self) -> Result<(), FullTextBitmapError> {
-        let mut keys: Vec<u32> = self.transition_deltas.iter().map(|e| *e.key()).collect();
-        keys.sort_unstable();
+    /// Partition 2: transition doc-ID bitmaps (flags `01`, chunked).
+    async fn write_transition_docs(&self) -> Result<(), FullTextBitmapError> {
+        let mut hashes: Vec<u32> = self.transition_deltas.iter().map(|e| *e.key()).collect();
+        hashes.sort_unstable();
 
-        // Preload blocks for all transition keys (doc + bucket).
         if let Some(reader) = &self.old_reader {
             reader
-                .load_keys(keys.iter().flat_map(|h| {
-                    [
-                        (String::new(), h | TRANSITION_DOC_FLAG),
-                        (String::new(), h | TRANSITION_BUCKET_FLAG),
-                    ]
+                .load_keys(hashes.iter().flat_map(|&h| {
+                    (0u32..=MAX_CHUNK)
+                        .map(move |c| (String::new(), TRANSITION_DOC_FLAG | (h << CHUNK_SHIFT) | c))
                 }))
                 .await;
         }
 
-        // Doc-ID bitmaps first: keys in [2^24, 2^25).
-        for &hash in &keys {
+        for &hash in &hashes {
             let Some(entry) = self.transition_deltas.get(&hash) else {
                 continue;
             };
             if entry.doc_adds.is_empty() && entry.doc_deletes.is_empty() {
                 continue;
             }
-            let doc_key = hash | TRANSITION_DOC_FLAG;
             let mut bitmap = match &self.old_reader {
-                Some(r) => r.get_bucket(doc_key).await?,
+                Some(r) => r.get_doc_bitmap(TRANSITION_DOC_FLAG, hash).await?,
                 None => RoaringBitmap::new(),
             };
             bitmap |= &entry.doc_adds;
             bitmap -= &entry.doc_deletes;
-            if !bitmap.is_empty() {
-                self.bitmap_writer.set("", doc_key, bitmap).await?;
-            }
+            self.write_doc_bitmap(TRANSITION_DOC_FLAG, hash, &bitmap)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Partition 3: transition bucket-ID bitmaps (flags `10`, not chunked).
+    async fn write_transition_buckets(&self) -> Result<(), FullTextBitmapError> {
+        let mut hashes: Vec<u32> = self.transition_deltas.iter().map(|e| *e.key()).collect();
+        hashes.sort_unstable();
+
+        if let Some(reader) = &self.old_reader {
+            reader
+                .load_keys(
+                    hashes
+                        .iter()
+                        .map(|&h| (String::new(), TRANSITION_BUCKET_FLAG | h)),
+                )
+                .await;
         }
 
-        // Bucket-ID bitmaps second: keys in [2^25, 2^26).
-        for hash in keys {
+        for hash in hashes {
             let Some((_, delta)) = self.transition_deltas.remove(&hash) else {
                 continue;
             };
             if delta.bucket_adds.is_empty() {
                 continue;
             }
-            let bkt_key = hash | TRANSITION_BUCKET_FLAG;
             let mut bitmap = match &self.old_reader {
-                Some(r) => r.get_bucket(bkt_key).await?,
+                Some(r) => r.get_id_bitmap(TRANSITION_BUCKET_FLAG | hash).await?,
                 None => RoaringBitmap::new(),
             };
             bitmap |= &delta.bucket_adds;
-            self.bitmap_writer.set("", bkt_key, bitmap).await?;
+            self.write_id_bitmap(TRANSITION_BUCKET_FLAG | hash, bitmap)
+                .await?;
         }
+        Ok(())
+    }
+
+    // --- Write helpers ---
+
+    /// Write a doc-ID bitmap, splitting it into 16M-range chunks.
+    /// Key encoding: `flag | (id << CHUNK_SHIFT) | chunk_index`.
+    async fn write_doc_bitmap(
+        &self,
+        flag: u32,
+        id: u32,
+        bitmap: &RoaringBitmap,
+    ) -> Result<(), FullTextBitmapError> {
+        let docs: Vec<u32> = bitmap.iter().collect();
+        for chunk_docs in docs.chunk_by(|a, b| a >> CHUNK_BITS == b >> CHUNK_BITS) {
+            let chunk = chunk_docs[0] >> CHUNK_BITS;
+            let chunk_bm: RoaringBitmap = chunk_docs.iter().copied().collect();
+            self.bitmap_writer
+                .set("", flag | (id << CHUNK_SHIFT) | chunk, chunk_bm)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Write a bounded-universe ID bitmap as a single entry.
+    async fn write_id_bitmap(
+        &self,
+        key: u32,
+        bitmap: RoaringBitmap,
+    ) -> Result<(), FullTextBitmapError> {
+        self.bitmap_writer.set("", key, bitmap).await?;
         Ok(())
     }
 }
@@ -344,19 +397,26 @@ impl FullTextBitmapReader {
         }
 
         // Load all transition bitmaps upfront.
-        self.load_keys(plan.transitions.iter().flat_map(|h| {
-            [
-                (String::new(), h | TRANSITION_BUCKET_FLAG),
-                (String::new(), h | TRANSITION_DOC_FLAG),
-            ]
-        }))
+        self.load_keys(
+            plan.transitions
+                .iter()
+                .flat_map(|&h| {
+                    (0u32..=MAX_CHUNK)
+                        .map(move |c| (String::new(), TRANSITION_DOC_FLAG | (h << CHUNK_SHIFT) | c))
+                })
+                .chain(
+                    plan.transitions
+                        .iter()
+                        .map(|&h| (String::new(), TRANSITION_BUCKET_FLAG | h)),
+                ),
+        )
         .await;
 
         let mut transitions = Vec::with_capacity(plan.transitions.len());
         for &hash in &plan.transitions {
             transitions.push((
-                self.get_bucket(hash | TRANSITION_BUCKET_FLAG).await?,
-                self.get_bucket(hash | TRANSITION_DOC_FLAG).await?,
+                self.get_id_bitmap(TRANSITION_BUCKET_FLAG | hash).await?,
+                self.get_doc_bitmap(TRANSITION_DOC_FLAG, hash).await?,
             ));
         }
 
@@ -386,18 +446,18 @@ impl FullTextBitmapReader {
         }
 
         // Stage 2: load doc bitmaps, AND across tokens + transitions.
-        self.load_keys(
-            bucket_sets
-                .iter()
-                .flat_map(|bs| bs.iter().map(|id| (String::new(), id))),
-        )
+        self.load_keys(bucket_sets.iter().flat_map(|bs| {
+            bs.iter().flat_map(|id| {
+                (0u32..=MAX_CHUNK).map(move |c| (String::new(), (id << CHUNK_SHIFT) | c))
+            })
+        }))
         .await;
 
         let mut doc_bitmaps = Vec::with_capacity(bucket_sets.len() + transitions.len());
         for bucket_set in &bucket_sets {
             let mut bm = RoaringBitmap::new();
             for bucket_id in bucket_set {
-                bm |= &self.get_bucket(bucket_id).await?;
+                bm |= &self.get_doc_bitmap(0, bucket_id).await?;
             }
             if bm.is_empty() {
                 return Ok(RoaringBitmap::new());
@@ -418,22 +478,28 @@ impl FullTextBitmapReader {
         self.bitmap_reader.load_data_for_keys(keys).await;
     }
 
-    /// Load a bitmap by key under `prefix=""`.
-    pub async fn get_bucket(&self, key: u32) -> Result<RoaringBitmap, FullTextBitmapError> {
-        Ok(self.bitmap_reader.get("", key).await?.unwrap_or_default())
+    // --- Read helpers ---
+
+    /// Load a doc-ID bitmap, merging all chunks via range read.
+    /// Key encoding: `flag | (id << CHUNK_SHIFT) | chunk_index`.
+    pub async fn get_doc_bitmap(
+        &self,
+        flag: u32,
+        id: u32,
+    ) -> Result<RoaringBitmap, FullTextBitmapError> {
+        let lo = flag | (id << CHUNK_SHIFT);
+        let hi = lo | MAX_CHUNK;
+        let entries = self.bitmap_reader.get_range(""..="", lo..=hi).await?;
+        let mut result = RoaringBitmap::new();
+        for (_, _, chunk_bm) in entries {
+            result |= chunk_bm;
+        }
+        Ok(result)
     }
 
-    /// Load a trigram bitmap by trigram string and positional key.
-    pub async fn get_trigram(
-        &self,
-        trigram: &str,
-        key: u32,
-    ) -> Result<RoaringBitmap, FullTextBitmapError> {
-        Ok(self
-            .bitmap_reader
-            .get(trigram, key)
-            .await?
-            .unwrap_or_default())
+    /// Load a bounded-universe ID bitmap via point read.
+    pub async fn get_id_bitmap(&self, key: u32) -> Result<RoaringBitmap, FullTextBitmapError> {
+        Ok(self.bitmap_reader.get("", key).await?.unwrap_or_default())
     }
 
     // --- Private helpers ---
@@ -481,7 +547,11 @@ impl FullTextBitmapReader {
 
             let mut bm = RoaringBitmap::new();
             for &key in keys {
-                bm |= &self.get_trigram(trigram, key).await?;
+                bm |= &self
+                    .bitmap_reader
+                    .get(trigram, key)
+                    .await?
+                    .unwrap_or_default();
             }
             bitmaps.push(bm);
         }
@@ -555,13 +625,13 @@ mod tests {
 
         // "hello" bucket (shared): doc 2 only.
         let hello_bucket = *hw_buckets.iter().find(|b| hr_buckets.contains(b)).unwrap();
-        let bm = reader.get_bucket(hello_bucket).await.unwrap();
+        let bm = reader.get_doc_bitmap(0, hello_bucket).await.unwrap();
         assert!(!bm.contains(1));
         assert!(bm.contains(2));
 
         // "world" bucket (unique to doc 1): empty after delete.
         let world_bucket = *hw_buckets.iter().find(|b| !hr_buckets.contains(b)).unwrap();
-        let bm = reader.get_bucket(world_bucket).await.unwrap();
+        let bm = reader.get_doc_bitmap(0, world_bucket).await.unwrap();
         assert!(bm.is_empty());
     }
 
@@ -581,19 +651,19 @@ mod tests {
             .iter()
             .find(|b| new_buckets.contains(b))
             .unwrap();
-        assert!(reader.get_bucket(hello).await.unwrap().contains(1));
+        assert!(reader.get_doc_bitmap(0, hello).await.unwrap().contains(1));
         // "world" only in old — deleted.
         let world = *old_buckets
             .iter()
             .find(|b| !new_buckets.contains(b))
             .unwrap();
-        assert!(!reader.get_bucket(world).await.unwrap().contains(1));
+        assert!(!reader.get_doc_bitmap(0, world).await.unwrap().contains(1));
         // "rust" only in new — added.
         let rust = *new_buckets
             .iter()
             .find(|b| !old_buckets.contains(b))
             .unwrap();
-        assert!(reader.get_bucket(rust).await.unwrap().contains(1));
+        assert!(reader.get_doc_bitmap(0, rust).await.unwrap().contains(1));
     }
 
     #[tokio::test]
@@ -606,12 +676,42 @@ mod tests {
         let reader = flush_and_read(writer, &provider).await;
 
         // "hel"(key=0), "ell"(key=1), "llo"(key=2)
-        assert!(reader.get_trigram("hel", 0).await.unwrap().contains(bucket));
-        assert!(reader.get_trigram("ell", 1).await.unwrap().contains(bucket));
-        assert!(reader.get_trigram("llo", 2).await.unwrap().contains(bucket));
+        assert!(reader
+            .bitmap_reader
+            .get("hel", 0)
+            .await
+            .unwrap()
+            .unwrap()
+            .contains(bucket));
+        assert!(reader
+            .bitmap_reader
+            .get("ell", 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .contains(bucket));
+        assert!(reader
+            .bitmap_reader
+            .get("llo", 2)
+            .await
+            .unwrap()
+            .unwrap()
+            .contains(bucket));
         // Wrong keys should not contain the bucket.
-        assert!(!reader.get_trigram("hel", 1).await.unwrap().contains(bucket));
-        assert!(!reader.get_trigram("llo", 0).await.unwrap().contains(bucket));
+        assert!(!reader
+            .bitmap_reader
+            .get("hel", 1)
+            .await
+            .unwrap()
+            .unwrap_or_default()
+            .contains(bucket));
+        assert!(!reader
+            .bitmap_reader
+            .get("llo", 0)
+            .await
+            .unwrap()
+            .unwrap_or_default()
+            .contains(bucket));
     }
 
     #[tokio::test]
@@ -625,10 +725,13 @@ mod tests {
 
         assert_eq!(transitions.len(), 2);
         for (hash, prev_bucket, curr_bucket) in &transitions {
-            let doc_bm = reader.get_bucket(hash | TRANSITION_DOC_FLAG).await.unwrap();
+            let doc_bm = reader
+                .get_doc_bitmap(TRANSITION_DOC_FLAG, *hash)
+                .await
+                .unwrap();
             assert!(doc_bm.contains(1));
             let bkt_bm = reader
-                .get_bucket(hash | TRANSITION_BUCKET_FLAG)
+                .get_id_bitmap(TRANSITION_BUCKET_FLAG | hash)
                 .await
                 .unwrap();
             assert!(bkt_bm.contains(*prev_bucket));
@@ -648,7 +751,10 @@ mod tests {
         let reader = flush_and_read(writer, &provider).await;
 
         for (hash, _, _) in &transitions {
-            let doc_bm = reader.get_bucket(hash | TRANSITION_DOC_FLAG).await.unwrap();
+            let doc_bm = reader
+                .get_doc_bitmap(TRANSITION_DOC_FLAG, *hash)
+                .await
+                .unwrap();
             assert!(!doc_bm.contains(1));
             assert!(doc_bm.contains(2));
         }
@@ -684,7 +790,7 @@ mod tests {
 
         // "hello" bucket: docs 2 and 3, not 1.
         let hello = *hw_buckets.iter().find(|b| hr_buckets.contains(b)).unwrap();
-        let bm = reader2.get_bucket(hello).await.unwrap();
+        let bm = reader2.get_doc_bitmap(0, hello).await.unwrap();
         assert!(!bm.contains(1));
         assert!(bm.contains(2));
         assert!(bm.contains(3));
@@ -770,5 +876,43 @@ mod tests {
         let result = reader.search(&query("hello")).await.unwrap();
         assert!(!result.contains(1));
         assert!(result.contains(2));
+    }
+
+    /// Verify that doc IDs spanning multiple 16M chunks are written and
+    /// read back correctly.
+    #[tokio::test]
+    async fn test_cross_chunk_doc_ids() {
+        let (_tmp, provider) = provider();
+        let writer = new_writer(&provider).await;
+
+        let chunk_size = 1u32 << CHUNK_BITS; // 16M
+        writer.add_document(0, tokenize("hello world"));
+        writer.add_document(1, tokenize("hello rust"));
+        writer.add_document(chunk_size, tokenize("hello world"));
+        writer.add_document(chunk_size + 1, tokenize("hello chroma"));
+        writer.add_document(chunk_size * 2, tokenize("hello world"));
+        let reader = flush_and_read(writer, &provider).await;
+
+        // "hello" appears in all 5 docs across 3 chunks.
+        let result = reader.search(&query("hello")).await.unwrap();
+        assert!(result.contains(0));
+        assert!(result.contains(1));
+        assert!(result.contains(chunk_size));
+        assert!(result.contains(chunk_size + 1));
+        assert!(result.contains(chunk_size * 2));
+
+        // "world" appears in docs 0, chunk_size, chunk_size*2.
+        let result = reader.search(&query("world")).await.unwrap();
+        assert!(result.contains(0));
+        assert!(!result.contains(1));
+        assert!(result.contains(chunk_size));
+        assert!(!result.contains(chunk_size + 1));
+        assert!(result.contains(chunk_size * 2));
+
+        // Multi-word search across chunks.
+        let result = reader.search(&query("hello world")).await.unwrap();
+        assert!(result.contains(0));
+        assert!(result.contains(chunk_size));
+        assert!(result.contains(chunk_size * 2));
     }
 }

--- a/rust/index/src/fulltext/bitmap_index.rs
+++ b/rust/index/src/fulltext/bitmap_index.rs
@@ -9,14 +9,14 @@ use uuid::Uuid;
 
 use super::tokenizer::{DocumentTokens, QueryPlan, TokenLookup};
 
-/// Key layout (32 bits): `[flags:2][id:24][chunk:6]`.
+/// Key layout (32 bits): `[partition:2][id:24][chunk:6]`.
 ///
 /// Doc-ID bitmaps (token buckets and transition docs) are chunked into
 /// 2^CHUNK_BITS (16M) doc-ID ranges, bounding per-entry bitmap size.
-/// Flags in the top 2 bits distinguish the partition:
-///   00 = token bucket doc-ID bitmap
-///   01 = transition doc-ID bitmap
-///   10 = transition bucket-ID bitmap (not chunked, chunk bits unused)
+/// The top 2 bits select the partition, placing each in a distinct key range:
+///   keys [0, 2^30)           — token bucket doc-ID bitmaps
+///   keys [2^30, 2^31)        — transition doc-ID bitmaps
+///   keys [2^31, 2^31 + 2^24) — transition bucket-ID bitmaps (not chunked)
 const CHUNK_BITS: u32 = 24;
 const CHUNK_SHIFT: u32 = 6;
 const MAX_CHUNK: u32 = (1 << CHUNK_SHIFT) - 1;
@@ -76,14 +76,15 @@ struct TrigramDelta {
 /// # Blockfile layout
 ///
 /// A single blockfile with four logical partitions under `prefix=""`,
-/// plus trigram entries under `prefix="{trigram}"`. The top 2 bits of
-/// the key distinguish the partition:
+/// plus trigram entries under `prefix="{trigram}"`. Keys are 32 bits
+/// laid out as `[partition:2][id:24][chunk:6]` (see constants above).
+/// The top 2 bits place each partition in a distinct key range:
 ///
-/// 1. `prefix=""`, flags `00` — token bucket doc-ID bitmaps (chunked).
+/// 1. `prefix=""`, keys `[0, 2^30)` — token bucket doc-ID bitmaps (chunked).
 ///    `key = (bucket_id << CHUNK_SHIFT) | chunk_index`.
-/// 2. `prefix=""`, flags `01` — transition doc-ID bitmaps (chunked).
+/// 2. `prefix=""`, keys `[2^30, 2^31)` — transition doc-ID bitmaps (chunked).
 ///    `key = TRANSITION_DOC_FLAG | (hash << CHUNK_SHIFT) | chunk_index`.
-/// 3. `prefix=""`, flags `10` — transition bucket-ID bitmaps (not chunked).
+/// 3. `prefix=""`, keys `[2^31, 2^31 + 2^24)` — transition bucket-ID bitmaps (not chunked).
 ///    `key = TRANSITION_BUCKET_FLAG | hash`.
 /// 4. `prefix="{trigram}"`, keys 0/1/2 — positional bucket-ID bitmaps.
 #[derive(Clone)]
@@ -153,9 +154,9 @@ impl FullTextBitmapWriter {
     /// Merge accumulated deltas into the blockfile.
     ///
     /// Writes in `(prefix, key)` sorted order as required by the blockfile:
-    /// 1. Token buckets (flags `00`)
-    /// 2. Transition doc bitmaps (flags `01`)
-    /// 3. Transition bucket bitmaps (flags `10`)
+    /// 1. Token buckets — keys `[0, 2^30)`
+    /// 2. Transition doc bitmaps — keys `[2^30, 2^31)`
+    /// 3. Transition bucket bitmaps — keys `[2^31, 2^31 + 2^24)`
     /// 4. Trigrams (`prefix="{trigram}"`)
     pub async fn write_to_blockfiles(&self) -> Result<(), FullTextBitmapError> {
         self.write_token_buckets().await?;
@@ -172,7 +173,7 @@ impl FullTextBitmapWriter {
 
     // --- Write phases (one per partition, in sorted key order) ---
 
-    /// Partition 1: token bucket doc-ID bitmaps (flags `00`, chunked).
+    /// Partition 1: token bucket doc-ID bitmaps, keys `[0, 2^30)` (chunked).
     async fn write_token_buckets(&self) -> Result<(), FullTextBitmapError> {
         let mut bucket_ids: Vec<u32> = self.token_deltas.iter().map(|e| *e.key()).collect();
         bucket_ids.sort_unstable();
@@ -244,7 +245,7 @@ impl FullTextBitmapWriter {
         Ok(())
     }
 
-    /// Partition 2: transition doc-ID bitmaps (flags `01`, chunked).
+    /// Partition 2: transition doc-ID bitmaps, keys `[2^30, 2^31)` (chunked).
     async fn write_transition_docs(&self) -> Result<(), FullTextBitmapError> {
         let mut hashes: Vec<u32> = self.transition_deltas.iter().map(|e| *e.key()).collect();
         hashes.sort_unstable();
@@ -277,7 +278,7 @@ impl FullTextBitmapWriter {
         Ok(())
     }
 
-    /// Partition 3: transition bucket-ID bitmaps (flags `10`, not chunked).
+    /// Partition 3: transition bucket-ID bitmaps, keys `[2^31, 2^31 + 2^24)` (not chunked).
     async fn write_transition_buckets(&self) -> Result<(), FullTextBitmapError> {
         let mut hashes: Vec<u32> = self.transition_deltas.iter().map(|e| *e.key()).collect();
         hashes.sort_unstable();

--- a/rust/types/src/segment.rs
+++ b/rust/types/src/segment.rs
@@ -336,14 +336,16 @@ impl Segment {
     }
 
     fn check_metadata_consistency(&self, schema: &Schema) -> Result<(), SchemaMismatchError> {
-        let base_keys: &[&str] = &[
-            FULL_TEXT_PLS,
-            STRING_METADATA,
-            BOOL_METADATA,
-            F32_METADATA,
-            U32_METADATA,
-        ];
+        let base_keys: &[&str] = &[STRING_METADATA, BOOL_METADATA, F32_METADATA, U32_METADATA];
         self.require_keys(base_keys, &[])?;
+
+        if schema.is_fts_enabled() {
+            if schema.is_token_bitmap_fts_enabled() {
+                self.require_keys(&[FULL_TEXT_TOKEN], &[FULL_TEXT_PLS])?;
+            } else {
+                self.require_keys(&[FULL_TEXT_PLS], &[FULL_TEXT_TOKEN])?;
+            }
+        }
 
         if schema.is_sparse_index_enabled() {
             let wand_keys: &[&str] = &[SPARSE_MAX, SPARSE_OFFSET_VALUE];

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -273,13 +273,28 @@ impl MetadataProvider<'_> {
                     }
                     Some(FtsIndexReader::TokenBitmap(analyzer, reader)) => {
                         let mut analyzer = analyzer.clone();
-                        let plan = analyzer.plan_query(query).map_err(|e| {
-                            MetadataIndexError::FullTextError(
-                                chroma_index::fulltext::types::FullTextIndexError::TokenizerError(
-                                    e.to_string(),
-                                ),
-                            )
-                        })?;
+                        // NOTE: When plan_query fails with NoSelectiveToken (query
+                        // too short for the tokenizer, e.g. "ab"), we return an empty
+                        // bitmap to match the legacy trigram index behavior, which
+                        // also silently returns empty for sub-trigram queries. Both
+                        // are technically false-negatives.
+                        let plan = match analyzer.plan_query(query) {
+                            Ok(plan) => plan,
+                            Err(chroma_index::fulltext::tokenizer::TokenizerError::NoSelectiveToken { .. }) => {
+                                tracing::trace!(
+                                    query = query,
+                                    "TokenBitmap: query too short for index, returning empty",
+                                );
+                                return Ok(RoaringBitmap::new());
+                            }
+                            Err(e) => {
+                                return Err(MetadataIndexError::FullTextError(
+                                    chroma_index::fulltext::types::FullTextIndexError::TokenizerError(
+                                        e.to_string(),
+                                    ),
+                                ).into());
+                            }
+                        };
                         let candidates = reader
                             .search(&plan)
                             .instrument(tracing::trace_span!(parent: Span::current(), "Filter by document contains (token bitmap)"))


### PR DESCRIPTION
## Summary

Chunk token bucket and transition doc-ID bitmaps into 2^CHUNK_BITS (16M) doc-ID ranges so that no single blockfile entry exceeds ~4 MB.

## Motivation

RoaringBitmap serialized size grows with the universe of stored values. At 100M+ docs with sparse doc IDs across the full u32 range, a single common-token bitmap can reach ~189 MB — far exceeding the default 8 MB block size. With 16M doc ID chunks, the maximize size per RoaringBitmap is ~2MB.

## Key Layout

The 32-bit blockfile key is split as [flags:2][id:24][chunk:6]:
- Flags 00 — token bucket doc-ID bitmaps (chunked), supports up to 64 chunks x 16M = 1B doc IDs
- Flags 01 — transition doc-ID bitmaps (chunked)
- Flags 10 — transition bucket-ID bitmaps (not chunked)
- Trigrams remain under prefix="{trigram}" with keys 0/1/2
All partitions under prefix="" are naturally sorted by flag bits: token buckets < transition docs < transition buckets.

## Changes

- Constants: CHUNK_BITS=24, CHUNK_SHIFT=6, MAX_CHUNK=63. Flags moved from bits 24-25 to bits 30-31 to make room for chunk index.
- Writer: 4 write phases in sorted key order. Two write helpers: write_doc_bitmap (chunks via slice::chunk_by) and write_id_bitmap (single entry). Reads existing chunks via get_range (efficient with the key-filtered block resolution from the parent PR), merges into global bitmap, applies delta, writes back chunked.
- Reader: Two read helpers: get_doc_bitmap (range read + OR across chunks) and get_id_bitmap (point read). search() updated to use new methods with chunked preloading.
- Tests: Existing tests updated. New test_cross_chunk_doc_ids with doc IDs at 0, 16M, 32M spanning 3 chunks.
- README: Updated layout docs.

## Validation

Benchmarked on CodeSearchNet 2.1M docs with CHUNK_BITS=18 (262K per chunk, 8 chunks):
- 100% recall across 400 queries
- Max bitmap size per entry: 32 KB
- Precision unchanged from unchunked baseline