### PR TITLE
[CHORE] improve Docker build cache efficiency

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -66,7 +66,7 @@ RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
   fi && \
   build_dir=$( [ "$RELEASE_MODE" = "1" ] && echo release || echo debug ) && \
   build_dir=$( [ "${ADDRESS_SANITIZER}" = "1" ] && echo "x86_64-unknown-linux-gnu/${build_dir}" || echo "${build_dir}" ) && \
-  for bin in chroma garbage_collector_service chroma-load log_service heap_tender_service query_service compaction_service work_queue_service fn_consumer sysdb_service spanner_migration foundation_service; do \
+  for bin in chroma garbage_collector_service chroma-load log_service heap_tender_service query_service compaction_service work_queue_service fn_consumer sysdb_service spanner_migration; do \
   cp "target/${build_dir}/${bin}" "./${bin}"; \
   done
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -18,6 +18,7 @@ ENV RUSTFLAGS=${ADDRESS_SANITIZER:+'-Z sanitizer=address'}
 ENV CC_x86_64_unknown_linux_gnu=${ADDRESS_SANITIZER:+gcc}
 ENV CXX_x86_64_unknown_linux_gnu=${ADDRESS_SANITIZER:+g++}
 ENV AR_x86_64_unknown_linux_gnu=${ADDRESS_SANITIZER:+ar}
+ENV CARGO_INCREMENTAL=0
 
 WORKDIR /chroma
 
@@ -65,8 +66,8 @@ RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
   fi && \
   build_dir=$( [ "$RELEASE_MODE" = "1" ] && echo release || echo debug ) && \
   build_dir=$( [ "${ADDRESS_SANITIZER}" = "1" ] && echo "x86_64-unknown-linux-gnu/${build_dir}" || echo "${build_dir}" ) && \
-  for bin in chroma garbage_collector_service chroma-load log_service heap_tender_service query_service compaction_service work_queue_service fn_consumer sysdb_service spanner_migration; do \
-  mv "target/${build_dir}/${bin}" "./${bin}"; \
+  for bin in chroma garbage_collector_service chroma-load log_service heap_tender_service query_service compaction_service work_queue_service fn_consumer sysdb_service spanner_migration foundation_service; do \
+  cp "target/${build_dir}/${bin}" "./${bin}"; \
   done
 
 FROM debian:stable-slim AS runner


### PR DESCRIPTION
## Description of changes

Replace mv with cp when extracting binaries from the cargo build
cache mount. Using mv destroys cached artifacts, forcing full rebuilds
on subsequent runs. Copying preserves the cache across builds.

Also set CARGO_INCREMENTAL=0, as incremental compilation is not
useful in Docker builds and wastes disk space in the cache mount.

Add foundation_service to the list of built binaries.

## Test plan

Local build plus CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
