### PR TITLE
[CHORE]  Bump OpenSSL to 0.10.79 for dependabot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6421,15 +6421,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -6459,9 +6458,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -7138,7 +7137,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ mdac = { path = "rust/mdac" }
 s3heap = { path = "rust/s3heap" }
 s3heap-service = { path = "rust/s3heap-service" }
 spanner-migrations = { path = "rust/spanner-migrations" }
+
 wal3 = { path = "rust/wal3" }
 worker = { path = "rust/worker" }
 


### PR DESCRIPTION
## Description of changes

I ran `cargo update -p openssl --precise 0.10.79` to bump dep.

## Test plan

CI

## Migration plan

None.

## Observability plan

None.

## Documentation Changes

None.
