### PR TITLE
[BUG](sysdb): avoid deadlock between flush and fork by aligning lock order

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1502,6 +1503,253 @@ func assertExpectedSegmentInfoExist(suite *APIsTestSuite, expectedSegment *model
 		filePaths[key] = filePath.Paths
 	}
 	suite.Equal(filePaths, expectedSegment.FilePaths)
+}
+
+type registerFilePathsBlocker struct {
+	segmentIDs     map[string]struct{}
+	registered     chan struct{}
+	release        chan struct{}
+	registeredOnce sync.Once
+	releaseOnce    sync.Once
+}
+
+func newRegisterFilePathsBlocker(flushSegmentCompactions []*model.FlushSegmentCompaction) *registerFilePathsBlocker {
+	segmentIDs := make(map[string]struct{}, len(flushSegmentCompactions))
+	for _, flushSegmentCompaction := range flushSegmentCompactions {
+		segmentIDs[flushSegmentCompaction.ID.String()] = struct{}{}
+	}
+
+	return &registerFilePathsBlocker{
+		segmentIDs: segmentIDs,
+		registered: make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+}
+
+func (b *registerFilePathsBlocker) releaseFlush() {
+	b.releaseOnce.Do(func() {
+		close(b.release)
+	})
+}
+
+func (b *registerFilePathsBlocker) shouldBlock(flushSegmentCompactions []*model.FlushSegmentCompaction) bool {
+	if len(flushSegmentCompactions) != len(b.segmentIDs) {
+		return false
+	}
+	for _, flushSegmentCompaction := range flushSegmentCompactions {
+		if _, ok := b.segmentIDs[flushSegmentCompaction.ID.String()]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *registerFilePathsBlocker) blockAfterRegister(ctx context.Context, flushSegmentCompactions []*model.FlushSegmentCompaction) error {
+	if !b.shouldBlock(flushSegmentCompactions) {
+		return nil
+	}
+
+	shouldWait := false
+	b.registeredOnce.Do(func() {
+		shouldWait = true
+		close(b.registered)
+	})
+	if !shouldWait {
+		return nil
+	}
+
+	select {
+	case <-b.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type registerFilePathsBlockingMetaDomain struct {
+	dbmodel.IMetaDomain
+	blocker *registerFilePathsBlocker
+}
+
+func (m *registerFilePathsBlockingMetaDomain) SegmentDb(ctx context.Context) dbmodel.ISegmentDb {
+	return &registerFilePathsBlockingSegmentDb{
+		ISegmentDb: m.IMetaDomain.SegmentDb(ctx),
+		ctx:        ctx,
+		blocker:    m.blocker,
+	}
+}
+
+type registerFilePathsBlockingSegmentDb struct {
+	dbmodel.ISegmentDb
+	ctx     context.Context
+	blocker *registerFilePathsBlocker
+}
+
+func (s *registerFilePathsBlockingSegmentDb) RegisterFilePaths(flushSegmentCompactions []*model.FlushSegmentCompaction) error {
+	if err := s.ISegmentDb.RegisterFilePaths(flushSegmentCompactions); err != nil {
+		return err
+	}
+	return s.blocker.blockAfterRegister(s.ctx, flushSegmentCompactions)
+}
+
+func waitForPostgresLockWait(ctx context.Context, db *gorm.DB) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		var blocked bool
+		err := db.WithContext(ctx).Raw(`
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_stat_activity
+				WHERE datname = current_database()
+					AND state = 'active'
+					AND wait_event_type = 'Lock'
+					AND query ILIKE '%FOR UPDATE%'
+			)
+		`).Scan(&blocked).Error
+		if err != nil {
+			return err
+		}
+		if blocked {
+			return nil
+		}
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func waitForAsyncErr(ctx context.Context, errCh <-chan error) error {
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (suite *APIsTestSuite) TestForkAndFlushCollectionCompactionDoNotDeadlock() {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	sourceCreateCollection := &model.CreateCollection{
+		ID:           types.NewUniqueID(),
+		Name:         "test_fork_flush_deadlock_source",
+		TenantID:     suite.tenantName,
+		DatabaseName: suite.databaseName,
+	}
+
+	sourceCreateMetadataSegment := &model.Segment{
+		ID:           types.NewUniqueID(),
+		Type:         "test_blockfile",
+		Scope:        "METADATA",
+		CollectionID: sourceCreateCollection.ID,
+	}
+
+	sourceCreateRecordSegment := &model.Segment{
+		ID:           types.NewUniqueID(),
+		Type:         "test_blockfile",
+		Scope:        "RECORD",
+		CollectionID: sourceCreateCollection.ID,
+	}
+
+	sourceCreateVectorSegment := &model.Segment{
+		ID:           types.NewUniqueID(),
+		Type:         "test_hnsw",
+		Scope:        "VECTOR",
+		CollectionID: sourceCreateCollection.ID,
+	}
+
+	_, _, err := suite.coordinator.CreateCollectionAndSegments(ctx, sourceCreateCollection, []*model.Segment{
+		sourceCreateMetadataSegment,
+		sourceCreateRecordSegment,
+		sourceCreateVectorSegment,
+	})
+	suite.Require().NoError(err)
+
+	sourceFlushCollectionCompaction := &model.FlushCollectionCompaction{
+		ID:                       sourceCreateCollection.ID,
+		TenantID:                 sourceCreateCollection.TenantID,
+		LogPosition:              1000,
+		CurrentCollectionVersion: 0,
+		FlushSegmentCompactions: []*model.FlushSegmentCompaction{
+			{
+				ID: sourceCreateMetadataSegment.ID,
+				FilePaths: map[string][]string{
+					"fts_index": {"metadata_sparse_index_file"},
+				},
+			},
+			{
+				ID: sourceCreateRecordSegment.ID,
+				FilePaths: map[string][]string{
+					"data_record": {"record_sparse_index_file"},
+				},
+			},
+			{
+				ID: sourceCreateVectorSegment.ID,
+				FilePaths: map[string][]string{
+					"hnsw_index": {"hnsw_source_layer_file"},
+				},
+			},
+		},
+		TotalRecordsPostCompaction: 1000,
+		SizeBytesPostCompaction:    65536,
+	}
+
+	originalMetaDomain := suite.coordinator.catalog.metaDomain
+	blocker := newRegisterFilePathsBlocker(sourceFlushCollectionCompaction.FlushSegmentCompactions)
+	suite.coordinator.catalog.metaDomain = &registerFilePathsBlockingMetaDomain{
+		IMetaDomain: originalMetaDomain,
+		blocker:     blocker,
+	}
+	defer func() {
+		blocker.releaseFlush()
+		suite.coordinator.catalog.metaDomain = originalMetaDomain
+	}()
+
+	flushErrCh := make(chan error, 1)
+	go func() {
+		_, err := suite.coordinator.FlushCollectionCompaction(ctx, sourceFlushCollectionCompaction)
+		flushErrCh <- err
+	}()
+
+	select {
+	case <-blocker.registered:
+	case err := <-flushErrCh:
+		suite.Require().NoError(err, "flush completed before the test could pause it")
+	case <-ctx.Done():
+		suite.Require().NoError(ctx.Err())
+	}
+
+	forkCollection := &model.ForkCollection{
+		SourceCollectionID:                   sourceCreateCollection.ID,
+		SourceCollectionLogCompactionOffset:  800,
+		SourceCollectionLogEnumerationOffset: 1200,
+		TargetCollectionID:                   types.NewUniqueID(),
+		TargetCollectionName:                 "test_fork_flush_deadlock_target",
+	}
+
+	forkErrCh := make(chan error, 1)
+	go func() {
+		_, _, err := suite.coordinator.ForkCollection(ctx, forkCollection)
+		forkErrCh <- err
+	}()
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer waitCancel()
+	suite.Require().NoError(waitForPostgresLockWait(waitCtx, suite.db))
+
+	blocker.releaseFlush()
+	suite.Require().NoError(waitForAsyncErr(ctx, flushErrCh))
+	suite.Require().NoError(waitForAsyncErr(ctx, forkErrCh))
+
+	collections, err := suite.coordinator.GetCollections(ctx, []types.UniqueID{forkCollection.TargetCollectionID}, nil, sourceCreateCollection.TenantID, sourceCreateCollection.DatabaseName, nil, nil, false)
+	suite.Require().NoError(err)
+	suite.Len(collections, 1)
 }
 
 func (suite *APIsTestSuite) TestForkCollection() {

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -1756,6 +1756,19 @@ func (tc *Catalog) FlushCollectionCompaction(ctx context.Context, flushCollectio
 			return common.ErrCollectionSoftDeleted
 		}
 
+		// Lock only the collection row before touching segment rows. Fork's
+		// LockCollection takes locks in collection row -> collection metadata ->
+		// segment rows -> segment metadata order; flush must take the same first
+		// lock to avoid deadlocks with fork while preserving the existing write
+		// order below.
+		isDeleted, err := tc.metaDomain.CollectionDb(txCtx).LockCollectionRow(flushCollectionCompaction.ID.String())
+		if err != nil {
+			return err
+		}
+		if *isDeleted {
+			return common.ErrCollectionSoftDeleted
+		}
+
 		// register files to Segment metadata
 		err = tc.metaDomain.SegmentDb(txCtx).RegisterFilePaths(flushCollectionCompaction.FlushSegmentCompactions)
 		if err != nil {
@@ -2030,39 +2043,57 @@ func (tc *Catalog) FlushCollectionCompactionForVersionedCollection(ctx context.C
 		var txErr error
 
 		executeOperations := func(ctx context.Context, tx *gorm.DB) error {
-			// NOTE: DO NOT move UpdateTenantLastCompactionTime & RegisterFilePaths to the end of the transaction.
-			//		 Keep both these operations before the UpdateLogPositionAndVersionInfo.
-			//       UpdateLogPositionAndVersionInfo acts as a CAS operation whose failure will roll back the transaction.
-			//       If order is changed, we can still potentially loose an update to Collection entry by
-			//       a concurrent transaction that updates Collection entry immediately after UpdateLogPositionAndVersionInfo completes.
-			// The other approach is to use a "SELECT FOR UPDATE" to lock the Collection entry at the start of the transaction,
-			// which is costlier than the current approach that does not lock the Collection entry.
-
 			// Create context with transaction if provided
 			if tx != nil {
 				ctx = dbcore.CtxWithTransaction(ctx, tx)
 			}
 
-			// register files to Segment metadata
-			err := tc.metaDomain.SegmentDb(ctx).RegisterFilePaths(flushCollectionCompaction.FlushSegmentCompactions)
+			// Lock only the collection row before touching segment rows. Fork's
+			// LockCollection takes locks in collection row -> collection metadata ->
+			// segment rows -> segment metadata order; flush must take the same first
+			// lock to avoid deadlocks with fork.
+			//
+			// Do not use LockCollection here. Flush only needs the collection row
+			// prelock; RegisterFilePaths below owns the segment row updates.
+			isDeleted, err := tc.metaDomain.CollectionDb(ctx).LockCollectionRow(flushCollectionCompaction.ID.String())
 			if err != nil {
 				return err
 			}
+			if *isDeleted {
+				return common.ErrCollectionSoftDeleted
+			}
+
+			// NOTE: Keep UpdateTenantLastCompactionTime and RegisterFilePaths
+			// before UpdateLogPositionAndVersionInfo. This preserves the
+			// historical write order while UpdateLogPositionAndVersionInfo remains
+			// the CAS operation whose failure rolls back the transaction.
+			//
+			// The explicit SELECT FOR UPDATE in LockCollectionRow above is the
+			// collection-row prelock that makes this path follow fork's lock order
+			// without changing the relative order of the writes below.
+
+			// register files to Segment metadata
+			err = tc.metaDomain.SegmentDb(ctx).RegisterFilePaths(flushCollectionCompaction.FlushSegmentCompactions)
+			if err != nil {
+				return err
+			}
+
+			lastCompactionTime := time.Now().Unix()
+
 			// update tenant last compaction time
 			// TODO: add a system configuration to disable
 			// since this might cause resource contention if one tenant has a lot of collection compactions at the same time
-			lastCompactionTime := time.Now().Unix()
 			err = tc.metaDomain.TenantDb(ctx).UpdateTenantLastCompactionTime(flushCollectionCompaction.TenantID, lastCompactionTime)
 			if err != nil {
 				return err
 			}
 
-			// At this point, a concurrent Transaction can still update/commit
-			// the Collection entry.
-			// Since this Tx is ReadCommitted, the result of other Tx will be
-			// visible to the statement below. Hence the statement below will
-			// use WHERE clause to ensure that its update will not go through
-			// if the Collection entry is updated by another Tx.
+			// A concurrent transaction that locked this collection row first may
+			// have committed before LockCollectionRow returned. Since this Tx is
+			// READ COMMITTED, the result of that Tx is visible to the statement
+			// below. Hence the statement below uses the WHERE clause to ensure
+			// that its update will not go through if the Collection entry is
+			// already updated by another Tx.
 
 			// Update collection log position and version
 			rowsAffected, err := tc.metaDomain.CollectionDb(ctx).UpdateLogPositionAndVersionInfo(
@@ -2088,9 +2119,6 @@ func (tc *Catalog) FlushCollectionCompactionForVersionedCollection(ctx context.C
 				// Error out the transaction, so that segment is not updated.
 				return common.ErrCollectionEntryIsStale
 			}
-
-			// CAS operation succeeded. Update tenant compaction time and then
-			// COMMIT the transaction.
 
 			// Set the result values that will be returned to the Compactor.
 			flushCollectionInfo.TenantLastCompactionTime = lastCompactionTime

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -459,6 +459,8 @@ func TestCatalog_FlushCollectionCompactionForVersionedCollection(t *testing.T) {
 
 	mockCollectionDb.On("GetCollectionEntries", types.FromUniqueID(collectionID), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockCollectionsAndMetadata, nil)
 	mockSegmentDb.On("GetSegments", mock.Anything, mock.Anything, mock.Anything, collectionID).Return(mockSegments, nil)
+	isDeleted := false
+	mockCollectionDb.On("LockCollectionRow", collectionID.String()).Return(&isDeleted, nil)
 	mockCollectionDb.On("UpdateLogPositionAndVersionInfo",
 		collectionID.String(),
 		logPosition,
@@ -668,6 +670,8 @@ func TestCatalog_FlushCollectionCompactionForVersionedCollectionWithEmptyFilePat
 
 	mockCollectionDb.On("GetCollectionEntries", types.FromUniqueID(collectionID), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockCollectionsAndMetadata, nil)
 	mockSegmentDb.On("GetSegments", mock.Anything, mock.Anything, mock.Anything, collectionID).Return(mockSegments, nil)
+	isDeleted := false
+	mockCollectionDb.On("LockCollectionRow", collectionID.String()).Return(&isDeleted, nil)
 	mockCollectionDb.On("UpdateLogPositionAndVersionInfo",
 		collectionID.String(),
 		logPosition,

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -630,6 +630,22 @@ func (s *collectionDb) UpdateVersionRelatedFields(collectionID, existingVersionF
 	return result.RowsAffected, nil
 }
 
+func (s *collectionDb) LockCollectionRow(collectionID string) (*bool, error) {
+	var collections []dbmodel.Collection
+	err := s.db.Model(&dbmodel.Collection{}).
+		Where("collections.id = ?", collectionID).Clauses(clause.Locking{
+		Strength: "UPDATE",
+	}).Find(&collections).Error
+	if err != nil {
+		return nil, err
+	}
+	if len(collections) == 0 {
+		return nil, common.ErrCollectionNotFound
+	}
+
+	return &collections[0].IsDeleted, nil
+}
+
 func (s *collectionDb) LockCollection(collectionID string) (*bool, error) {
 	var collections []dbmodel.Collection
 	err := s.db.Model(&dbmodel.Collection{}).

--- a/go/pkg/sysdb/metastore/db/dbmodel/collection.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/collection.go
@@ -71,6 +71,7 @@ type ICollectionDb interface {
 	GetCollectionSize(collectionID string) (uint64, error)
 	ListCollectionsToGc(cutoffTimeSecs *uint64, limit *uint64, tenantID *string, minVersionsIfAlive *uint64) ([]*CollectionToGc, error)
 	UpdateVersionRelatedFields(collectionID, existingVersionFileName, newVersionFileName string, oldestVersionTs *time.Time, numActiveVersions *int) (int64, error)
+	LockCollectionRow(collectionID string) (*bool, error)
 	LockCollection(collectionID string) (*bool, error)
 	UpdateCollectionLineageFilePath(collectionID string, currentLineageFilePath *string, newLineageFilePath string) error
 	BatchGetCollectionVersionFilePaths(collectionIDs []string) (map[string]string, error)

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
@@ -480,6 +480,36 @@ func (_m *ICollectionDb) LockCollection(collectionID string) (*bool, error) {
 	return r0, r1
 }
 
+// LockCollectionRow provides a mock function with given fields: collectionID
+func (_m *ICollectionDb) LockCollectionRow(collectionID string) (*bool, error) {
+	ret := _m.Called(collectionID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LockCollectionRow")
+	}
+
+	var r0 *bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*bool, error)); ok {
+		return rf(collectionID)
+	}
+	if rf, ok := ret.Get(0).(func(string) *bool); ok {
+		r0 = rf(collectionID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*bool)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(collectionID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Update provides a mock function with given fields: in
 func (_m *ICollectionDb) Update(in *dbmodel.Collection) error {
 	ret := _m.Called(in)


### PR DESCRIPTION
## Description of changes

FlushCollectionCompaction previously locked segment rows (via
RegisterFilePaths) before the collection row, while ForkCollection locks
the collection row first (via LockCollection) then segment rows. Under
concurrent execution these opposing lock orders can deadlock on Postgres
row-level locks.

Reorder both FlushCollectionCompaction and its versioned variant so the
collection row is updated/locked before RegisterFilePaths, matching the
collection-then-segments order used by ForkCollection. All three
operations remain in the same transaction, so a failure after the
collection update still rolls back segment and tenant writes.

Add TestForkAndFlushCollectionCompactionDoNotDeadlock which launches a
flush and a fork concurrently, using a blocking ISegmentDb decorator to
force the timing window that previously triggered the deadlock.

## Test plan

CI + locally the new test failed before the fix and passes after.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
