### PR TITLE
[ENH]: Function's add_input() calls for python and rust clients

### DIFF
--- a/chromadb/api/models/AttachedFunction.py
+++ b/chromadb/api/models/AttachedFunction.py
@@ -1,9 +1,10 @@
-from typing import TYPE_CHECKING, Optional, Dict, Any, Tuple
+from typing import TYPE_CHECKING, Optional, Dict, Any, Union
 from uuid import UUID
 import json
 
 if TYPE_CHECKING:
     from chromadb.api import ServerAPI  # noqa: F401
+    from chromadb.api.models.Collection import Collection  # noqa: F401
 
 
 class AttachedFunction:
@@ -74,15 +75,32 @@ class AttachedFunction:
         """The function parameters."""
         return self._params
 
-    def add_input(self, input_collection_id: UUID) -> Tuple["AttachedFunction", bool]:
-        """Add a new input collection to this async attached function."""
-        return self._client.add_attached_function_input(
+    def add_input(
+        self, input_collection: Union["Collection", UUID, str]
+    ) -> "AttachedFunction":
+        """Add a new input collection to this async attached function.
+
+        Args:
+            input_collection: A `Collection`, collection UUID, or UUID string.
+
+        Returns:
+            AttachedFunction: A handle for the attached function scoped to the newly added input.
+        """
+        if hasattr(input_collection, "id"):
+            input_collection_id = input_collection.id
+        elif isinstance(input_collection, UUID):
+            input_collection_id = input_collection
+        else:
+            input_collection_id = UUID(str(input_collection))
+
+        attached_function, _created = self._client.add_attached_function_input(
             name=self._name,
             existing_input_collection_id=self._input_collection_id,
             new_input_collection_id=input_collection_id,
             tenant=self._tenant,
             database=self._database,
         )
+        return attached_function
 
     @staticmethod
     def _normalize_params(params: Optional[Any]) -> Dict[str, Any]:

--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -420,6 +420,50 @@ def test_attach_to_output_collection_succeeds_for_async_upstream(
     assert created is True
 
 
+def test_async_attached_function_can_add_multiple_inputs(
+    basic_http_client: System,
+) -> None:
+    """Test that an async attached function can add another input collection through the client handle."""
+    client = ClientCreator.from_system(basic_http_client)
+    client.reset()
+
+    input_collection_1 = client.create_collection(name="multi_input_collection_1")
+    input_collection_1.add(ids=["id1"], documents=["doc1"])
+
+    input_collection_2 = client.create_collection(name="multi_input_collection_2")
+    input_collection_2.add(ids=["id2"], documents=["doc2"])
+
+    attached_fn, created = input_collection_1.attach_function(
+        name="multi_input_async_function",
+        function=DUMMY_ASYNC_FUNCTION,
+        output_collection="multi_input_output_collection",
+        params=None,
+    )
+
+    assert created is True
+    assert attached_fn.input_collection_id == input_collection_1.id
+
+    added_input_fn = attached_fn.add_input(input_collection_2)
+    assert added_input_fn.id == attached_fn.id
+    assert added_input_fn.name == attached_fn.name
+    assert added_input_fn.function_name == attached_fn.function_name
+    assert added_input_fn.input_collection_id == input_collection_2.id
+    assert added_input_fn.output_collection == attached_fn.output_collection
+
+    retrieved_from_first_input = input_collection_1.get_attached_function(
+        attached_fn.name
+    )
+    assert retrieved_from_first_input == attached_fn
+
+    retrieved_from_second_input = input_collection_2.get_attached_function(
+        attached_fn.name
+    )
+    assert retrieved_from_second_input == added_input_fn
+
+    # Re-adding the same input should be idempotent and return the same handle shape.
+    assert added_input_fn.add_input(input_collection_2) == added_input_fn
+
+
 def test_attach_to_output_collection_fails_for_mixed_sync_and_async_upstream(
     basic_http_client: System,
 ) -> None:

--- a/rust/chroma/src/attached_function.rs
+++ b/rust/chroma/src/attached_function.rs
@@ -1,0 +1,82 @@
+//! Attached function handle for interacting with function attachments on collections.
+
+use std::sync::Arc;
+
+use chroma_types::{AttachedFunctionApiResponse, CollectionUuid};
+
+use crate::{client::ChromaHttpClientError, ChromaHttpClient};
+
+/// A handle to an attached function bound to a specific input collection.
+///
+/// This type represents one attached-function instance as viewed from a particular
+/// input collection. For multi-input async attached functions, calling
+/// [`add_input`](Self::add_input) returns another handle scoped to the newly added
+/// input collection.
+#[derive(Clone)]
+pub struct ChromaAttachedFunction {
+    pub(crate) client: ChromaHttpClient,
+    pub(crate) attached_function: Arc<AttachedFunctionApiResponse>,
+}
+
+impl std::fmt::Debug for ChromaAttachedFunction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChromaAttachedFunction")
+            .field("id", &self.attached_function.id)
+            .field("name", &self.attached_function.name)
+            .field("function_name", &self.attached_function.function_name)
+            .field(
+                "input_collection_id",
+                &self.attached_function.input_collection_id,
+            )
+            .field(
+                "output_collection",
+                &self.attached_function.output_collection_name,
+            )
+            .finish()
+    }
+}
+
+impl ChromaAttachedFunction {
+    /// Returns the unique identifier of the attached function instance.
+    pub fn id(&self) -> chroma_types::AttachedFunctionUuid {
+        self.attached_function.id
+    }
+
+    /// Returns the user-assigned name of the attached function instance.
+    pub fn name(&self) -> &str {
+        &self.attached_function.name
+    }
+
+    /// Returns the built-in function name.
+    pub fn function_name(&self) -> &str {
+        &self.attached_function.function_name
+    }
+
+    /// Returns the input collection currently associated with this handle.
+    pub fn input_collection_id(&self) -> CollectionUuid {
+        self.attached_function.input_collection_id
+    }
+
+    /// Returns the output collection name.
+    pub fn output_collection(&self) -> &str {
+        &self.attached_function.output_collection_name
+    }
+
+    /// Adds a new input collection to this attached function.
+    ///
+    /// The server enforces that only async attached functions may have multiple
+    /// input collections. This method is idempotent: if the input is already
+    /// attached, the existing association is returned.
+    pub async fn add_input(
+        &self,
+        input_collection_id: CollectionUuid,
+    ) -> Result<Self, ChromaHttpClientError> {
+        self.client
+            .add_attached_function_input(
+                self.attached_function.input_collection_id,
+                self.attached_function.name.clone(),
+                input_collection_id,
+            )
+            .await
+    }
+}

