### PR TITLE
[BLD] Enable mypy lint in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -259,6 +259,9 @@ jobs:
           pre-commit run --all-files prettier
           pre-commit run --all-files check-yaml
         continue-on-error: true
+      - name: Run mypy
+        shell: bash
+        run: pre-commit run --all-files mypy
       - name: Cargo fmt check
         shell: bash
         run: cargo fmt -- --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
     rev: "v1.10.0"
     hooks:
       - id: mypy
+        files: "^chromadb/"
         args:
           [
             --strict,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,48 @@ mypy_path = "rust/python_bindings"
 module = ["chromadb.proto.*"]
 ignore_errors = true
 
+[[tool.mypy.overrides]]
+module = ["chromadb.test.*"]
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = [
+    "chromadb.api.async_fastapi",
+    "chromadb.api.client",
+    "chromadb.api.fastapi",
+    "chromadb.api.models.CollectionCommon",
+    "chromadb.api.rust",
+    "chromadb.api.segment",
+    "chromadb.api.types",
+    "chromadb.auth.simple_rbac_authz",
+    "chromadb.auth.token_authn",
+    "chromadb.chromadb_rust_bindings",
+    "chromadb.cli.cli",
+    "chromadb.cli.utils",
+    "chromadb.config",
+    "chromadb.db.base",
+    "chromadb.db.impl.grpc.client",
+    "chromadb.db.impl.grpc.server",
+    "chromadb.db.impl.sqlite",
+    "chromadb.db.impl.sqlite_pool",
+    "chromadb.db.mixins.embeddings_queue",
+    "chromadb.db.mixins.sysdb",
+    "chromadb.execution.executor.local",
+    "chromadb.execution.expression.operator",
+    "chromadb.ingest.impl.utils",
+    "chromadb.logservice.logservice",
+    "chromadb.rate_limit.simple_rate_limit",
+    "chromadb.segment.impl.manager.cache.cache",
+    "chromadb.segment.impl.metadata.sqlite",
+    "chromadb.segment.impl.vector.hnsw_params",
+    "chromadb.segment.impl.vector.local_persistent_hnsw",
+    "chromadb.server.fastapi",
+    "chromadb.telemetry.opentelemetry.grpc",
+    "chromadb.utils.embedding_functions.*",
+    "chromadb.utils.results",
+]
+ignore_errors = true
+
 [project.scripts]
 chroma = "chromadb.cli.cli:app"
 


### PR DESCRIPTION
## Summary
- Add a dedicated **Run mypy** CI step so mypy failures fail the job (separate from pre-commit steps that use `continue-on-error: true`).
- Scope the mypy pre-commit hook to `chromadb/` to avoid unrelated `types` shadow errors in sample apps.
- Add incremental `[[tool.mypy.overrides]]` in `pyproject.toml` for modules with existing type debt.

Fixes #2054

## Test plan
- [x] `pre-commit run --all-files mypy`
- [x] `pre-commit run --all-files check-yaml`