### PR TITLE
[TST] extract shared hypothesis settings for embedding state machine tests

### DIFF
--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -39,6 +39,7 @@ from chromadb.test.conftest import (
     is_client_in_process,
     NOT_CLUSTER_ONLY,
     create_isolated_database,
+    override_hypothesis_profile,
 )
 import numpy as np
 import uuid
@@ -52,6 +53,15 @@ traces: DefaultDict[str, int] = defaultdict(lambda: 0)
 
 
 VERSION_INCREASE_WAIT_TIME = 300
+
+EMBEDDINGS_STATE_MACHINE_SETTINGS = settings(
+    deadline=90000,
+    parent=override_hypothesis_profile(
+        normal=hypothesis.settings(max_examples=76),
+        slow=hypothesis.settings(max_examples=152),
+    ),
+    suppress_health_check=[HealthCheck.filter_too_much],
+)
 
 
 def trace(key: str) -> None:
@@ -476,9 +486,7 @@ def test_embeddings_state(caplog: pytest.LogCaptureFixture, client: ClientAPI) -
     caplog.set_level(logging.ERROR)
     run_state_machine_as_test(
         lambda: EmbeddingStateMachine(client),
-        settings=settings(
-            deadline=90000, suppress_health_check=[HealthCheck.filter_too_much]
-        ),
+        settings=EMBEDDINGS_STATE_MACHINE_SETTINGS,
     )  # type: ignore
     print_traces()
 
@@ -494,9 +502,7 @@ def test_embeddings_state_with_search(
     caplog.set_level(logging.ERROR)
     run_state_machine_as_test(
         lambda: EmbeddingStateMachine(client, use_search=True),
-        settings=settings(
-            deadline=90000, suppress_health_check=[HealthCheck.filter_too_much]
-        ),
+        settings=EMBEDDINGS_STATE_MACHINE_SETTINGS,
     )  # type: ignore
     print_traces()
 


### PR DESCRIPTION
## Description of changes

Define EMBEDDINGS_STATE_MACHINE_SETTINGS at module level using
override_hypothesis_profile to configure max_examples per profile
(76 for normal, 152 for slow). Replace duplicated inline settings in
test_embeddings_state and test_embeddings_state_with_search with the
shared constant.

Codex imagines that based upon p of failure being 29 in 490 that 76 will
still catch 99% of failures of this particular test.  152 is more nines.

## Test plan

I collected tests locally and am relying upon CI.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
