### PR TITLE
[BUG]: GC should preserve one version before the functions log offset

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -46,7 +46,7 @@ use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use futures::TryStreamExt;
 use petgraph::algo::toposort;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::SystemTime;
 use thiserror::Error;
@@ -55,12 +55,6 @@ use tracing::Span;
 use wal3::LogPosition;
 
 use crate::mcmr::RegionsAndTopologies;
-
-#[derive(Debug, Clone)]
-enum AttachedFunctionOffset {
-    NotFetched,
-    Fetched(Option<u64>),
-}
 
 #[derive(Debug)]
 pub struct GarbageCollectorOrchestrator {
@@ -94,9 +88,6 @@ pub struct GarbageCollectorOrchestrator {
 
     num_files_deleted: u32,
     num_versions_deleted: u32,
-
-    attached_fn_completion_offset: AttachedFunctionOffset,
-    file_listing_complete: bool,
 
     enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
 }
@@ -153,9 +144,6 @@ impl GarbageCollectorOrchestrator {
 
             num_files_deleted: 0,
             num_versions_deleted: 0,
-
-            attached_fn_completion_offset: AttachedFunctionOffset::NotFetched,
-            file_listing_complete: false,
 
             enable_dangerous_option_to_ignore_min_versions_for_wal3,
             max_concurrent_list_files_operations_per_collection,
@@ -261,6 +249,51 @@ fn build_versions_to_mark(
                     database_id: collection_info.database_id.clone(),
                 })
             })())
