### PR TITLE
[BUG](auth): use consistent naming for foundation authz action strings

### DIFF
--- a/rust/frontend-core/src/auth.rs
+++ b/rust/frontend-core/src/auth.rs
@@ -76,8 +76,8 @@ impl Display for AuthzAction {
             AuthzAction::Search => write!(f, "collection:search"),
             AuthzAction::CreateAttachedFunction => write!(f, "collection:create_attached_function"),
             AuthzAction::RemoveAttachedFunction => write!(f, "collection:remove_attached_function"),
-            AuthzAction::InitFoundation => write!(f, "foundation:init"),
-            AuthzAction::ViewFoundation => write!(f, "foundation:view"),
+            AuthzAction::InitFoundation => write!(f, "foundation:init_foundation"),
+            AuthzAction::ViewFoundation => write!(f, "foundation:view_foundation"),
         }
     }
 }


### PR DESCRIPTION
## Description of changes

Rename Display strings for InitFoundation and ViewFoundation from
"foundation:init" and "foundation:view" to "foundation:init_foundation"
and "foundation:view_foundation", matching the naming convention used by
all other AuthzAction variants (e.g., "collection:get_collection",
"db:create_collection").

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