--- a/rust/chroma/src/client/chroma_http_client.rs
+++ b/rust/chroma/src/client/chroma_http_client.rs
@@ -17,7 +17,11 @@ use std::time::Duration;
 use thiserror::Error;
 
 use chroma_api_types::{GetUserIdentityResponse, HeartbeatResponse};
+use chroma_types::{
+    AddAttachedFunctionInputRequest, AddAttachedFunctionInputResponse, GetAttachedFunctionResponse,
+};
 
+use crate::attached_function::ChromaAttachedFunction;
 use crate::client::ChromaHttpClientOptions;
 use crate::client::ChromaHttpClientOptionsError;
 use crate::collection::ChromaCollection;
@@ -729,6 +733,67 @@ impl ChromaHttpClient {
         Ok(ChromaCollection::new(self.clone(), collection))
     }
 
+    /// Retrieves an attached function by name for a specific collection.
+    pub async fn get_attached_function(
+        &self,
+        input_collection_id: chroma_types::CollectionUuid,
+        name: impl AsRef<str>,
+    ) -> Result<ChromaAttachedFunction, ChromaHttpClientError> {
+        let tenant_id = self.get_tenant_id().await?;
+        let database_name = self.get_database_name().await?;
+
+        let response = self
+            .send_read_only::<(), (), GetAttachedFunctionResponse>(
+                "get_attached_function",
+                Method::GET,
+                format!(
+                    "/api/v2/tenants/{}/databases/{}/collections/{}/functions/{}",
+                    tenant_id,
+                    database_name,
+                    input_collection_id,
+                    name.as_ref()
+                ),
+                None,
+                None,
+            )
+            .await?;
+
+        Ok(ChromaAttachedFunction {
+            client: self.clone(),
+            attached_function: Arc::new(response.attached_function),
+        })
+    }
+
+    /// Adds a new input collection to an existing attached function.
+    pub async fn add_attached_function_input(
+        &self,
+        existing_input_collection_id: chroma_types::CollectionUuid,
+        name: impl AsRef<str>,
+        new_input_collection_id: chroma_types::CollectionUuid,
+    ) -> Result<ChromaAttachedFunction, ChromaHttpClientError> {
+        let tenant_id = self.get_tenant_id().await?;
+        let database_name = self.get_database_name().await?;
+        let request = AddAttachedFunctionInputRequest::try_new(new_input_collection_id)?;
+
+        let response = self
+            .send::<AddAttachedFunctionInputRequest, (), AddAttachedFunctionInputResponse>(
+                "add_attached_function_input",
+                Method::POST,
+                format!(
+                    "/api/v2/tenants/{}/databases/{}/collections/{}/attached_functions/{}/add_input",
+                    tenant_id, database_name, existing_input_collection_id, name.as_ref()
+                ),
+                Some(request),
+                None,
+            )
+            .await?;
+
+        Ok(ChromaAttachedFunction {
+            client: self.clone(),
+            attached_function: Arc::new(response.attached_function),
+        })
+    }
+
     /// Removes a collection and all its records from the database.
     ///
     /// Permanently deletes the collection and all contained embeddings, metadata, and documents.
