### PR TITLE
[ENH](worker): Align work queue and fn-consumer tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11427,6 +11427,7 @@ dependencies = [
  "tokio-util",
  "tonic 0.14.5",
  "tonic-health",
+ "tower 0.5.3",
  "tracing",
  "tracing-opentelemetry",
  "uuid",

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -53,6 +53,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
 tonic-health = { workspace = true }
+tower = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 num_cpus = { workspace = true }

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -249,6 +249,9 @@ impl FnConsumerManager {
     }
 
     async fn poll_and_dispatch(&mut self) {
+        let span = tracing::debug_span!("FnConsumerManager::poll_and_dispatch");
+        let _guard = span.enter();
+
         self.evict_expired();
         let rem = self.compute_remaining_capacity();
         if rem == 0 {

--- a/rust/worker/src/work_queue/server.rs
+++ b/rust/worker/src/work_queue/server.rs
@@ -71,6 +71,7 @@ pub async fn service_entrypoint() {
 
     // Start server (this blocks forever)
     tonic::transport::Server::builder()
+        .layer(chroma_tracing::GrpcServerTraceLayer)
         .add_service(server)
         .add_service(health_service)
         .serve(addr)

--- a/rust/worker/src/work_queue/work_queue_client.rs
+++ b/rust/worker/src/work_queue/work_queue_client.rs
@@ -7,11 +7,13 @@ use chroma_types::chroma_proto::{
 use std::time::Duration;
 use tonic::transport::Endpoint;
 use tonic::Request;
+use tower::ServiceBuilder;
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct WorkQueueClient {
-    client: WorkQueueServiceClient<tonic::transport::Channel>,
+    client:
+        WorkQueueServiceClient<chroma_tracing::GrpcClientTraceService<tonic::transport::Channel>>,
 }
 
 #[allow(dead_code)]
@@ -29,25 +31,36 @@ impl WorkQueueClient {
             .connect_timeout(Duration::from_millis(config.connect_timeout_ms))
             .timeout(Duration::from_millis(config.request_timeout_ms));
 
-        let client = WorkQueueServiceClient::connect(endpoint)
-            .await
-            .map_err(|e| {
-                let err: Box<dyn ChromaError> =
-                    Box::new(WorkQueueClientError::ConnectionError(e.to_string()));
-                err
-            })?;
+        let channel = endpoint.connect().await.map_err(|e| {
+            let err: Box<dyn ChromaError> =
+                Box::new(WorkQueueClientError::ConnectionError(e.to_string()));
+            err
+        })?;
+        let channel = ServiceBuilder::new()
+            .layer(chroma_tracing::GrpcClientTraceLayer)
+            .service(channel);
+        let client = WorkQueueServiceClient::new(channel);
 
         Ok(Self { client })
     }
 
     pub async fn new(endpoint: String) -> Result<Self, Box<dyn ChromaError>> {
-        let client = WorkQueueServiceClient::connect(endpoint)
+        let channel = Endpoint::from_shared(endpoint)
+            .map_err(|e| {
+                Box::new(WorkQueueClientError::ConnectionError(e.to_string()))
+                    as Box<dyn ChromaError>
+            })?
+            .connect()
             .await
             .map_err(|e| {
                 let err: Box<dyn ChromaError> =
                     Box::new(WorkQueueClientError::ConnectionError(e.to_string()));
                 err
             })?;
+        let channel = ServiceBuilder::new()
+            .layer(chroma_tracing::GrpcClientTraceLayer)
+            .service(channel);
+        let client = WorkQueueServiceClient::new(channel);
 
         Ok(Self { client })
     }

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -123,6 +123,7 @@ impl WorkQueueManager {
     //     self.distributor = Some(WorkDistributor::new(members));
     // }
 
+    #[tracing::instrument(name = "WorkQueueManager::load_state", skip(self))]
     async fn load_state(&mut self) -> Result<(), WorkQueueError> {
         match self
             .storage
@@ -155,6 +156,7 @@ impl WorkQueueManager {
         }
     }
 
+    #[tracing::instrument(name = "WorkQueueManager::persist", skip(self), level = "debug")]
     async fn persist(&mut self) -> Result<(), WorkQueueError> {
         if !self.state.dirty {
             self.notify_pending_responses();
@@ -276,6 +278,7 @@ impl WorkQueueManager {
     }
 
     // Call sysdb's TryFinishAsyncAttachedFunctionInvocation
+    #[tracing::instrument(name = "WorkQueueManager::try_finish_invocation", skip(self))]
     async fn try_finish_invocation(
         &mut self,
         fn_id: &AttachedFunctionUuid,
@@ -320,6 +323,11 @@ impl WorkQueueManager {
     }
 
     // Check invocation completion status with detailed status
+    #[tracing::instrument(
+        name = "WorkQueueManager::check_invocations_status",
+        skip(self, items),
+        level = "debug"
+    )]
     async fn check_invocations_status(
         &mut self,
         items: &[WorkQueueRecord],
@@ -359,6 +367,7 @@ impl WorkQueueManager {
     }
 
     // Check all pending items on startup and repair any that need it
+    #[tracing::instrument(name = "WorkQueueManager::check_and_repair_pending_items", skip(self))]
     async fn check_and_repair_pending_items(&mut self) {
         if self.state.pending_work.is_empty() {
             tracing::info!("No pending work items to check for repair");


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Add gRPC trace layers to the work-queue server and client so requests follow the same tracing pattern used by other services
  - Add named work-queue manager spans around state load, persist, invocation status checks, finish finalization, and startup repair checks
  - Add a fn-consumer manager poll span so scheduling/capacity decisions are visible without wrapping the compaction workflow itself
- New functionality
  - No user-facing functionality changes; this is observability-only

## Test plan

- [x] `cargo fmt --package worker --check`
- [x] `cargo check -p worker`
- [x] `cargo clippy -p worker -- -D warnings`

## Migration plan

No migrations or compatibility changes. This only adds tracing instrumentation and uses the existing gRPC trace layers.

## Observability plan

The change adds spans at the worker service boundaries and manager-level control points:
- work-queue gRPC requests are traced on both client and server sides
- work-queue manager operations now emit named spans for queue state lifecycle and repair paths
- fn-consumer polling now emits a named span, while the downstream compaction workflow continues to provide the detailed execution trace

## Documentation Changes

No documentation changes required.