### PR TITLE
[ENH](foundation-api): Flatten init route path

### DIFF
--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -18,7 +18,7 @@ pub struct FoundationApiConfig {
     pub foundation: FoundationConfig,
 }
 
-/// Names of the database and collections that `POST /api/foundation/init`
+/// Names of the database and collections that `POST /api/init`
 /// ensures. Overridable via env vars (e.g. `CHROMA_FOUNDATION__DATABASE_NAME`)
 /// so deployments and tests can point at non-default workspaces without a
 /// code change.

--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -1,7 +1,7 @@
 //! Foundation API HTTP server.
 //!
 //! Per ADR "Foundation API: Long-Term Home", this crate hosts the foundation
-//! HTTP route surface (`/api/foundation/{ask,recall,brief,init}`, future
+//! HTTP route surface (`/api/{ask,recall,brief,init}`, future
 //! sync-domain endpoints). It depends on `frontend-core` for Axum scaffolding,
 //! middleware, the `AuthenticateAndAuthorize` trait, config primitives, error
 //! types, and OTEL bootstrap. It does NOT depend on `chroma-frontend`, and it

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -23,7 +23,7 @@ pub struct FoundationInitResponse {
     pub wiki_revisions_collection_id: String,
 }
 
-/// `POST /api/foundation/init` — idempotent bootstrap for a team's Foundation
+/// `POST /api/init` — idempotent bootstrap for a team's Foundation
 /// workspace. Ensures the configured Foundation database and the wiki +
 /// wiki_revisions collections (names overridable via
 /// `CHROMA_FOUNDATION__*` env vars) exist in the tenant resolved from the

--- a/rust/foundation-api/src/routes/mod.rs
+++ b/rust/foundation-api/src/routes/mod.rs
@@ -4,5 +4,5 @@ use axum::{routing::post, Router};
 pub(crate) mod init;
 
 pub(crate) fn router() -> Router<FoundationApiServer> {
-    Router::new().route("/api/foundation/init", post(init::foundation_init))
+    Router::new().route("/api/init", post(init::foundation_init))
 }


### PR DESCRIPTION
Rename the bootstrap route from POST /api/foundation/init to
POST /api/init, collapsing the /foundation path
segment into a single hyphenated path. The endpoint has no
consumers yet, so the URL change is safe. Doc comments updated
to match the new route surface.