@@ -940,54 +1005,6 @@ impl ChromaHttpClient {
 
         let created = response.created;
         Ok((response, created))
-    }
-
-    /// Gets an attached function by name for a specific collection.
-    ///
-    /// # Arguments
-    ///
-    /// * `input_collection_id` - UUID of the collection the function is attached to
-    /// * `name` - Name of the attached function instance
-    ///
-    /// # Returns
-    ///
-    /// The attached function details including its ID, function name, and output collection.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use chroma::ChromaHttpClient;
-    /// # async fn example(client: ChromaHttpClient) -> Result<(), Box<dyn std::error::Error>> {
-    /// let response = client.get_attached_function(
-    ///     "00000000-0000-0000-0000-000000000001",
-    ///     "my_stats",
-    /// ).await?;
-    /// println!("Function: {}", response.attached_function.function_name);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn get_attached_function(
-        &self,
-        input_collection_id: impl AsRef<str>,
-        name: impl AsRef<str>,
-    ) -> Result<chroma_types::GetAttachedFunctionResponse, ChromaHttpClientError> {
-        let tenant_id = self.get_tenant_id().await?;
-        let database_name = self.get_database_name().await?;
-
-        self.send_read_only(
-            "get_attached_function",
-            Method::GET,
-            format!(
-                "/api/v2/tenants/{}/databases/{}/collections/{}/functions/{}",
-                tenant_id,
-                database_name,
-                input_collection_id.as_ref(),
-                name.as_ref()
-            ),
-            None::<()>,
-            None::<()>,
-        )
-        .await
     }
 
     /// Detaches a function from a collection, preventing further executions.

--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -20,17 +20,17 @@ use chroma_types::{
     plan::{ReadLevel, SearchPayload},
     AddCollectionRecordsRequest, AddCollectionRecordsResponse, AttachFunctionResponse, Collection,
     CollectionUuid, DeleteCollectionRecordsRequest, DeleteCollectionRecordsResponse,
-    DetachFunctionResponse, EmbeddingFunctionConfiguration, GetAttachedFunctionResponse,
-    GetRequest, GetResponse, IncludeList, IndexStatusResponse, Metadata, QueryRequest,
-    QueryResponse, Schema, SearchRequest, SearchResponse, UpdateCollectionRecordsRequest,
-    UpdateCollectionRecordsResponse, UpdateMetadata, UpsertCollectionRecordsRequest,
-    UpsertCollectionRecordsResponse, Where, EMBEDDING_KEY,
+    DetachFunctionResponse, EmbeddingFunctionConfiguration, GetRequest, GetResponse, IncludeList,
+    IndexStatusResponse, Metadata, QueryRequest, QueryResponse, Schema, SearchRequest,
+    SearchResponse, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
+    UpdateMetadata, UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, Where,
+    EMBEDDING_KEY,
 };
 use reqwest::Method;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::embed::{chroma_cloud::ChromaCloudQwenEmbeddingFunction, EmbeddingFunction};
