### PR TITLE
[CHORE] Bump protoc version to exploit caching.

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -30,7 +30,7 @@ runs:
       uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ inputs.github-token }}
-        version: v31.1
+        version: v35.0
     - name: Set up cache
       uses: Swatinem/rust-cache@v2
       with:


### PR DESCRIPTION
## Description of changes

In short, the major unreliability in CI is the setup-protoc job.  This
job does two scouts to github to fetch release lists unless a version is
pinned.  Previously I pinned one version for efficiency and reliability.
I now suspect that version to be cold and thus served with an error by
GitHub.  Pinning latest version so we exploit locality in caching,
optimistically.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
