### PR TITLE
[BUG]: Align completion offsets to compaction boundaries

### DIFF
--- a/rust/segment/src/version_file.rs
+++ b/rust/segment/src/version_file.rs
@@ -235,7 +235,11 @@ impl VersionFileManager {
             ));
         }
 
-        if collection_info.database_name != collection.database {
+        // NOTE(tanujnay112): Versionfiles seem to avoid populating its database_name
+        // field, so we skip this check if the version file has an empty database_name.
+        if !collection_info.database_name.is_empty()
+            && collection_info.database_name != collection.database
+        {
             tracing::error!(
                 expected_database_name = %collection.database,
                 version_file_database_name = %collection_info.database_name,

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -356,7 +356,7 @@ impl TestSysDb {
         Ok(tenants)
     }
 
-    fn update_collection_version_file(
+    async fn update_collection_version_file(
         &mut self,
         collection_id: CollectionUuid,
         segment_flush_info: Arc<[SegmentFlushInfo]>,
@@ -368,117 +368,137 @@ impl TestSysDb {
         // The new entry should have the correct file paths for the segment,
         // and the version number should be the next number in the sequence.
 
-        let mut inner = self.inner.lock();
-        // Get the current version file for the collection or create a new one
-        let mut version_file = match inner.collection_to_version_file.get(&collection_id) {
-            Some(existing_file) => existing_file.clone(),
-            None => {
-                // Initialize new CollectionVersionFile with version 0
-                let mut new_file = CollectionVersionFile::default();
-                let collection_info = CollectionInfoImmutable {
-                    collection_id: collection_id.to_string(),
-                    ..Default::default()
-                };
-                new_file.collection_info_immutable = Some(collection_info);
+        let (version_file_name, version_file_bytes, storage, version_file) = {
+            let mut inner = self.inner.lock();
+            // Get the current version file for the collection or create a new one
+            let mut version_file = match inner.collection_to_version_file.get(&collection_id) {
+                Some(existing_file) => existing_file.clone(),
+                None => {
+                    // Initialize new CollectionVersionFile with version 0
+                    let mut new_file = CollectionVersionFile::default();
+                    let collection_info = CollectionInfoImmutable {
+                        collection_id: collection_id.to_string(),
+                        ..Default::default()
+                    };
+                    new_file.collection_info_immutable = Some(collection_info);
 
-                let mut version_history = CollectionVersionHistory::default();
-                let version_info = CollectionVersionInfo {
-                    version: 0,
-                    created_at_secs: if inner.mock_time > 0 {
-                        inner.mock_time as i64
-                    } else {
-                        chrono::Utc::now().timestamp()
-                    },
-                    version_change_reason: VersionChangeReason::DataCompaction as i32,
-                    collection_info_mutable: Some(Default::default()),
-                    ..Default::default()
-                };
-                version_history.versions = vec![version_info];
-                new_file.version_history = Some(version_history);
-                new_file
+                    let mut version_history = CollectionVersionHistory::default();
+                    let version_info = CollectionVersionInfo {
+                        version: 0,
+                        created_at_secs: if inner.mock_time > 0 {
+                            inner.mock_time as i64
+                        } else {
+                            chrono::Utc::now().timestamp()
+                        },
+                        version_change_reason: VersionChangeReason::DataCompaction as i32,
+                        collection_info_mutable: Some(Default::default()),
+                        ..Default::default()
+                    };
+                    version_history.versions = vec![version_info];
+                    new_file.version_history = Some(version_history);
+                    new_file
+                }
+            };
+
+            let time_secs = if inner.mock_time > 0 {
+                inner.mock_time as i64
+            } else {
+                chrono::Utc::now().timestamp()
+            };
+
+            // Get current version history
+            let mut version_history = version_file.version_history.unwrap_or_default();
+            let last_version_info = version_history
+                .versions
+                .last()
+                .cloned()
+                .unwrap_or_default()
+                .clone();
+            let mut collection_info = last_version_info
+                .collection_info_mutable
+                .unwrap_or_default();
+            collection_info.current_collection_version = last_version_info.version + 1;
+            collection_info.current_log_position = log_position;
+            collection_info.updated_at_secs = time_secs;
+            collection_info.last_compaction_time_secs = time_secs;
+
+            // Create new version info with segment file paths
+            let next_version = last_version_info.version + 1;
+            let mut version_info = CollectionVersionInfo {
+                version: next_version,
+                created_at_secs: time_secs,
+                version_change_reason: VersionChangeReason::DataCompaction as i32,
+                collection_info_mutable: Some(collection_info),
+                ..Default::default()
+            };
+
+            let mut segment_info = CollectionSegmentInfo::default();
+            let mut flush_compaction_infos = Vec::new();
+
+            for segment_flush_info in segment_flush_info.iter() {
+                let flush_compaction_info: FlushSegmentCompactionInfo = segment_flush_info
+                    .try_into()
+                    .expect("Failed to convert SegmentFlushInfo");
+                flush_compaction_infos.push(flush_compaction_info);
             }
+
+            if flush_compaction_infos.is_empty() {
+                flush_compaction_infos = inner
+                    .segments
+                    .values()
+                    .filter(|segment| segment.collection == collection_id)
+                    .map(|segment| FlushSegmentCompactionInfo {
+                        segment_id: segment.id.to_string(),
+                        file_paths: segment
+                            .file_path
+                            .iter()
+                            .map(|(key, paths)| {
+                                (
+                                    key.clone(),
+                                    chroma_types::chroma_proto::FilePaths {
+                                        paths: paths.clone(),
+                                    },
+                                )
+                            })
+                            .collect(),
+                    })
+                    .collect();
+            }
+
+            segment_info.segment_compaction_info = flush_compaction_infos;
+            version_info.segment_info = Some(segment_info);
+
+            version_history.versions.push(version_info);
+            version_file.version_history = Some(version_history);
+
+            tracing::debug!(line = line!(), "version_file: \n{:#?}", version_file);
+
+            let version_file_name = format!(
+                "{}{}/{}",
+                VERSION_FILE_S3_PREFIX, collection_id, next_version
+            );
+
+            let collection = inner
+                .collections
+                .get_mut(&collection_id)
+                .expect("Expected collection");
+            collection.version_file_path = Some(version_file_name.clone());
+
+            let version_file_bytes = version_file.encode_to_vec();
+            let storage = inner.storage.clone();
+
+            (version_file_name, version_file_bytes, storage, version_file)
         };
-
-        let time_secs = if inner.mock_time > 0 {
-            inner.mock_time as i64
-        } else {
-            chrono::Utc::now().timestamp()
-        };
-
-        // Get current version history
-        let mut version_history = version_file.version_history.unwrap_or_default();
-        let last_version_info = version_history
-            .versions
-            .last()
-            .cloned()
-            .unwrap_or_default()
-            .clone();
-        let mut collection_info = last_version_info
-            .collection_info_mutable
-            .unwrap_or_default();
-        collection_info.current_collection_version = last_version_info.version + 1;
-        collection_info.current_log_position = log_position;
-        collection_info.updated_at_secs = time_secs;
-        collection_info.last_compaction_time_secs = time_secs;
-
-        // Create new version info with segment file paths
-        let next_version = last_version_info.version + 1;
-        let mut version_info = CollectionVersionInfo {
-            version: next_version,
-            created_at_secs: time_secs,
-            version_change_reason: VersionChangeReason::DataCompaction as i32,
-            collection_info_mutable: Some(collection_info),
-            ..Default::default()
-        };
-
-        let mut segment_info = CollectionSegmentInfo::default();
-        let mut flush_compaction_infos = Vec::new();
-
-        // Iterate through all segment flush infos
-        for segment_flush_info in segment_flush_info.iter() {
-            let flush_compaction_info: FlushSegmentCompactionInfo = segment_flush_info
-                .try_into()
-                .expect("Failed to convert SegmentFlushInfo");
-            flush_compaction_infos.push(flush_compaction_info);
-        }
-
-        segment_info.segment_compaction_info = flush_compaction_infos;
-        version_info.segment_info = Some(segment_info);
-
-        // Add new version to history
-        version_history.versions.push(version_info);
-        version_file.version_history = Some(version_history);
-
-        tracing::debug!(line = line!(), "version_file: \n{:#?}", version_file);
-
-        // Update the version file name.
-        let version_file_name = format!(
-            "{}{}/{}",
-            VERSION_FILE_S3_PREFIX, collection_id, next_version
-        );
-
-        let collection = inner
-            .collections
-            .get_mut(&collection_id)
-            .expect("Expected collection");
-        collection.version_file_path = Some(version_file_name.clone());
-
-        // Serialize the version file to bytes and write to storage
-        let version_file_bytes = version_file.encode_to_vec();
-
-        // Extract storage reference before unlocking
-        let storage = inner.storage.clone();
-        drop(inner);
 
         // Write the serialized bytes to storage
         if let Some(storage) = storage {
-            let result = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(storage.put_bytes(
+            let result = storage
+                .put_bytes(
                     &version_file_name,
                     version_file_bytes,
                     PutOptions::default(),
-                ))
-            });
+                )
+                .await;
             if result.is_err() {
                 return Err("Failed to write version file to storage".to_string());
             }
@@ -598,8 +618,9 @@ impl TestSysDb {
         }
 
         // Update the in-memory version file
-        let result =
-            self.update_collection_version_file(collection_id, segment_flush_info, log_position);
+        let result = self
+            .update_collection_version_file(collection_id, segment_flush_info, log_position)
+            .await;
         if result.is_err() {
             return Err(FlushCompactionError::FailedToFlushCompaction(
                 tonic::Status::internal("Failed to update version file"),

--- a/rust/types/src/segment.rs
+++ b/rust/types/src/segment.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::collection_schema::Schema;
 use crate::{chroma_proto, DatabaseUuid};
 use chroma_error::{ChromaError, ErrorCodes};
+use chroma_proto::CollectionVersionInfo;
 use std::{collections::HashMap, str::FromStr};
 use thiserror::Error;
 use tonic::Status;
@@ -127,6 +128,46 @@ pub struct Segment {
 }
 
 impl Segment {
+    /// Returns this segment with its identity/metadata preserved but without
+    /// any on-disk file paths.
+    pub fn empty_segment(&self) -> Self {
+        let mut segment = self.clone();
+        segment.file_path.clear();
+        segment
+    }
+
+    pub fn historical_segment_for_version(
+        &self,
+        version: &CollectionVersionInfo,
+        segment_id: SegmentUuid,
+    ) -> Result<Self, String> {
+        let mut historical_segment = self.clone();
+        let all_segments_info = version.segment_info.as_ref().ok_or_else(|| {
+            format!(
+                "Invariant violation: collection version {} is missing segment info",
+                version.version
+            )
+        })?;
+
+        let segment_info = all_segments_info
+            .segment_compaction_info
+            .iter()
+            .find(|segment_info| segment_info.segment_id == segment_id.to_string())
+            .ok_or_else(|| {
+                format!(
+                    "Invariant violation: collection version {} is missing segment {}",
+                    version.version, segment_id
+                )
+            })?;
+
+        historical_segment.file_path = segment_info
+            .file_paths
+            .iter()
+            .map(|(key, value)| (key.clone(), value.paths.clone()))
+            .collect::<HashMap<_, _>>();
+        Ok(historical_segment)
+    }
+
     // INVARIANT: THIS ALWAYS RETURNS AT LEAST ONE SHARD
     pub fn get_shards(&self) -> Result<Vec<SegmentShard>, SegmentShardError> {
         let num_shards = self.num_shards()?;

--- a/rust/worker/benches/load.rs
+++ b/rust/worker/benches/load.rs
@@ -58,7 +58,7 @@ pub fn empty_fetch_log(collection_uuid: CollectionUuid) -> FetchLogOperator {
         database_name: chroma_types::DatabaseName::new("bench_db").unwrap(),
         fetch_log_concurrency: 10,
         fragment_fetcher: None,
-        log_upper_bound_offset: 0,
+        log_upper_bound_offset: None,
     }
 }
 

--- a/rust/worker/src/execution/operators/fetch_log.rs
+++ b/rust/worker/src/execution/operators/fetch_log.rs
@@ -53,9 +53,9 @@ pub struct FetchLogOperator {
     pub database_name: DatabaseName,
     pub fetch_log_concurrency: usize,
     pub fragment_fetcher: Option<Arc<FragmentFetcher>>,
-    /// Upper bound log offset scouted by the frontend. When > 0, the operator
-    /// uses this as the ceiling and skips its own ScoutLogs call.
-    pub log_upper_bound_offset: i64,
+    /// Exclusive upper bound on log offsets. When present, the operator uses
+    /// this as the ceiling and skips its own scout call.
+    pub log_upper_bound_offset: Option<u64>,
 }
 
 type FetchLogInput = ();
@@ -87,8 +87,8 @@ impl FetchLogOperator {
     #[tracing::instrument(skip(self))]
     async fn run_grpc_pull(&self) -> Result<FetchLogOutput, FetchLogError> {
         let mut log_client = self.log_client.clone();
-        let mut limit_offset = if self.log_upper_bound_offset > 0 {
-            self.log_upper_bound_offset as u64
+        let mut limit_offset = if let Some(log_upper_bound_offset) = self.log_upper_bound_offset {
+            log_upper_bound_offset
         } else {
             log_client
                 .scout_logs(
@@ -177,7 +177,9 @@ impl FetchLogOperator {
             )
             .await?;
 
-        let mut limit_offset = response.first_uninserted_record_offset;
+        let mut limit_offset = self
+            .log_upper_bound_offset
+            .unwrap_or(response.first_uninserted_record_offset);
         if let Some(maximum_fetch_count) = self.maximum_fetch_count {
             limit_offset = std::cmp::min(
                 limit_offset,
@@ -278,7 +280,7 @@ mod tests {
             database_name: chroma_types::DatabaseName::new("test-db").unwrap(),
             fetch_log_concurrency: 10,
             fragment_fetcher: None,
-            log_upper_bound_offset: 0,
+            log_upper_bound_offset: None,
         };
 
         let logs = fetch_log_operator
@@ -307,7 +309,7 @@ mod tests {
             database_name: chroma_types::DatabaseName::new("test-db").unwrap(),
             fetch_log_concurrency: 10,
             fragment_fetcher: None,
-            log_upper_bound_offset: 0,
+            log_upper_bound_offset: None,
         };
 
         let logs = fetch_log_operator
@@ -336,7 +338,7 @@ mod tests {
             database_name: chroma_types::DatabaseName::new("test-db").unwrap(),
             fetch_log_concurrency: 10,
             fragment_fetcher: None,
-            log_upper_bound_offset: 5,
+            log_upper_bound_offset: Some(5),
         };
 
         let logs = fetch_log_operator
@@ -365,7 +367,7 @@ mod tests {
             database_name: chroma_types::DatabaseName::new("test-db").unwrap(),
             fetch_log_concurrency: 10,
             fragment_fetcher: None,
-            log_upper_bound_offset: 7,
+            log_upper_bound_offset: Some(7),
         };
 
         let logs = fetch_log_operator

--- a/rust/worker/src/execution/operators/get_async_fn_fetch_boundaries.rs
+++ b/rust/worker/src/execution/operators/get_async_fn_fetch_boundaries.rs
@@ -1,0 +1,87 @@
+use async_trait::async_trait;
+use chroma_blockstore::provider::BlockfileProvider;
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_segment::version_file::{VersionFileError, VersionFileManager};
+use chroma_system::{Operator, OperatorType};
+use chroma_types::{Collection, Segment};
+use thiserror::Error;
+
+use crate::execution::orchestration::async_function_boundary::{
+    resolve_boundary_plan_from_version_file, AsyncFnBoundaryPlan,
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct GetAsyncFnFetchBoundariesOperator;
+
+impl GetAsyncFnFetchBoundariesOperator {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct GetAsyncFnFetchBoundariesInput {
+    pub collection: Collection,
+    pub record_segment: Segment,
+    pub completion_offset: i64,
+    pub max_compaction_size: usize,
+    pub blockfile_provider: BlockfileProvider,
+}
+
+pub(crate) type GetAsyncFnFetchBoundariesOutput = AsyncFnBoundaryPlan;
+
+#[derive(Debug, Error)]
+pub enum GetAsyncFnFetchBoundariesError {
+    #[error("Blockfile provider storage is required for async function version lookup")]
+    MissingBlockfileStorage,
+    #[error("Error fetching version file: {0}")]
+    VersionFile(#[from] VersionFileError),
+    #[error("Async function boundary resolution failed: {0}")]
+    Boundary(String),
+}
+
+impl ChromaError for GetAsyncFnFetchBoundariesError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
+}
+
+#[async_trait]
+impl Operator<GetAsyncFnFetchBoundariesInput, GetAsyncFnFetchBoundariesOutput>
+    for GetAsyncFnFetchBoundariesOperator
+{
+    type Error = GetAsyncFnFetchBoundariesError;
+
+    fn get_type(&self) -> OperatorType {
+        OperatorType::IO
+    }
+
+    async fn run(
+        &self,
+        input: &GetAsyncFnFetchBoundariesInput,
+    ) -> Result<GetAsyncFnFetchBoundariesOutput, Self::Error> {
+        let version_file = if input
+            .collection
+            .version_file_path
+            .as_ref()
+            .is_some_and(|path| !path.is_empty())
+        {
+            let storage = input
+                .blockfile_provider
+                .storage()
+                .ok_or(GetAsyncFnFetchBoundariesError::MissingBlockfileStorage)?;
+            let version_file_manager = VersionFileManager::new(storage.as_ref().clone());
+            Some(version_file_manager.fetch(&input.collection).await?)
+        } else {
+            None
+        };
+
+        resolve_boundary_plan_from_version_file(
+            version_file.as_ref(),
+            input.completion_offset,
+            input.max_compaction_size,
+            &input.record_segment,
+        )
+        .map_err(GetAsyncFnFetchBoundariesError::Boundary)
+    }
+}

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -17,6 +17,7 @@ pub(super) mod spann_fetch_pl;
 
 pub mod filter;
 pub mod filter_logs_for_shard;
+pub mod get_async_fn_fetch_boundaries;
 pub mod idf;
 pub mod knn_hnsw;
 pub mod knn_log;

--- a/rust/worker/src/execution/orchestration/async_function_boundary.rs
+++ b/rust/worker/src/execution/orchestration/async_function_boundary.rs
@@ -1,0 +1,266 @@
+use std::collections::HashMap;
+
+use chroma_types::chroma_proto::{CollectionVersionFile, CollectionVersionInfo, FilePaths};
+use chroma_types::Segment;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AsyncFnBoundaryPlan {
+    pub(crate) historical_record_segment: Segment,
+    pub(crate) target_log_position: i64,
+}
+
+pub(crate) fn resolve_boundary_plan_from_version_file(
+    version_file: Option<&CollectionVersionFile>,
+    completion_offset: i64,
+    max_compaction_size: usize,
+    live_record_segment: &Segment,
+) -> Result<AsyncFnBoundaryPlan, String> {
+    let empty_record_segment = empty_record_segment(live_record_segment);
+
+    let Some(version_file) = version_file else {
+        return Err(format!(
+            "async fn completion offset {} has no next compaction boundary",
+            completion_offset
+        ));
+    };
+
+    let version_history = match version_file.version_history.as_ref() {
+        Some(history) => history,
+        None => {
+            return Err(format!(
+                "async fn completion offset {} has no next compaction boundary",
+                completion_offset
+            ));
+        }
+    };
+
+    let version_infos = version_history
+        .versions
+        .iter()
+        .filter(|version| !version.marked_for_deletion)
+        .filter_map(|version| {
+            version
+                .collection_info_mutable
+                .as_ref()
+                .map(|mutable| (version, mutable.current_log_position))
+        });
+
+    let mut historical_version = None;
+    let mut next_boundary = None;
+    for (version, log_position) in version_infos.rev() {
+        if log_position > completion_offset {
+            next_boundary = Some(log_position);
+            continue;
+        }
+
+        historical_version = Some((version, log_position));
+        break;
+    }
+
+    let historical_record_segment = match historical_version {
+        Some((_, log_position)) if completion_offset > 0 && log_position < completion_offset => {
+            return Err(format!(
+                "async fn completion offset {} does not align to a compaction boundary",
+                completion_offset
+            ));
+        }
+        Some((version, _)) => historical_record_segment_for_version(live_record_segment, version),
+        None => empty_record_segment,
+    };
+
+    if let Some(next_boundary) = next_boundary {
+        let log_window_size = usize::try_from(next_boundary - completion_offset)
+            .map_err(|_| "next boundary precedes completion offset".to_string())?;
+        if log_window_size > max_compaction_size {
+            return Err(format!(
+                "next compaction boundary window {} exceeds max_compaction_size {}",
+                log_window_size, max_compaction_size
+            ));
+        }
+    } else {
+        return Err(format!(
+            "async fn completion offset {} has no next compaction boundary",
+            completion_offset
+        ));
+    }
+
+    Ok(AsyncFnBoundaryPlan {
+        historical_record_segment,
+        target_log_position: next_boundary.unwrap(),
+    })
+}
+
+fn empty_record_segment(record_segment: &Segment) -> Segment {
+    let mut segment = record_segment.clone();
+    segment.file_path.clear();
+    segment
+}
+
+fn historical_record_segment_for_version(
+    record_segment: &Segment,
+    version: &CollectionVersionInfo,
+) -> Segment {
+    let mut historical_segment = record_segment.clone();
+    let Some(segment_info) = version.segment_info.as_ref() else {
+        historical_segment.file_path.clear();
+        return historical_segment;
+    };
+
+    let Some(record_segment_info) = segment_info
+        .segment_compaction_info
+        .iter()
+        .find(|segment_info| segment_info.segment_id == record_segment.id.to_string())
+    else {
+        historical_segment.file_path.clear();
+        return historical_segment;
+    };
+
+    historical_segment.file_path = record_segment_info
+        .file_paths
+        .iter()
+        .map(|(key, value)| (key.clone(), file_paths_to_vec(value)))
+        .collect::<HashMap<_, _>>();
+    historical_segment
+}
+
+fn file_paths_to_vec(file_paths: &FilePaths) -> Vec<String> {
+    file_paths.paths.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use chroma_types::chroma_proto::{
+        CollectionInfoMutable, CollectionSegmentInfo, CollectionVersionFile,
+        CollectionVersionHistory, CollectionVersionInfo, FilePaths, FlushSegmentCompactionInfo,
+    };
+    use chroma_types::{CollectionUuid, Segment, SegmentScope, SegmentType, SegmentUuid};
+
+    use super::resolve_boundary_plan_from_version_file;
+
+    fn test_record_segment() -> Segment {
+        Segment {
+            id: SegmentUuid::new(),
+            r#type: SegmentType::BlockfileRecord,
+            scope: SegmentScope::RECORD,
+            collection: CollectionUuid::new(),
+            metadata: None,
+            file_path: HashMap::from([(
+                "offset_id_to_data".to_string(),
+                vec!["live/path".to_string()],
+            )]),
+        }
+    }
+
+    fn version_info(
+        version: i64,
+        current_log_position: i64,
+        segment_id: SegmentUuid,
+        record_path: &str,
+    ) -> CollectionVersionInfo {
+        CollectionVersionInfo {
+            version,
+            collection_info_mutable: Some(CollectionInfoMutable {
+                current_log_position,
+                ..Default::default()
+            }),
+            segment_info: Some(CollectionSegmentInfo {
+                segment_compaction_info: vec![FlushSegmentCompactionInfo {
+                    segment_id: segment_id.to_string(),
+                    file_paths: HashMap::from([(
+                        "offset_id_to_data".to_string(),
+                        FilePaths {
+                            paths: vec![record_path.to_string()],
+                        },
+                    )]),
+                }],
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn no_version_file_means_no_executable_boundary() {
+        let record_segment = test_record_segment();
+        let err =
+            resolve_boundary_plan_from_version_file(None, -1, 1024, &record_segment).unwrap_err();
+        assert!(err.contains("no next compaction boundary"));
+    }
+
+    #[test]
+    fn resolves_exact_boundary_and_next_boundary() {
+        let record_segment = test_record_segment();
+        let version_file = CollectionVersionFile {
+            version_history: Some(CollectionVersionHistory {
+                versions: vec![
+                    version_info(1, 100, record_segment.id, "record/v100"),
+                    version_info(2, 150, record_segment.id, "record/v150"),
+                ],
+            }),
+            ..Default::default()
+        };
+
+        let plan = resolve_boundary_plan_from_version_file(
+            Some(&version_file),
+            100,
+            1024,
+            &record_segment,
+        )
+        .unwrap();
+
+        assert_eq!(plan.target_log_position, 150);
+        assert_eq!(
+            plan.historical_record_segment.file_path["offset_id_to_data"],
+            vec!["record/v100".to_string()]
+        );
+    }
+
+    #[test]
+    fn completion_offset_zero_uses_empty_state_and_first_boundary() {
+        let record_segment = test_record_segment();
+        let version_file = CollectionVersionFile {
+            version_history: Some(CollectionVersionHistory {
+                versions: vec![
+                    version_info(1, 100, record_segment.id, "record/v100"),
+                    version_info(2, 150, record_segment.id, "record/v150"),
+                ],
+            }),
+            ..Default::default()
+        };
+
+        let plan =
+            resolve_boundary_plan_from_version_file(Some(&version_file), 0, 1024, &record_segment)
+                .unwrap();
+
+        assert_eq!(plan.target_log_position, 100);
+        assert!(
+            plan.historical_record_segment.file_path.is_empty(),
+            "completion offset zero should use the empty pre-compaction state"
+        );
+    }
+
+    #[test]
+    fn rejects_non_boundary_completion_offsets_after_first_compaction() {
+        let record_segment = test_record_segment();
+        let version_file = CollectionVersionFile {
+            version_history: Some(CollectionVersionHistory {
+                versions: vec![
+                    version_info(1, 100, record_segment.id, "record/v100"),
+                    version_info(2, 150, record_segment.id, "record/v150"),
+                ],
+            }),
+            ..Default::default()
+        };
+
+        let err = resolve_boundary_plan_from_version_file(
+            Some(&version_file),
+            125,
+            1024,
+            &record_segment,
+        )
+        .unwrap_err();
+
+        assert!(err.contains("does not align to a compaction boundary"));
+    }
+}

--- a/rust/worker/src/execution/orchestration/async_function_boundary.rs
+++ b/rust/worker/src/execution/orchestration/async_function_boundary.rs
@@ -1,12 +1,18 @@
-use std::collections::HashMap;
-
-use chroma_types::chroma_proto::{CollectionVersionFile, CollectionVersionInfo, FilePaths};
+use chroma_types::chroma_proto::CollectionVersionFile;
 use chroma_types::Segment;
 
 #[derive(Debug, Clone)]
 pub(crate) struct AsyncFnBoundaryPlan {
-    pub(crate) historical_record_segment: Segment,
+    pub(crate) historical_record_segment: Option<Segment>,
     pub(crate) target_log_position: i64,
+}
+
+impl AsyncFnBoundaryPlan {
+    pub(crate) fn record_segment_for_reader(&self, live_record_segment: &Segment) -> Segment {
+        self.historical_record_segment
+            .clone()
+            .unwrap_or_else(|| live_record_segment.empty_segment())
+    }
 }
 
 pub(crate) fn resolve_boundary_plan_from_version_file(
@@ -15,8 +21,6 @@ pub(crate) fn resolve_boundary_plan_from_version_file(
     max_compaction_size: usize,
     live_record_segment: &Segment,
 ) -> Result<AsyncFnBoundaryPlan, String> {
-    let empty_record_segment = empty_record_segment(live_record_segment);
-
     let Some(version_file) = version_file else {
         return Err(format!(
             "async fn completion offset {} has no next compaction boundary",
@@ -37,96 +41,68 @@ pub(crate) fn resolve_boundary_plan_from_version_file(
     let version_infos = version_history
         .versions
         .iter()
+        // GC only marks versions for deletion after a newer version supersedes them.
+        // Fn-consumers should only resolve boundaries against the still-live versions
+        // whose segment files are expected to remain readable. GC makes sure to
+        // keep at least one version live below the completion offset.
         .filter(|version| !version.marked_for_deletion)
         .filter_map(|version| {
             version
                 .collection_info_mutable
                 .as_ref()
                 .map(|mutable| (version, mutable.current_log_position))
-        });
+        })
+        .collect::<Vec<_>>();
 
     let mut historical_version = None;
     let mut next_boundary = None;
-    for (version, log_position) in version_infos.rev() {
-        if log_position > completion_offset {
-            next_boundary = Some(log_position);
-            continue;
+    for (version, log_position) in version_infos.into_iter().rev() {
+        if log_position <= completion_offset {
+            historical_version = Some((version, log_position));
+            break;
         }
 
-        historical_version = Some((version, log_position));
-        break;
+        next_boundary = Some(log_position);
     }
 
     let historical_record_segment = match historical_version {
         Some((_, log_position)) if completion_offset > 0 && log_position < completion_offset => {
             return Err(format!(
-                "async fn completion offset {} does not align to a compaction boundary",
+                "Invariant violation: async fn completion offset {} does not align to a compaction boundary",
                 completion_offset
             ));
         }
-        Some((version, _)) => historical_record_segment_for_version(live_record_segment, version),
-        None => empty_record_segment,
+        Some((version, _)) => Some(
+            live_record_segment.historical_segment_for_version(version, live_record_segment.id)?,
+        ),
+        None => None,
     };
 
-    if let Some(next_boundary) = next_boundary {
-        let log_window_size = usize::try_from(next_boundary - completion_offset)
-            .map_err(|_| "next boundary precedes completion offset".to_string())?;
-        if log_window_size > max_compaction_size {
-            return Err(format!(
-                "next compaction boundary window {} exceeds max_compaction_size {}",
-                log_window_size, max_compaction_size
-            ));
-        }
-    } else {
-        return Err(format!(
+    let target_log_position = next_boundary.ok_or_else(|| {
+        format!(
             "async fn completion offset {} has no next compaction boundary",
             completion_offset
+        )
+    })?;
+    let log_window_size =
+        usize::try_from(target_log_position - completion_offset).map_err(|_| {
+            format!(
+                "Invariant violation: next compaction boundary {} precedes completion offset {}",
+                target_log_position, completion_offset
+            )
+        })?;
+    if log_window_size > max_compaction_size {
+        return Err(format!(
+            "next compaction boundary window {} exceeds max_compaction_size {}",
+            log_window_size, max_compaction_size
         ));
     }
 
     Ok(AsyncFnBoundaryPlan {
         historical_record_segment,
-        target_log_position: next_boundary.unwrap(),
+        target_log_position,
     })
 }
-
-fn empty_record_segment(record_segment: &Segment) -> Segment {
-    let mut segment = record_segment.clone();
-    segment.file_path.clear();
-    segment
-}
-
-fn historical_record_segment_for_version(
-    record_segment: &Segment,
-    version: &CollectionVersionInfo,
-) -> Segment {
-    let mut historical_segment = record_segment.clone();
-    let Some(segment_info) = version.segment_info.as_ref() else {
-        historical_segment.file_path.clear();
-        return historical_segment;
-    };
-
-    let Some(record_segment_info) = segment_info
-        .segment_compaction_info
-        .iter()
-        .find(|segment_info| segment_info.segment_id == record_segment.id.to_string())
-    else {
-        historical_segment.file_path.clear();
-        return historical_segment;
-    };
-
-    historical_segment.file_path = record_segment_info
-        .file_paths
-        .iter()
-        .map(|(key, value)| (key.clone(), file_paths_to_vec(value)))
-        .collect::<HashMap<_, _>>();
-    historical_segment
-}
-
-fn file_paths_to_vec(file_paths: &FilePaths) -> Vec<String> {
-    file_paths.paths.clone()
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -211,7 +187,7 @@ mod tests {
 
         assert_eq!(plan.target_log_position, 150);
         assert_eq!(
-            plan.historical_record_segment.file_path["offset_id_to_data"],
+            plan.historical_record_segment.unwrap().file_path["offset_id_to_data"],
             vec!["record/v100".to_string()]
         );
     }
@@ -235,7 +211,7 @@ mod tests {
 
         assert_eq!(plan.target_log_position, 100);
         assert!(
-            plan.historical_record_segment.file_path.is_empty(),
+            plan.historical_record_segment.is_none(),
             "completion offset zero should use the empty pre-compaction state"
         );
     }
@@ -261,6 +237,67 @@ mod tests {
         )
         .unwrap_err();
 
+        assert!(err.contains("does not align to a compaction boundary"));
+    }
+
+    #[test]
+    fn ignores_deleted_versions_when_finding_next_boundary() {
+        let record_segment = test_record_segment();
+        let mut deleted_version = version_info(2, 150, record_segment.id, "record/v150");
+        deleted_version.marked_for_deletion = true;
+
+        let version_file = CollectionVersionFile {
+            version_history: Some(CollectionVersionHistory {
+                versions: vec![
+                    version_info(1, 100, record_segment.id, "record/v100"),
+                    deleted_version,
+                    version_info(3, 200, record_segment.id, "record/v200"),
+                ],
+            }),
+            ..Default::default()
+        };
+
+        let plan = resolve_boundary_plan_from_version_file(
+            Some(&version_file),
+            100,
+            1024,
+            &record_segment,
+        )
+        .unwrap();
+
+        assert_eq!(plan.target_log_position, 200);
+        assert_eq!(
+            plan.historical_record_segment.unwrap().file_path["offset_id_to_data"],
+            vec!["record/v100".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_completion_offsets_that_only_match_deleted_versions() {
+        let record_segment = test_record_segment();
+        let mut deleted_version = version_info(2, 150, record_segment.id, "record/v150");
+        deleted_version.marked_for_deletion = true;
+
+        let version_file = CollectionVersionFile {
+            version_history: Some(CollectionVersionHistory {
+                versions: vec![
+                    version_info(1, 100, record_segment.id, "record/v100"),
+                    deleted_version,
+                    version_info(3, 200, record_segment.id, "record/v200"),
+                ],
+            }),
+            ..Default::default()
+        };
+
+        let err = resolve_boundary_plan_from_version_file(
+            Some(&version_file),
+            150,
+            1024,
+            &record_segment,
+        )
+        .unwrap_err();
+
+        assert!(err.contains("Invariant violation"));
         assert!(err.contains("does not align to a compaction boundary"));
     }
 }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -546,6 +546,7 @@ impl CompactionContext {
             self.fragment_fetcher.clone(),
             self.bloom_filter_manager.clone(),
             self.work_queue_client.clone(),
+            self.is_fn_consumer,
             self.log_start_offset,
         );
 
@@ -1230,7 +1231,7 @@ mod tests {
             database_name: chroma_types::DatabaseName::new("test_db").unwrap(),
             fetch_log_concurrency: 10,
             fragment_fetcher: None,
-            log_upper_bound_offset: 0,
+            log_upper_bound_offset: None,
         };
 
         let filter = Filter {
@@ -1413,7 +1414,7 @@ mod tests {
             database_name: database_name.clone(),
             fetch_log_concurrency: 10,
             fragment_fetcher: None,
-            log_upper_bound_offset: 0,
+            log_upper_bound_offset: None,
         };
 
         let limit = Limit {
@@ -1511,7 +1512,7 @@ mod tests {
             database_name: database_name.clone(),
             fetch_log_concurrency: 10,
             fragment_fetcher: None,
-            log_upper_bound_offset: 0,
+            log_upper_bound_offset: None,
         };
 
         // Query again to verify FTS still works after rebuild
@@ -1667,7 +1668,7 @@ mod tests {
             database_name: chroma_types::DatabaseName::new("test_db").unwrap(),
             fetch_log_concurrency: 10,
             fragment_fetcher: None,
-            log_upper_bound_offset: 0,
+            log_upper_bound_offset: None,
         };
         let filter = Filter {
             query_ids: None,
@@ -4932,7 +4933,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_k8s_integration_async_attached_function() {
         // Setup test environment
         let config = RootConfig::default();
@@ -4943,36 +4944,20 @@ mod tests {
             .expect("Should be able to initialize dispatcher");
         let dispatcher_handle = system.start_component(dispatcher);
 
-        // Connect to Grpc SysDb (requires Tilt running)
-        let grpc_sysdb = chroma_sysdb::GrpcSysDb::try_from_config(
-            &(
-                chroma_sysdb::GrpcSysDbConfig {
-                    host: "localhost".to_string(),
-                    port: 50051,
-                    connect_timeout_ms: 5000,
-                    request_timeout_ms: 10000,
-                    num_channels: 4,
-                },
-                None,
-            ),
-            &registry,
-        )
-        .await
-        .expect("Should connect to grpc sysdb");
-        let mut sysdb = SysDb::Grpc(grpc_sysdb);
-
-        // Connect to WorkQueue (requires Tilt running)
-        let work_queue_client = crate::work_queue::work_queue_client::WorkQueueClient::new(
-            "http://localhost:50058".to_string(),
-        )
-        .await
-        .expect("Should connect to work queue");
-
         let test_segments = TestDistributedSegment::new().await;
+        let mut test_sysdb = TestSysDb::new();
+        test_sysdb.set_storage(
+            test_segments
+                .blockfile_provider
+                .storage()
+                .map(|storage| storage.as_ref().clone()),
+        );
+        let mut sysdb = SysDb::Test(test_sysdb);
         let mut in_memory_log = InMemoryLog::new();
 
-        // Create input collection
-        let collection_id = CollectionUuid::new();
+        // Create input collection using the fixture collection ID so the
+        // prebuilt segments in `test_segments` remain associated correctly.
+        let collection_id = test_segments.collection.collection_id;
         let database_name =
             chroma_types::DatabaseName::new(test_segments.collection.database.clone())
                 .expect("database name should be valid");
@@ -5017,33 +5002,10 @@ mod tests {
             .await
             .expect("Should be able to update log_position");
 
-        // Create async attached function via sysdb
-        let test_run_id = uuid::Uuid::new_v4();
-        let attached_function_name = format!("test_async_fn_{}", test_run_id);
-        let output_collection_name = format!("test_async_output_{}", test_run_id);
-
-        let (attached_function_id, _created) = sysdb
-            .create_attached_function(
-                attached_function_name.clone(),
-                "dummy_async".to_string(), // This is the async operator
-                collection_id,
-                output_collection_name.clone(),
-                serde_json::Value::Object(serde_json::Map::new()), // Empty params
-                tenant.clone(),
-                db.clone(),
-                1, // min_records_for_invocation
-            )
-            .await
-            .expect("Attached function creation should succeed");
-
-        let output_schema = chroma_types::Schema::new_default(chroma_types::KnnIndex::Hnsw);
-        let output_schema_str = serde_json::to_string(&output_schema).unwrap();
-        sysdb
-            .finish_create_attached_function(attached_function_id, output_schema_str)
-            .await
-            .unwrap();
-
-        // Add 5 records
+        // Add 300 records with zero-based offsets.  The in-memory log test
+        // double treats requested log offsets as storage indices, so the
+        // logical `LogRecord.log_offset` values must stay aligned with the
+        // contiguous internal offsets.
         for i in 0..300 {
             let log_record = chroma_types::LogRecord {
                 log_offset: i,
@@ -5074,93 +5036,113 @@ mod tests {
 
         let log = Log::InMemory(in_memory_log);
 
-        // Run compaction with work queue client
-        let compact_result = Box::pin(compact(
-            system.clone(),
-            collection_id,
-            database_name.clone(),
+        // Run three regular compactions to create boundaries at 99, 199, and 299.
+        // The async fn-consumer will later read from the historical version at 99
+        // and fetch only through the next boundary at 199.
+        for expected_log_position in [99, 199, 299] {
+            let compact_result = Box::pin(compact(
+                system.clone(),
+                collection_id,
+                database_name.clone(),
+                None,
+                50,
+                10,
+                100, // one boundary per run
+                50,
+                log.clone(),
+                sysdb.clone(),
+                test_segments.blockfile_provider.clone(),
+                test_segments.hnsw_provider.clone(),
+                test_segments.spann_provider.clone(),
+                dispatcher_handle.clone(),
+                false,
+                None,
+                None,
+                None,
+                None,
+                None, // poison_offset for test
+            ))
+            .await;
+
+            assert!(
+                compact_result.is_ok(),
+                "Compaction should succeed: {:?}",
+                compact_result.err()
+            );
+
+            let collection_after_compact = sysdb
+                .get_collection_with_segments(None, collection_id)
+                .await
+                .expect("Collection should exist after compaction");
+            assert_eq!(
+                collection_after_compact.collection.log_position, expected_log_position,
+                "Expected collection log_position to advance to the compaction boundary"
+            );
+        }
+
+        // Now simulate fn-consumer execution from the first boundary. This must:
+        // 1. read against the historical version compacted through offset 99
+        // 2. stop fetching at the next committed boundary (199)
+        // 3. materialize exactly the 100 records in (99, 199]
+        let mut fn_consumer_context = CompactionContext::new_with_log_offset(
             None,
             50,
             10,
             1000,
             50,
-            log,
+            log.clone(),
             sysdb.clone(),
             test_segments.blockfile_provider.clone(),
             test_segments.hnsw_provider.clone(),
             test_segments.spann_provider.clone(),
             dispatcher_handle.clone(),
             false,
+            true, // is_fn_consumer
             None,
             None,
             None,
-            Some(work_queue_client.clone()),
-            None, // poison_offset for test
-        ))
-        .await;
-
-        assert!(
-            compact_result.is_ok(),
-            "Compaction should succeed: {:?}",
-            compact_result.err()
+            None,
+            99,
         );
 
-        // Verify the attached function was found
-        let attached_functions = sysdb
-            .get_attached_functions(
-                Some(attached_function_name.clone()),
-                Some(collection_id),
-                vec![],
-                true,
-            )
+        let fetch_response = fn_consumer_context
+            .run_get_logs(collection_id, database_name.clone(), system.clone(), false)
             .await
-            .expect("Attached function query should succeed");
-        let attached_function_after_compact = attached_functions
-            .into_iter()
-            .next()
-            .expect("Attached function should be found");
+            .expect("fn-consumer log fetch should succeed");
 
-        assert!(
-            attached_function_after_compact
-                .output_collection_id
-                .is_some(),
-            "Output collection should be created"
-        );
+        match fetch_response {
+            LogFetchOrchestratorResponse::Success(success) => {
+                assert_eq!(
+                    success.collection_info.pulled_log_offset, 199,
+                    "fn-consumer should only fetch through the next committed boundary"
+                );
 
-        let _output_collection_id = attached_function_after_compact
-            .output_collection_id
-            .expect("Output collection should exist");
+                let total_materialized_records: usize = success
+                    .materialized
+                    .iter()
+                    .map(|batch| batch.result.len())
+                    .sum();
+                assert_eq!(
+                    total_materialized_records, 100,
+                    "fn-consumer should materialize exactly the records between boundaries"
+                );
 
-        // Check work queue for the async function
-        let mut wq_client = work_queue_client.clone();
-        let work_response = wq_client
-            .get_work("test_shard".to_string(), 10)
-            .await
-            .expect("Should be able to get work from queue");
-
-        // Filter for our specific function
-        println!("Got {} items, expected {}", work_response.items.len(), 1);
-        println!(
-            "Looking for fn_id: {}, coll_id: {}",
-            attached_function_id.0, collection_id
-        );
-
-        for item in &work_response.items {
-            println!(
-                "Work item: fn_id: {}, coll_id: {}, offset: {}",
-                item.fn_id, item.input_coll_id, item.completion_offset
-            );
+                for batch in &success.materialized {
+                    for shard_result in batch.result.iter() {
+                        for record in shard_result {
+                            assert_eq!(
+                                record.get_operation(),
+                                chroma_types::MaterializedLogOperation::AddNew,
+                                "historical version lookup should keep the boundary window as new adds"
+                            );
+                        }
+                    }
+                }
+            }
+            other => panic!("expected successful fn-consumer fetch, got {other:?}"),
         }
 
-        let our_work_item = work_response.items.into_iter().find(|item| {
-            item.fn_id == attached_function_id.0.to_string()
-                && item.input_coll_id == collection_id.to_string()
-        });
-
-        assert!(
-            our_work_item.is_some(),
-            "Should find our async function in the work queue"
-        );
+        Box::pin(fn_consumer_context.cleanup()).await;
 
         // Clean up - delete the collections
         // Note: We don't have segment IDs easily available here, so we can't delete

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -5144,6 +5144,68 @@ mod tests {
 
         Box::pin(fn_consumer_context.cleanup()).await;
 
+        // Repeat from the second boundary to prove fn-consumer continues to hop
+        // exactly one committed compaction window at a time.
+        let mut second_window_context = CompactionContext::new_with_log_offset(
+            None,
+            50,
+            10,
+            1000,
+            50,
+            log.clone(),
+            sysdb.clone(),
+            test_segments.blockfile_provider.clone(),
+            test_segments.hnsw_provider.clone(),
+            test_segments.spann_provider.clone(),
+            dispatcher_handle.clone(),
+            false,
+            true, // is_fn_consumer
+            None,
+            None,
+            None,
+            None,
+            199,
+        );
+
+        let second_fetch_response = second_window_context
+            .run_get_logs(collection_id, database_name.clone(), system.clone(), false)
+            .await
+            .expect("second fn-consumer log fetch should succeed");
+
+        match second_fetch_response {
+            LogFetchOrchestratorResponse::Success(success) => {
+                assert_eq!(
+                    success.collection_info.pulled_log_offset, 299,
+                    "fn-consumer should continue to the next committed boundary on later runs"
+                );
+
+                let total_materialized_records: usize = success
+                    .materialized
+                    .iter()
+                    .map(|batch| batch.result.len())
+                    .sum();
+                assert_eq!(
+                    total_materialized_records, 100,
+                    "each fn-consumer run should materialize exactly one compaction window"
+                );
+
+                for batch in &success.materialized {
+                    for shard_result in batch.result.iter() {
+                        for record in shard_result {
+                            assert_eq!(
+                                record.get_operation(),
+                                chroma_types::MaterializedLogOperation::AddNew,
+                                "later boundary windows should also replay as new adds"
+                            );
+                        }
+                    }
+                }
+            }
+            other => panic!("expected successful second fn-consumer fetch, got {other:?}"),
+        }
+
+        Box::pin(second_window_context.cleanup()).await;
+
         // Clean up - delete the collections
         // Note: We don't have segment IDs easily available here, so we can't delete
         // the collections. In a real test cleanup, you'd want to track the segment IDs.

--- a/rust/worker/src/execution/orchestration/count.rs
+++ b/rust/worker/src/execution/orchestration/count.rs
@@ -381,7 +381,7 @@ mod tests {
                         .unwrap(),
                         fetch_log_concurrency: 10,
                         fragment_fetcher: None,
-                        log_upper_bound_offset: TOTAL as i64,
+                        log_upper_bound_offset: Some(TOTAL as u64),
                     },
                     read_level,
                     limit,

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -340,32 +340,22 @@ impl Orchestrator for LogFetchOrchestrator {
 
 impl LogFetchOrchestrator {
     async fn get_async_fn_fetch_boundaries(
-        &mut self,
         collection: &chroma_types::Collection,
         record_segment: &chroma_types::Segment,
         completion_offset: i64,
-        ctx: &ComponentContext<Self>,
-    ) -> Option<AsyncFnBoundaryPlan> {
-        let boundary_plan = match self
-            .ok_or_terminate(
-                GetAsyncFnFetchBoundariesOperator::new()
-                    .run(&GetAsyncFnFetchBoundariesInput {
-                        collection: collection.clone(),
-                        record_segment: record_segment.clone(),
-                        completion_offset,
-                        max_compaction_size: self.context.max_compaction_size,
-                        blockfile_provider: self.context.blockfile_provider.clone(),
-                    })
-                    .await
-                    .map_err(LogFetchOrchestratorError::from),
-                ctx,
-            )
+        max_compaction_size: usize,
+        blockfile_provider: BlockfileProvider,
+    ) -> Result<AsyncFnBoundaryPlan, LogFetchOrchestratorError> {
+        GetAsyncFnFetchBoundariesOperator::new()
+            .run(&GetAsyncFnFetchBoundariesInput {
+                collection: collection.clone(),
+                record_segment: record_segment.clone(),
+                completion_offset,
+                max_compaction_size,
+                blockfile_provider,
+            })
             .await
-        {
-            Some(plan) => plan,
-            None => return None,
-        };
-        Some(boundary_plan)
+            .map_err(LogFetchOrchestratorError::from)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -550,46 +540,50 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
         let mut log_upper_bound_offset = None;
 
         if self.context.is_fn_consumer {
-            let completion_offset = match self
-                .ok_or_terminate(
-                    self.context.log_start_offset.ok_or_else(|| {
-                        LogFetchOrchestratorError::InvariantViolation(
-                            "fn-consumer log fetch requires log_start_offset",
-                        )
-                    }),
-                    ctx,
-                )
-                .await
-            {
+            let completion_offset = match self.context.log_start_offset {
                 Some(offset) => offset,
-                None => return,
+                None => {
+                    self.terminate_with_result(
+                        Err(LogFetchOrchestratorError::InvariantViolation(
+                            "fn-consumer log fetch requires log_start_offset",
+                        )),
+                        ctx,
+                    )
+                    .await;
+                    return;
+                }
             };
 
-            let boundary_plan = match self
-                .get_async_fn_fetch_boundaries(
-                    &collection,
-                    &output.record_segment,
-                    completion_offset,
-                    ctx,
-                )
-                .await
+            let max_compaction_size = self.context.max_compaction_size;
+            let blockfile_provider = self.context.blockfile_provider.clone();
+            let boundary_plan = match LogFetchOrchestrator::get_async_fn_fetch_boundaries(
+                &collection,
+                &output.record_segment,
+                completion_offset,
+                max_compaction_size,
+                blockfile_provider,
+            )
+            .await
             {
-                Some(plan) => plan,
-                None => return,
+                Ok(plan) => plan,
+                Err(err) => {
+                    self.terminate_with_result(Err(err), ctx).await;
+                    return;
+                }
             };
 
             tracing::info!(
                 collection_id = %collection.collection_id,
                 completion_offset,
                 target_log_position = boundary_plan.target_log_position,
-                historical_record_segment_id = %boundary_plan.historical_record_segment.id,
+                uses_pre_compaction_state = boundary_plan.historical_record_segment.is_none(),
                 "Resolved async function execution boundary"
             );
 
-            record_segment_for_reader = boundary_plan.historical_record_segment;
+            record_segment_for_reader =
+                boundary_plan.record_segment_for_reader(&output.record_segment);
             pulled_log_offset = boundary_plan.target_log_position;
-            log_upper_bound_offset =
-                Some(u64::try_from(boundary_plan.target_log_position + 1).unwrap_or_default());
+            log_upper_bound_offset = Some((boundary_plan.target_log_position + 1) as u64);
         }
 
         // Create RecordSegmentReader for MaterializeLogOperator

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -18,8 +18,8 @@ use chroma_segment::{
 };
 use chroma_sysdb::sysdb::SysDb;
 use chroma_system::{
-    wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
-    OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
+    wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Operator,
+    Orchestrator, OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
     Chunk, CollectionUuid, JobId, LogRecord, MetadataValue, SchemaMismatchError, SegmentFlushInfo,
@@ -38,6 +38,10 @@ use crate::{
         operators::{
             fetch_log::{FetchLogError, FetchLogOperator, FetchLogOutput},
             fragment_fetch::FragmentFetcher,
+            get_async_fn_fetch_boundaries::{
+                GetAsyncFnFetchBoundariesError, GetAsyncFnFetchBoundariesInput,
+                GetAsyncFnFetchBoundariesOperator,
+            },
             get_collection_and_segments::{
                 GetCollectionAndSegmentsError, GetCollectionAndSegmentsOperator,
                 GetCollectionAndSegmentsOutput,
@@ -60,9 +64,12 @@ use crate::{
                 SourceRecordSegmentV2Operator, SourceRecordSegmentV2Output,
             },
         },
-        orchestration::compact::{
-            CollectionCompactInfo, CompactWriters, CompactionContext, CompactionContextError,
-            ExecutionState,
+        orchestration::{
+            async_function_boundary::AsyncFnBoundaryPlan,
+            compact::{
+                CollectionCompactInfo, CompactWriters, CompactionContext, CompactionContextError,
+                ExecutionState,
+            },
         },
     },
     work_queue::work_queue_client::WorkQueueClient,
@@ -124,6 +131,8 @@ pub enum LogFetchOrchestratorError {
     MetadataSegmentWriter(#[from] chroma_segment::blockfile_metadata::MetadataSegmentWriterError),
     #[error("Error creating vector segment writer: {0}")]
     VectorSegmentWriter(#[from] chroma_segment::types::VectorSegmentWriterError),
+    #[error("Error resolving async fn-consumer fetch plan: {0}")]
+    GetAsyncFnFetchBoundaries(#[from] GetAsyncFnFetchBoundariesError),
 }
 
 impl ChromaError for LogFetchOrchestratorError {
@@ -170,6 +179,7 @@ impl ChromaError for LogFetchOrchestratorError {
                 Self::CountError(e) => e.should_trace_error(),
                 Self::MetadataSegmentWriter(e) => e.should_trace_error(),
                 Self::VectorSegmentWriter(e) => e.should_trace_error(),
+                Self::GetAsyncFnFetchBoundaries(e) => e.should_trace_error(),
             }
         }
     }
@@ -329,6 +339,35 @@ impl Orchestrator for LogFetchOrchestrator {
 }
 
 impl LogFetchOrchestrator {
+    async fn get_async_fn_fetch_boundaries(
+        &mut self,
+        collection: &chroma_types::Collection,
+        record_segment: &chroma_types::Segment,
+        completion_offset: i64,
+        ctx: &ComponentContext<Self>,
+    ) -> Option<AsyncFnBoundaryPlan> {
+        let boundary_plan = match self
+            .ok_or_terminate(
+                GetAsyncFnFetchBoundariesOperator::new()
+                    .run(&GetAsyncFnFetchBoundariesInput {
+                        collection: collection.clone(),
+                        record_segment: record_segment.clone(),
+                        completion_offset,
+                        max_compaction_size: self.context.max_compaction_size,
+                        blockfile_provider: self.context.blockfile_provider.clone(),
+                    })
+                    .await
+                    .map_err(LogFetchOrchestratorError::from),
+                ctx,
+            )
+            .await
+        {
+            Some(plan) => plan,
+            None => return None,
+        };
+        Some(boundary_plan)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         collection_id: CollectionUuid,
@@ -347,6 +386,7 @@ impl LogFetchOrchestrator {
         fragment_fetcher: Option<Arc<FragmentFetcher>>,
         bloom_filter_manager: Option<BloomFilterManager>,
         work_queue_client: Option<WorkQueueClient>,
+        is_fn_consumer: bool,
         log_start_offset: Option<i64>,
     ) -> Self {
         let mut context = CompactionContext::new(
@@ -362,7 +402,7 @@ impl LogFetchOrchestrator {
             spann_provider,
             dispatcher.clone(),
             false, // LogFetchOrchestrator doesn't need is_function_disabled
-            false, // is_fn_consumer
+            is_fn_consumer,
             fragment_fetcher,
             bloom_filter_manager,
             None, // shard_size
@@ -505,12 +545,58 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
         };
 
         let collection = output.collection.clone();
+        let mut record_segment_for_reader = output.record_segment.clone();
+        let mut pulled_log_offset = collection.log_position;
+        let mut log_upper_bound_offset = None;
+
+        if self.context.is_fn_consumer {
+            let completion_offset = match self
+                .ok_or_terminate(
+                    self.context.log_start_offset.ok_or_else(|| {
+                        LogFetchOrchestratorError::InvariantViolation(
+                            "fn-consumer log fetch requires log_start_offset",
+                        )
+                    }),
+                    ctx,
+                )
+                .await
+            {
+                Some(offset) => offset,
+                None => return,
+            };
+
+            let boundary_plan = match self
+                .get_async_fn_fetch_boundaries(
+                    &collection,
+                    &output.record_segment,
+                    completion_offset,
+                    ctx,
+                )
+                .await
+            {
+                Some(plan) => plan,
+                None => return,
+            };
+
+            tracing::info!(
+                collection_id = %collection.collection_id,
+                completion_offset,
+                target_log_position = boundary_plan.target_log_position,
+                historical_record_segment_id = %boundary_plan.historical_record_segment.id,
+                "Resolved async function execution boundary"
+            );
+
+            record_segment_for_reader = boundary_plan.historical_record_segment;
+            pulled_log_offset = boundary_plan.target_log_position;
+            log_upper_bound_offset =
+                Some(u64::try_from(boundary_plan.target_log_position + 1).unwrap_or_default());
+        }
 
         // Create RecordSegmentReader for MaterializeLogOperator
         let record_segment_reader = match self
             .ok_or_terminate(
                 Box::pin(RecordSegmentReader::from_segment(
-                    &output.record_segment,
+                    &record_segment_for_reader,
                     &self.context.blockfile_provider,
                     self.context.bloom_filter_manager.clone(),
                 ))
@@ -619,7 +705,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                     database_name,
                     fetch_log_concurrency: self.context.fetch_log_concurrency,
                     fragment_fetcher: self.context.fragment_fetcher.clone(),
-                    log_upper_bound_offset: 0,
+                    log_upper_bound_offset,
                 }),
                 (),
                 ctx.receiver(),
@@ -651,7 +737,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
             collection_id: collection.collection_id,
             collection: collection.clone(),
             writers: None,
-            pulled_log_offset: collection.log_position,
+            pulled_log_offset,
             hnsw_index_uuid: None,
             schema: collection.schema.clone(),
             original_segment_flush_infos,

--- a/rust/worker/src/execution/orchestration/mod.rs
+++ b/rust/worker/src/execution/orchestration/mod.rs
@@ -1,4 +1,5 @@
 pub mod apply_logs_orchestrator;
+pub(crate) mod async_function_boundary;
 pub mod attached_function_orchestrator;
 pub(crate) mod compact;
 pub(crate) mod count;

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -1015,7 +1015,7 @@ mod tests {
             }),
             shard_index: 0,
             num_shards: 1,
-            log_upper_bound_offset: -1,
+            log_upper_bound_offset: 0,
         }
     }
 

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -277,7 +277,8 @@ impl WorkerServer {
             database_name,
             fetch_log_concurrency: self.fetch_log_concurrency,
             fragment_fetcher,
-            log_upper_bound_offset,
+            log_upper_bound_offset: (log_upper_bound_offset > 0)
+                .then_some(log_upper_bound_offset as u64),
         })
     }
 
@@ -1014,7 +1015,7 @@ mod tests {
             }),
             shard_index: 0,
             num_shards: 1,
-            log_upper_bound_offset: 0,
+            log_upper_bound_offset: -1,
         }
     }
 


### PR DESCRIPTION
## Description of changes

This PR fixes a bug where async function (fn-consumer) completions could be processed at arbitrary log offsets rather than at compaction boundaries.  This caused a lot of data inconsistency when the fn consumer pulled a set of records that were not directly incremental to the most recently compacted version.

The core idea for the fix: when a fn-consumer runs, it must read from the historical record segment at the previous compaction boundary and only fetch logs up to the _next_ committed compaction boundary — not to the live head.

The changes fall into three logical groups:

1. A new `async_function_boundary` module that encodes the boundary-alignment logic
2. A new `GetAsyncFnFetchBoundariesOperator` that fetches the version file and invokes that logic
3. Wiring changes in `LogFetchOrchestrator` and `CompactionContext` to use the operator when `is_fn_consumer` is true
4. Mechanical type change: `log_upper_bound_offset: i64` → `Option<u64>` throughout

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_