### PR TITLE
[CHORE] Plumb tenant/db id through to HttpGen

### DIFF
--- a/rust/types/src/task.rs
+++ b/rust/types/src/task.rs
@@ -75,9 +75,9 @@ pub struct AttachedFunction {
     pub output_collection_id: Option<CollectionUuid>,
     /// Optional JSON parameters for the function
     pub params: Option<String>,
-    /// Tenant name this attached function belongs to (despite field name, this is a name not a UUID)
+    /// Tenant ID this attached function belongs to
     pub tenant_id: String,
-    /// Database name this attached function belongs to (despite field name, this is a name not a UUID)
+    /// Database ID this attached function belongs to
     pub database_id: String,
     /// Timestamp of the last successful function run
     #[serde(skip, default)]

--- a/rust/worker/src/execution/functions/http_generate.rs
+++ b/rust/worker/src/execution/functions/http_generate.rs
@@ -26,7 +26,7 @@ struct GenerateRecord {
 #[derive(Debug, Serialize)]
 struct GenerateRecordSet {
     tenant_id: String,
-    database_name: String,
+    database_id: String,
     source_collection: String,
     source_kind: String,
     output_collection: String,
@@ -58,7 +58,7 @@ pub struct HttpGenerateExecutor {
     source_kind: String,
     output_collection: String,
     tenant_id: String,
-    database_name: String,
+    database_id: String,
     modal_key: String,
     modal_secret: String,
     client: reqwest::Client,
@@ -132,7 +132,7 @@ impl HttpGenerateExecutor {
             tenant_id: af.tenant_id.clone(),
             // Note(hammadb): See rust/types/src/task.rs which notes that database_id is a name not a UUID
             // this is odd, but keeping it as is for transmission here.
-            database_name: af.database_id.clone(),
+            database_id: af.database_id.clone(),
             modal_key,
             modal_secret,
             client: reqwest::Client::builder()
@@ -323,7 +323,7 @@ impl AttachedFunctionExecutor for HttpGenerateExecutor {
         let request_body = GenerateRequest {
             record_set: GenerateRecordSet {
                 tenant_id: self.tenant_id.clone(),
-                database_name: self.database_name.clone(),
+                database_id: self.database_id.clone(),
                 source_collection: self.source_collection.clone(),
                 source_kind: self.source_kind.clone(),
                 output_collection: self.output_collection.clone(),

--- a/rust/worker/src/execution/functions/http_generate.rs
+++ b/rust/worker/src/execution/functions/http_generate.rs
@@ -130,8 +130,6 @@ impl HttpGenerateExecutor {
             source_kind,
             output_collection: af.output_collection_name.clone(),
             tenant_id: af.tenant_id.clone(),
-            // Note(hammadb): See rust/types/src/task.rs which notes that database_id is a name not a UUID
-            // this is odd, but keeping it as is for transmission here.
             database_id: af.database_id.clone(),
             modal_key,
             modal_secret,

--- a/rust/worker/src/execution/functions/http_generate.rs
+++ b/rust/worker/src/execution/functions/http_generate.rs
@@ -25,6 +25,8 @@ struct GenerateRecord {
 
 #[derive(Debug, Serialize)]
 struct GenerateRecordSet {
+    tenant_id: String,
+    database_name: String,
     source_collection: String,
     source_kind: String,
     output_collection: String,
@@ -55,6 +57,8 @@ pub struct HttpGenerateExecutor {
     source_collection: String,
     source_kind: String,
     output_collection: String,
+    tenant_id: String,
+    database_name: String,
     modal_key: String,
     modal_secret: String,
     client: reqwest::Client,
@@ -125,6 +129,10 @@ impl HttpGenerateExecutor {
             source_collection,
             source_kind,
             output_collection: af.output_collection_name.clone(),
+            tenant_id: af.tenant_id.clone(),
+            // Note(hammadb): See rust/types/src/task.rs which notes that database_id is a name not a UUID
+            // this is odd, but keeping it as is for transmission here.
+            database_name: af.database_id.clone(),
             modal_key,
             modal_secret,
             client: reqwest::Client::builder()
@@ -314,6 +322,8 @@ impl AttachedFunctionExecutor for HttpGenerateExecutor {
         let num_records = records.len();
         let request_body = GenerateRequest {
             record_set: GenerateRecordSet {
+                tenant_id: self.tenant_id.clone(),
+                database_name: self.database_name.clone(),
                 source_collection: self.source_collection.clone(),
                 source_kind: self.source_kind.clone(),
                 output_collection: self.output_collection.clone(),


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Plumbs tenant/db id to http gen for downstream use.
- New functionality
  - None

## Test plan
_How are these changes tested?_
- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None required, receivers ignore fields they don't understand

## Observability plan
None required for this change

## Documentation Changes
None