+        })
+        .collect()
+}
+
+fn build_version_log_positions(
+    version_files: &HashMap<CollectionUuid, Arc<CollectionVersionFile>>,
+) -> Result<HashMap<CollectionUuid, BTreeMap<u64, i64>>, GarbageCollectorError> {
+    version_files
+        .iter()
+        .map(|(collection_id, version_file)| {
+            let version_history = version_file.version_history.as_ref().ok_or(
+                GarbageCollectorError::InvariantViolation(
+                    "Expected version file to contain version history".to_string(),
+                ),
+            )?;
+
+            let version_log_positions = version_history
+                .versions
+                .iter()
+                .filter_map(|version_info| {
+                    let collection_info = version_info.collection_info_mutable.as_ref()?;
+                    Some(
+                        collection_info
+                            .current_log_position
+                            .try_into()
+                            .map_err(|_| {
+                                GarbageCollectorError::InvariantViolation(
+                                    "Expected log offset to be unsigned".to_string(),
+                                )
+                            })
+                            .map(|log_position| (version_info.version, log_position)),
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .fold(BTreeMap::new(), |mut acc, (version, log_position)| {
+                    acc.entry(log_position)
+                        .and_modify(|existing_version: &mut i64| {
+                            *existing_version = (*existing_version).max(version);
+                        })
+                        .or_insert(version);
+                    acc
+                });
+
+            Ok::<_, GarbageCollectorError>((*collection_id, version_log_positions))
         })
         .collect()
 }
@@ -401,20 +434,17 @@ impl GarbageCollectorOrchestrator {
         self.version_files = output.version_files;
         self.graph = Some(output.graph.clone());
 
-        let task = wrap(
-            Box::new(ComputeVersionsToDeleteOperator {}),
-            ComputeVersionsToDeleteInput {
-                graph: output.graph,
-                soft_deleted_collections: self.soft_deleted_collections_to_gc.clone(),
-                cutoff_time: self.version_absolute_cutoff_time,
-                min_versions_to_keep: self.min_versions_to_keep,
+        let fetch_min_offset_task = wrap(
+            Box::new(FetchMinAttachedFunctionCompletionOffsetOperator::default()),
+            FetchMinAttachedFunctionCompletionOffsetInput {
+                sysdb_client: self.sysdb_client.clone(),
+                collection_ids: self.version_files.keys().cloned().collect(),
             },
             ctx.receiver(),
             self.context.task_cancellation_token.clone(),
         );
-
         self.dispatcher()
-            .send(task, Some(Span::current()))
+            .send(fetch_min_offset_task, Some(Span::current()))
             .await
             .map_err(GarbageCollectorError::Channel)?;
         Ok(())
@@ -439,7 +469,6 @@ impl GarbageCollectorOrchestrator {
 
         self.versions_to_delete_output = Some(output.clone());
 
-        // First, mark versions as deleted in sysdb
         let versions_to_mark = build_versions_to_mark(&output.versions, &self.version_files)?;
 
         if !versions_to_mark.is_empty() {
@@ -452,20 +481,6 @@ impl GarbageCollectorOrchestrator {
         } else {
             tracing::debug!("No versions to mark for deletion in SysDb.");
         }
-
-        let fetch_min_offset_task = wrap(
-            Box::new(FetchMinAttachedFunctionCompletionOffsetOperator::default()),
-            FetchMinAttachedFunctionCompletionOffsetInput {
-                sysdb_client: self.sysdb_client.clone(),
-                collection_id: self.collection_id,
-            },
-            ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
-        );
-        self.dispatcher()
-            .send(fetch_min_offset_task, Some(Span::current()))
-            .await
-            .map_err(GarbageCollectorError::Channel)?;
 
         // Now, list files for each version
         let root_manager = self.root_manager.clone();
@@ -529,91 +544,17 @@ impl GarbageCollectorOrchestrator {
 
         tracing::debug!("Files listed for all versions.");
 
+        self.start_delete_unused_logs_operator(ctx).await?;
         self.start_delete_unused_files_operator(ctx).await?;
-        self.file_listing_complete = true;
-        self.try_start_delete_unused_logs_operator(ctx).await?;
-
         Ok(())
     }
 
-    async fn try_start_delete_unused_logs_operator(
+    async fn start_delete_unused_logs_operator(
         &mut self,
         ctx: &ComponentContext<Self>,
     ) -> Result<(), GarbageCollectorError> {
-        if !self.ready_to_start_delete_unused_logs() {
-            return Ok(());
-        }
-
         let collections_to_destroy = self.soft_deleted_collections_to_gc.clone();
-        let mut collections_to_garbage_collect = HashMap::new();
-        let versions_to_delete = self.versions_to_delete_output.as_ref().ok_or(
-            GarbageCollectorError::InvariantViolation(
-                "Expected versions_to_delete_output to be set".to_string(),
-            ),
-        )?;
-
-        for (collection_id, versions) in &versions_to_delete.versions {
-            let Some(&min_version_to_keep) = versions
-                .iter()
-                .filter_map(|(version, action)| {
-                    (matches!(action, CollectionVersionAction::Keep) && *version > 0)
-                        .then_some(version)
-                })
-                .min()
-            else {
-                continue;
-            };
-            let version_file = self.version_files.get(collection_id).ok_or(
-                GarbageCollectorError::InvariantViolation(
-                    "Expected version file to be present".to_string(),
-                ),
-            )?;
-            let version_history = &version_file
-                .as_ref()
-                .version_history
-                .as_ref()
-                .ok_or(GarbageCollectorError::InvariantViolation(
-                    "Expected version file to contain version history".to_string(),
-                ))?
-                .versions;
-            let min_compaction_log_offset = version_history
-                .iter()
-                .find(|version_info| version_info.version == min_version_to_keep)
-                .ok_or(GarbageCollectorError::InvariantViolation(
-                    "Expected min kept version to be present in version history".to_string(),
-                ))?
-                .collection_info_mutable
-                .as_ref()
-                .ok_or(GarbageCollectorError::InvariantViolation(
-                    "Expected collection info to be present in version history".to_string(),
-                ))?
-                .current_log_position
-                .try_into()
-                .map_err(|_| {
-                    GarbageCollectorError::InvariantViolation(
-                        "Expected log offset to be unsigned".to_string(),
-                    )
-                })?;
-            // The minimum offset to keep is one after the minimum compaction offset.
-            let mut min_offset_to_keep = LogPosition::from_offset(min_compaction_log_offset) + 1u64;
-            // Attached functions may be behind compaction; clamp to the lowest
-            // completion_offset across live attached functions on this collection.
-            // TODO(tanujnay112): This needs to be changed when we support forking
-            // with functions. We would need to drop the assumption there is only
-            // one collection with an attached function in this fork tree and
-            // receive min_min_attached_fn_completion_offset for each collection
-            // in this forktree. That needs to be derived inline with where the
-            // fork tree is constructed.
-            if *collection_id == self.collection_id {
-                if let AttachedFunctionOffset::Fetched(Some(min_completion_offset)) =
-                    &self.attached_fn_completion_offset
-                {
-                    let attached_fn_floor = LogPosition::from_offset(*min_completion_offset) + 1u64;
-                    min_offset_to_keep = min_offset_to_keep.min(attached_fn_floor);
-                }
-            }
-            collections_to_garbage_collect.insert(*collection_id, min_offset_to_keep);
-        }
+        let collections_to_garbage_collect = self.compute_collections_to_garbage_collect()?;
 
         let task = wrap(
             Box::new(DeleteUnusedLogsOperator {
@@ -640,12 +581,58 @@ impl GarbageCollectorOrchestrator {
         Ok(())
     }
 
-    fn ready_to_start_delete_unused_logs(&self) -> bool {
-        self.file_listing_complete
-            && !matches!(
-                self.attached_fn_completion_offset,
-                AttachedFunctionOffset::NotFetched
-            )
+    fn compute_collections_to_garbage_collect(
+        &self,
+    ) -> Result<HashMap<CollectionUuid, LogPosition>, GarbageCollectorError> {
+        let mut collections_to_garbage_collect = HashMap::new();
+        let versions_to_delete = self.versions_to_delete_output.as_ref().ok_or(
+            GarbageCollectorError::InvariantViolation(
+                "Expected versions_to_delete_output to be set".to_string(),
+            ),
+        )?;
+
+        for (collection_id, versions) in &versions_to_delete.versions {
+            let version_file = self.version_files.get(collection_id).ok_or(
+                GarbageCollectorError::InvariantViolation(
+                    "Expected version file to be present".to_string(),
+                ),
+            )?;
+            let version_history = &version_file
+                .as_ref()
+                .version_history
+                .as_ref()
+                .ok_or(GarbageCollectorError::InvariantViolation(
+                    "Expected version file to contain version history".to_string(),
+                ))?
+                .versions;
+            // Derive the WAL floor from the earliest kept version that still
+            // has a known compaction log position.
+            let min_compaction_log_offset = version_history
+                .iter()
+                .filter_map(|version_info| {
+                    let action = versions.get(&version_info.version)?;
+                    if !matches!(action, CollectionVersionAction::Keep) {
+                        return None;
+                    }
+                    let collection_info = version_info.collection_info_mutable.as_ref()?;
+                    let log_offset: u64 = collection_info.current_log_position.try_into().ok()?;
+                    Some((version_info.version, log_offset))
+                })
+                .min_by_key(|(version, _)| *version)
+                .map(|(_, log_offset)| log_offset);
+            let Some(min_compaction_log_offset) = min_compaction_log_offset else {
+                tracing::debug!(
+                    collection_id = %collection_id,
+                    "Skipping log GC cutoff for collection because no kept version has collection_info_mutable"
+                );
+                continue;
+            };
+            // The minimum offset to keep is one after the minimum compaction offset.
+            let min_offset_to_keep = LogPosition::from_offset(min_compaction_log_offset) + 1u64;
+            collections_to_garbage_collect.insert(*collection_id, min_offset_to_keep);
+        }
+
+        Ok(collections_to_garbage_collect)
     }
 
     async fn handle_list_files_at_version_output(
@@ -1197,12 +1184,47 @@ impl
             None => return,
         };
         tracing::debug!(
-            min_completion_offset = ?output.min_completion_offset,
-            "Fetched min attached function completion offset"
+            min_completion_offsets = ?output.min_completion_offsets,
+            "Fetched min attached function completion offsets"
         );
-        self.attached_fn_completion_offset =
-            AttachedFunctionOffset::Fetched(output.min_completion_offset);
-        let res = self.try_start_delete_unused_logs_operator(ctx).await;
+        let graph = self
+            .graph
+            .clone()
+            .ok_or(GarbageCollectorError::InvariantViolation(
+                "Expected graph to be set".to_string(),
+            ));
+        let version_log_positions = build_version_log_positions(&self.version_files);
+
+        let res = match (graph, version_log_positions) {
+            (Ok(graph), Ok(version_log_positions)) => {
+                let task = wrap(
+                    Box::new(ComputeVersionsToDeleteOperator {}),
+                    ComputeVersionsToDeleteInput {
+                        graph,
+                        soft_deleted_collections: self.soft_deleted_collections_to_gc.clone(),
+                        cutoff_time: self.version_absolute_cutoff_time,
+                        min_versions_to_keep: self.min_versions_to_keep,
+                        min_attached_function_completion_offsets: output
+                            .min_completion_offsets
+                            .into_iter()
+                            .filter_map(|(collection_id, min_completion_offset)| {
+                                min_completion_offset.map(|offset| (collection_id, offset))
+                            })
+                            .collect(),
+                        version_log_positions,
+                    },
+                    ctx.receiver(),
+                    self.context.task_cancellation_token.clone(),
+                );
+
+                self.dispatcher()
+                    .send(task, Some(Span::current()))
+                    .await
+                    .map_err(GarbageCollectorError::Channel)
+            }
+            (Err(err), _) => Err(err),
+            (_, Err(err)) => Err(err),
+        };
         self.ok_or_terminate(res, ctx).await;
     }
 }
@@ -1232,7 +1254,6 @@ impl Handler<TaskResult<DeleteVersionsAtSysDbOutput, DeleteVersionsAtSysDbError>
 #[cfg(test)]
 mod tests {
     use super::build_versions_to_mark;
-    use super::AttachedFunctionOffset;
     use super::GarbageCollectorError;
     use super::GarbageCollectorOrchestrator;
     use crate::operators::compute_versions_to_delete_from_graph::CollectionVersionAction;
@@ -1247,8 +1268,9 @@ mod tests {
     use chroma_system::{Dispatcher, Orchestrator, System};
     use chroma_types::{
         chroma_proto::{
-            CollectionInfoImmutable, CollectionSegmentInfo, CollectionVersionFile,
-            CollectionVersionHistory, CollectionVersionInfo, FilePaths, FlushSegmentCompactionInfo,
+            CollectionInfoImmutable, CollectionInfoMutable, CollectionSegmentInfo,
+            CollectionVersionFile, CollectionVersionHistory, CollectionVersionInfo, FilePaths,
+            FlushSegmentCompactionInfo,
         },
         CollectionUuid, Segment, SegmentFlushInfo, SegmentScope, SegmentType, SegmentUuid,
     };
@@ -1548,7 +1570,13 @@ mod tests {
                     vec![]
                 },
             }),
-            collection_info_mutable: None,
+            collection_info_mutable: Some(CollectionInfoMutable {
+                current_log_position: version,
+                current_collection_version: version,
+                updated_at_secs: 0,
+                dimension: 0,
+                last_compaction_time_secs: 0,
+            }),
             created_at_secs: 0,
             version_change_reason: 0,
             version_file_name: String::new(),
@@ -1640,50 +1668,6 @@ mod tests {
         let mut paths = file_paths.iter().collect::<Vec<_>>();
         paths.sort();
         paths
-    }
-
-    #[tokio::test]
-    async fn delete_unused_logs_gate_is_closed_when_neither_prerequisite_is_ready() {
-        let (_storage_dir, storage) = test_storage();
-        let mut orchestrator = test_orchestrator(storage, CollectionUuid::new());
-
-        orchestrator.file_listing_complete = false;
-        orchestrator.attached_fn_completion_offset = AttachedFunctionOffset::NotFetched;
-
-        assert!(!orchestrator.ready_to_start_delete_unused_logs());
-    }
-
-    #[tokio::test]
-    async fn delete_unused_logs_gate_is_closed_when_only_file_listing_is_complete() {
-        let (_storage_dir, storage) = test_storage();
-        let mut orchestrator = test_orchestrator(storage, CollectionUuid::new());
-
-        orchestrator.file_listing_complete = true;
-        orchestrator.attached_fn_completion_offset = AttachedFunctionOffset::NotFetched;
-
-        assert!(!orchestrator.ready_to_start_delete_unused_logs());
-    }
-
-    #[tokio::test]
-    async fn delete_unused_logs_gate_is_closed_when_only_attached_function_offset_is_fetched() {
-        let (_storage_dir, storage) = test_storage();
-        let mut orchestrator = test_orchestrator(storage, CollectionUuid::new());
-
-        orchestrator.file_listing_complete = false;
-        orchestrator.attached_fn_completion_offset = AttachedFunctionOffset::Fetched(Some(42));
-
-        assert!(!orchestrator.ready_to_start_delete_unused_logs());
-    }
-
-    #[tokio::test]
-    async fn delete_unused_logs_gate_opens_when_both_prerequisites_are_ready() {
-        let (_storage_dir, storage) = test_storage();
-        let mut orchestrator = test_orchestrator(storage, CollectionUuid::new());
-
-        orchestrator.file_listing_complete = true;
-        orchestrator.attached_fn_completion_offset = AttachedFunctionOffset::Fetched(None);
-
-        assert!(orchestrator.ready_to_start_delete_unused_logs());
     }
 
     #[tokio::test]

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -8,12 +8,11 @@ use chroma_system::System;
 use chroma_types::chroma_proto::log_service_client::LogServiceClient;
 use chroma_types::chroma_proto::sys_db_client::SysDbClient;
 use chroma_types::chroma_proto::{
-    CreateCollectionRequest, CreateDatabaseRequest, CreateTenantRequest, InspectLogStateRequest,
-    InspectLogStateResponse, ListCollectionVersionsRequest, ListCollectionVersionsResponse,
-    OperationRecord, PushLogsRequest, Segment, SegmentScope, Vector,
+    CreateCollectionRequest, CreateDatabaseRequest, CreateTenantRequest,
+    ListCollectionVersionsRequest, ListCollectionVersionsResponse, OperationRecord,
+    PushLogsRequest, Segment, SegmentScope, Vector,
 };
 use chroma_types::InternalCollectionConfiguration;
-use chroma_types::{CollectionUuid, DatabaseName};
 use std::time::Duration;
 use tonic::transport::Channel;
 use uuid::Uuid;
@@ -37,20 +36,6 @@ impl ChromaGrpcClients {
             sysdb: SysDbClient::new(sysdb_channel),
             log_service: LogServiceClient::new(logservice_channel),
         })
-    }
-
-    pub async fn inspect_log_state(
-        &mut self,
-        collection_id: CollectionUuid,
-        database_name: &DatabaseName,
-    ) -> Result<InspectLogStateResponse, tonic::Status> {
-        self.log_service
-            .inspect_log_state(InspectLogStateRequest {
-                collection_id: collection_id.to_string(),
-                database_name: database_name.clone().into_string(),
-            })
-            .await
-            .map(|response| response.into_inner())
     }
 
     pub async fn create_database_and_collection(

--- a/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
+++ b/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
@@ -5,7 +5,7 @@ use chroma_system::{Operator, OperatorType};
 use chroma_types::CollectionUuid;
 use chrono::{DateTime, Utc};
 use petgraph::visit::Topo;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use thiserror::Error;
 
 #[derive(Clone, Debug)]
@@ -17,6 +17,8 @@ pub struct ComputeVersionsToDeleteInput {
     pub soft_deleted_collections: HashSet<CollectionUuid>,
     pub cutoff_time: DateTime<Utc>,
     pub min_versions_to_keep: u32,
+    pub min_attached_function_completion_offsets: HashMap<CollectionUuid, u64>,
+    pub version_log_positions: HashMap<CollectionUuid, BTreeMap<u64, i64>>,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -40,6 +42,8 @@ pub enum ComputeVersionsToDeleteError {
     ParseError(#[from] prost::DecodeError),
     #[error("Graph is missing expected node")]
     MissingVersionGraphNode,
+    #[error("Version log positions missing for collection {0}")]
+    MissingVersionLogPositionsForCollection(CollectionUuid),
 }
 
 impl ChromaError for ComputeVersionsToDeleteError {
@@ -86,16 +90,42 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
             }
         }
 
-        for (_, versions) in versions_by_collection
+        for (collection_id, versions) in versions_by_collection
             .iter_mut()
             .filter(|(collection_id, _)| !input.soft_deleted_collections.contains(collection_id))
         {
-            for (version, created_at, mode) in versions
-                .iter_mut()
-                .rev()
-                .skip(input.min_versions_to_keep as usize)
-            {
-                if *created_at < input.cutoff_time {
+            let min_completion_offset = input
+                .min_attached_function_completion_offsets
+                .get(collection_id)
+                .copied();
+            let fn_protected_version = if let Some(min_completion_offset) = min_completion_offset {
+                let version_log_positions = input.version_log_positions.get(collection_id).ok_or(
+                    ComputeVersionsToDeleteError::MissingVersionLogPositionsForCollection(
+                        *collection_id,
+                    ),
+                )?;
+                // Pick the latest version at or below the attached
+                // function's completion floor.
+                version_log_positions
+                    .range(..=min_completion_offset)
+                    .next_back()
+                    .map(|(_, version)| *version)
+            } else {
+                None
+            };
+
+            for (i, (version, created_at, mode)) in versions.iter_mut().rev().enumerate() {
+                if fn_protected_version == Some(*version) {
+                    tracing::debug!(
+                        collection_id = %collection_id,
+                        protected_version = *version,
+                        min_completion_offset,
+                        "Keeping version <= attached function completion offset"
+                    );
+                    *mode = CollectionVersionAction::Keep;
+                } else if i >= input.min_versions_to_keep as usize
+                    && *created_at < input.cutoff_time
+                {
                     tracing::debug!(
                         version = *version,
                         created_at = %created_at,
@@ -217,6 +247,8 @@ mod tests {
             cutoff_time: now - Duration::hours(6),
             min_versions_to_keep: 1,
             soft_deleted_collections: HashSet::new(),
+            min_attached_function_completion_offsets: HashMap::new(),
+            version_log_positions: HashMap::new(),
         };
 
         let mut result = ComputeVersionsToDeleteOperator {}
@@ -330,6 +362,8 @@ mod tests {
             cutoff_time: now - Duration::hours(6),
             min_versions_to_keep: 1,
             soft_deleted_collections: HashSet::new(),
+            min_attached_function_completion_offsets: HashMap::new(),
+            version_log_positions: HashMap::new(),
         };
 
         let mut result = ComputeVersionsToDeleteOperator {}
@@ -461,6 +495,8 @@ mod tests {
             cutoff_time: now - Duration::hours(6),
             min_versions_to_keep: 1,
             soft_deleted_collections: HashSet::from([b_collection_id]), // B was soft deleted
+            min_attached_function_completion_offsets: HashMap::new(),
+            version_log_positions: HashMap::new(),
         };
 
         let mut result = ComputeVersionsToDeleteOperator {}
@@ -501,5 +537,141 @@ mod tests {
         let mut c_versions = c_versions.into_iter().collect::<Vec<_>>();
         c_versions.sort_by_key(|(version, _)| *version);
         assert_eq!(c_versions, vec![(0, CollectionVersionAction::Keep)]);
+    }
+
+    #[tokio::test]
+    async fn test_compute_versions_to_delete_keeps_version_below_attached_function_floor() {
+        let now = Utc::now();
+        let collection_id = CollectionUuid::new();
+
+        let mut graph = VersionGraph::new();
+        let v0 = graph.add_node(VersionGraphNode {
+            collection_id,
+            version: 0,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(48),
+            },
+        });
+        let v90 = graph.add_node(VersionGraphNode {
+            collection_id,
+            version: 90,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(24),
+            },
+        });
+        let v100 = graph.add_node(VersionGraphNode {
+            collection_id,
+            version: 100,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(1),
+            },
+        });
+        graph.add_edge(v0, v90, ());
+        graph.add_edge(v90, v100, ());
+
+        let input = ComputeVersionsToDeleteInput {
+            graph,
+            cutoff_time: now - Duration::hours(6),
+            min_versions_to_keep: 1,
+            soft_deleted_collections: HashSet::new(),
+            min_attached_function_completion_offsets: HashMap::from([(collection_id, 95)]),
+            version_log_positions: HashMap::from([(
+                collection_id,
+                BTreeMap::from([(0, 0), (90, 90), (100, 100)]),
+            )]),
+        };
+
+        let mut result = ComputeVersionsToDeleteOperator {}
+            .run(&input)
+            .await
+            .unwrap();
+        let versions = result.versions.remove(&collection_id).unwrap();
+
+        assert_eq!(versions.get(&90), Some(&CollectionVersionAction::Keep));
+        assert_eq!(versions.get(&100), Some(&CollectionVersionAction::Keep));
+    }
+
+    #[tokio::test]
+    async fn test_compute_versions_to_delete_keeps_versions_for_multiple_collections() {
+        let now = Utc::now();
+        let collection_a = CollectionUuid::new();
+        let collection_b = CollectionUuid::new();
+
+        let mut graph = VersionGraph::new();
+        let a_v0 = graph.add_node(VersionGraphNode {
+            collection_id: collection_a,
+            version: 0,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(48),
+            },
+        });
+        let a_v90 = graph.add_node(VersionGraphNode {
+            collection_id: collection_a,
+            version: 90,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(24),
+            },
+        });
+        let a_v100 = graph.add_node(VersionGraphNode {
+            collection_id: collection_a,
+            version: 100,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(1),
+            },
+        });
+        graph.add_edge(a_v0, a_v90, ());
+        graph.add_edge(a_v90, a_v100, ());
+
+        let b_v0 = graph.add_node(VersionGraphNode {
+            collection_id: collection_b,
+            version: 0,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(48),
+            },
+        });
+        let b_v40 = graph.add_node(VersionGraphNode {
+            collection_id: collection_b,
+            version: 40,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(24),
+            },
+        });
+        let b_v50 = graph.add_node(VersionGraphNode {
+            collection_id: collection_b,
+            version: 50,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(1),
+            },
+        });
+        graph.add_edge(b_v0, b_v40, ());
+        graph.add_edge(b_v40, b_v50, ());
+
+        let input = ComputeVersionsToDeleteInput {
+            graph,
+            cutoff_time: now - Duration::hours(6),
+            min_versions_to_keep: 1,
+            soft_deleted_collections: HashSet::new(),
+            min_attached_function_completion_offsets: HashMap::from([
+                (collection_a, 95),
+                (collection_b, 45),
+            ]),
+            version_log_positions: HashMap::from([
+                (collection_a, BTreeMap::from([(0, 0), (90, 90), (100, 100)])),
+                (collection_b, BTreeMap::from([(0, 0), (40, 40), (50, 50)])),
+            ]),
+        };
+
+        let mut result = ComputeVersionsToDeleteOperator {}
+            .run(&input)
+            .await
+            .unwrap();
+
+        let a_versions = result.versions.remove(&collection_a).unwrap();
+        assert_eq!(a_versions.get(&90), Some(&CollectionVersionAction::Keep));
+        assert_eq!(a_versions.get(&100), Some(&CollectionVersionAction::Keep));
+
+        let b_versions = result.versions.remove(&collection_b).unwrap();
+        assert_eq!(b_versions.get(&40), Some(&CollectionVersionAction::Keep));
+        assert_eq!(b_versions.get(&50), Some(&CollectionVersionAction::Keep));
     }
 }

--- a/rust/garbage_collector/src/operators/fetch_min_attached_function_completion_offset.rs
+++ b/rust/garbage_collector/src/operators/fetch_min_attached_function_completion_offset.rs
@@ -11,20 +11,20 @@ pub struct FetchMinAttachedFunctionCompletionOffsetOperator {}
 
 pub struct FetchMinAttachedFunctionCompletionOffsetInput {
     pub sysdb_client: SysDb,
-    pub collection_id: CollectionUuid,
+    pub collection_ids: Vec<CollectionUuid>,
 }
 
 impl Debug for FetchMinAttachedFunctionCompletionOffsetInput {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FetchMinAttachedFunctionCompletionOffsetInput")
-            .field("collection_id", &self.collection_id)
+            .field("collection_ids", &self.collection_ids)
             .finish_non_exhaustive()
     }
 }
 
 #[derive(Debug)]
 pub struct FetchMinAttachedFunctionCompletionOffsetOutput {
-    pub min_completion_offset: Option<u64>,
+    pub min_completion_offsets: std::collections::HashMap<CollectionUuid, Option<u64>>,
 }
 
 #[derive(Error, Debug)]
@@ -61,21 +61,25 @@ impl
         FetchMinAttachedFunctionCompletionOffsetOutput,
         FetchMinAttachedFunctionCompletionOffsetError,
     > {
-        // TODO(tanujny112): replace with a server-side MIN(completion_offset) aggregate so
-        // we don't pay to serialize every AttachedFunction row.
-        let attached_functions = input
-            .sysdb_client
-            .clone()
-            .list_attached_functions(input.collection_id)
-            .await?;
+        let mut min_completion_offsets = std::collections::HashMap::new();
+        for collection_id in &input.collection_ids {
+            // TODO(tanujnay112): replace with a server-side MIN(completion_offset)
+            // aggregate so we don't pay to serialize every AttachedFunction row.
+            let attached_functions = input
+                .sysdb_client
+                .clone()
+                .list_attached_functions(*collection_id)
+                .await?;
 
-        let min_completion_offset = attached_functions
-            .iter()
-            .map(|af| af.completion_offset)
-            .min();
+            let min_completion_offset = attached_functions
+                .iter()
+                .map(|af| af.completion_offset)
+                .min();
+            min_completion_offsets.insert(*collection_id, min_completion_offset);
+        }
 
         Ok(FetchMinAttachedFunctionCompletionOffsetOutput {
-            min_completion_offset,
+            min_completion_offsets,
         })
     }
 }
@@ -127,11 +131,14 @@ mod tests {
 
         let input = FetchMinAttachedFunctionCompletionOffsetInput {
             sysdb_client: sysdb,
-            collection_id,
+            collection_ids: vec![collection_id],
         };
 
         let output = operator.run(&input).await.unwrap();
-        assert_eq!(output.min_completion_offset, None);
+        assert_eq!(
+            output.min_completion_offsets.get(&collection_id),
+            Some(&None)
+        );
     }
 
     #[tokio::test]
@@ -171,11 +178,14 @@ mod tests {
         let operator = FetchMinAttachedFunctionCompletionOffsetOperator::default();
         let input = FetchMinAttachedFunctionCompletionOffsetInput {
             sysdb_client: sysdb,
-            collection_id,
+            collection_ids: vec![collection_id],
         };
 
         let output = operator.run(&input).await.unwrap();
-        assert_eq!(output.min_completion_offset, Some(80));
+        assert_eq!(
+            output.min_completion_offsets.get(&collection_id),
+            Some(&Some(80))
+        );
     }
 
     #[tokio::test]
@@ -201,10 +211,69 @@ mod tests {
         let operator = FetchMinAttachedFunctionCompletionOffsetOperator::default();
         let input = FetchMinAttachedFunctionCompletionOffsetInput {
             sysdb_client: sysdb,
-            collection_id: target_collection, // Different from where function is attached
+            collection_ids: vec![target_collection], // Different from where function is attached
         };
 
         let output = operator.run(&input).await.unwrap();
-        assert_eq!(output.min_completion_offset, None);
+        assert_eq!(
+            output.min_completion_offsets.get(&target_collection),
+            Some(&None)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_min_offset_multiple_collections() {
+        let collection_a = CollectionUuid::new();
+        let collection_b = CollectionUuid::new();
+
+        let mut test_sysdb = TestSysDb::new();
+        let mut attached_functions = HashMap::new();
+        attached_functions.insert(
+            collection_a,
+            vec![create_test_attached_function(
+                AttachedFunctionUuid::new(),
+                "fn_a",
+                collection_a,
+                Some(CollectionUuid::new()),
+                42,
+            )],
+        );
+        attached_functions.insert(
+            collection_b,
+            vec![
+                create_test_attached_function(
+                    AttachedFunctionUuid::new(),
+                    "fn_b1",
+                    collection_b,
+                    Some(CollectionUuid::new()),
+                    100,
+                ),
+                create_test_attached_function(
+                    AttachedFunctionUuid::new(),
+                    "fn_b2",
+                    collection_b,
+                    Some(CollectionUuid::new()),
+                    75,
+                ),
+            ],
+        );
+        test_sysdb.set_attached_functions(attached_functions);
+        let sysdb = SysDb::Test(test_sysdb);
+
+        let operator = FetchMinAttachedFunctionCompletionOffsetOperator::default();
+        let input = FetchMinAttachedFunctionCompletionOffsetInput {
+            sysdb_client: sysdb,
+            collection_ids: vec![collection_a, collection_b],
+        };
+
+        let output = operator.run(&input).await.unwrap();
+        assert_eq!(
+            output.min_completion_offsets.get(&collection_a),
+            Some(&Some(42))
+        );
+        assert_eq!(
+            output.min_completion_offsets.get(&collection_b),
+            Some(&Some(75))
+        );
     }
 }

--- a/rust/garbage_collector/src/test_gc_with_attached_functions.rs
+++ b/rust/garbage_collector/src/test_gc_with_attached_functions.rs
@@ -1,19 +1,20 @@
 #[cfg(test)]
 mod tests {
     use crate::garbage_collector_orchestrator_v2::GarbageCollectorOrchestrator;
-    use crate::helper::{setup_tilt_log, setup_tilt_storage, ChromaGrpcClients};
+    use crate::helper::{setup_tilt_log, setup_tilt_storage};
     use chroma_blockstore::RootManager;
     use chroma_cache::nop::NopCache;
     use chroma_config::registry::Registry;
     use chroma_log::Log;
-    use chroma_storage::GetOptions;
+    use chroma_storage::{GetOptions, PutOptions};
     use chroma_sysdb::{GetCollectionsOptions, TestSysDb};
     use chroma_system::{Dispatcher, Orchestrator, System};
     use chroma_types::{
         AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName, Operation,
         OperationRecord, Segment, SegmentFlushInfo, SegmentScope, SegmentType, SegmentUuid,
+        USER_ID_BLOOM_FILTER,
     };
-    use chrono::DateTime;
+    use chrono::Utc;
     use std::{collections::HashMap, sync::Arc, time::SystemTime};
     use uuid::Uuid;
     use wal3::{Cursor, CursorName, CursorStore, CursorStoreOptions, LogPosition};
@@ -44,15 +45,34 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_k8s_integration_gc_preserves_logs_for_attached_function() {
-        let mut clients = match ChromaGrpcClients::new().await {
-            Ok(clients) => clients,
-            Err(err) => {
-                panic!("Skipping test: Tilt gRPC services not reachable: {err:?}. Is Tilt running?")
-            }
-        };
+    async fn assert_paths_exist(
+        storage: &chroma_storage::Storage,
+        paths: &[String],
+        message: &str,
+    ) {
+        for path in paths {
+            storage
+                .get(path, GetOptions::default())
+                .await
+                .unwrap_or_else(|_| panic!("{message}: missing {path}"));
+        }
+    }
 
+    async fn assert_paths_deleted(
+        storage: &chroma_storage::Storage,
+        paths: &[String],
+        message: &str,
+    ) {
+        for path in paths {
+            assert!(
+                storage.get(path, GetOptions::default()).await.is_err(),
+                "{message}: still found {path}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_k8s_integration_gc_preserves_version_floor_for_attached_function() {
         let registry = Registry::new();
         let storage = setup_tilt_storage(&registry)
             .await
@@ -127,16 +147,74 @@ mod tests {
         }
 
         let mut seed_logs = grpc_log.clone();
-        push_test_logs(&mut seed_logs, collection_id, &database, 100).await;
+        push_test_logs(&mut seed_logs, collection_id, &database, 60).await;
+        let first_compaction_offset = 50;
+        let first_version_paths = vec![
+            format!("gc-attached-functions/{collection_id}/v1/metadata.bin"),
+            format!("gc-attached-functions/{collection_id}/v1/postings.bin"),
+        ];
+        for path in &first_version_paths {
+            storage
+                .put_bytes(path, vec![1, 2, 3], PutOptions::default())
+                .await
+                .expect("first version file path should be written");
+        }
 
-        let state_before_compaction = clients
-            .inspect_log_state(collection_id, &database)
+        sysdb
+            .flush_compaction(
+                tenant.clone(),
+                database.clone(),
+                collection_id,
+                first_compaction_offset,
+                0,
+                Arc::new([SegmentFlushInfo {
+                    segment_id,
+                    file_paths: HashMap::from([(
+                        USER_ID_BLOOM_FILTER.to_string(),
+                        first_version_paths.clone(),
+                    )]),
+                }]),
+                60,
+                0,
+                None,
+            )
             .await
-            .expect("inspect_log_state should succeed");
-        let compaction_offset = state_before_compaction
-            .limit
-            .checked_sub(1)
-            .expect("log should contain at least one record");
+            .expect("first flush_compaction should succeed");
+
+        push_test_logs(&mut seed_logs, collection_id, &database, 60).await;
+        let second_compaction_offset = 110;
+        let second_version_paths = vec![
+            format!("gc-attached-functions/{collection_id}/v2/metadata.bin"),
+            format!("gc-attached-functions/{collection_id}/v2/postings.bin"),
+        ];
+        for path in &second_version_paths {
+            storage
+                .put_bytes(path, vec![4, 5, 6], PutOptions::default())
+                .await
+                .expect("second version file path should be written");
+        }
+
+        sysdb
+            .flush_compaction(
+                tenant.clone(),
+                database.clone(),
+                collection_id,
+                second_compaction_offset,
+                1,
+                Arc::new([SegmentFlushInfo {
+                    segment_id,
+                    file_paths: HashMap::from([(
+                        USER_ID_BLOOM_FILTER.to_string(),
+                        second_version_paths.clone(),
+                    )]),
+                }]),
+                120,
+                0,
+                None,
+            )
+            .await
+            .expect("second flush_compaction should succeed");
+
         let cursor_store = CursorStore::new(
             CursorStoreOptions::default(),
             Arc::new(storage.clone()),
@@ -147,36 +225,13 @@ mod tests {
             .init(
                 &CursorName::new("so_you_may_gc").expect("cursor name should be valid"),
                 Cursor {
-                    position: LogPosition::from_offset(compaction_offset),
-                    epoch_us: compaction_offset,
+                    position: LogPosition::from_offset(second_compaction_offset as u64),
+                    epoch_us: second_compaction_offset as u64,
                     writer: "test-writer".to_string(),
                 },
             )
             .await
             .expect("cursor should initialize");
-
-        let new_compaction_offset: i64 = 80;
-
-        sysdb
-            .flush_compaction(
-                tenant.clone(),
-                database.clone(),
-                collection_id,
-                new_compaction_offset,
-                0,
-                Arc::new([SegmentFlushInfo {
-                    segment_id,
-                    file_paths: HashMap::from([(
-                        "foo".to_string(),
-                        vec![uuid::Uuid::new_v4().to_string()],
-                    )]),
-                }]),
-                0,
-                0,
-                None,
-            )
-            .await
-            .expect("flush_compaction should succeed");
 
         let mut collections = sysdb
             .get_collections(GetCollectionsOptions {
@@ -187,25 +242,7 @@ mod tests {
             .expect("get_collections should succeed");
         let collection = collections.pop().expect("collection should exist");
 
-        let now = DateTime::from_timestamp(
-            SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .expect("system time should be after epoch")
-                .as_secs() as i64,
-            0,
-        )
-        .expect("timestamp should be valid");
-
-        let fragment_prefix = format!("{}/log/", collection_id.storage_prefix_for_log());
-        let fragment_count_before_first_gc = storage
-            .list_prefix(&fragment_prefix, GetOptions::default())
-            .await
-            .expect("list_prefix before first GC should succeed")
-            .len();
-        assert!(
-            fragment_count_before_first_gc > 0,
-            "expected WAL fragments before first GC"
-        );
+        let now = Utc::now();
 
         let orchestrator = GarbageCollectorOrchestrator::new(
             collection_id,
@@ -236,47 +273,29 @@ mod tests {
             .await
             .expect("first GC run should succeed");
 
-        let state_after_first_gc = clients
-            .inspect_log_state(collection_id, &database)
+        assert_paths_exist(
+            &storage,
+            &first_version_paths,
+            "first GC should preserve the first compacted version while the attached function is behind",
+        )
+        .await;
+        assert_paths_exist(
+            &storage,
+            &second_version_paths,
+            "first GC should keep the current compacted version",
+        )
+        .await;
+
+        let first_gc_versions = sysdb
+            .list_collection_versions(collection_id)
             .await
-            .expect("inspect_log_state should succeed");
-        assert_eq!(
-            state_after_first_gc.start, 51,
-            "first GC should keep logs starting at offset 51 while the attached function is behind"
-        );
-        let mut read_logs = grpc_log.clone();
-        let read_from_50 = read_logs
-            .read("test_tenant", database.clone(), collection_id, 50, 2, None)
-            .await;
+            .expect("list_collection_versions after first GC should succeed");
         assert!(
-            read_from_50.is_err(),
-            "offset 50 should no longer be readable after the first GC pass"
+            first_gc_versions.iter().any(|version| version.version == 1),
+            "first GC should retain the first compacted version in version history"
         );
 
-        let read_from_51 = read_logs
-            .read("test_tenant", database.clone(), collection_id, 51, 1, None)
-            .await
-            .expect("read from offset 51 should succeed");
-        assert_eq!(
-            read_from_51.first().map(|r| r.log_offset),
-            Some(51),
-            "offset 51 should remain readable after the first GC pass"
-        );
-
-        let fragment_count_after_first_gc = storage
-            .list_prefix(&fragment_prefix, GetOptions::default())
-            .await
-            .expect("list_prefix after first GC should succeed")
-            .len();
-        assert!(
-            fragment_count_after_first_gc < fragment_count_before_first_gc,
-            "first GC should delete some WAL fragments: before={} after={}",
-            fragment_count_before_first_gc,
-            fragment_count_after_first_gc
-        );
-
-        // Attached function is ahead of compaction now.
-        let new_completion_offset = new_compaction_offset + 4;
+        let new_completion_offset = second_compaction_offset + 4;
 
         let finish_request =
             chroma_types::chroma_proto::TryFinishAsyncAttachedFunctionInvocationRequest {
@@ -300,7 +319,7 @@ mod tests {
             None,
             now,
             now,
-            sysdb,
+            sysdb.clone(),
             dispatcher_handle,
             system.clone(),
             storage.clone(),
@@ -319,26 +338,28 @@ mod tests {
             .await
             .expect("second GC run should succeed");
 
-        let state_after_second_gc = clients
-            .inspect_log_state(collection_id, &database)
-            .await
-            .expect("inspect_log_state should succeed");
-        assert_eq!(
-            state_after_second_gc.start,
-            (new_compaction_offset + 1) as u64,
-            "once the attached function catches up, GC should advance to the compaction boundary"
-        );
+        assert_paths_deleted(
+            &storage,
+            &first_version_paths,
+            "second GC should delete the first compacted version once the attached function catches up",
+        )
+        .await;
+        assert_paths_exist(
+            &storage,
+            &second_version_paths,
+            "second GC should keep the current compacted version",
+        )
+        .await;
 
-        let fragment_count_after_second_gc = storage
-            .list_prefix(&fragment_prefix, GetOptions::default())
+        let second_gc_versions = sysdb
+            .list_collection_versions(collection_id)
             .await
-            .expect("list_prefix after second GC should succeed")
-            .len();
+            .expect("list_collection_versions after second GC should succeed");
         assert!(
-            fragment_count_after_second_gc < fragment_count_after_first_gc,
-            "second GC should delete additional WAL fragments: first={} second={}",
-            fragment_count_after_first_gc,
-            fragment_count_after_second_gc
+            second_gc_versions
+                .iter()
+                .all(|version| version.version != 1),
+            "second GC should delete the first compacted version from version history"
         );
 
         system.stop().await;

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -618,25 +618,51 @@ impl TestSysDb {
         _epoch_id: i64,
         versions: Vec<VersionListForCollection>,
     ) -> Result<(), String> {
-        // For testing success case, return Ok when versions are not empty
-        if !versions.is_empty() && !versions[0].versions.is_empty() {
-            // Simulate error case when version is 0
-            if versions[0].versions.contains(&0) {
-                return Err("Failed to mark version for deletion".to_string());
+        let mut inner = self.inner.lock();
+        for version_list in versions {
+            let collection_id = CollectionUuid(
+                uuid::Uuid::parse_str(&version_list.collection_id)
+                    .map_err(|e| format!("Invalid collection ID: {e}"))?,
+            );
+            let version_file = inner
+                .collection_to_version_file
+                .get_mut(&collection_id)
+                .ok_or_else(|| format!("Collection not found: {}", version_list.collection_id))?;
+            let version_history = version_file.version_history.as_mut().ok_or_else(|| {
+                format!("Version history missing: {}", version_list.collection_id)
+            })?;
+
+            for version in &mut version_history.versions {
+                if version_list.versions.contains(&version.version) {
+                    version.marked_for_deletion = true;
+                }
             }
-            Ok(())
-        } else {
-            Ok(())
         }
+        Ok(())
     }
 
     pub async fn delete_collection_version(
         &self,
-        _versions: Vec<VersionListForCollection>,
+        versions: Vec<VersionListForCollection>,
     ) -> HashMap<String, bool> {
-        // For testing, return success for all collections
         let mut results = HashMap::new();
-        for version_list in _versions {
+        let mut inner = self.inner.lock();
+        for version_list in versions {
+            let Ok(collection_uuid) = uuid::Uuid::parse_str(&version_list.collection_id) else {
+                results.insert(version_list.collection_id, true);
+                continue;
+            };
+            let collection_id = CollectionUuid(collection_uuid);
+            let Some(version_file) = inner.collection_to_version_file.get_mut(&collection_id)
+            else {
+                results.insert(version_list.collection_id, true);
+                continue;
+            };
+            if let Some(version_history) = version_file.version_history.as_mut() {
+                version_history
+                    .versions
+                    .retain(|version| !version_list.versions.contains(&version.version));
+            }
             results.insert(version_list.collection_id, true);
         }
         results


### PR DESCRIPTION
## Description of changes

This PR fixes a bug where the GC was not preserving the version that corresponds to the log offset an attached function is currently at. Previously, the attached function's completion offset was used to clamp the WAL floor _after_ versions were already decided. The new approach moves the attached function offset check _into_ the version selection step, so the version whose log position is at or below the function's floor is explicitly kept — and only then are files and logs GC'd.

The key structural change: `FetchMinAttachedFunctionCompletionOffset` now runs **before** `ComputeVersionsToDelete` (not after), and the offset data is passed into the version computation so it can protect the right version.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_