-use crate::{client::ChromaHttpClientError, ChromaHttpClient};
+use crate::{client::ChromaHttpClientError, ChromaAttachedFunction, ChromaHttpClient};
 
 #[derive(Deserialize)]
 struct ForkCountResponse {
@@ -271,6 +271,20 @@ impl ChromaCollection {
     /// ```
     pub fn id(&self) -> CollectionUuid {
         self.collection.collection_id
+    }
+
+    /// Gets an attached function by name for this collection.
+    ///
+    /// Returns a handle scoped to this collection's participation in the attached
+    /// function. For multi-input async attached functions, the returned handle can
+    /// be used to add more input collections via [`ChromaAttachedFunction::add_input`].
+    pub async fn get_attached_function(
+        &self,
+        name: impl AsRef<str>,
+    ) -> Result<ChromaAttachedFunction, ChromaHttpClientError> {
+        self.client
+            .get_attached_function(self.collection.collection_id, name)
+            .await
     }
 
     /// Returns the version number of this collection's schema or configuration.
@@ -1092,31 +1106,6 @@ impl ChromaCollection {
             .await?;
         let created = response.created;
         Ok((response, created))
-    }
-
-    /// Gets an attached function by name for this collection.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Name of the attached function instance
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use chroma::ChromaCollection;
-    /// # async fn example(collection: ChromaCollection) -> Result<(), Box<dyn std::error::Error>> {
-    /// let response = collection.get_attached_function("my_stats").await?;
-    /// println!("Function: {}", response.attached_function.function_name);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn get_attached_function(
-        &self,
-        name: impl AsRef<str>,
-    ) -> Result<GetAttachedFunctionResponse, ChromaHttpClientError> {
-        let path = format!("functions/{}", name.as_ref());
-        self.send::<(), _>(true, "get_attached_function", &path, Method::GET, None)
-            .await
     }
 
     /// Detaches a function from this collection, preventing further executions.

--- a/rust/chroma/src/lib.rs
+++ b/rust/chroma/src/lib.rs
@@ -100,11 +100,13 @@
 
 #![deny(missing_docs)]
 
+mod attached_function;
 pub mod client;
 mod collection;
 pub mod embed;
 pub mod types;
 
+pub use attached_function::ChromaAttachedFunction;
 pub use client::ChromaHttpClient;
 pub use client::ChromaHttpClientOptions;
 pub use collection::ChromaCollection;

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -2640,7 +2640,7 @@ impl ServiceBasedFrontend {
                 add_input_result.output_schema_str,
             )
             .await
-            .map_err(|e| chroma_types::AttachFunctionError::Internal(Box::new(e)))?;
+            .map_err(chroma_types::AttachFunctionError::from)?;
 
         Ok(AddAttachedFunctionInputResponse {
             attached_function: AttachedFunctionApiResponse::from_attached_function(

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -2634,7 +2634,7 @@ pub struct GetAttachedFunctionResponse {
     pub attached_function: AttachedFunctionApiResponse,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct AddAttachedFunctionInputResponse {
     pub attached_function: AttachedFunctionApiResponse,


### PR DESCRIPTION
## Description of changes

This PR is the final layer in a 4-PR stack that adds multi-input support for async attached functions. The previous PRs added the server-side route and fn-consumer scaffolding; this PR wires up the **Python and Rust client-side** `add_input()` calls so callers can actually use the new endpoint.

Key changes:

- **Python**: `AttachedFunction.add_input()` now accepts a `Collection`, `UUID`, or UUID string (previously only `UUID`), and returns `AttachedFunction` instead of a raw tuple.
- **Rust**: A new `ChromaAttachedFunction` handle type is introduced; `get_attached_function` and `add_attached_function_input` are refactored to return it; `ChromaCollection.get_attached_function` is updated to delegate to the new client method.
- **Observability**: `materialize_logs` in `rust/segment` gains detailed tracing spans for each log-processing branch.
- **Minor**: `AddAttachedFunctionInputResponse` gains `Deserialize` (needed by the Rust client to parse the response), and `get_attached_function` on the old client path is replaced by the new typed version.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_