### PR TITLE
[CHORE] Share whoami_and_authorize across foundation routes

### DIFF
--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -13,11 +13,9 @@ use serde::Serialize;
 use std::collections::HashMap;
 use uuid::Uuid;
 
+use super::whoami::whoami_and_authorize;
 use crate::{
-    auth::{AuthError, AuthenticateAndAuthorize, AuthzAction, AuthzResource},
-    config::FoundationConfig,
-    errors::ServerError,
-    server::FoundationApiServer,
+    auth::AuthzAction, config::FoundationConfig, errors::ServerError, server::FoundationApiServer,
 };
 
 #[derive(Serialize)]
@@ -41,7 +39,9 @@ pub async fn foundation_init(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
 ) -> Result<Json<FoundationInitResponse>, ServerError> {
-    let tenant = whoami_and_authorize(&*server.auth, &headers, AuthzAction::InitFoundation).await?;
+    let tenant = whoami_and_authorize(&*server.auth, &headers, AuthzAction::InitFoundation)
+        .await?
+        .tenant;
 
     let _guard =
         server.scorecard_request(&["op:foundation_init", &format!("tenant:{}", tenant)])?;
@@ -276,106 +276,10 @@ async fn ensure_collection(
     Ok(collection)
 }
 
-/// Resolve the caller's tenant from the auth token, then check that the
-/// caller is allowed to perform `action` against that tenant.
-///
-/// The two-step shape exists because the Cloud `authenticate_and_authorize`
-/// impl enforces `resource.tenant == user_identity.tenant` (returns 403 on
-/// mismatch, including `resource.tenant == None`). The Noop impl ignores
-/// resource entirely, which is why a single-call handler that passed
-/// `tenant: None` looked fine in tests but 403'd under Cloud auth.
-async fn whoami_and_authorize(
-    auth: &dyn AuthenticateAndAuthorize,
-    headers: &HeaderMap,
-    action: AuthzAction,
-) -> Result<String, AuthError> {
-    let identity = auth.get_user_identity(headers).await?;
-    let tenant = identity.tenant.clone();
-    auth.authenticate_and_authorize(
-        headers,
-        action,
-        AuthzResource {
-            tenant: Some(tenant.clone()),
-            database: None,
-            collection: None,
-        },
-    )
-    .await?;
-    Ok(tenant)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chroma_api_types::GetUserIdentityResponse;
     use chroma_types::SegmentType;
-    use std::collections::HashSet;
-    use std::future::{ready, Future};
-    use std::pin::Pin;
-    use std::sync::Mutex;
-
-    /// Fake `AuthenticateAndAuthorize` that returns a fixed tenant from
-    /// `get_user_identity` and records the `AuthzResource` passed to
-    /// `authenticate_and_authorize` so tests can assert on it.
-    struct FakeAuth {
-        tenant: String,
-        captured_action: Mutex<Option<AuthzAction>>,
-        captured_resource: Mutex<Option<AuthzResource>>,
-    }
-
-    impl FakeAuth {
-        fn new(tenant: &str) -> Self {
-            Self {
-                tenant: tenant.to_string(),
-                captured_action: Mutex::new(None),
-                captured_resource: Mutex::new(None),
-            }
-        }
-
-        fn identity(&self) -> GetUserIdentityResponse {
-            GetUserIdentityResponse {
-                user_id: String::new(),
-                tenant: self.tenant.clone(),
-                databases: HashSet::new(),
-            }
-        }
-    }
-
-    impl AuthenticateAndAuthorize for FakeAuth {
-        fn authenticate_and_authorize(
-            &self,
-            _headers: &axum::http::HeaderMap,
-            action: AuthzAction,
-            resource: AuthzResource,
-        ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
-        {
-            *self.captured_action.lock().unwrap() = Some(action);
-            *self.captured_resource.lock().unwrap() = Some(resource);
-            let identity = self.identity();
-            Box::pin(ready(Ok(identity)))
-        }
-
-        fn authenticate_and_authorize_collection(
-            &self,
-            _headers: &axum::http::HeaderMap,
-            _action: AuthzAction,
-            _resource: AuthzResource,
-            _collection: chroma_types::Collection,
-        ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
-        {
-            let identity = self.identity();
-            Box::pin(ready(Ok(identity)))
-        }
-
-        fn get_user_identity(
-            &self,
-            _headers: &axum::http::HeaderMap,
-        ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
-        {
-            let identity = self.identity();
-            Box::pin(ready(Ok(identity)))
-        }
-    }
 
     #[test]
     fn foundation_schema_has_sparse_vector_index() {
@@ -436,34 +340,5 @@ mod tests {
             "plan must include a SPANN vector segment, got: {:?}",
             plan.segments.iter().map(|s| &s.r#type).collect::<Vec<_>>()
         );
-    }
-
-    #[tokio::test]
-    async fn whoami_and_authorize_passes_resolved_tenant_to_authz() {
-        let fake = FakeAuth::new("team_abc");
-        let headers = HeaderMap::new();
-
-        let tenant = whoami_and_authorize(&fake, &headers, AuthzAction::InitFoundation)
-            .await
-            .expect("auth should succeed");
-
-        assert_eq!(tenant, "team_abc");
-        let captured_action = fake
-            .captured_action
-            .lock()
-            .unwrap()
-            .expect("authenticate_and_authorize should have been called");
-        assert_eq!(captured_action, AuthzAction::InitFoundation);
-        let captured = fake
-            .captured_resource
-            .lock()
-            .unwrap()
-            .clone()
-            .expect("authenticate_and_authorize should have been called");
-        // Regression: before this fix the handler passed `tenant: None`,
-        // which the Cloud authz impl always rejects with 403.
-        assert_eq!(captured.tenant, Some("team_abc".to_string()));
-        assert_eq!(captured.database, None);
-        assert_eq!(captured.collection, None);
     }
 }

--- a/rust/foundation-api/src/routes/mod.rs
+++ b/rust/foundation-api/src/routes/mod.rs
@@ -2,6 +2,7 @@ use crate::server::FoundationApiServer;
 use axum::{routing::post, Router};
 
 pub(crate) mod init;
+pub(super) mod whoami;
 
 pub(crate) fn router() -> Router<FoundationApiServer> {
     Router::new().route("/api/init", post(init::foundation_init))

--- a/rust/foundation-api/src/routes/whoami.rs
+++ b/rust/foundation-api/src/routes/whoami.rs
@@ -1,0 +1,137 @@
+use axum::http::HeaderMap;
+use chroma_api_types::GetUserIdentityResponse;
+
+use crate::auth::{AuthError, AuthenticateAndAuthorize, AuthzAction, AuthzResource};
+
+/// Resolve the caller's identity from the auth token, then check that the
+/// caller is allowed to perform `action` against their tenant.
+///
+/// The two-step shape exists because the Cloud `authenticate_and_authorize`
+/// impl enforces `resource.tenant == user_identity.tenant` (returns 403 on
+/// mismatch, including `resource.tenant == None`). The Noop impl ignores
+/// resource entirely, which is why a single-call handler that passed
+/// `tenant: None` looked fine in tests but 403'd under Cloud auth.
+pub(super) async fn whoami_and_authorize(
+    auth: &dyn AuthenticateAndAuthorize,
+    headers: &HeaderMap,
+    action: AuthzAction,
+) -> Result<GetUserIdentityResponse, AuthError> {
+    let identity = auth.get_user_identity(headers).await?;
+    auth.authenticate_and_authorize(
+        headers,
+        action,
+        AuthzResource {
+            tenant: Some(identity.tenant.clone()),
+            database: None,
+            collection: None,
+        },
+    )
+    .await?;
+    Ok(identity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::future::{ready, Future};
+    use std::pin::Pin;
+    use std::sync::Mutex;
+
+    /// Fake auth that returns a fixed identity and records the action /
+    /// resource passed to `authenticate_and_authorize` so tests can
+    /// assert on it.
+    struct FakeAuth {
+        user_id: String,
+        tenant: String,
+        captured_action: Mutex<Option<AuthzAction>>,
+        captured_resource: Mutex<Option<AuthzResource>>,
+    }
+
+    impl FakeAuth {
+        fn new(user_id: &str, tenant: &str) -> Self {
+            Self {
+                user_id: user_id.to_string(),
+                tenant: tenant.to_string(),
+                captured_action: Mutex::new(None),
+                captured_resource: Mutex::new(None),
+            }
+        }
+
+        fn identity(&self) -> GetUserIdentityResponse {
+            GetUserIdentityResponse {
+                user_id: self.user_id.clone(),
+                tenant: self.tenant.clone(),
+                databases: HashSet::new(),
+            }
+        }
+    }
+
+    impl AuthenticateAndAuthorize for FakeAuth {
+        fn authenticate_and_authorize(
+            &self,
+            _headers: &HeaderMap,
+            action: AuthzAction,
+            resource: AuthzResource,
+        ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
+        {
+            *self.captured_action.lock().unwrap() = Some(action);
+            *self.captured_resource.lock().unwrap() = Some(resource);
+            let identity = self.identity();
+            Box::pin(ready(Ok(identity)))
+        }
+
+        fn authenticate_and_authorize_collection(
+            &self,
+            _headers: &HeaderMap,
+            _action: AuthzAction,
+            _resource: AuthzResource,
+            _collection: chroma_types::Collection,
+        ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
+        {
+            let identity = self.identity();
+            Box::pin(ready(Ok(identity)))
+        }
+
+        fn get_user_identity(
+            &self,
+            _headers: &HeaderMap,
+        ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
+        {
+            let identity = self.identity();
+            Box::pin(ready(Ok(identity)))
+        }
+    }
+
+    #[tokio::test]
+    async fn passes_resolved_tenant_to_authz_and_returns_full_identity() {
+        let fake = FakeAuth::new("user_99", "team_abc");
+        let headers = HeaderMap::new();
+
+        let identity = whoami_and_authorize(&fake, &headers, AuthzAction::InitFoundation)
+            .await
+            .expect("auth should succeed");
+
+        assert_eq!(identity.tenant, "team_abc");
+        assert_eq!(identity.user_id, "user_99");
+
+        let captured_action = fake
+            .captured_action
+            .lock()
+            .unwrap()
+            .expect("authenticate_and_authorize should have been called");
+        assert_eq!(captured_action, AuthzAction::InitFoundation);
+
+        let captured = fake
+            .captured_resource
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("authenticate_and_authorize should have been called");
+        // Regression: before this fix the handler passed `tenant: None`,
+        // which the Cloud authz impl always rejects with 403.
+        assert_eq!(captured.tenant, Some("team_abc".to_string()));
+        assert_eq!(captured.database, None);
+        assert_eq!(captured.collection, None);
+    }
+}


### PR DESCRIPTION
## Description of changes

Lifts the two-step auth dance out of `routes/init.rs` and into a new shared
`routes/whoami.rs` so future foundation-api route handlers can reuse it
without re-inlining the gotcha that the Cloud authz impl 403s when
`resource.tenant != identity.tenant` (including `tenant: None`). The helper
now returns the full `GetUserIdentityResponse` rather than just the tenant
string, so callers that also need `user_id` don't have to make a second
`get_user_identity` call.

`/api/init` keeps identical behavior; this is a pure refactor that sets up
the stacked PR (#7150) which adds `/api/ask` as the first new caller.

## Test plan

- `cargo test -p foundation-api` — 4 tests pass (3 existing init schema
  tests + the relocated `whoami_and_authorize_passes_resolved_tenant_to_authz`
  test, renamed to reflect that the helper now also returns the full identity).
- `cargo clippy -p foundation-api --all-targets` — clean.
- `cargo fmt -p foundation-api --check` — clean.

## Migration plan

N/A. Internal refactor; no API surface change.

## Observability plan

N/A. Logging/tracing is unchanged.

## Documentation Changes

The two-step gotcha doc-comment moved from `init.rs::whoami_and_authorize`
to `whoami.rs::whoami_and_authorize`; no other doc updates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ka61oT9xg8YCm4AWePjQ6U)_