### PR TITLE
[ENH] /init: create source collections + attach foundation function

### DIFF
--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -32,6 +32,12 @@ pub struct FoundationConfig {
     pub wiki_collection: String,
     #[serde(default = "FoundationConfig::default_wiki_revisions_collection")]
     pub wiki_revisions_collection: String,
+    /// Source collections (one per ingest source) that `/init` ensures.
+    /// These receive the chunk-sibling grouping flag so the attached
+    /// function observes the per-job end-of-job marker after all of a
+    /// job's chunk records (ADR 0001 §6 in chroma-core/foundation).
+    #[serde(default = "FoundationConfig::default_source_collections")]
+    pub source_collections: Vec<String>,
 }
 
 impl FoundationConfig {
@@ -44,6 +50,9 @@ impl FoundationConfig {
     fn default_wiki_revisions_collection() -> String {
         "wiki_revisions".to_string()
     }
+    fn default_source_collections() -> Vec<String> {
+        vec!["slack".to_string(), "notion".to_string()]
+    }
 }
 
 impl Default for FoundationConfig {
@@ -52,6 +61,7 @@ impl Default for FoundationConfig {
             database_name: Self::default_database_name(),
             wiki_collection: Self::default_wiki_collection(),
             wiki_revisions_collection: Self::default_wiki_revisions_collection(),
+            source_collections: Self::default_source_collections(),
         }
     }
 }

