### PR TITLE
[DOC] Add Ejentum cognitive harness recipe to examples/use_with

### DIFF
--- a/examples/use_with/ejentum/README.md
+++ b/examples/use_with/ejentum/README.md
@@ -1,0 +1,105 @@
+# Use Chroma with Ejentum cognitive harness
+
+[Ejentum](https://ejentum.com) is a cognitive harness API that returns task-matched reasoning scaffolds for one of four modes (`reasoning`, `code`, `anti-deception`, `memory`). The `memory` mode is the relevant one here: it returns perception scaffolds (what to attend to, what to suppress, what to verify) for *deciding* what to store and *scoring* what to retrieve, rather than storing or retrieving anything itself.
+
+That makes it a natural complement to Chroma. Chroma handles the storage and vector recall; Ejentum's memory harness shapes the human-readable decisions around what deserves storage and what's actually relevant once retrieved.
+
+This recipe covers two patterns:
+
+1. **Pre-storage filter.** Before calling `collection.add(...)`, retrieve a perception scaffold and use it to decide whether the candidate document deserves indexing. Keeps the index lean.
+2. **Post-recall scoring.** After `collection.query(...)` returns top-k by similarity, use a different scaffold to assess which results actually fit the user's current intent before passing them to your downstream LLM. Similarity is not the same as relevance.
+
+Both patterns are plain Python composition over Chroma's public client and Ejentum's public REST gateway, so they slot into any pipeline that already uses Chroma.
+
+## Setup
+
+Get an Ejentum API key at [ejentum.com/dashboard](https://ejentum.com/dashboard). Free and paid tiers are available.
+
+```bash
+pip install chromadb openai requests
+export OPENAI_API_KEY=sk-...
+export EJENTUM_API_KEY=ek_...
+```
+
+The runnable example is in `harness_around_chroma.py` in this directory. The two patterns it demonstrates are also shown inline below.
+
+## Pattern 1: Pre-storage filter
+
+Index every utterance and you get a noisy collection. Use the memory harness to gate `collection.add` so only signals worth long-term storage land in the index.
+
+```python
+from openai import OpenAI
+import chromadb
+import requests, os
+
+EJENTUM_URL = "https://ejentum-main-ab125c3.zuplo.app/logicv1/"
+
+def harness(query: str, mode: str = "memory") -> str:
+    r = requests.post(
+        EJENTUM_URL,
+        json={"query": query, "mode": mode},
+        headers={"Authorization": f"Bearer {os.environ['EJENTUM_API_KEY']}"},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return r.json()[0].get(mode, "")
+
+def should_index(candidate: str, client: OpenAI) -> tuple[bool, str]:
+    scaffold = harness(
+        f"I am deciding whether to commit this statement to a vector store "
+        f"for long-term recall. Sharpen: signal vs noise, specific vs generic, "
+        f"future-recall value. Statement: {candidate!r}",
+        mode="memory",
+    )
+    completion = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content":
+                "Apply the perception scaffold below, then answer "
+                "INDEX or SKIP on the first line and a short reason on "
+                f"the second.\n\n[SCAFFOLD]\n{scaffold}\n[END]"},
+            {"role": "user", "content": candidate},
+        ],
+        temperature=0,
+    )
+    verdict, _, reason = completion.choices[0].message.content.strip().partition("\n")
+    return verdict.strip().upper() == "INDEX", reason.strip()
+```
+
+## Pattern 2: Post-recall scoring
+
+`collection.query` returns top-k by similarity. That's an upstream signal of "near," not a downstream judgement of "useful." The harness sharpens the second.
+
+```python
+def rerank_with_harness(question: str, hits: list[str], client: OpenAI) -> list[str]:
+    if not hits:
+        return hits
+    scaffold = harness(
+        f"I am scoring vector-store hits for relevance to a current question. "
+        f"Sharpen: actual fit vs lexical match, recency-bias risk, whether each "
+        f"hit shifts the answer. Question: {question!r}",
+        mode="memory",
+    )
+    enumerated = "\n".join(f"[{i}] {h}" for i, h in enumerate(hits))
+    completion = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content":
+                "Apply the perception scaffold below, then list the indices "
+                "of hits that materially help answer the question. "
+                f"Comma-separated, indices only.\n\n[SCAFFOLD]\n{scaffold}\n[END]"},
+            {"role": "user", "content": f"Question: {question}\n\nHits:\n{enumerated}"},
+        ],
+        temperature=0,
+    )
+    chosen = {int(s.strip()) for s in completion.choices[0].message.content.split(",") if s.strip().isdigit()}
+    return [h for i, h in enumerate(hits) if i in chosen]
+```
+
+## Where this fits in your pipeline
+
+Both gates are optional and composable with the rest of Chroma's API. They cost one Ejentum call (a few hundred milliseconds) plus one short LLM call each. Run the pre-storage filter once per candidate; run the post-recall reranker once per user question after `collection.query`.
+
+For high-volume write paths, batch the gate per session rather than per utterance, or sample it. The post-recall reranker is cheap enough to run on every retrieval since both inputs are short.
+
+See `harness_around_chroma.py` for an end-to-end runnable demo that exercises both patterns against a small Chroma collection.

--- a/examples/use_with/ejentum/harness_around_chroma.py
+++ b/examples/use_with/ejentum/harness_around_chroma.py
@@ -1,0 +1,150 @@
+"""End-to-end demo: Ejentum cognitive harness around a Chroma collection.
+
+Demonstrates two patterns, both as plain Python composition over Chroma's
+public client and Ejentum's REST gateway:
+
+1. Pre-storage filter. Use the memory harness to decide whether a
+   candidate statement deserves a `collection.add(...)` call.
+2. Post-recall scoring. After `collection.query(...)`, use the harness
+   as a reranker that flags hits as materially relevant vs. just lexically
+   similar.
+
+Run:
+    pip install chromadb openai requests
+    export OPENAI_API_KEY=sk-...
+    export EJENTUM_API_KEY=ek_...    # https://ejentum.com/dashboard
+    python harness_around_chroma.py
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+
+import chromadb
+import requests
+from openai import OpenAI
+
+
+EJENTUM_URL = "https://ejentum-main-ab125c3.zuplo.app/logicv1/"
+
+
+def harness(query: str, mode: str = "memory") -> str:
+    """Fetch a perception scaffold from the Ejentum REST gateway."""
+    r = requests.post(
+        EJENTUM_URL,
+        json={"query": query, "mode": mode},
+        headers={"Authorization": f"Bearer {os.environ['EJENTUM_API_KEY']}"},
+        timeout=10,
+    )
+    r.raise_for_status()
+    payload = r.json()
+    return payload[0].get(mode, "") if payload else ""
+
+
+def should_index(candidate: str, openai_client: OpenAI) -> tuple[bool, str]:
+    scaffold = harness(
+        f"I am deciding whether to commit this statement to a vector store "
+        f"for long-term recall. Sharpen: signal vs noise, specific vs generic, "
+        f"future-recall value. Statement: {candidate!r}",
+        mode="memory",
+    )
+    completion = openai_client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Apply the perception scaffold below, then answer INDEX or "
+                    "SKIP on the first line and a short reason on the second.\n\n"
+                    f"[SCAFFOLD]\n{scaffold}\n[END]"
+                ),
+            },
+            {"role": "user", "content": candidate},
+        ],
+        temperature=0,
+    )
+    text = completion.choices[0].message.content.strip()
+    verdict, _, reason = text.partition("\n")
+    return verdict.strip().upper() == "INDEX", reason.strip()
+
+
+def rerank_with_harness(
+    question: str, hits: list[str], openai_client: OpenAI
+) -> list[str]:
+    if not hits:
+        return hits
+    scaffold = harness(
+        f"I am scoring vector-store hits for relevance to a current question. "
+        f"Sharpen: actual fit vs lexical match, recency-bias risk, whether each "
+        f"hit shifts the answer. Question: {question!r}",
+        mode="memory",
+    )
+    enumerated = "\n".join(f"[{i}] {h}" for i, h in enumerate(hits))
+    completion = openai_client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Apply the perception scaffold below, then list the indices "
+                    "of memories that materially help answer the question. "
+                    "Output a comma-separated list of indices and nothing else.\n\n"
+                    f"[SCAFFOLD]\n{scaffold}\n[END]"
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Question: {question}\n\nMemories:\n{enumerated}",
+            },
+        ],
+        temperature=0,
+    )
+    chosen = {
+        int(s.strip())
+        for s in completion.choices[0].message.content.split(",")
+        if s.strip().isdigit()
+    }
+    return [h for i, h in enumerate(hits) if i in chosen]
+
+
+def main() -> None:
+    openai_client = OpenAI()
+    chroma_client = chromadb.Client()
+    collection = chroma_client.get_or_create_collection("alice_notes")
+
+    candidates = [
+        "I prefer Python over TypeScript for new backend services.",
+        "Today is Friday.",
+        "My team uses GitHub Actions for CI, and we deploy twice a week.",
+        "The conference room is on the 3rd floor.",
+        "I am moving away from REST and toward gRPC for internal services.",
+    ]
+
+    print("== Pre-storage filter ==")
+    for candidate in candidates:
+        keep, why = should_index(candidate, openai_client)
+        if keep:
+            collection.add(documents=[candidate], ids=[f"id-{len(collection.get()['ids'])}"])
+            print(f"INDEXED  {candidate!r}\n         {textwrap.shorten(why, 120)}")
+        else:
+            print(f"SKIPPED  {candidate!r}\n         {textwrap.shorten(why, 120)}")
+
+    print()
+    print("== Post-recall scoring ==")
+    question = "What stack does my team use?"
+    raw = collection.query(query_texts=[question], n_results=5)
+    hits = raw["documents"][0]
+    print(f"Raw chroma hits (top {len(hits)} by similarity):")
+    for h in hits:
+        print(f"  - {h!r}")
+
+    relevant = rerank_with_harness(question, hits, openai_client)
+    print()
+    print(f"After harness rerank ({len(relevant)} kept):")
+    for h in relevant:
+        print(f"  + {h!r}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a `use_with/ejentum/` recipe demonstrating how to wrap the [Ejentum cognitive harness](https://ejentum.com) (memory mode) around a Chroma collection in two patterns:

1. **Pre-storage filter.** Call the memory harness before `collection.add(...)` to decide whether a candidate document deserves indexing. Keeps the collection lean.
2. **Post-recall scoring.** After `collection.query(...)` returns top-k by similarity, use the harness as a reranker that flags hits as materially useful versus lexically similar. Similarity is not the same as relevance for the user's current question.

Both patterns are plain-Python composition over Chroma's public client and Ejentum's public REST gateway. Nothing replaces or wraps Chroma APIs; the harness sits outside the store as a perception layer.

## Files

- `examples/use_with/ejentum/README.md`: explains the two patterns, when each helps, and links to the runnable demo. Matches the shape of `examples/use_with/ollama.md`.
- `examples/use_with/ejentum/harness_around_chroma.py`: end-to-end runnable demo that exercises both patterns against a small in-memory Chroma collection.

Slot follows the existing `examples/use_with/{cohere,jina,roboflow}/` and `examples/use_with/ollama.md` pattern: per-vendor folder with a short README and (optionally) a runnable artifact.

## Why this fits

The Ejentum memory harness returns perception scaffolds (what to attend to, what to suppress, what to verify) for *deciding* what to store and *scoring* what to retrieve. It does not store or retrieve anything itself. That makes it a clean complement to Chroma, not a competitor. The recipe is explicit about this: Chroma stays the storage primitive; the harness shapes the gates around it.

## Affiliation

I maintain `ejentum-mcp`. Submitting this recipe because the pre-storage-filter pattern is a real use we've shipped against `mem0` in a sibling cookbook ([mem0ai/mem0#5238](https://github.com/mem0ai/mem0/pull/5238)) and it generalises cleanly to any vector store. Chroma's `examples/use_with/` is the right surface for this shape. Ejentum has free and paid tiers; the README links to the dashboard for keys, not to a checkout.

## Test plan

- [x] Mirrors the structure of existing `examples/use_with/{cohere,jina,roboflow,ollama}` entries.
- [x] Voice scrubbed (no em dashes).
- [x] Demo script uses only documented Chroma APIs (`Client`, `get_or_create_collection`, `add`, `query`, `get`).
- [x] No new top-level dependencies beyond `chromadb`, `openai`, `requests`.
- [ ] Local `python harness_around_chroma.py` against live `OPENAI_API_KEY` + `EJENTUM_API_KEY` (cannot run in this environment with live keys; happy to follow up if the reviewer spots an issue).