### PR TITLE
[ENH] Group chunk siblings into one compaction partition

### DIFF
--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -1284,6 +1284,14 @@ impl ChromaError for ListCollectionVersionsError {
 pub const CHROMA_KEY: &str = "chroma:";
 pub const CHROMA_DOCUMENT_KEY: &str = "chroma:document";
 pub const CHROMA_URI_KEY: &str = "chroma:uri";
+/// Collection-metadata flag (a `MetadataValue::Bool(true)`) that opts a
+/// collection into chunk-sibling grouping during log partitioning: records
+/// whose ids share a base before a trailing `-{idx}` are kept in one
+/// partition so they materialize in WAL order. Foundation source
+/// collections set this so the attached function observes a trailing
+/// end-of-job marker after all sibling chunks. Read by the worker's
+/// `PartitionOperator`; set by the foundation `/init` endpoint.
+pub const CHROMA_GROUP_CHUNK_SIBLINGS_KEY: &str = "chroma:group_chunk_siblings";
 
 ////////////////////////// AddCollectionRecords //////////////////////////
 

--- a/rust/worker/src/execution/operators/partition_log.rs
+++ b/rust/worker/src/execution/operators/partition_log.rs
@@ -10,11 +10,10 @@ use thiserror::Error;
 /// `MetadataValue::Bool(true)` enables it; absent or any other value
 /// leaves the default (group by exact id) in place.
 ///
-/// The flag is *read* here; the code that *sets* it on the relevant
-/// collections (foundation source collections) lands in a separate PR.
-/// Until that ships, no collection carries the flag and this operator
-/// behaves exactly as before.
-pub const GROUP_CHUNK_SIBLINGS_METADATA_KEY: &str = "chroma:group_chunk_siblings";
+/// The flag is *read* here; the code that *sets* it on foundation source
+/// collections lives in the foundation `/init` endpoint. Re-exported from
+/// `chroma_types` so reader and writer share one definition.
+pub use chroma_types::CHROMA_GROUP_CHUNK_SIBLINGS_KEY as GROUP_CHUNK_SIBLINGS_METADATA_KEY;
 
 /// Grouping key used to assign a record to a partition.
 ///

--- a/rust/worker/src/execution/operators/partition_log.rs
+++ b/rust/worker/src/execution/operators/partition_log.rs
@@ -5,6 +5,17 @@ use chroma_types::{Chunk, LogRecord};
 use std::collections::HashMap;
 use thiserror::Error;
 
+/// Collection-metadata key that opts a collection into chunk-sibling
+/// grouping during partitioning (see [`chunk_grouping_key`]). A
+/// `MetadataValue::Bool(true)` enables it; absent or any other value
+/// leaves the default (group by exact id) in place.
+///
+/// The flag is *read* here; the code that *sets* it on the relevant
+/// collections (foundation source collections) lands in a separate PR.
+/// Until that ships, no collection carries the flag and this operator
+/// behaves exactly as before.
+pub const GROUP_CHUNK_SIBLINGS_METADATA_KEY: &str = "chroma:group_chunk_siblings";
+
 /// Grouping key used to assign a record to a partition.
 ///
 /// A record whose id ends in `-{digits}` (e.g. `mydoc-0`, `mydoc-12`)
@@ -21,13 +32,16 @@ use thiserror::Error;
 /// invariant is preserved. Records whose id does not match `{base}-{digits}`
 /// are returned unchanged.
 ///
-/// Trade-off (flagged for review): ids that legitimately end in
-/// `-{digits}` but are NOT chunk siblings (e.g. `report-2024`,
-/// `report-2023`) will be co-located in one partition. This is
-/// correctness-neutral — they remain distinct records — but can reduce
-/// compaction parallelism for collections that use such an id scheme.
-/// If that proves too coarse, this should be gated behind a
-/// per-collection flag rather than applied globally.
+/// This folding is **opt-in per collection** via the
+/// [`GROUP_CHUNK_SIBLINGS_METADATA_KEY`] collection-metadata flag, so it
+/// only affects collections that have explicitly enabled it (foundation
+/// source collections). Collections without the flag continue to group
+/// by exact id. The opt-in gate exists because ids that legitimately end
+/// in `-{digits}` but are NOT chunk siblings (e.g. `report-2024`,
+/// `report-2023`) would otherwise be co-located in one partition —
+/// correctness-neutral (they stay distinct records) but a parallelism
+/// cost we don't want to impose on collections that don't need the
+/// ordering guarantee.
 fn chunk_grouping_key(id: &str) -> &str {
     match id.rsplit_once('-') {
         Some((base, suffix))
@@ -60,6 +74,12 @@ pub struct PartitionOperator {}
 pub struct PartitionInput {
     pub(crate) records: Chunk<LogRecord>,
     pub(crate) max_partition_size: usize,
+    /// When true, chunk siblings (`{base}-{idx}`) are grouped under their
+    /// shared base so they land in one partition (see [`chunk_grouping_key`]).
+    /// Gated per-collection via the [`GROUP_CHUNK_SIBLINGS_METADATA_KEY`]
+    /// collection-metadata flag; defaults to false so behavior is unchanged
+    /// for every collection that hasn't opted in.
+    pub(crate) group_chunk_siblings: bool,
 }
 
 impl PartitionInput {
@@ -69,10 +89,17 @@ impl PartitionInput {
     /// * `max_partition_size` - The maximum size of a partition. Since we are trying to
     ///   partition the records by id, which can casue the partition size to be larger than this
     ///   value.
-    pub fn new(records: Chunk<LogRecord>, max_partition_size: usize) -> Self {
+    /// * `group_chunk_siblings` - When true, fold chunk siblings onto a
+    ///   shared base when partitioning (opt-in per collection).
+    pub fn new(
+        records: Chunk<LogRecord>,
+        max_partition_size: usize,
+        group_chunk_siblings: bool,
+    ) -> Self {
         PartitionInput {
             records,
             max_partition_size,
+            group_chunk_siblings,
         }
     }
 }
@@ -104,12 +131,20 @@ impl PartitionOperator {
         &self,
         records: &Chunk<LogRecord>,
         partition_size: usize,
+        group_chunk_siblings: bool,
     ) -> Vec<Chunk<LogRecord>> {
         let mut map = HashMap::new();
         for data in records.iter() {
             let log_record = data.0;
             let index = data.1;
-            let key = chunk_grouping_key(&log_record.record.id).to_string();
+            // Only fold chunk siblings onto a shared base when the
+            // collection has opted in; otherwise group by the exact id
+            // (unchanged behavior for every other collection).
+            let key = if group_chunk_siblings {
+                chunk_grouping_key(&log_record.record.id).to_string()
+            } else {
+                log_record.record.id.clone()
+            };
             map.entry(key).or_insert_with(Vec::new).push(index);
         }
         let mut result = Vec::new();
@@ -166,7 +201,7 @@ impl Operator<PartitionInput, PartitionOutput> for PartitionOperator {
     async fn run(&self, input: &PartitionInput) -> Result<PartitionOutput, PartitionError> {
         let records = &input.records;
         let partition_size = self.determine_partition_size(records.len(), input.max_partition_size);
-        let deduped_records = self.partition(records, partition_size);
+        let deduped_records = self.partition(records, partition_size, input.group_chunk_siblings);
         return Ok(PartitionOutput {
             records: deduped_records,
         });
@@ -221,7 +256,7 @@ mod tests {
         // Test group size is larger than the number of records
         let chunk = Chunk::new(data.clone());
         let operator = PartitionOperator::new();
-        let input = PartitionInput::new(chunk, 4);
+        let input = PartitionInput::new(chunk, 4, false);
         let result = operator.run(&input).await.unwrap();
         assert_eq!(result.records.len(), 1);
         assert_eq!(result.records[0].len(), 3);
@@ -229,7 +264,7 @@ mod tests {
         // Test group size is the same as the number of records
         let chunk = Chunk::new(data.clone());
         let operator = PartitionOperator::new();
-        let input = PartitionInput::new(chunk, 3);
+        let input = PartitionInput::new(chunk, 3, false);
         let result = operator.run(&input).await.unwrap();
         assert_eq!(result.records.len(), 1);
         assert_eq!(result.records[0].len(), 3);
@@ -237,7 +272,7 @@ mod tests {
         // Test group size is smaller than the number of records
         let chunk = Chunk::new(data.clone());
         let operator = PartitionOperator::new();
-        let input = PartitionInput::new(chunk, 2);
+        let input = PartitionInput::new(chunk, 2, false);
         let mut result = operator.run(&input).await.unwrap();
 
         // The result can be 1 or 2 groups depending on the order of the records.
@@ -253,7 +288,7 @@ mod tests {
         // Test group size is smaller than the number of records
         let chunk = Chunk::new(data.clone());
         let operator = PartitionOperator::new();
-        let input = PartitionInput::new(chunk, 1);
+        let input = PartitionInput::new(chunk, 1, false);
         let mut result = operator.run(&input).await.unwrap();
         assert_eq!(result.records.len(), 2);
         result.records.sort_by_key(|x| x.len());
@@ -279,13 +314,8 @@ mod tests {
         assert_eq!(chunk_grouping_key("report-2024"), "report");
     }
 
-    #[tokio::test]
-    async fn test_chunk_siblings_share_a_partition() {
-        // Three chunks of one document plus one unrelated record. Even
-        // at partition_size == 1, the chunk siblings must stay together
-        // (they share grouping key "doc"), so we get exactly 2
-        // partitions: {doc-0, doc-1, doc-2} and {other}.
-        let mk = |offset: i64, id: &str| LogRecord {
+    fn chunk_record(offset: i64, id: &str) -> LogRecord {
+        LogRecord {
             log_offset: offset,
             record: OperationRecord {
                 id: id.to_string(),
@@ -295,22 +325,52 @@ mod tests {
                 document: None,
                 operation: Operation::Add,
             },
-        };
+        }
+    }
+
+    #[tokio::test]
+    async fn test_chunk_siblings_share_a_partition_when_opted_in() {
+        // Three chunks of one document plus one unrelated record, with
+        // group_chunk_siblings = true. Even at partition_size == 1, the
+        // chunk siblings stay together (shared grouping key "doc"), so we
+        // get exactly 2 partitions: {doc-0, doc-1, doc-2} and {other}.
         let data: Arc<[LogRecord]> = vec![
-            mk(1, "doc-0"),
-            mk(2, "doc-1"),
-            mk(3, "doc-2"),
-            mk(4, "other"),
+            chunk_record(1, "doc-0"),
+            chunk_record(2, "doc-1"),
+            chunk_record(3, "doc-2"),
+            chunk_record(4, "other"),
         ]
         .into();
 
         let operator = PartitionOperator::new();
-        let input = PartitionInput::new(Chunk::new(data), 1);
+        let input = PartitionInput::new(Chunk::new(data), 1, true);
         let mut result = operator.run(&input).await.unwrap();
 
         assert_eq!(result.records.len(), 2);
         result.records.sort_by_key(|x| x.len());
         assert_eq!(result.records[0].len(), 1); // {other}
         assert_eq!(result.records[1].len(), 3); // {doc-0, doc-1, doc-2}
+    }
+
+    #[tokio::test]
+    async fn test_chunk_siblings_not_grouped_when_opted_out() {
+        // Same input with group_chunk_siblings = false (the default):
+        // each chunk is a distinct id, so at partition_size == 1 they do
+        // NOT fold together. We get one partition per distinct id (4).
+        let data: Arc<[LogRecord]> = vec![
+            chunk_record(1, "doc-0"),
+            chunk_record(2, "doc-1"),
+            chunk_record(3, "doc-2"),
+            chunk_record(4, "other"),
+        ]
+        .into();
+
+        let operator = PartitionOperator::new();
+        let input = PartitionInput::new(Chunk::new(data), 1, false);
+        let result = operator.run(&input).await.unwrap();
+
+        // Four distinct grouping keys -> four single-record partitions.
+        assert_eq!(result.records.len(), 4);
+        assert!(result.records.iter().all(|r| r.len() == 1));
     }
 }

--- a/rust/worker/src/execution/operators/partition_log.rs
+++ b/rust/worker/src/execution/operators/partition_log.rs
@@ -5,12 +5,52 @@ use chroma_types::{Chunk, LogRecord};
 use std::collections::HashMap;
 use thiserror::Error;
 
+/// Grouping key used to assign a record to a partition.
+///
+/// A record whose id ends in `-{digits}` (e.g. `mydoc-0`, `mydoc-12`)
+/// is grouped under its base (`mydoc`), so that all chunks of one
+/// document land in the same partition. The partition operator
+/// guarantees in-order processing *within* a partition but not across
+/// partitions, so co-locating a document's chunks is what lets a
+/// downstream consumer (e.g. a foundation attached function) observe a
+/// trailing end-of-job marker on `{base}-0` only after every sibling
+/// chunk — see ADR 0001 §6 in chroma-core/foundation.
+///
+/// This only ever *enlarges* groups: a given concrete id always maps to
+/// a single key, so the existing "all ops for one id in one partition"
+/// invariant is preserved. Records whose id does not match `{base}-{digits}`
+/// are returned unchanged.
+///
+/// Trade-off (flagged for review): ids that legitimately end in
+/// `-{digits}` but are NOT chunk siblings (e.g. `report-2024`,
+/// `report-2023`) will be co-located in one partition. This is
+/// correctness-neutral — they remain distinct records — but can reduce
+/// compaction parallelism for collections that use such an id scheme.
+/// If that proves too coarse, this should be gated behind a
+/// per-collection flag rather than applied globally.
+fn chunk_grouping_key(id: &str) -> &str {
+    match id.rsplit_once('-') {
+        Some((base, suffix))
+            if !base.is_empty()
+                && !suffix.is_empty()
+                && suffix.bytes().all(|b| b.is_ascii_digit()) =>
+        {
+            base
+        }
+        _ => id,
+    }
+}
+
 #[derive(Debug)]
 /// The partition Operator takes a DataChunk and presents a copy-free
 /// view of N partitions by breaking the data into partitions by max_partition_size. It will group operations
 /// on the same key into the same partition. Due to this, the max_partition_size is a
 /// soft-limit, since if there are more operations to a key than max_partition_size we cannot
 /// partition the data.
+///
+/// Keys are computed by [`chunk_grouping_key`], which folds chunk
+/// siblings (`{base}-{idx}`) onto a shared base so a document's chunks
+/// stay in one partition.
 pub struct PartitionOperator {}
 
 /// The input to the partition operator.
@@ -69,7 +109,7 @@ impl PartitionOperator {
         for data in records.iter() {
             let log_record = data.0;
             let index = data.1;
-            let key = log_record.record.id.clone();
+            let key = chunk_grouping_key(&log_record.record.id).to_string();
             map.entry(key).or_insert_with(Vec::new).push(index);
         }
         let mut result = Vec::new();
@@ -219,5 +259,58 @@ mod tests {
         result.records.sort_by_key(|x| x.len());
         assert_eq!(result.records[0].len(), 1);
         assert_eq!(result.records[1].len(), 2);
+    }
+
+    #[test]
+    fn test_chunk_grouping_key() {
+        // Chunk siblings fold onto their base.
+        assert_eq!(chunk_grouping_key("mydoc-0"), "mydoc");
+        assert_eq!(chunk_grouping_key("mydoc-12"), "mydoc");
+        assert_eq!(chunk_grouping_key("sha256hex-9999"), "sha256hex");
+        // Only the final `-{digits}` segment is stripped.
+        assert_eq!(chunk_grouping_key("a-b-0"), "a-b");
+        // Non-chunk ids pass through unchanged.
+        assert_eq!(chunk_grouping_key("mydoc"), "mydoc");
+        assert_eq!(chunk_grouping_key("mydoc-abc"), "mydoc-abc");
+        assert_eq!(chunk_grouping_key("mydoc-"), "mydoc-");
+        assert_eq!(chunk_grouping_key("-0"), "-0"); // empty base: leave alone
+        assert_eq!(chunk_grouping_key(""), "");
+        // Documented trade-off: a legitimately-numbered id is folded too.
+        assert_eq!(chunk_grouping_key("report-2024"), "report");
+    }
+
+    #[tokio::test]
+    async fn test_chunk_siblings_share_a_partition() {
+        // Three chunks of one document plus one unrelated record. Even
+        // at partition_size == 1, the chunk siblings must stay together
+        // (they share grouping key "doc"), so we get exactly 2
+        // partitions: {doc-0, doc-1, doc-2} and {other}.
+        let mk = |offset: i64, id: &str| LogRecord {
+            log_offset: offset,
+            record: OperationRecord {
+                id: id.to_string(),
+                embedding: None,
+                encoding: None,
+                metadata: None,
+                document: None,
+                operation: Operation::Add,
+            },
+        };
+        let data: Arc<[LogRecord]> = vec![
+            mk(1, "doc-0"),
+            mk(2, "doc-1"),
+            mk(3, "doc-2"),
+            mk(4, "other"),
+        ]
+        .into();
+
+        let operator = PartitionOperator::new();
+        let input = PartitionInput::new(Chunk::new(data), 1);
+        let mut result = operator.run(&input).await.unwrap();
+
+        assert_eq!(result.records.len(), 2);
+        result.records.sort_by_key(|x| x.len());
+        assert_eq!(result.records[0].len(), 1); // {other}
+        assert_eq!(result.records[1].len(), 3); // {doc-0, doc-1, doc-2}
     }
 }

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -22,8 +22,8 @@ use chroma_system::{
     OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
-    Chunk, CollectionUuid, JobId, LogRecord, SchemaMismatchError, SegmentFlushInfo, SegmentScope,
-    SegmentShard, SegmentShardError,
+    Chunk, CollectionUuid, JobId, LogRecord, MetadataValue, SchemaMismatchError, SegmentFlushInfo,
+    SegmentScope, SegmentShard, SegmentShardError,
 };
 use opentelemetry::trace::TraceContextExt;
 use std::sync::{atomic::AtomicU32, Arc};
@@ -46,7 +46,10 @@ use crate::{
                 MaterializeLogInput, MaterializeLogOperator, MaterializeLogOperatorError,
                 MaterializeLogOutput,
             },
-            partition_log::{PartitionError, PartitionInput, PartitionOperator, PartitionOutput},
+            partition_log::{
+                PartitionError, PartitionInput, PartitionOperator, PartitionOutput,
+                GROUP_CHUNK_SIBLINGS_METADATA_KEY,
+            },
             prefetch_segment::{
                 PrefetchSegmentError, PrefetchSegmentInput, PrefetchSegmentOperator,
                 PrefetchSegmentOutput,
@@ -383,7 +386,23 @@ impl LogFetchOrchestrator {
         self.state = ExecutionState::Partition;
         let operator = PartitionOperator::new();
         tracing::info!("Sending N Records: {:?}", records.len());
-        let input = PartitionInput::new(records, self.context.max_partition_size);
+        // Opt-in per collection: fold chunk siblings ({base}-{idx}) onto a
+        // shared base so they partition together and preserve per-document
+        // WAL order. Defaults to false when the collection (or its
+        // metadata) doesn't carry the flag.
+        let group_chunk_siblings = self
+            .context
+            .get_collection_info()
+            .ok()
+            .and_then(|info| info.collection.metadata.as_ref())
+            .and_then(|metadata| metadata.get(GROUP_CHUNK_SIBLINGS_METADATA_KEY))
+            .map(|value| matches!(value, MetadataValue::Bool(true)))
+            .unwrap_or(false);
+        let input = PartitionInput::new(
+            records,
+            self.context.max_partition_size,
+            group_chunk_siblings,
+        );
         let task = wrap(
             operator,
             input,


### PR DESCRIPTION
## Summary

`PartitionOperator::partition` (`rust/worker/src/execution/operators/partition_log.rs`) groups log records by `record.id` so all operations on one id land in a single partition. The operator guarantees in-order processing *within* a partition, but **not across** partitions.

Chunks of one document are distinct ids (`{base}-0`, `{base}-1`, …), so today they can be split across partitions and materialized out of order relative to each other.

This PR adds an **opt-in** mode (`chunk_grouping_key`) that folds a trailing `-{digits}` chunk suffix onto its base, so a document's chunks share a partition and preserve per-document WAL order.

## Gating (per review decision)

The folding is **off by default** and enabled **per collection** via a new collection-metadata flag:

- `GROUP_CHUNK_SIBLINGS_METADATA_KEY` = `"chroma:group_chunk_siblings"`. A `MetadataValue::Bool(true)` on the collection's metadata turns it on.
- `PartitionInput` carries a `group_chunk_siblings: bool`; the log-fetch orchestrator reads the flag from the collection metadata and threads it in.
- **The code that *sets* this flag on foundation source collections lands in [a separate PR.](https://github.com/chroma-core/chroma/pull/7134)** Until that ships, no collection carries the flag, so this PR is a no-op for every existing collection — behavior is byte-identical to before.

This replaces the original global approach in this PR's first revision. Gating avoids the parallelism cost for collections whose ids legitimately end in `-{digits}` (e.g. `report-2024`) — they only get co-located if the collection opts in.

## Why

The foundation sync-status work (ADR 0001 §6, chroma-core/foundation) needs an end-of-job marker: the sync pipeline writes a trailing `Mutation::Update` to `{base}-0` *after* every chunk Create, and the foundation attached function treats observing `job_id` on that record as "this upload is fully synthesized." That only works if the marker is observed **after** all sibling chunks — i.e. if the chunks process in WAL order, which requires them in the same partition. Foundation source collections will set the metadata flag; everything else is unaffected.

## Correctness

The folding only ever **enlarges** groups: a concrete id always maps to a single key, so the existing "all ops for one id in one partition" invariant is preserved. No same-id group is ever split. For opted-in collections, unrelated ids ending in `-{digits}` are co-located (correctness-neutral; they remain distinct records).

## Test plan

- [x] Unit tests added:
  - `test_chunk_grouping_key` — fold / passthrough / edge cases (incl. the `report-2024` fold).
  - `test_chunk_siblings_share_a_partition_when_opted_in` — flag on: 3 chunks + 1 unrelated record at `partition_size = 1` → 2 partitions.
  - `test_chunk_siblings_not_grouped_when_opted_out` — flag off (default): same input → 4 single-record partitions (unchanged behavior).
- [ ] **CI must run these** — I could not run the worker test suite locally: this environment's rustc (Homebrew 1.94.1) differs from the repo-pinned 1.92.0 and `wal3` fails to compile under 1.94.1 (independently of this change). `cargo fmt` is clean; the edit is small and self-contained, but it has not been compiled locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)