### PR TITLE
[CHORE](frontend): Reduce dev cache TTL to 2s

### DIFF
--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -17,7 +17,7 @@ collections_with_segments_provider:
     lru:
       name: "collections_with_segments_cache"
       capacity: 1000
-  cache_ttl_secs: 60
+  cache_ttl_secs: 2
   permitted_parallelism: 180
   cache_invalidation_retry_policy:
     delay_ms: 0

--- a/rust/frontend/sample_configs/distributed2.yaml
+++ b/rust/frontend/sample_configs/distributed2.yaml
@@ -22,7 +22,7 @@ collections_with_segments_provider:
     lru:
       name: "collections_with_segments_cache"
       capacity: 1000
-  cache_ttl_secs: 60
+  cache_ttl_secs: 2
   permitted_parallelism: 180
   cache_invalidation_retry_policy:
     delay_ms: 0

--- a/rust/frontend/sample_configs/distributed_mcmr.yaml
+++ b/rust/frontend/sample_configs/distributed_mcmr.yaml
@@ -22,7 +22,7 @@ collections_with_segments_provider:
     lru:
       name: "collections_with_segments_cache"
       capacity: 1000
-  cache_ttl_secs: 60
+  cache_ttl_secs: 2
   permitted_parallelism: 180
   cache_invalidation_retry_policy:
     delay_ms: 0

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -257,4 +257,23 @@ mod tests {
         let config = FrontendServerConfig::load_from_path("sample_configs/single_node_full.yaml");
         assert_eq!(config.port, 8000);
     }
+
+    #[test]
+    fn tilt_dev_configs_use_short_cache_ttl() {
+        for path in [
+            "sample_configs/distributed.yaml",
+            "sample_configs/distributed_mcmr.yaml",
+            "sample_configs/distributed2.yaml",
+        ] {
+            let config = FrontendServerConfig::load_from_path(path);
+            assert_eq!(
+                config
+                    .frontend
+                    .collections_with_segments_provider
+                    .cache_ttl_secs,
+                2,
+                "{path}"
+            );
+        }
+    }
 }

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -206,10 +206,11 @@ impl CollectionsWithSegmentsProvider {
             let collection_id = collection_and_segments.collection.collection_id;
             let collection_and_segments_with_ttl = CollectionAndSegmentsWithTtl {
                 collection_and_segments,
+                // Cache for the configured TTL.
                 expires_at: SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .expect("Do not deploy before UNIX epoch")
-                    + Duration::from_secs(self.cache_ttl_secs as u64), // Cache for 1 minute
+                    + Duration::from_secs(self.cache_ttl_secs as u64),
             };
             self.collections_with_segments_cache
                 .insert(collection_id, collection_and_segments_with_ttl)


### PR DESCRIPTION
## Description of changes

Lower collections_with_segments cache TTL from 60s to 2s in the
distributed dev configs so that compaction results are
visible sooner during local development.

Add a test asserting all Tilt dev configs use the short TTL, and
remove a stale inline comment that hard-coded "1 minute".

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
