### PR TITLE
[CLN](k8s): foundation replicas use chart-default pattern

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.88
+version: 0.1.89
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/foundation-service.yaml
+++ b/k8s/distributed-chroma/templates/foundation-service.yaml
@@ -15,11 +15,7 @@ metadata:
   name: foundation-server-deployment
   namespace: {{ .Values.namespace }}
 spec:
-  {{- if hasKey .Values.foundationService "replicaCount" }}
   replicas: {{ .Values.foundationService.replicaCount }}
-  {{- else }}
-  replicas: 1
-  {{- end }}
   selector:
     matchLabels:
       app: foundation-server


### PR DESCRIPTION
## Summary

#7161 fixed the `replicaCount: 0` bug with a `hasKey` block, but that's
not how any other service template in `distributed-chroma` is structured.
Every other service — `rustFrontendService`, `sysdb`, `queryService`,
`compactionService`, `workQueueService`, `fnConsumer`, `rustSysdbService`,
`garbageCollector`, `rustLogService` — just renders the value directly:

```yaml
replicas: {{ .Values.<service>.replicaCount }}
```

…with the default living in `values.yaml`. Match that convention:

```yaml
replicas: {{ .Values.foundationService.replicaCount }}
```

`values.yaml` already declares `foundationService.replicaCount: 1`, so
the default behavior for consumers who don't override is unchanged. Bump
`Chart.yaml` `0.1.88` → `0.1.89`.

## Tested
`helm template` against this branch:
- `--set foundationService.replicaCount=0` → `replicas: 0` ✅
- `--set foundationService.replicaCount=2` → `replicas: 2` ✅
- unset → `replicas: 1` (chart default applies) ✅

## Why two PRs (this + #7161)
#7161 unblocked the bug urgently with a working but non-idiomatic
construct; this PR matches the convention the rest of the chart uses.
The chroma-core/k8s side (#2971) just needs to bump its
`distributed-chroma` dep to whichever version lands last.