--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -43,9 +43,11 @@ pub struct FoundationConfig {
     #[serde(default = "FoundationConfig::default_function_name")]
     pub function_name: String,
     /// Modal endpoint the attached function POSTs to. Threaded into the
-    /// attach `params` as `endpoint_url`. Default mirrors the POC.
-    #[serde(default = "FoundationConfig::default_function_endpoint_url")]
-    pub function_endpoint_url: String,
+    /// attach `params` as `endpoint_url`. Required — there is intentionally
+    /// no default, so a deploy can't silently fall back to a hardcoded
+    /// endpoint; `/init` errors if it is unset (absent in config -> `None`).
+    #[serde(default)]
+    pub function_endpoint_url: Option<String>,
     /// How many new source-collection records accumulate before the
     /// attached function is invoked. Matches the chroma frontend default.
     #[serde(default = "FoundationConfig::default_min_records_for_invocation")]
@@ -68,9 +70,6 @@ impl FoundationConfig {
     fn default_function_name() -> String {
         "http_generate".to_string()
     }
-    fn default_function_endpoint_url() -> String {
-        "https://chroma-core--foundation-research-generate-api.modal.run".to_string()
-    }
     fn default_min_records_for_invocation() -> u64 {
         100
     }
@@ -84,7 +83,7 @@ impl Default for FoundationConfig {
             wiki_revisions_collection: Self::default_wiki_revisions_collection(),
             source_collections: Self::default_source_collections(),
             function_name: Self::default_function_name(),
-            function_endpoint_url: Self::default_function_endpoint_url(),
+            function_endpoint_url: None,
             min_records_for_invocation: Self::default_min_records_for_invocation(),
         }
     }

--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -38,6 +38,18 @@ pub struct FoundationConfig {
     /// job's chunk records (ADR 0001 §6 in chroma-core/foundation).
     #[serde(default = "FoundationConfig::default_source_collections")]
     pub source_collections: Vec<String>,
+    /// Server-registered function attached to each source collection
+    /// (its output is the wiki collection). Default mirrors the POC.
+    #[serde(default = "FoundationConfig::default_function_name")]
+    pub function_name: String,
+    /// Modal endpoint the attached function POSTs to. Threaded into the
+    /// attach `params` as `endpoint_url`. Default mirrors the POC.
+    #[serde(default = "FoundationConfig::default_function_endpoint_url")]
+    pub function_endpoint_url: String,
+    /// How many new source-collection records accumulate before the
+    /// attached function is invoked. Matches the chroma frontend default.
+    #[serde(default = "FoundationConfig::default_min_records_for_invocation")]
+    pub min_records_for_invocation: u64,
 }
 
 impl FoundationConfig {
@@ -53,6 +65,15 @@ impl FoundationConfig {
     fn default_source_collections() -> Vec<String> {
         vec!["slack".to_string(), "notion".to_string()]
     }
+    fn default_function_name() -> String {
+        "http_generate".to_string()
+    }
+    fn default_function_endpoint_url() -> String {
+        "https://chroma-core--foundation-research-generate-api.modal.run".to_string()
+    }
+    fn default_min_records_for_invocation() -> u64 {
+        100
+    }
 }
 
 impl Default for FoundationConfig {
@@ -62,6 +83,9 @@ impl Default for FoundationConfig {
             wiki_collection: Self::default_wiki_collection(),
             wiki_revisions_collection: Self::default_wiki_revisions_collection(),
             source_collections: Self::default_source_collections(),
+            function_name: Self::default_function_name(),
+            function_endpoint_url: Self::default_function_endpoint_url(),
+            min_records_for_invocation: Self::default_min_records_for_invocation(),
         }
     }
 }

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -1,9 +1,10 @@
 use axum::{extract::State, http::HeaderMap, Json};
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_sysdb::SysDb;
+use chroma_sysdb::{AttachFunctionError, SysDb};
 use chroma_types::{
-    Collection, CreateDatabaseError, DatabaseName, IndexConfig, KnnIndex, Metadata, MetadataValue,
-    Schema, SparseIndexAlgorithm, SparseVectorIndexConfig, CHROMA_GROUP_CHUNK_SIBLINGS_KEY,
+    Collection, CollectionUuid, CreateDatabaseError, DatabaseName, IndexConfig, KnnIndex, Metadata,
+    MetadataValue, Schema, SparseIndexAlgorithm, SparseVectorIndexConfig,
+    CHROMA_GROUP_CHUNK_SIBLINGS_KEY,
 };
 use frontend_core::collection_ops::{
     plan_create_collection, supported_segment_types, ExecutorKind, TenantFeatureFlags,
@@ -14,6 +15,7 @@ use uuid::Uuid;
 
 use crate::{
     auth::{AuthError, AuthenticateAndAuthorize, AuthzAction, AuthzResource},
+    config::FoundationConfig,
     errors::ServerError,
     server::FoundationApiServer,
 };
@@ -73,7 +75,9 @@ pub async fn foundation_init(
     // Source collections are the attached function's *input*. They carry
     // the chunk-sibling grouping flag so a job's chunk records stay in one
     // partition and the trailing end-of-job marker on `{base}-0` is
-    // observed after every sibling chunk (ADR 0001 §6).
+    // observed after every sibling chunk (ADR 0001 §6). Each gets the
+    // server-side function attached, with the wiki collection as output —
+    // mirroring the foundation CLI POC (chroma-core/foundation #97).
     let mut source_collection_ids = HashMap::new();
     for source_name in &foundation_cfg.source_collections {
         let source = ensure_collection(
@@ -82,6 +86,15 @@ pub async fn foundation_init(
             db_name.clone(),
             source_name,
             Some(group_chunk_siblings_metadata()),
+        )
+        .await?;
+        ensure_attached_function(
+            &mut sysdb,
+            tenant.clone(),
+            foundation_cfg.database_name.clone(),
+            source.collection_id,
+            source_name,
+            foundation_cfg,
         )
         .await?;
         source_collection_ids.insert(source_name.clone(), source.collection_id.to_string());
@@ -107,6 +120,50 @@ fn group_chunk_siblings_metadata() -> Metadata {
         MetadataValue::Bool(true),
     );
     metadata
+}
+
+/// Idempotently attach the foundation function to a source collection,
+/// mirroring the CLI POC (chroma-core/foundation #97): the function reads
+/// the source collection and writes synthesized content to the wiki
+/// collection. The attachment name is `{source}_to_wiki`; `params` carry
+/// the modal `endpoint_url` plus `source_collection` / `source_kind`.
+///
+/// `/init` is safe to call repeatedly, so an already-attached function
+/// (`AlreadyExists` or `CollectionAlreadyHasFunction`) is treated as
+/// success rather than an error.
+async fn ensure_attached_function(
+    sysdb: &mut SysDb,
+    tenant: String,
+    database_name: String,
+    input_collection_id: CollectionUuid,
+    source_name: &str,
+    cfg: &FoundationConfig,
+) -> Result<(), ServerError> {
+    let attachment_name = format!("{source_name}_to_wiki");
+    let params = serde_json::json!({
+        "endpoint_url": cfg.function_endpoint_url,
+        "source_collection": source_name,
+        "source_kind": source_name,
+    });
+    match sysdb
+        .create_attached_function(
+            attachment_name,
+            cfg.function_name.clone(),
+            input_collection_id,
+            cfg.wiki_collection.clone(),
+            params,
+            tenant,
+            database_name,
+            cfg.min_records_for_invocation,
+        )
+        .await
+    {
+        Ok(_) => Ok(()),
+        // Idempotent: the function is already attached to this collection.
+        Err(AttachFunctionError::AlreadyExists(_))
+        | Err(AttachFunctionError::CollectionAlreadyHasFunction(_)) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -122,6 +122,20 @@ fn group_chunk_siblings_metadata() -> Metadata {
     metadata
 }
 
+/// Raised when `/init` needs the attached-function endpoint URL but the
+/// deployment never configured `foundation.function_endpoint_url`. Surfaced
+/// as a 500 so a misconfigured deploy fails loudly instead of attaching the
+/// function with a missing/placeholder endpoint.
+#[derive(Debug, thiserror::Error)]
+#[error("foundation.function_endpoint_url is not configured")]
+struct MissingFunctionEndpointUrl;
+
+impl ChromaError for MissingFunctionEndpointUrl {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
+}
+
 /// Idempotently attach the foundation function to a source collection,
 /// mirroring the CLI POC (chroma-core/foundation #97): the function reads
 /// the source collection and writes synthesized content to the wiki
@@ -140,8 +154,12 @@ async fn ensure_attached_function(
     cfg: &FoundationConfig,
 ) -> Result<(), ServerError> {
     let attachment_name = format!("{source_name}_to_wiki");
+    let endpoint_url = cfg
+        .function_endpoint_url
+        .as_ref()
+        .ok_or(MissingFunctionEndpointUrl)?;
     let params = serde_json::json!({
-        "endpoint_url": cfg.function_endpoint_url,
+        "endpoint_url": endpoint_url,
         "source_collection": source_name,
         "source_kind": source_name,
     });

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -2,13 +2,14 @@ use axum::{extract::State, http::HeaderMap, Json};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_sysdb::SysDb;
 use chroma_types::{
-    Collection, CreateDatabaseError, DatabaseName, IndexConfig, KnnIndex, Schema,
-    SparseIndexAlgorithm, SparseVectorIndexConfig,
+    Collection, CreateDatabaseError, DatabaseName, IndexConfig, KnnIndex, Metadata, MetadataValue,
+    Schema, SparseIndexAlgorithm, SparseVectorIndexConfig, CHROMA_GROUP_CHUNK_SIBLINGS_KEY,
 };
 use frontend_core::collection_ops::{
     plan_create_collection, supported_segment_types, ExecutorKind, TenantFeatureFlags,
 };
 use serde::Serialize;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::{
@@ -24,6 +25,9 @@ pub struct FoundationInitResponse {
     pub database_id: String,
     pub wiki_collection_id: String,
     pub wiki_revisions_collection_id: String,
+    /// Source collection name -> id for each ensured source collection
+    /// (slack, notion, …). Each carries the chunk-sibling grouping flag.
+    pub source_collection_ids: std::collections::HashMap<String, String>,
 }
 
 /// `POST /api/foundation/init` — idempotent bootstrap for a team's Foundation
@@ -46,20 +50,42 @@ pub async fn foundation_init(
 
     let mut sysdb = server.sysdb.clone();
     let database_id = ensure_database(&mut sysdb, db_name.clone(), tenant.clone()).await?;
+
+    // Wiki collections are the attached function's *output*; they don't
+    // need chunk-sibling grouping (no end-of-job marker is read from them).
     let wiki = ensure_collection(
         &mut sysdb,
         tenant.clone(),
         db_name.clone(),
         &foundation_cfg.wiki_collection,
+        None,
     )
     .await?;
     let wiki_revisions = ensure_collection(
         &mut sysdb,
         tenant.clone(),
-        db_name,
+        db_name.clone(),
         &foundation_cfg.wiki_revisions_collection,
+        None,
     )
     .await?;
+
+    // Source collections are the attached function's *input*. They carry
+    // the chunk-sibling grouping flag so a job's chunk records stay in one
+    // partition and the trailing end-of-job marker on `{base}-0` is
+    // observed after every sibling chunk (ADR 0001 §6).
+    let mut source_collection_ids = HashMap::new();
+    for source_name in &foundation_cfg.source_collections {
+        let source = ensure_collection(
+            &mut sysdb,
+            tenant.clone(),
+            db_name.clone(),
+            source_name,
+            Some(group_chunk_siblings_metadata()),
+        )
+        .await?;
+        source_collection_ids.insert(source_name.clone(), source.collection_id.to_string());
+    }
 
     Ok(Json(FoundationInitResponse {
         tenant,
@@ -67,7 +93,20 @@ pub async fn foundation_init(
         database_id: database_id.to_string(),
         wiki_collection_id: wiki.collection_id.to_string(),
         wiki_revisions_collection_id: wiki_revisions.collection_id.to_string(),
+        source_collection_ids,
     }))
+}
+
+/// Collection metadata that opts a source collection into chunk-sibling
+/// grouping during compaction/partitioning (see
+/// [`chroma_types::CHROMA_GROUP_CHUNK_SIBLINGS_KEY`]).
+fn group_chunk_siblings_metadata() -> Metadata {
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        CHROMA_GROUP_CHUNK_SIBLINGS_KEY.to_string(),
+        MetadataValue::Bool(true),
+    );
+    metadata
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -132,6 +171,7 @@ async fn ensure_collection(
     tenant: String,
     database_name: DatabaseName,
     collection_name: &str,
+    metadata: Option<Metadata>,
 ) -> Result<Collection, ServerError> {
     let schema = foundation_collection_schema();
     let plan = plan_create_collection(
@@ -152,7 +192,7 @@ async fn ensure_collection(
             plan.segments,
             plan.configuration,
             plan.schema,
-            None,
+            metadata,
             // NOTE(hammadb): Foundation uses Qwen0.6B by default which is 1024 dims
             Some(1024),
             GET_OR_CREATE,

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -1284,6 +1284,14 @@ impl ChromaError for ListCollectionVersionsError {
 pub const CHROMA_KEY: &str = "chroma:";
 pub const CHROMA_DOCUMENT_KEY: &str = "chroma:document";
 pub const CHROMA_URI_KEY: &str = "chroma:uri";
+/// Collection-metadata flag (a `MetadataValue::Bool(true)`) that opts a
+/// collection into chunk-sibling grouping during log partitioning: records
+/// whose ids share a base before a trailing `-{idx}` are kept in one
+/// partition so they materialize in WAL order. Foundation source
+/// collections set this so the attached function observes a trailing
+/// end-of-job marker after all sibling chunks. Read by the worker's
+/// `PartitionOperator`; set by the foundation `/init` endpoint.
+pub const CHROMA_GROUP_CHUNK_SIBLINGS_KEY: &str = "chroma:group_chunk_siblings";
 
 ////////////////////////// AddCollectionRecords //////////////////////////
 

--- a/rust/worker/src/execution/operators/partition_log.rs
+++ b/rust/worker/src/execution/operators/partition_log.rs
@@ -10,11 +10,10 @@ use thiserror::Error;
 /// `MetadataValue::Bool(true)` enables it; absent or any other value
 /// leaves the default (group by exact id) in place.
 ///
-/// The flag is *read* here; the code that *sets* it on the relevant
-/// collections (foundation source collections) lands in a separate PR.
-/// Until that ships, no collection carries the flag and this operator
-/// behaves exactly as before.
-pub const GROUP_CHUNK_SIBLINGS_METADATA_KEY: &str = "chroma:group_chunk_siblings";
+/// The flag is *read* here; the code that *sets* it on foundation source
+/// collections lives in the foundation `/init` endpoint. Re-exported from
+/// `chroma_types` so reader and writer share one definition.
+pub use chroma_types::CHROMA_GROUP_CHUNK_SIBLINGS_KEY as GROUP_CHUNK_SIBLINGS_METADATA_KEY;
 
 /// Grouping key used to assign a record to a partition.
 ///

--- a/rust/worker/src/execution/operators/partition_log.rs
+++ b/rust/worker/src/execution/operators/partition_log.rs
@@ -5,6 +5,17 @@ use chroma_types::{Chunk, LogRecord};
 use std::collections::HashMap;
 use thiserror::Error;
 
+/// Collection-metadata key that opts a collection into chunk-sibling
+/// grouping during partitioning (see [`chunk_grouping_key`]). A
+/// `MetadataValue::Bool(true)` enables it; absent or any other value
+/// leaves the default (group by exact id) in place.
+///
+/// The flag is *read* here; the code that *sets* it on the relevant
+/// collections (foundation source collections) lands in a separate PR.
+/// Until that ships, no collection carries the flag and this operator
+/// behaves exactly as before.
+pub const GROUP_CHUNK_SIBLINGS_METADATA_KEY: &str = "chroma:group_chunk_siblings";
+
 /// Grouping key used to assign a record to a partition.
 ///
 /// A record whose id ends in `-{digits}` (e.g. `mydoc-0`, `mydoc-12`)
@@ -21,13 +32,16 @@ use thiserror::Error;
 /// invariant is preserved. Records whose id does not match `{base}-{digits}`
 /// are returned unchanged.
 ///
-/// Trade-off (flagged for review): ids that legitimately end in
-/// `-{digits}` but are NOT chunk siblings (e.g. `report-2024`,
-/// `report-2023`) will be co-located in one partition. This is
-/// correctness-neutral — they remain distinct records — but can reduce
-/// compaction parallelism for collections that use such an id scheme.
-/// If that proves too coarse, this should be gated behind a
-/// per-collection flag rather than applied globally.
+/// This folding is **opt-in per collection** via the
+/// [`GROUP_CHUNK_SIBLINGS_METADATA_KEY`] collection-metadata flag, so it
+/// only affects collections that have explicitly enabled it (foundation
+/// source collections). Collections without the flag continue to group
+/// by exact id. The opt-in gate exists because ids that legitimately end
+/// in `-{digits}` but are NOT chunk siblings (e.g. `report-2024`,
+/// `report-2023`) would otherwise be co-located in one partition —
+/// correctness-neutral (they stay distinct records) but a parallelism
+/// cost we don't want to impose on collections that don't need the
+/// ordering guarantee.
 fn chunk_grouping_key(id: &str) -> &str {
     match id.rsplit_once('-') {
         Some((base, suffix))
@@ -60,6 +74,12 @@ pub struct PartitionOperator {}
 pub struct PartitionInput {
     pub(crate) records: Chunk<LogRecord>,
     pub(crate) max_partition_size: usize,
+    /// When true, chunk siblings (`{base}-{idx}`) are grouped under their
+    /// shared base so they land in one partition (see [`chunk_grouping_key`]).
+    /// Gated per-collection via the [`GROUP_CHUNK_SIBLINGS_METADATA_KEY`]
+    /// collection-metadata flag; defaults to false so behavior is unchanged
+    /// for every collection that hasn't opted in.
+    pub(crate) group_chunk_siblings: bool,
 }
 
 impl PartitionInput {
@@ -69,10 +89,17 @@ impl PartitionInput {
     /// * `max_partition_size` - The maximum size of a partition. Since we are trying to
     ///   partition the records by id, which can casue the partition size to be larger than this
     ///   value.
-    pub fn new(records: Chunk<LogRecord>, max_partition_size: usize) -> Self {
+    /// * `group_chunk_siblings` - When true, fold chunk siblings onto a
+    ///   shared base when partitioning (opt-in per collection).
+    pub fn new(
+        records: Chunk<LogRecord>,
+        max_partition_size: usize,
+        group_chunk_siblings: bool,
+    ) -> Self {
         PartitionInput {
             records,
             max_partition_size,
+            group_chunk_siblings,
         }
     }
 }
@@ -104,12 +131,20 @@ impl PartitionOperator {
         &self,
         records: &Chunk<LogRecord>,
         partition_size: usize,
+        group_chunk_siblings: bool,
     ) -> Vec<Chunk<LogRecord>> {
         let mut map = HashMap::new();
         for data in records.iter() {
             let log_record = data.0;
             let index = data.1;
-            let key = chunk_grouping_key(&log_record.record.id).to_string();
+            // Only fold chunk siblings onto a shared base when the
+            // collection has opted in; otherwise group by the exact id
+            // (unchanged behavior for every other collection).
+            let key = if group_chunk_siblings {
+                chunk_grouping_key(&log_record.record.id).to_string()
+            } else {
+                log_record.record.id.clone()
+            };
             map.entry(key).or_insert_with(Vec::new).push(index);
         }
         let mut result = Vec::new();
@@ -166,7 +201,7 @@ impl Operator<PartitionInput, PartitionOutput> for PartitionOperator {
     async fn run(&self, input: &PartitionInput) -> Result<PartitionOutput, PartitionError> {
         let records = &input.records;
         let partition_size = self.determine_partition_size(records.len(), input.max_partition_size);
-        let deduped_records = self.partition(records, partition_size);
+        let deduped_records = self.partition(records, partition_size, input.group_chunk_siblings);
         return Ok(PartitionOutput {
             records: deduped_records,
         });
@@ -221,7 +256,7 @@ mod tests {
         // Test group size is larger than the number of records
         let chunk = Chunk::new(data.clone());
         let operator = PartitionOperator::new();
-        let input = PartitionInput::new(chunk, 4);
+        let input = PartitionInput::new(chunk, 4, false);
         let result = operator.run(&input).await.unwrap();
         assert_eq!(result.records.len(), 1);
         assert_eq!(result.records[0].len(), 3);
@@ -229,7 +264,7 @@ mod tests {
         // Test group size is the same as the number of records
         let chunk = Chunk::new(data.clone());
         let operator = PartitionOperator::new();
-        let input = PartitionInput::new(chunk, 3);
+        let input = PartitionInput::new(chunk, 3, false);
         let result = operator.run(&input).await.unwrap();
         assert_eq!(result.records.len(), 1);
         assert_eq!(result.records[0].len(), 3);
@@ -237,7 +272,7 @@ mod tests {
         // Test group size is smaller than the number of records
         let chunk = Chunk::new(data.clone());
         let operator = PartitionOperator::new();
-        let input = PartitionInput::new(chunk, 2);
+        let input = PartitionInput::new(chunk, 2, false);
         let mut result = operator.run(&input).await.unwrap();
 
         // The result can be 1 or 2 groups depending on the order of the records.
@@ -253,7 +288,7 @@ mod tests {
         // Test group size is smaller than the number of records
         let chunk = Chunk::new(data.clone());
         let operator = PartitionOperator::new();
-        let input = PartitionInput::new(chunk, 1);
+        let input = PartitionInput::new(chunk, 1, false);
         let mut result = operator.run(&input).await.unwrap();
         assert_eq!(result.records.len(), 2);
         result.records.sort_by_key(|x| x.len());
@@ -279,13 +314,8 @@ mod tests {
         assert_eq!(chunk_grouping_key("report-2024"), "report");
     }
 
-    #[tokio::test]
-    async fn test_chunk_siblings_share_a_partition() {
-        // Three chunks of one document plus one unrelated record. Even
-        // at partition_size == 1, the chunk siblings must stay together
-        // (they share grouping key "doc"), so we get exactly 2
-        // partitions: {doc-0, doc-1, doc-2} and {other}.
-        let mk = |offset: i64, id: &str| LogRecord {
+    fn chunk_record(offset: i64, id: &str) -> LogRecord {
+        LogRecord {
             log_offset: offset,
             record: OperationRecord {
                 id: id.to_string(),
@@ -295,22 +325,52 @@ mod tests {
                 document: None,
                 operation: Operation::Add,
             },
-        };
+        }
+    }
+
+    #[tokio::test]
+    async fn test_chunk_siblings_share_a_partition_when_opted_in() {
+        // Three chunks of one document plus one unrelated record, with
+        // group_chunk_siblings = true. Even at partition_size == 1, the
+        // chunk siblings stay together (shared grouping key "doc"), so we
+        // get exactly 2 partitions: {doc-0, doc-1, doc-2} and {other}.
         let data: Arc<[LogRecord]> = vec![
-            mk(1, "doc-0"),
-            mk(2, "doc-1"),
-            mk(3, "doc-2"),
-            mk(4, "other"),
+            chunk_record(1, "doc-0"),
+            chunk_record(2, "doc-1"),
+            chunk_record(3, "doc-2"),
+            chunk_record(4, "other"),
         ]
         .into();
 
         let operator = PartitionOperator::new();
-        let input = PartitionInput::new(Chunk::new(data), 1);
+        let input = PartitionInput::new(Chunk::new(data), 1, true);
         let mut result = operator.run(&input).await.unwrap();
 
         assert_eq!(result.records.len(), 2);
         result.records.sort_by_key(|x| x.len());
         assert_eq!(result.records[0].len(), 1); // {other}
         assert_eq!(result.records[1].len(), 3); // {doc-0, doc-1, doc-2}
+    }
+
+    #[tokio::test]
+    async fn test_chunk_siblings_not_grouped_when_opted_out() {
+        // Same input with group_chunk_siblings = false (the default):
+        // each chunk is a distinct id, so at partition_size == 1 they do
+        // NOT fold together. We get one partition per distinct id (4).
+        let data: Arc<[LogRecord]> = vec![
+            chunk_record(1, "doc-0"),
+            chunk_record(2, "doc-1"),
+            chunk_record(3, "doc-2"),
+            chunk_record(4, "other"),
+        ]
+        .into();
+
+        let operator = PartitionOperator::new();
+        let input = PartitionInput::new(Chunk::new(data), 1, false);
+        let result = operator.run(&input).await.unwrap();
+
+        // Four distinct grouping keys -> four single-record partitions.
+        assert_eq!(result.records.len(), 4);
+        assert!(result.records.iter().all(|r| r.len() == 1));
     }
 }

--- a/rust/worker/src/execution/operators/partition_log.rs
+++ b/rust/worker/src/execution/operators/partition_log.rs
@@ -5,12 +5,52 @@ use chroma_types::{Chunk, LogRecord};
 use std::collections::HashMap;
 use thiserror::Error;
 
+/// Grouping key used to assign a record to a partition.
+///
+/// A record whose id ends in `-{digits}` (e.g. `mydoc-0`, `mydoc-12`)
+/// is grouped under its base (`mydoc`), so that all chunks of one
+/// document land in the same partition. The partition operator
+/// guarantees in-order processing *within* a partition but not across
+/// partitions, so co-locating a document's chunks is what lets a
+/// downstream consumer (e.g. a foundation attached function) observe a
+/// trailing end-of-job marker on `{base}-0` only after every sibling
+/// chunk — see ADR 0001 §6 in chroma-core/foundation.
+///
+/// This only ever *enlarges* groups: a given concrete id always maps to
+/// a single key, so the existing "all ops for one id in one partition"
+/// invariant is preserved. Records whose id does not match `{base}-{digits}`
+/// are returned unchanged.
+///
+/// Trade-off (flagged for review): ids that legitimately end in
+/// `-{digits}` but are NOT chunk siblings (e.g. `report-2024`,
+/// `report-2023`) will be co-located in one partition. This is
+/// correctness-neutral — they remain distinct records — but can reduce
+/// compaction parallelism for collections that use such an id scheme.
+/// If that proves too coarse, this should be gated behind a
+/// per-collection flag rather than applied globally.
+fn chunk_grouping_key(id: &str) -> &str {
+    match id.rsplit_once('-') {
+        Some((base, suffix))
+            if !base.is_empty()
+                && !suffix.is_empty()
+                && suffix.bytes().all(|b| b.is_ascii_digit()) =>
+        {
+            base
+        }
+        _ => id,
+    }
+}
+
 #[derive(Debug)]
 /// The partition Operator takes a DataChunk and presents a copy-free
 /// view of N partitions by breaking the data into partitions by max_partition_size. It will group operations
 /// on the same key into the same partition. Due to this, the max_partition_size is a
 /// soft-limit, since if there are more operations to a key than max_partition_size we cannot
 /// partition the data.
+///
+/// Keys are computed by [`chunk_grouping_key`], which folds chunk
+/// siblings (`{base}-{idx}`) onto a shared base so a document's chunks
+/// stay in one partition.
 pub struct PartitionOperator {}
 
 /// The input to the partition operator.
@@ -69,7 +109,7 @@ impl PartitionOperator {
         for data in records.iter() {
             let log_record = data.0;
             let index = data.1;
-            let key = log_record.record.id.clone();
+            let key = chunk_grouping_key(&log_record.record.id).to_string();
             map.entry(key).or_insert_with(Vec::new).push(index);
         }
         let mut result = Vec::new();
@@ -219,5 +259,58 @@ mod tests {
         result.records.sort_by_key(|x| x.len());
         assert_eq!(result.records[0].len(), 1);
         assert_eq!(result.records[1].len(), 2);
+    }
+
+    #[test]
+    fn test_chunk_grouping_key() {
+        // Chunk siblings fold onto their base.
+        assert_eq!(chunk_grouping_key("mydoc-0"), "mydoc");
+        assert_eq!(chunk_grouping_key("mydoc-12"), "mydoc");
+        assert_eq!(chunk_grouping_key("sha256hex-9999"), "sha256hex");
+        // Only the final `-{digits}` segment is stripped.
+        assert_eq!(chunk_grouping_key("a-b-0"), "a-b");
+        // Non-chunk ids pass through unchanged.
+        assert_eq!(chunk_grouping_key("mydoc"), "mydoc");
+        assert_eq!(chunk_grouping_key("mydoc-abc"), "mydoc-abc");
+        assert_eq!(chunk_grouping_key("mydoc-"), "mydoc-");
+        assert_eq!(chunk_grouping_key("-0"), "-0"); // empty base: leave alone
+        assert_eq!(chunk_grouping_key(""), "");
+        // Documented trade-off: a legitimately-numbered id is folded too.
+        assert_eq!(chunk_grouping_key("report-2024"), "report");
+    }
+
+    #[tokio::test]
+    async fn test_chunk_siblings_share_a_partition() {
+        // Three chunks of one document plus one unrelated record. Even
+        // at partition_size == 1, the chunk siblings must stay together
+        // (they share grouping key "doc"), so we get exactly 2
+        // partitions: {doc-0, doc-1, doc-2} and {other}.
+        let mk = |offset: i64, id: &str| LogRecord {
+            log_offset: offset,
+            record: OperationRecord {
+                id: id.to_string(),
+                embedding: None,
+                encoding: None,
+                metadata: None,
+                document: None,
+                operation: Operation::Add,
+            },
+        };
+        let data: Arc<[LogRecord]> = vec![
+            mk(1, "doc-0"),
+            mk(2, "doc-1"),
+            mk(3, "doc-2"),
+            mk(4, "other"),
+        ]
+        .into();
+
+        let operator = PartitionOperator::new();
+        let input = PartitionInput::new(Chunk::new(data), 1);
+        let mut result = operator.run(&input).await.unwrap();
+
+        assert_eq!(result.records.len(), 2);
+        result.records.sort_by_key(|x| x.len());
+        assert_eq!(result.records[0].len(), 1); // {other}
+        assert_eq!(result.records[1].len(), 3); // {doc-0, doc-1, doc-2}
     }
 }

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -22,8 +22,8 @@ use chroma_system::{
     OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
-    Chunk, CollectionUuid, JobId, LogRecord, SchemaMismatchError, SegmentFlushInfo, SegmentScope,
-    SegmentShard, SegmentShardError,
+    Chunk, CollectionUuid, JobId, LogRecord, MetadataValue, SchemaMismatchError, SegmentFlushInfo,
+    SegmentScope, SegmentShard, SegmentShardError,
 };
 use opentelemetry::trace::TraceContextExt;
 use std::sync::{atomic::AtomicU32, Arc};
@@ -46,7 +46,10 @@ use crate::{
                 MaterializeLogInput, MaterializeLogOperator, MaterializeLogOperatorError,
                 MaterializeLogOutput,
             },
-            partition_log::{PartitionError, PartitionInput, PartitionOperator, PartitionOutput},
+            partition_log::{
+                PartitionError, PartitionInput, PartitionOperator, PartitionOutput,
+                GROUP_CHUNK_SIBLINGS_METADATA_KEY,
+            },
             prefetch_segment::{
                 PrefetchSegmentError, PrefetchSegmentInput, PrefetchSegmentOperator,
                 PrefetchSegmentOutput,
@@ -383,7 +386,23 @@ impl LogFetchOrchestrator {
         self.state = ExecutionState::Partition;
         let operator = PartitionOperator::new();
         tracing::info!("Sending N Records: {:?}", records.len());
-        let input = PartitionInput::new(records, self.context.max_partition_size);
+        // Opt-in per collection: fold chunk siblings ({base}-{idx}) onto a
+        // shared base so they partition together and preserve per-document
+        // WAL order. Defaults to false when the collection (or its
+        // metadata) doesn't carry the flag.
+        let group_chunk_siblings = self
+            .context
+            .get_collection_info()
+            .ok()
+            .and_then(|info| info.collection.metadata.as_ref())
+            .and_then(|metadata| metadata.get(GROUP_CHUNK_SIBLINGS_METADATA_KEY))
+            .map(|value| matches!(value, MetadataValue::Bool(true)))
+            .unwrap_or(false);
+        let input = PartitionInput::new(
+            records,
+            self.context.max_partition_size,
+            group_chunk_siblings,
+        );
         let task = wrap(
             operator,
             input,


### PR DESCRIPTION
> **Draft.** Stacked on #7133 (the worker change that *reads* the chunk-sibling flag). Merge #7133 first, then rebase this onto main.

## Summary

Extends the foundation `/init` endpoint to mirror the CLI POC (chroma-core/foundation #97), so `/init` is the single bootstrap for a team's foundation workspace. On top of the existing wiki + wiki_revisions creation, `/init` now:

1. **Ensures the source collections** (slack, notion; configurable via `CHROMA_FOUNDATION__SOURCE_COLLECTIONS`).
2. **Sets `chroma:group_chunk_siblings = true`** on each source collection so the worker's `PartitionOperator` (#7133) keeps a job's chunk records in one partition — the ordering the end-of-job marker relies on (ADR 0001 §6).
3. **Attaches the foundation function** to each source collection via `SysDb::create_attached_function`, with the wiki collection as output — the server-side equivalent of the POC's HTTP attach.

## Function attach (mirrors POC #97)

- Attachment name `{source}_to_wiki`; operator `http_generate` (configurable).
- `params`: `{ endpoint_url, source_collection, source_kind }` — `endpoint_url` defaults to the modal URL from the POC; `source_collection`/`source_kind` are the source name.
- `min_records_for_invocation` defaults to 100 (matches the chroma frontend default).
- **No `seed_output_collection` step** — per @hammadb, the output dimension is already hardcoded to 1024 in `/init`'s collection creation (chroma #7127, already on main).
- **Idempotent**: `AlreadyExists` / `CollectionAlreadyHasFunction` are treated as success, so `/init` stays safe to call repeatedly.

## Shared constant

The chunk-sibling flag key is promoted to `chroma_types::CHROMA_GROUP_CHUNK_SIBLINGS_KEY` so the reader (worker `PartitionOperator`) and writer (`/init`) share one definition; `partition_log.rs` re-exports it.

## Wiki collections deliberately untouched

Wiki/wiki_revisions are the function's *output* — no chunk-sibling flag, no attach. The marker mechanism operates on the source/input side.

## Caveat: get-or-create idempotency

`/init` uses get-or-create for collections. If a source collection **already exists** without the flag (e.g. created by an earlier upload), the metadata isn't retroactively updated. `/init` must run before the first upload (it's the bootstrap). The function attach is independently idempotent. Pre-existing source collections would need a one-off metadata backfill — out of scope here.

## Test plan

- [x] `cargo check -p foundation-api`, `cargo check -p chroma-types` pass.
- [x] `cargo test -p foundation-api --lib routes::init` — 4/4 pass.
- [ ] **CI must run the worker suite** — the `partition_log.rs` re-export couldn't be compiled locally (Homebrew rustc 1.94.1 vs pinned 1.92.0; `wal3` fails under 1.94.1 independent of this change).
- [ ] End-to-end (post-#7133-merge): `/init` → source collections carry the flag + have `http_generate` attached → uploads chunk into them → attached function runs and observes the end-of-job marker last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)