### PR TITLE
[BUG](k8s): respect foundation replicaCount: 0

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.87
+version: 0.1.88
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/foundation-service.yaml
+++ b/k8s/distributed-chroma/templates/foundation-service.yaml
@@ -15,7 +15,11 @@ metadata:
   name: foundation-server-deployment
   namespace: {{ .Values.namespace }}
 spec:
-  replicas: {{ .Values.foundationService.replicaCount | default 1 }}
+  {{- if hasKey .Values.foundationService "replicaCount" }}
+  replicas: {{ .Values.foundationService.replicaCount }}
+  {{- else }}
+  replicas: 1
+  {{- end }}
   selector:
     matchLabels:
       app: foundation-server


### PR DESCRIPTION
Helm's `default` treats `0` as falsy, so a chart consumer that sets
`foundationService.replicaCount: 0` would render `replicas: 1`. Argo would silently start a pod.

Bump `Chart.yaml` `0.1.87` → `0.1.88` to trigger the publish workflow.

