### PR TITLE
[ENH](k8s): add foundationService to distributed-chroma chart

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.86
+version: 0.1.87
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/foundation-service.yaml
+++ b/k8s/distributed-chroma/templates/foundation-service.yaml
@@ -1,0 +1,118 @@
+{{- if (and .Values.foundationService .Values.foundationService.enabled) -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foundation-server-config
+  namespace: {{ .Values.namespace }}
+data:
+  config.yaml: |
+{{ .Values.foundationService.configuration | indent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foundation-server-deployment
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.foundationService.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app: foundation-server
+  template:
+    metadata:
+      namespace: {{ .Values.namespace }}
+      labels:
+        app: foundation-server
+    spec:
+      containers:
+        - name: foundation-server
+          image: "{{ .Values.foundationService.image.repository }}:{{ .Values.foundationService.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          {{- if .Values.foundationService.resources }}
+          resources:
+            requests:
+              cpu: {{ .Values.foundationService.resources.requests.cpu }}
+              memory: {{ .Values.foundationService.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.foundationService.resources.limits.cpu }}
+              memory: {{ .Values.foundationService.resources.limits.memory }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.foundationService.port | default 8000 }}
+              name: http
+          readinessProbe:
+            periodSeconds: 1
+            failureThreshold: 30 # 30 seconds to allow for initial startup
+            httpGet:
+              port: {{ .Values.foundationService.port | default 8000 }}
+              path: /api/v2/healthcheck
+          livenessProbe:
+            periodSeconds: 10
+            failureThreshold: 3
+            httpGet:
+              port: {{ .Values.foundationService.port | default 8000 }}
+              path: /api/v2/healthcheck
+          env:
+            - name: CONFIG_PATH
+              value: "/config/config.yaml"
+            {{- with .Values.foundationService.env }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: foundation-server-config
+              mountPath: /config/
+      {{- with .Values.foundationService.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.foundationService.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.foundationService.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      volumes:
+        - name: foundation-server-config
+          configMap:
+            name: foundation-server-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foundation-server
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    - name: http
+      port: {{ .Values.foundationService.port | default 8000 }}
+      targetPort: http
+  selector:
+    app: foundation-server
+  type: ClusterIP
+{{- with .Values.foundationService.ingress }}
+{{- if .host }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: foundation-server-ingress
+  namespace: {{ $.Values.namespace }}
+spec:
+  ingressClassName: haproxy
+  rules:
+    - host: {{ .host }}
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: foundation-server
+                port:
+                  number: {{ $.Values.foundationService.port | default 8000 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -13,6 +13,22 @@ rustFrontendService:
     requests:
       cpu: '1000m'
       memory: '512Mi'
+foundationService:
+  # Hosted-only by default. Hosted deployments override `enabled: true` and
+  # supply their own image; pure-OSS users can opt in by enabling it and
+  # pointing at their own foundation-service binary.
+  enabled: false
+  image:
+    repository: 'foundation-service'
+    tag: 'latest'
+  replicaCount: 1
+  port: 8000
+  configuration: |
+    foundation:
+      port: 8000
+      listen_address: "0.0.0.0"
+    auth: noop
+    ingestion_engine: noop
 sysdb:
   image:
     repository: 'sysdb'


### PR DESCRIPTION
## Summary

Adds `foundation-service` as an opt-in component of the `distributed-chroma`
chart, paralleling the existing `rustFrontendService` setup. The template is
generic (image + config + service + optional ingress); whether you deploy it,
and which image, is controlled by values.

## Why

Today the foundation service is deployed via **two** independently authored k8s
templates — one in `hosted-chroma/tilt/foundation-service/` (Tilt local dev)
and another duplicate in `chroma-core/k8s` at
`chroma-data-plane/templates/foundation-server.yaml` (prod). They've already
drifted (port 8010 vs 8000; probes vs no probes). Unifying them in
`distributed-chroma` follows the same pattern `rustFrontendService` uses: one
generic template here; hosted-chroma overrides image/values for hosted; prod
consumes via the OCI dep and overrides per-env. (See hosted-chroma issue
#7582 / Tracking the broader unification.)

## What's in this PR
- **New `templates/foundation-service.yaml`** — wrapped in
  `{{- if (and .Values.foundationService .Values.foundationService.enabled) -}}`
  so it's a no-op for pure-OSS users. Body adapted from prod's
  `foundation-server.yaml` (the superset), with the OSS-chart conventions
  (`{{ .Values.namespace }}` instead of hard-coded `chroma`) and adds
  `readinessProbe` / `livenessProbe` on `/api/v2/healthcheck`.
- **`values.yaml`** — adds `foundationService:` defaults: `enabled: false`,
  port 8000, `auth: noop` configuration. `nodeSelector` / `tolerations` /
  `affinity` / `env` / `ingress` / `resources` all unset (conditional).
- **`Chart.yaml`** — bump `0.1.86` → `0.1.87` (publish workflow trigger).

## Tested
- [x] `helm template … k8s/distributed-chroma` — default (enabled: false): **no foundation manifests**, no OSS regression.
- [x] `--set foundationService.enabled=true --set foundationService.image.repository=foundation-service` — renders ConfigMap + Service + Deployment with probes.
- [x] `--set foundationService.ingress.host=foundation-api.example.com` — also renders Ingress.

## Follow-ups (separate PRs, not blocking this one)
- hosted-chroma: enable `foundationService` in `tilt/additional-distributed-chroma-values.yaml`; delete `tilt/foundation-service/`.
- chroma-core/k8s: bump the `distributed-chroma` dep to 0.1.87; re-nest the existing prod `foundationService:` values under `distributed-chroma:`; delete the duplicate `chroma-data-plane/templates/foundation-server.yaml`.

## Precedent
This is exactly the shape `rustFrontendService` already uses. OSS-purity is preserved: pure-OSS users see no change (default off), and the template stays generic so an open-source foundation image could plug into the same slot.