### PR TITLE
[BUG]: WQS repairs on bootup

### DIFF
--- a/go/pkg/sysdb/coordinator/check_invocation_status_test.go
+++ b/go/pkg/sysdb/coordinator/check_invocation_status_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type AreInvocationsDoneTestSuite struct {
+type CheckInvocationStatusTestSuite struct {
 	suite.Suite
 	mockMetaDomain         *dbmodel_mocks.IMetaDomain
 	mockAttachedFunctionDb *dbmodel_mocks.IAttachedFunctionDb
 	coordinator            *Coordinator
 }
 
-func (suite *AreInvocationsDoneTestSuite) SetupTest() {
+func (suite *CheckInvocationStatusTestSuite) SetupTest() {
 	suite.mockMetaDomain = &dbmodel_mocks.IMetaDomain{}
 	suite.mockMetaDomain.Test(suite.T())
 
@@ -34,12 +34,12 @@ func (suite *AreInvocationsDoneTestSuite) SetupTest() {
 	}
 }
 
-func (suite *AreInvocationsDoneTestSuite) TearDownTest() {
+func (suite *CheckInvocationStatusTestSuite) TearDownTest() {
 	suite.mockMetaDomain.AssertExpectations(suite.T())
 	suite.mockAttachedFunctionDb.AssertExpectations(suite.T())
 }
 
-func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_Success() {
+func (suite *CheckInvocationStatusTestSuite) TestCheckInvocationStatus_Success() {
 	ctx := context.Background()
 
 	// Test data
@@ -70,11 +70,15 @@ func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_Success() {
 		},
 	}
 
-	suite.mockAttachedFunctionDb.On("AreInvocationsDone", expectedItems).
-		Return([]bool{true, false, true}, nil).Once()
+	suite.mockAttachedFunctionDb.On("CheckInvocationStatus", expectedItems).
+		Return([]dbmodel.InvocationStatusResult{
+			{Status: dbmodel.InvocationStatusDone, CurrentCompletionOffset: 150},
+			{Status: dbmodel.InvocationStatusNotDone, CurrentCompletionOffset: 200},
+			{Status: dbmodel.InvocationStatusNeedsRepair, CurrentCompletionOffset: 75},
+		}, nil).Once()
 
 	// Create request
-	req := &coordinatorpb.AreInvocationsDoneRequest{
+	req := &coordinatorpb.CheckInvocationStatusRequest{
 		Items: []*coordinatorpb.InvocationCheckItem{
 			{
 				FunctionId:        fnID1.String(),
@@ -95,39 +99,45 @@ func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_Success() {
 	}
 
 	// Execute
-	resp, err := suite.coordinator.AreInvocationsDone(ctx, req)
+	resp, err := suite.coordinator.CheckInvocationStatus(ctx, req)
 
 	// Assert
 	suite.NoError(err)
 	suite.NotNil(resp)
-	suite.Equal([]bool{true, false, true}, resp.Done)
+	suite.Len(resp.Results, 3)
+	suite.Equal(coordinatorpb.InvocationStatus_INVOCATION_STATUS_DONE, resp.Results[0].Status)
+	suite.Equal(int64(150), resp.Results[0].CurrentCompletionOffset)
+	suite.Equal(coordinatorpb.InvocationStatus_INVOCATION_STATUS_NOT_DONE, resp.Results[1].Status)
+	suite.Equal(int64(200), resp.Results[1].CurrentCompletionOffset)
+	suite.Equal(coordinatorpb.InvocationStatus_INVOCATION_STATUS_NEEDS_REPAIR, resp.Results[2].Status)
+	suite.Equal(int64(75), resp.Results[2].CurrentCompletionOffset)
 }
 
-func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_EmptyRequest() {
+func (suite *CheckInvocationStatusTestSuite) TestCheckInvocationStatus_EmptyRequest() {
 	ctx := context.Background()
 
 	// No mocks needed for empty request
 
 	// Create request
-	req := &coordinatorpb.AreInvocationsDoneRequest{
+	req := &coordinatorpb.CheckInvocationStatusRequest{
 		Items: []*coordinatorpb.InvocationCheckItem{},
 	}
 
 	// Execute
-	resp, err := suite.coordinator.AreInvocationsDone(ctx, req)
+	resp, err := suite.coordinator.CheckInvocationStatus(ctx, req)
 
 	// Assert
 	suite.NoError(err)
 	suite.NotNil(resp)
-	suite.Equal([]bool{}, resp.Done)
+	suite.Equal([]*coordinatorpb.InvocationStatusResult{}, resp.Results)
 }
 
-func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_InvalidFunctionID() {
+func (suite *CheckInvocationStatusTestSuite) TestCheckInvocationStatus_InvalidFunctionID() {
 	ctx := context.Background()
 	collectionID := uuid.New().String()
 
 	// Create request with invalid UUID
-	req := &coordinatorpb.AreInvocationsDoneRequest{
+	req := &coordinatorpb.CheckInvocationStatusRequest{
 		Items: []*coordinatorpb.InvocationCheckItem{
 			{
 				FunctionId:        "invalid-uuid",
@@ -138,19 +148,19 @@ func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_InvalidFunction
 	}
 
 	// Execute
-	_, err := suite.coordinator.AreInvocationsDone(ctx, req)
+	_, err := suite.coordinator.CheckInvocationStatus(ctx, req)
 
 	// Assert
 	suite.Error(err)
 	suite.Contains(err.Error(), "invalid function_id at index 0")
 }
 
-func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_InvalidCollectionID() {
+func (suite *CheckInvocationStatusTestSuite) TestCheckInvocationStatus_InvalidCollectionID() {
 	ctx := context.Background()
 	fnID := uuid.New()
 
 	// Create request with invalid collection UUID
-	req := &coordinatorpb.AreInvocationsDoneRequest{
+	req := &coordinatorpb.CheckInvocationStatusRequest{
 		Items: []*coordinatorpb.InvocationCheckItem{
 			{
 				FunctionId:        fnID.String(),
@@ -161,14 +171,14 @@ func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_InvalidCollecti
 	}
 
 	// Execute
-	_, err := suite.coordinator.AreInvocationsDone(ctx, req)
+	_, err := suite.coordinator.CheckInvocationStatus(ctx, req)
 
 	// Assert
 	suite.Error(err)
 	suite.Contains(err.Error(), "invalid input_collection_id at index 0")
 }
 
-func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_DatabaseError() {
+func (suite *CheckInvocationStatusTestSuite) TestCheckInvocationStatus_DatabaseError() {
 	ctx := context.Background()
 	fnID := uuid.New()
 	collectionID := uuid.New().String()
@@ -184,11 +194,11 @@ func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_DatabaseError()
 		},
 	}
 
-	suite.mockAttachedFunctionDb.On("AreInvocationsDone", expectedItems).
+	suite.mockAttachedFunctionDb.On("CheckInvocationStatus", expectedItems).
 		Return(nil, errors.New("database error")).Once()
 
 	// Create request
-	req := &coordinatorpb.AreInvocationsDoneRequest{
+	req := &coordinatorpb.CheckInvocationStatusRequest{
 		Items: []*coordinatorpb.InvocationCheckItem{
 			{
 				FunctionId:        fnID.String(),
@@ -199,19 +209,19 @@ func (suite *AreInvocationsDoneTestSuite) TestAreInvocationsDone_DatabaseError()
 	}
 
 	// Execute
-	_, err := suite.coordinator.AreInvocationsDone(ctx, req)
+	_, err := suite.coordinator.CheckInvocationStatus(ctx, req)
 
 	// Assert
 	suite.Error(err)
 	suite.Contains(err.Error(), "database error")
 }
 
-func TestAreInvocationsDoneSuite(t *testing.T) {
-	suite.Run(t, new(AreInvocationsDoneTestSuite))
+func TestCheckInvocationStatusSuite(t *testing.T) {
+	suite.Run(t, new(CheckInvocationStatusTestSuite))
 }
 
-// TestAreInvocationsDone_BasicFunctionality tests that the function correctly identifies done/not-done invocations
-func TestAreInvocationsDone_BasicFunctionality(t *testing.T) {
+// TestCheckInvocationStatus_BasicFunctionality tests that the function correctly identifies all three status states
+func TestCheckInvocationStatus_BasicFunctionality(t *testing.T) {
 	ctx := context.Background()
 
 	// Setup mocks
@@ -231,7 +241,7 @@ func TestAreInvocationsDone_BasicFunctionality(t *testing.T) {
 	fnID2 := uuid.New() // Done: soft deleted
 	fnID3 := uuid.New() // Done: hard deleted (not in DB)
 	fnID4 := uuid.New() // Done: current_completion_offset > provided_completion_offset AND heap_entry_pending=false
-	fnID5 := uuid.New() // Not done: current_completion_offset > provided_completion_offset BUT heap_entry_pending=true
+	fnID5 := uuid.New() // NeedsRepair: current_completion_offset > provided_completion_offset AND heap_entry_pending=true
 	collectionID := uuid.New().String()
 
 	// Setup mock
@@ -250,12 +260,18 @@ func TestAreInvocationsDone_BasicFunctionality(t *testing.T) {
 	// - fnID2: done (soft deleted)
 	// - fnID3: done (hard deleted/not in DB)
 	// - fnID4: done (current_completion_offset > provided_completion_offset AND heap_entry_pending=false)
-	// - fnID5: not done (heap_entry_pending=true)
-	mockAttachedFunctionDb.On("AreInvocationsDone", expectedItems).
-		Return([]bool{false, true, true, true, false}, nil).Once()
+	// - fnID5: needs repair (current_completion_offset > provided_completion_offset AND heap_entry_pending=true)
+	mockAttachedFunctionDb.On("CheckInvocationStatus", expectedItems).
+		Return([]dbmodel.InvocationStatusResult{
+			{Status: dbmodel.InvocationStatusNotDone, CurrentCompletionOffset: 100},
+			{Status: dbmodel.InvocationStatusDone, CurrentCompletionOffset: 50},
+			{Status: dbmodel.InvocationStatusDone, CurrentCompletionOffset: 50},
+			{Status: dbmodel.InvocationStatusDone, CurrentCompletionOffset: 75},
+			{Status: dbmodel.InvocationStatusNeedsRepair, CurrentCompletionOffset: 75},
+		}, nil).Once()
 
 	// Create request
-	req := &coordinatorpb.AreInvocationsDoneRequest{
+	req := &coordinatorpb.CheckInvocationStatusRequest{
 		Items: []*coordinatorpb.InvocationCheckItem{
 			{FunctionId: fnID1.String(), InputCollectionId: collectionID, CompletionOffset: 100},
 			{FunctionId: fnID2.String(), InputCollectionId: collectionID, CompletionOffset: 50},
@@ -266,19 +282,33 @@ func TestAreInvocationsDone_BasicFunctionality(t *testing.T) {
 	}
 
 	// Execute
-	resp, err := coordinator.AreInvocationsDone(ctx, req)
+	resp, err := coordinator.CheckInvocationStatus(ctx, req)
 
 	// Assert
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-	assert.Equal(t, []bool{false, true, true, true, false}, resp.Done)
+	assert.Len(t, resp.Results, 5)
+	assert.Equal(t, []coordinatorpb.InvocationStatus{
+		coordinatorpb.InvocationStatus_INVOCATION_STATUS_NOT_DONE,
+		coordinatorpb.InvocationStatus_INVOCATION_STATUS_DONE,
+		coordinatorpb.InvocationStatus_INVOCATION_STATUS_DONE,
+		coordinatorpb.InvocationStatus_INVOCATION_STATUS_DONE,
+		coordinatorpb.InvocationStatus_INVOCATION_STATUS_NEEDS_REPAIR,
+	}, []coordinatorpb.InvocationStatus{
+		resp.Results[0].Status,
+		resp.Results[1].Status,
+		resp.Results[2].Status,
+		resp.Results[3].Status,
+		resp.Results[4].Status,
+	})
 
 	// Verify the results match our expectations:
-	assert.False(t, resp.Done[0], "fnID1: current_completion_offset <= provided_completion_offset should be NOT done")
-	assert.True(t, resp.Done[1], "fnID2: soft deleted should be done")
-	assert.True(t, resp.Done[2], "fnID3: hard deleted should be done")
-	assert.True(t, resp.Done[3], "fnID4: current_completion_offset > provided_completion_offset AND heap_entry_pending=false should be done")
-	assert.False(t, resp.Done[4], "fnID5: heap_entry_pending=true should be NOT done")
+	assert.Equal(t, coordinatorpb.InvocationStatus_INVOCATION_STATUS_NOT_DONE, resp.Results[0].Status, "fnID1: current_completion_offset <= provided_completion_offset should be NOT done")
+	assert.Equal(t, coordinatorpb.InvocationStatus_INVOCATION_STATUS_DONE, resp.Results[1].Status, "fnID2: soft deleted should be done")
+	assert.Equal(t, coordinatorpb.InvocationStatus_INVOCATION_STATUS_DONE, resp.Results[2].Status, "fnID3: hard deleted should be done")
+	assert.Equal(t, coordinatorpb.InvocationStatus_INVOCATION_STATUS_DONE, resp.Results[3].Status, "fnID4: current_completion_offset > provided_completion_offset AND heap_entry_pending=false should be done")
+	assert.Equal(t, coordinatorpb.InvocationStatus_INVOCATION_STATUS_NEEDS_REPAIR, resp.Results[4].Status, "fnID5: heap_entry_pending=true should be NEEDS_REPAIR")
+	assert.Equal(t, int64(75), resp.Results[4].CurrentCompletionOffset, "fnID5 should return the new completion offset to queue for repair")
 
 	mockMetaDomain.AssertExpectations(t)
 	mockAttachedFunctionDb.AssertExpectations(t)

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -886,13 +886,14 @@ func (s *Coordinator) FinalizeAsyncAttachedFunctionRepair(ctx context.Context, r
 	return &coordinatorpb.FinalizeAsyncAttachedFunctionRepairResponse{}, nil
 }
 
-// AreInvocationsDone checks if multiple attached function invocations have completed
-// by comparing current completion_offset against provided old completion offsets.
-func (s *Coordinator) AreInvocationsDone(ctx context.Context, req *coordinatorpb.AreInvocationsDoneRequest) (*coordinatorpb.AreInvocationsDoneResponse, error) {
-	log := log.With(zap.String("method", "AreInvocationsDone"))
+// CheckInvocationStatus checks the status of multiple attached function invocations
+// by comparing current completion_offset against provided old completion offsets and checking heap_entry_pending flag.
+// Returns one of three states for each invocation: NOT_DONE (default), DONE, or NEEDS_REPAIR.
+func (s *Coordinator) CheckInvocationStatus(ctx context.Context, req *coordinatorpb.CheckInvocationStatusRequest) (*coordinatorpb.CheckInvocationStatusResponse, error) {
+	log := log.With(zap.String("method", "CheckInvocationStatus"))
 
 	if len(req.Items) == 0 {
-		return &coordinatorpb.AreInvocationsDoneResponse{Done: []bool{}}, nil
+		return &coordinatorpb.CheckInvocationStatusResponse{Results: []*coordinatorpb.InvocationStatusResult{}}, nil
 	}
 
 	// Convert proto request items to dbmodel items
@@ -900,14 +901,14 @@ func (s *Coordinator) AreInvocationsDone(ctx context.Context, req *coordinatorpb
 	for i, item := range req.Items {
 		functionID, err := uuid.Parse(item.FunctionId)
 		if err != nil {
-			log.Error("AreInvocationsDone: invalid function_id", zap.Error(err), zap.String("function_id", item.FunctionId))
+			log.Error("CheckInvocationStatus: invalid function_id", zap.Error(err), zap.String("function_id", item.FunctionId))
 			return nil, status.Errorf(codes.InvalidArgument, "invalid function_id at index %d: %v", i, err)
 		}
 
 		// Validate input collection ID as UUID
 		_, err = uuid.Parse(item.InputCollectionId)
 		if err != nil {
-			log.Error("AreInvocationsDone: invalid input_collection_id", zap.Error(err), zap.String("input_collection_id", item.InputCollectionId))
+			log.Error("CheckInvocationStatus: invalid input_collection_id", zap.Error(err), zap.String("input_collection_id", item.InputCollectionId))
 			return nil, status.Errorf(codes.InvalidArgument, "invalid input_collection_id at index %d: %v", i, err)
 		}
 
@@ -919,15 +920,33 @@ func (s *Coordinator) AreInvocationsDone(ctx context.Context, req *coordinatorpb
 	}
 
 	// Call the database method
-	done, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).AreInvocationsDone(items)
+	results, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).CheckInvocationStatus(items)
 	if err != nil {
-		log.Error("AreInvocationsDone: failed to check invocation status", zap.Error(err))
+		log.Error("CheckInvocationStatus: failed to check invocation status", zap.Error(err))
 		return nil, err
 	}
 
-	log.Debug("AreInvocationsDone: completed successfully",
-		zap.Int("items_count", len(items)),
-		zap.Int("results_count", len(done)))
+	// Convert dbmodel statuses to proto statuses
+	protoResults := make([]*coordinatorpb.InvocationStatusResult, len(results))
+	for i, result := range results {
+		var protoStatus coordinatorpb.InvocationStatus
+		switch result.Status {
+		case dbmodel.InvocationStatusNotDone:
+			protoStatus = coordinatorpb.InvocationStatus_INVOCATION_STATUS_NOT_DONE
+		case dbmodel.InvocationStatusDone:
+			protoStatus = coordinatorpb.InvocationStatus_INVOCATION_STATUS_DONE
+		case dbmodel.InvocationStatusNeedsRepair:
+			protoStatus = coordinatorpb.InvocationStatus_INVOCATION_STATUS_NEEDS_REPAIR
+		}
+		protoResults[i] = &coordinatorpb.InvocationStatusResult{
+			Status:                  protoStatus,
+			CurrentCompletionOffset: result.CurrentCompletionOffset,
+		}
+	}
 
-	return &coordinatorpb.AreInvocationsDoneResponse{Done: done}, nil
+	log.Debug("CheckInvocationStatus: completed successfully",
+		zap.Int("items_count", len(items)),
+		zap.Int("results_count", len(results)))
+
+	return &coordinatorpb.CheckInvocationStatusResponse{Results: protoResults}, nil
 }

--- a/go/pkg/sysdb/grpc/task_service.go
+++ b/go/pkg/sysdb/grpc/task_service.go
@@ -169,13 +169,13 @@ func (s *Server) FinalizeAsyncAttachedFunctionRepair(ctx context.Context, req *c
 	return res, nil
 }
 
-func (s *Server) AreInvocationsDone(ctx context.Context, req *coordinatorpb.AreInvocationsDoneRequest) (*coordinatorpb.AreInvocationsDoneResponse, error) {
-	log.Info("AreInvocationsDone",
+func (s *Server) CheckInvocationStatus(ctx context.Context, req *coordinatorpb.CheckInvocationStatusRequest) (*coordinatorpb.CheckInvocationStatusResponse, error) {
+	log.Info("CheckInvocationStatus",
 		zap.Int("items_count", len(req.Items)))
 
 	// Check if the number of items exceeds the limit
 	if len(req.Items) > s.maxAreInvocationsDoneItems {
-		log.Error("AreInvocationsDone: too many items",
+		log.Error("CheckInvocationStatus: too many items",
 			zap.Int("items_count", len(req.Items)),
 			zap.Int("max_allowed", s.maxAreInvocationsDoneItems))
 		grpcErr, err := grpcutils.BuildInvalidArgumentGrpcError("items",
@@ -186,9 +186,9 @@ func (s *Server) AreInvocationsDone(ctx context.Context, req *coordinatorpb.AreI
 		return nil, grpcErr
 	}
 
-	res, err := s.coordinator.AreInvocationsDone(ctx, req)
+	res, err := s.coordinator.CheckInvocationStatus(ctx, req)
 	if err != nil {
-		log.Error("AreInvocationsDone failed", zap.Error(err))
+		log.Error("CheckInvocationStatus failed", zap.Error(err))
 		// If it's already a gRPC status error, return it directly
 		if _, ok := status.FromError(err); ok {
 			return nil, err
@@ -196,8 +196,8 @@ func (s *Server) AreInvocationsDone(ctx context.Context, req *coordinatorpb.AreI
 		return nil, grpcutils.BuildInternalGrpcError(err.Error())
 	}
 
-	log.Info("AreInvocationsDone completed",
+	log.Info("CheckInvocationStatus completed",
 		zap.Int("items_count", len(req.Items)),
-		zap.Int("results_count", len(res.Done)))
+		zap.Int("results_count", len(res.Results)))
 	return res, nil
 }

--- a/go/pkg/sysdb/metastore/db/dao/task.go
+++ b/go/pkg/sysdb/metastore/db/dao/task.go
@@ -403,12 +403,15 @@ func (s *attachedFunctionDb) HardDeleteAttachedFunction(id uuid.UUID) error {
 	return nil
 }
 
-// AreInvocationsDone checks if multiple attached function invocations have completed
+// CheckInvocationStatus checks the status of multiple attached function invocations
 // by comparing current completion_offset against provided completion_offset and checking
-// heap_entry_pending flag. Returns a slice of booleans indicating completion status for each input item.
-func (s *attachedFunctionDb) AreInvocationsDone(items []dbmodel.InvocationCheckItem) ([]bool, error) {
+// heap_entry_pending flag. Returns a slice of InvocationStatusResult indicating status for each input item:
+// - InvocationStatusNotDone: default case
+// - InvocationStatusDone: if not heap_entry_pending and af.completion_offset > ii.completion_offset
+// - InvocationStatusNeedsRepair: if heap_entry_pending and af.completion_offset > ii.completion_offset
+func (s *attachedFunctionDb) CheckInvocationStatus(items []dbmodel.InvocationCheckItem) ([]dbmodel.InvocationStatusResult, error) {
 	if len(items) == 0 {
-		return []bool{}, nil
+		return []dbmodel.InvocationStatusResult{}, nil
 	}
 
 	// Prepare arrays for UNNEST
@@ -435,10 +438,13 @@ func (s *attachedFunctionDb) AreInvocationsDone(items []dbmodel.InvocationCheckI
 		)
 		SELECT ii.ord,
 		       CASE
-		           WHEN af.id IS NULL THEN true  -- Hard deleted (not in DB)
-		           WHEN af.is_deleted THEN true   -- Soft deleted
-		           ELSE af.completion_offset > ii.completion_offset AND NOT af.heap_entry_pending
-		       END AS is_done
+		           WHEN af.id IS NULL THEN 1  -- Hard deleted (not in DB) -> Done
+		           WHEN af.is_deleted THEN 1   -- Soft deleted -> Done
+		           WHEN af.completion_offset > ii.completion_offset AND af.heap_entry_pending THEN 2  -- NeedsRepair
+		           WHEN af.completion_offset > ii.completion_offset AND NOT af.heap_entry_pending THEN 1  -- Done
+		           ELSE 0  -- NotDone (default case)
+		       END AS status,
+		       COALESCE(af.completion_offset, ii.completion_offset) AS current_completion_offset
 		FROM input_items ii
 		LEFT JOIN attached_functions af
 			ON af.id = ii.fn_id::uuid
@@ -447,26 +453,30 @@ func (s *attachedFunctionDb) AreInvocationsDone(items []dbmodel.InvocationCheckI
 	`, ordinals, fnIDs, collectionIDs, completionOffsets).Rows()
 
 	if err != nil {
-		log.Error("AreInvocationsDone: query failed", zap.Error(err))
+		log.Error("CheckInvocationStatus: query failed", zap.Error(err))
 		return nil, err
 	}
 	defer rows.Close()
 
-	results := make([]bool, len(items))
+	results := make([]dbmodel.InvocationStatusResult, len(items))
 	for rows.Next() {
 		var ord int64
-		var isDone bool
-		if err := rows.Scan(&ord, &isDone); err != nil {
-			log.Error("AreInvocationsDone: scan failed", zap.Error(err))
+		var status int
+		var currentCompletionOffset int64
+		if err := rows.Scan(&ord, &status, &currentCompletionOffset); err != nil {
+			log.Error("CheckInvocationStatus: scan failed", zap.Error(err))
 			return nil, err
 		}
 		if ord >= 0 && ord < int64(len(results)) {
-			results[ord] = isDone
+			results[ord] = dbmodel.InvocationStatusResult{
+				Status:                  dbmodel.InvocationStatus(status),
+				CurrentCompletionOffset: currentCompletionOffset,
+			}
 		}
 	}
 
 	if err := rows.Err(); err != nil {
-		log.Error("AreInvocationsDone: rows iteration error", zap.Error(err))
+		log.Error("CheckInvocationStatus: rows iteration error", zap.Error(err))
 		return nil, err
 	}
 

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
@@ -16,24 +16,24 @@ type IAttachedFunctionDb struct {
 	mock.Mock
 }
 
-// AreInvocationsDone provides a mock function with given fields: items
-func (_m *IAttachedFunctionDb) AreInvocationsDone(items []dbmodel.InvocationCheckItem) ([]bool, error) {
+// CheckInvocationStatus provides a mock function with given fields: items
+func (_m *IAttachedFunctionDb) CheckInvocationStatus(items []dbmodel.InvocationCheckItem) ([]dbmodel.InvocationStatusResult, error) {
 	ret := _m.Called(items)
 
 	if len(ret) == 0 {
-		panic("no return value specified for AreInvocationsDone")
+		panic("no return value specified for CheckInvocationStatus")
 	}
 
-	var r0 []bool
+	var r0 []dbmodel.InvocationStatusResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]dbmodel.InvocationCheckItem) ([]bool, error)); ok {
+	if rf, ok := ret.Get(0).(func([]dbmodel.InvocationCheckItem) ([]dbmodel.InvocationStatusResult, error)); ok {
 		return rf(items)
 	}
-	if rf, ok := ret.Get(0).(func([]dbmodel.InvocationCheckItem) []bool); ok {
+	if rf, ok := ret.Get(0).(func([]dbmodel.InvocationCheckItem) []dbmodel.InvocationStatusResult); ok {
 		r0 = rf(items)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]bool)
+			r0 = ret.Get(0).([]dbmodel.InvocationStatusResult)
 		}
 	}
 

--- a/go/pkg/sysdb/metastore/db/dbmodel/task.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/task.go
@@ -57,11 +57,24 @@ type IAttachedFunctionDb interface {
 	CleanupExpiredPartial(maxAgeSeconds uint64) ([]uuid.UUID, error)
 	GetAttachedFunctionsToGc(cutoffTime time.Time, limit int32) ([]*AttachedFunction, error)
 	HardDeleteAttachedFunction(id uuid.UUID) error
-	AreInvocationsDone(items []InvocationCheckItem) ([]bool, error)
+	CheckInvocationStatus(items []InvocationCheckItem) ([]InvocationStatusResult, error)
 }
 
 type InvocationCheckItem struct {
 	FunctionID        uuid.UUID
 	InputCollectionID string
 	CompletionOffset  int64
+}
+
+type InvocationStatus int
+
+const (
+	InvocationStatusNotDone InvocationStatus = iota
+	InvocationStatusDone
+	InvocationStatusNeedsRepair
+)
+
+type InvocationStatusResult struct {
+	Status                  InvocationStatus
+	CurrentCompletionOffset int64
 }

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -710,12 +710,23 @@ message InvocationCheckItem {
   int64 completion_offset = 3;
 }
 
-message AreInvocationsDoneRequest {
+enum InvocationStatus {
+  INVOCATION_STATUS_NOT_DONE = 0;
+  INVOCATION_STATUS_DONE = 1;
+  INVOCATION_STATUS_NEEDS_REPAIR = 2;
+}
+
+message CheckInvocationStatusRequest {
   repeated InvocationCheckItem items = 1;
 }
 
-message AreInvocationsDoneResponse {
-  repeated bool done = 1;
+message InvocationStatusResult {
+  InvocationStatus status = 1;
+  int64 current_completion_offset = 2;
+}
+
+message CheckInvocationStatusResponse {
+  repeated InvocationStatusResult results = 1;
 }
 
 message IncrementCompactionFailureCountRequest {
@@ -770,7 +781,7 @@ service SysDB {
   rpc GetFunctions(GetFunctionsRequest) returns (GetFunctionsResponse) {}
   rpc GetAttachedFunctionsToGc(GetAttachedFunctionsToGcRequest) returns (GetAttachedFunctionsToGcResponse) {}
   rpc FinishAttachedFunctionDeletion(FinishAttachedFunctionDeletionRequest) returns (FinishAttachedFunctionDeletionResponse) {}
-  rpc AreInvocationsDone(AreInvocationsDoneRequest) returns (AreInvocationsDoneResponse) {}
+  rpc CheckInvocationStatus(CheckInvocationStatusRequest) returns (CheckInvocationStatusResponse) {}
   rpc FlushCollectionCompactionAndAttachedFunction(FlushCollectionCompactionAndAttachedFunctionRequest) returns (FlushCollectionCompactionAndAttachedFunctionResponse) {}
   rpc TryFinishAsyncAttachedFunctionInvocation(TryFinishAsyncAttachedFunctionInvocationRequest) returns (TryFinishAsyncAttachedFunctionInvocationResponse) {}
   rpc FinalizeAsyncAttachedFunctionRepair(FinalizeAsyncAttachedFunctionRepairRequest) returns (FinalizeAsyncAttachedFunctionRepairResponse) {}

--- a/rust/rust-sysdb/src/server.rs
+++ b/rust/rust-sysdb/src/server.rs
@@ -13,10 +13,10 @@ use chroma_storage::Storage;
 use chroma_types::chroma_proto::collection_version_info::VersionChangeReason;
 use chroma_types::chroma_proto::{
     sys_db_server::{SysDb, SysDbServer},
-    AreInvocationsDoneRequest, AreInvocationsDoneResponse, AttachFunctionRequest,
-    AttachFunctionResponse, BatchGetCollectionSoftDeleteStatusRequest,
+    AttachFunctionRequest, AttachFunctionResponse, BatchGetCollectionSoftDeleteStatusRequest,
     BatchGetCollectionSoftDeleteStatusResponse, BatchGetCollectionVersionFilePathsRequest,
     BatchGetCollectionVersionFilePathsResponse, CheckCollectionsRequest, CheckCollectionsResponse,
+    CheckInvocationStatusRequest, CheckInvocationStatusResponse,
     CleanupExpiredPartialAttachedFunctionsRequest, CleanupExpiredPartialAttachedFunctionsResponse,
     CountCollectionsRequest, CountCollectionsResponse, CountForksRequest, CountForksResponse,
     CreateCollectionRequest, CreateCollectionResponse, CreateDatabaseRequest,
@@ -990,12 +990,12 @@ impl SysDb for SysdbService {
         ))
     }
 
-    async fn are_invocations_done(
+    async fn check_invocation_status(
         &self,
-        _request: Request<AreInvocationsDoneRequest>,
-    ) -> Result<Response<AreInvocationsDoneResponse>, Status> {
+        _request: Request<CheckInvocationStatusRequest>,
+    ) -> Result<Response<CheckInvocationStatusResponse>, Status> {
         Err(Status::unimplemented(
-            "are_invocations_done is not supported",
+            "check_invocation_status is not supported",
         ))
     }
 }

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -2814,15 +2814,15 @@ impl SysDb {
         }
     }
 
-    pub async fn are_invocations_done(
+    pub async fn check_invocation_status(
         &mut self,
-        request: chroma_types::chroma_proto::AreInvocationsDoneRequest,
+        request: chroma_types::chroma_proto::CheckInvocationStatusRequest,
     ) -> Result<
-        tonic::Response<chroma_types::chroma_proto::AreInvocationsDoneResponse>,
+        tonic::Response<chroma_types::chroma_proto::CheckInvocationStatusResponse>,
         tonic::Status,
     > {
         match self {
-            SysDb::Grpc(grpc) => grpc.client.clone().are_invocations_done(request).await,
+            SysDb::Grpc(grpc) => grpc.client.clone().check_invocation_status(request).await,
             SysDb::Sqlite(_) => unimplemented!(),
             SysDb::Test(_) => unimplemented!(),
         }

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -3,9 +3,12 @@ mod tests {
     use crate::work_queue::work_queue_client::WorkQueueClient;
     use chroma_config::registry::Registry;
     use chroma_config::Configurable;
-    use chroma_sysdb::SysDb;
-    use chroma_types::chroma_proto::{AreInvocationsDoneRequest, InvocationCheckItem};
-    use chroma_types::{AttachedFunctionUuid, CollectionUuid};
+    use chroma_sysdb::{DatabaseOrTopology, GetCollectionsOptions, SysDb};
+    use chroma_types::chroma_proto::{
+        CheckInvocationStatusRequest, InvocationCheckItem, InvocationStatus,
+    };
+    use chroma_types::{AttachedFunctionUuid, CollectionUuid, DatabaseName, SegmentFlushInfo};
+    use std::sync::Arc;
     use uuid::Uuid;
 
     struct TestContext {
@@ -333,6 +336,7 @@ mod tests {
             let coll_id = CollectionUuid::new();
             let initial_offset = 100;
             let new_offset = 150;
+            let advanced_log_position = 200;
 
             // Create collection
             create_test_collection(&mut ctx.sysdb, coll_id, &ctx.tenant_id, &ctx.database_name)
@@ -343,6 +347,35 @@ mod tests {
             let fn_id = create_test_attached_function(&mut ctx.sysdb, coll_id)
                 .await
                 .expect("Failed to create async attached function");
+
+            let database_name =
+                DatabaseName::new(ctx.database_name.clone()).expect("Invalid database name");
+            let collections = ctx
+                .sysdb
+                .get_collections(GetCollectionsOptions {
+                    collection_id: Some(coll_id),
+                    tenant: Some(ctx.tenant_id.clone()),
+                    database_or_topology: Some(DatabaseOrTopology::Database(database_name.clone())),
+                    ..Default::default()
+                })
+                .await
+                .expect("Failed to fetch collection before advancing log position");
+            assert_eq!(collections.len(), 1, "Expected exactly one collection");
+
+            ctx.sysdb
+                .flush_compaction(
+                    ctx.tenant_id.clone(),
+                    database_name,
+                    coll_id,
+                    advanced_log_position,
+                    collections[0].version,
+                    Arc::<[SegmentFlushInfo]>::from([]),
+                    0,
+                    0,
+                    None,
+                )
+                .await
+                .expect("Failed to advance collection log position");
 
             // Push work
             ctx.work_queue_client
@@ -356,7 +389,7 @@ mod tests {
                 .await
                 .expect("Failed to finish work");
 
-            // Get work - should not contain our finished work
+            // Get work - should contain the requeued repair work at the new offset
             let work_items = ctx
                 .work_queue_client
                 .get_work("test_shard".to_string(), 10)
@@ -368,25 +401,28 @@ mod tests {
                 work_items.items.len()
             );
 
-            // Filter to check our function is not in the queue
+            // Filter to check our function is in the queue with the repaired offset
             let our_items: Vec<_> = work_items
                 .items
                 .iter()
                 .filter(|item| item.fn_id == fn_id.to_string())
                 .collect();
 
-            // Work should be completed (not in queue)
             assert_eq!(
                 our_items.len(),
-                0,
-                "Expected 0 work items for our function after repair"
+                1,
+                "Expected 1 work item for our function after finish_work requeued repair"
+            );
+            assert_eq!(
+                our_items[0].completion_offset, new_offset,
+                "Expected repaired work item to use the new completion offset"
             );
 
             // Check invocation status via sysdb
-            let are_done_response = ctx
+            let status_response = ctx
                 .sysdb
                 .clone()
-                .are_invocations_done(AreInvocationsDoneRequest {
+                .check_invocation_status(CheckInvocationStatusRequest {
                     items: vec![
                         InvocationCheckItem {
                             function_id: fn_id.to_string(),
@@ -405,20 +441,31 @@ mod tests {
                 .into_inner();
 
             // Verify invocation statuses
-            assert_eq!(are_done_response.done.len(), 2);
+            assert_eq!(status_response.results.len(), 2);
             println!(
-                "Invocation status: initial_offset={} done={}, new_offset={} done={}",
-                initial_offset, are_done_response.done[0], new_offset, are_done_response.done[1]
+                "Invocation status: initial_offset={} status={:?}, new_offset={} status={:?}",
+                initial_offset,
+                status_response.results[0].status,
+                new_offset,
+                status_response.results[1].status
             );
 
             // The initial offset (100) should be marked as done since we finished at 150
-            assert!(are_done_response.done[0], "Initial offset should be done");
+            assert_eq!(
+                status_response.results[0].status,
+                InvocationStatus::Done as i32,
+                "Initial offset should be done"
+            );
 
-            // The new_offset (150) should NOT be done because we never pushed work at that offset
-            // We only pushed work at offset 100, then called finish_work with offset 150
-            assert!(
-                !are_done_response.done[1],
-                "New offset should NOT be done - we never pushed work at that offset"
+            // The server finalizes repair before responding, so the new offset is back to a normal queued state.
+            assert_eq!(
+                status_response.results[1].status,
+                InvocationStatus::NotDone as i32,
+                "New offset should be marked as not done after repair is finalized"
+            );
+            assert_eq!(
+                status_response.results[1].current_completion_offset, new_offset,
+                "The queued work item should retain the new completion offset after repair"
             );
         })
         .await;

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -15,7 +15,7 @@ use chroma_sysdb::SysDb;
 use chroma_system::{Component, ComponentContext, ComponentRuntime, Handler};
 use chroma_types::chroma_proto::{
     try_finish_async_attached_function_invocation_response::Result as TryFinishResult,
-    AreInvocationsDoneRequest, InvocationCheckItem,
+    CheckInvocationStatusRequest, InvocationCheckItem, InvocationStatus, InvocationStatusResult,
     TryFinishAsyncAttachedFunctionInvocationRequest,
 };
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
@@ -69,6 +69,36 @@ pub(crate) struct WorkQueueManager {
         FinishResult,
         oneshot::Sender<Result<FinishResult, WorkQueueError>>,
     )>,
+}
+
+#[derive(Debug)]
+enum InvocationCompletionStatus {
+    NotDone,
+    Done,
+    NeedsRepair(i64),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum InvocationCompletionStatusConversionError {
+    #[error("invalid invocation status: {0}")]
+    InvalidStatus(i32),
+}
+
+impl TryFrom<InvocationStatusResult> for InvocationCompletionStatus {
+    type Error = InvocationCompletionStatusConversionError;
+
+    fn try_from(result: InvocationStatusResult) -> Result<Self, Self::Error> {
+        match InvocationStatus::try_from(result.status) {
+            Ok(InvocationStatus::Done) => Ok(InvocationCompletionStatus::Done),
+            Ok(InvocationStatus::NeedsRepair) => Ok(InvocationCompletionStatus::NeedsRepair(
+                result.current_completion_offset,
+            )),
+            Ok(InvocationStatus::NotDone) => Ok(InvocationCompletionStatus::NotDone),
+            Err(_) => Err(InvocationCompletionStatusConversionError::InvalidStatus(
+                result.status,
+            )),
+        }
+    }
 }
 
 impl WorkQueueManager {
@@ -276,11 +306,24 @@ impl WorkQueueManager {
         }
     }
 
-    // Check invocation completion status
-    async fn check_invocations_done(
+    // Check invocation completion status (boolean version for compatibility)
+    async fn are_invocations_done(
         &mut self,
         items: &[WorkQueueRecord],
     ) -> Result<Vec<bool>, WorkQueueError> {
+        let statuses = self.check_invocations_status(items).await?;
+        // Map DONE to true, everything else (NOT_DONE, NEEDS_REPAIR) to false
+        Ok(statuses
+            .into_iter()
+            .map(|status| matches!(status, InvocationCompletionStatus::Done))
+            .collect())
+    }
+
+    // Check invocation completion status with detailed status
+    async fn check_invocations_status(
+        &mut self,
+        items: &[WorkQueueRecord],
+    ) -> Result<Vec<InvocationCompletionStatus>, WorkQueueError> {
         if items.is_empty() {
             return Ok(vec![]);
         }
@@ -294,17 +337,117 @@ impl WorkQueueManager {
             })
             .collect();
 
-        let request = AreInvocationsDoneRequest {
+        let request = CheckInvocationStatusRequest {
             items: invocation_items,
         };
 
         let response = self
             .sysdb
-            .are_invocations_done(request)
+            .check_invocation_status(request)
             .await
             .map_err(|e| WorkQueueError::CheckInvocationsFailed(e.message().to_string()))?;
 
-        Ok(response.into_inner().done)
+        let statuses = response
+            .into_inner()
+            .results
+            .into_iter()
+            .map(InvocationCompletionStatus::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| WorkQueueError::CheckInvocationsFailed(e.to_string()))?;
+
+        Ok(statuses)
+    }
+
+    // Check all pending items on startup and repair any that need it
+    async fn check_and_repair_pending_items(&mut self) {
+        if self.state.pending_work.is_empty() {
+            tracing::info!("No pending work items to check for repair");
+            return;
+        }
+
+        tracing::info!(
+            "Checking {} pending work items for repair",
+            self.state.pending_work.len()
+        );
+
+        // Get all pending items
+        let items: Vec<_> = self.state.pending_work.iter().cloned().collect();
+
+        // Check their statuses
+        let statuses = match self.check_invocations_status(&items).await {
+            Ok(statuses) => statuses,
+            Err(e) => {
+                tracing::error!("Failed to check invocation statuses for repair: {}", e);
+                return;
+            }
+        };
+
+        // Find items that need repair
+        let items_needing_repair: Vec<_> = items
+            .into_iter()
+            .zip(statuses.iter())
+            .filter_map(|(item, status)| match status {
+                InvocationCompletionStatus::NeedsRepair(current_completion_offset) => {
+                    Some((item, *current_completion_offset))
+                }
+                _ => None,
+            })
+            .collect();
+
+        if items_needing_repair.is_empty() {
+            tracing::info!("No items need repair");
+            return;
+        }
+
+        tracing::warn!("Found {} items needing repair", items_needing_repair.len());
+
+        for (item, current_completion_offset) in &items_needing_repair {
+            tracing::info!(
+                "Queueing repair for fn_id: {}, input_coll_id: {}, old_completion_offset: {}, current_completion_offset: {}",
+                item.fn_id,
+                item.input_coll_id,
+                item.completion_offset,
+                current_completion_offset
+            );
+
+            self.state
+                .push_work(item.fn_id, item.input_coll_id, *current_completion_offset);
+        }
+
+        if let Err(e) = self.persist().await {
+            tracing::error!(
+                "Failed to persist repaired work queue state; skipping sysdb repair finalization: {}",
+                e
+            );
+            return;
+        }
+
+        for (item, _) in items_needing_repair {
+            tracing::info!(
+                "Finalizing repair for fn_id: {}, input_coll_id: {}",
+                item.fn_id,
+                item.input_coll_id
+            );
+
+            let repair_request =
+                chroma_types::chroma_proto::FinalizeAsyncAttachedFunctionRepairRequest {
+                    attached_function_id: item.fn_id.to_string(),
+                };
+
+            if let Err(e) = self
+                .sysdb
+                .finalize_async_attached_function_repair(repair_request)
+                .await
+            {
+                tracing::error!(
+                    "Failed to finalize repair for function {}: {}",
+                    item.fn_id,
+                    e
+                );
+            }
+        }
+
+        tracing::info!("Repair check completed");
     }
 }
 
@@ -331,6 +474,9 @@ impl Component for WorkQueueManager {
             panic!("Cannot start without valid state");
         }
 
+        // Check all heap items to see if any need repair
+        self.check_and_repair_pending_items().await;
+
         // Schedule periodic persistence
         ctx.scheduler.schedule(
             PeriodicPersistMessage,
@@ -338,10 +484,6 @@ impl Component for WorkQueueManager {
             ctx,
             || None,
         );
-
-        // TODO(tanujnay112): Check to see if any entry needs repair.
-        // This is done by looking at all the heap items and seeing if
-        // any of them need a repair according to sysdb.
     }
 
     async fn on_stop(&mut self) -> Result<(), Box<dyn ChromaError>> {
@@ -456,7 +598,7 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
         // Check invocations done
         // TODO(tanujnay112): We won't need this if we make sure finish_work
         // deletes the work item from the queue and we look for repair on bootup.
-        let done_flags = match self.check_invocations_done(&items).await {
+        let done_flags = match self.are_invocations_done(&items).await {
             Ok(flags) => flags,
             Err(e) => {
                 tracing::error!("Failed to check invocations done: {}", e);

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -13,19 +13,16 @@ use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use std::str::FromStr;
 use tonic::{Request, Response, Status};
 
-#[allow(dead_code)]
 pub struct WorkQueueServer {
     manager: ComponentHandle<WorkQueueManager>,
     sysdb: SysDb,
 }
 
-#[allow(dead_code)]
 impl WorkQueueServer {
     pub fn new(manager: ComponentHandle<WorkQueueManager>, sysdb: SysDb) -> Self {
         Self { manager, sysdb }
     }
 
-    #[allow(dead_code)]
     pub fn into_service(self) -> WorkQueueServiceServer<Self> {
         WorkQueueServiceServer::new(self)
     }


### PR DESCRIPTION
## Description of changes

This PR renames `AreInvocationsDone` (which returned `[]bool`) to `CheckInvocationStatus` (which returns a three-state enum). The key semantic change is that the old binary done/not-done is replaced with three states:

- `NOT_DONE` (0) — default, work still in progress
- `DONE` (1) — completed (soft/hard deleted, or offset advanced with no pending heap entry)
- `NEEDS_REPAIR` (2) — offset advanced but `heap_entry_pending=true`, meaning the WQS crashed mid-repair

The new `NEEDS_REPAIR` state enables the work queue manager to automatically repair stale entries on bootup, which is the core bug fix this PR addresses.

In the proto we replaced the RPC for `AreInvocationsDone` with ``CheckInvocationStatus` this is not backwards compatible but that is fine as there is not production use for the former RPC yet.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_