### PR TITLE
[ENH](frontend): Track proptest state locally

### DIFF
--- a/rust/frontend/tests/proptest_helpers/arbitrary.rs
+++ b/rust/frontend/tests/proptest_helpers/arbitrary.rs
@@ -1,19 +1,30 @@
-use crate::{CollectionRequest, FrontendReferenceState};
+use crate::CollectionRequest;
 use chroma_types::{
     strategies::{
         arbitrary_metadata, arbitrary_update_metadata, TestWhereFilter, TestWhereFilterParams,
         DOCUMENT_TEXT_STRATEGY,
     },
-    AddCollectionRecordsRequest, DeleteCollectionRecordsRequest, GetRequest, Include, IncludeList,
+    AddCollectionRecordsRequest, DeleteCollectionRecordsRequest, GetRequest, IncludeList,
     QueryRequest, UpdateCollectionRecordsRequest, UpsertCollectionRecordsRequest,
 };
 use proptest::{prelude::*, sample::SizeRange};
+
+use super::frontend_reference::FrontendGenerationState;
 
 pub struct CollectionRequestArbitraryParams {
     pub min_log_size: usize,
     pub max_log_size: usize,
     pub metadata_num_pairs: SizeRange,
-    pub current_state: FrontendReferenceState,
+    pub current_state: Option<FrontendGenerationState>,
+}
+
+impl CollectionRequestArbitraryParams {
+    pub fn new(current_state: FrontendGenerationState) -> Self {
+        Self {
+            current_state: Some(current_state),
+            ..Default::default()
+        }
+    }
 }
 
 impl Default for CollectionRequestArbitraryParams {
@@ -22,7 +33,7 @@ impl Default for CollectionRequestArbitraryParams {
             min_log_size: 0,
             max_log_size: 10,
             metadata_num_pairs: (0..=10usize).into(),
-            current_state: FrontendReferenceState::default(),
+            current_state: None,
         }
     }
 }
@@ -36,10 +47,12 @@ impl Arbitrary for CollectionRequest {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
-        let state = args.current_state;
-        let collection = state.collection.clone().unwrap();
+        let state = args
+            .current_state
+            .expect("collection request generation requires current reference state");
+        let collection = state.collection.clone();
         let embedding_strategy = state.get_embedding_strategy();
-        let known_ids = state.get_known_ids();
+        let known_ids = state.known_ids.clone();
 
         let id_strategy = if known_ids.is_empty() {
             "\\PC{1,}".boxed()
@@ -239,7 +252,7 @@ impl Arbitrary for CollectionRequest {
             update_strategy,
             upsert_strategy,
             delete_strategy,
-            arbitrary_get_request(&state),
+            arbitrary_get_request(state),
             // todo: enable KNN requests
             // arbitrary_query_request(state),
         ]
@@ -248,46 +261,17 @@ impl Arbitrary for CollectionRequest {
 }
 
 fn arbitrary_get_request(
-    state: &FrontendReferenceState,
+    state: FrontendGenerationState,
 ) -> impl Strategy<Value = CollectionRequest> {
-    let collection = state.collection.clone().unwrap();
-
-    let frontend = state.frontend.clone().unwrap();
-    let records = frontend
-        .get(
-            GetRequest::try_new(
-                collection.tenant.clone(),
-                collection.database.clone(),
-                collection.collection_id,
-                None,
-                None,
-                None,
-                0,
-                IncludeList(vec![Include::Metadata, Include::Document]),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-    let documents = records
-        .documents
-        .unwrap()
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
-    let metadatas = records
-        .metadatas
-        .unwrap()
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+    let collection = state.collection.clone();
 
     let where_strategy = any_with::<TestWhereFilter>(TestWhereFilterParams {
-        seed_documents: Some(documents),
-        seed_metadata: Some(metadatas),
+        seed_documents: Some(state.seed_documents.clone()),
+        seed_metadata: Some(state.seed_metadata.clone()),
         ..Default::default()
     });
 
-    let known_ids = state.get_known_ids();
+    let known_ids = state.known_ids.clone();
 
     let ids_strategy = if !known_ids.is_empty() {
         let known_ids_len = known_ids.len();
@@ -343,46 +327,17 @@ fn arbitrary_get_request(
 
 #[allow(dead_code)]
 fn arbitrary_query_request(
-    state: &FrontendReferenceState,
+    state: FrontendGenerationState,
 ) -> impl Strategy<Value = CollectionRequest> {
-    let collection = state.collection.clone().unwrap();
-
-    let frontend = state.frontend.clone().unwrap();
-    let records = frontend
-        .get(
-            GetRequest::try_new(
-                collection.tenant.clone(),
-                collection.database.clone(),
-                collection.collection_id,
-                None,
-                None,
-                None,
-                0,
-                IncludeList(vec![Include::Metadata, Include::Document]),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-    let documents = records
-        .documents
-        .unwrap()
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
-    let metadatas = records
-        .metadatas
-        .unwrap()
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+    let collection = state.collection.clone();
 
     let where_strategy = any_with::<TestWhereFilter>(TestWhereFilterParams {
-        seed_documents: Some(documents),
-        seed_metadata: Some(metadatas),
+        seed_documents: Some(state.seed_documents.clone()),
+        seed_metadata: Some(state.seed_metadata.clone()),
         ..Default::default()
     });
 
-    let known_ids = state.get_known_ids();
+    let known_ids = state.known_ids.clone();
 
     let ids_strategy = if !known_ids.is_empty() {
         let known_ids_len = known_ids.len();

--- a/rust/frontend/tests/proptest_helpers/frontend_reference.rs
+++ b/rust/frontend/tests/proptest_helpers/frontend_reference.rs
@@ -1,17 +1,44 @@
 use crate::CollectionRequest;
 use chroma_frontend::impls::in_memory_frontend::InMemoryFrontend;
-use chroma_types::{Collection, CreateCollectionRequest, DatabaseName, GetRequest, IncludeList};
+use chroma_types::{
+    AddCollectionRecordsRequest, Collection, CreateCollectionRequest, DatabaseName,
+    DeleteCollectionRecordsRequest, GetRequest, IncludeList, Metadata, MetadataValue,
+    UpdateCollectionRecordsRequest, UpdateMetadata, UpsertCollectionRecordsRequest, CHROMA_KEY,
+};
 use proptest::prelude::*;
 use proptest_state_machine::ReferenceStateMachine;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use super::arbitrary::CollectionRequestArbitraryParams;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct FrontendRecordState {
+    document: Option<String>,
+    metadata: Option<Metadata>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct FrontendGenerationState {
+    pub collection: Collection,
+    pub dimension: usize,
+    pub known_ids: Vec<String>,
+    pub seed_documents: Vec<String>,
+    pub seed_metadata: Vec<Metadata>,
+}
+
+impl FrontendGenerationState {
+    pub fn get_embedding_strategy(&self) -> impl Strategy<Value = Vec<f32>> + Clone {
+        proptest::collection::vec((0.0..=1.0f32).no_shrink(), self.dimension)
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct FrontendReferenceState {
     pub collection: Option<Collection>,
     pub frontend: Option<InMemoryFrontend>,
     pub runtime: Arc<tokio::runtime::Runtime>,
+    records: BTreeMap<String, FrontendRecordState>,
 }
 
 impl Default for FrontendReferenceState {
@@ -20,6 +47,7 @@ impl Default for FrontendReferenceState {
             collection: None,
             frontend: None,
             runtime: Arc::new(tokio::runtime::Runtime::new().unwrap()),
+            records: BTreeMap::new(),
         }
     }
 }
@@ -28,44 +56,190 @@ impl std::fmt::Debug for FrontendReferenceState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FrontendReferenceState")
             .field("collection", &self.collection)
+            .field("record_count", &self.records.len())
             .finish()
     }
 }
 
 impl FrontendReferenceState {
     pub fn get_known_ids(&self) -> Vec<String> {
-        let frontend = self.frontend.as_ref().unwrap();
-        let collection = self.collection.clone().unwrap();
+        self.records.keys().cloned().collect()
+    }
 
-        let records = frontend
-            .get(
-                GetRequest::try_new(
-                    collection.tenant,
-                    collection.database,
-                    collection.collection_id,
-                    None,
-                    None,
-                    None,
-                    0,
-                    IncludeList(vec![]),
-                )
-                .unwrap(),
-            )
-            .unwrap();
+    pub fn contains_known_id(&self, id: &str) -> bool {
+        self.records.contains_key(id)
+    }
 
-        let mut ids = records.ids;
-        ids.sort_unstable();
-        ids
+    pub fn current_count(&self) -> u32 {
+        self.records.len() as u32
     }
 
     pub fn get_dimension(&self) -> usize {
         self.collection.clone().unwrap().dimension.unwrap() as usize
     }
 
-    pub fn get_embedding_strategy(&self) -> impl Strategy<Value = Vec<f32>> + Clone {
-        // todo: should shrink be enabled?
-        // todo: try storing embedding strategy on self
-        proptest::collection::vec((0.0..=1.0f32).no_shrink(), self.get_dimension())
+    pub fn generation_state(&self) -> FrontendGenerationState {
+        FrontendGenerationState {
+            collection: self.collection.clone().unwrap(),
+            dimension: self.get_dimension(),
+            known_ids: self.get_known_ids(),
+            seed_documents: self
+                .records
+                .values()
+                .filter_map(|record| record.document.clone())
+                .collect(),
+            seed_metadata: self
+                .records
+                .values()
+                .filter_map(|record| record.metadata.clone())
+                .collect(),
+        }
+    }
+
+    fn metadata_from_add_metadata(metadata: &Metadata) -> Option<Metadata> {
+        let metadata = metadata
+            .iter()
+            .filter(|(key, _)| !key.starts_with(CHROMA_KEY))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Metadata>();
+
+        if metadata.is_empty() {
+            None
+        } else {
+            Some(metadata)
+        }
+    }
+
+    fn merge_update_metadata(metadata: &mut Option<Metadata>, update: Option<&UpdateMetadata>) {
+        let Some(update) = update else {
+            return;
+        };
+
+        let mut merged = metadata.clone().unwrap_or_default();
+        let mut changed = false;
+
+        for (key, value) in update {
+            if key.starts_with(CHROMA_KEY) {
+                continue;
+            }
+
+            changed = true;
+            match MetadataValue::try_from(value) {
+                Ok(value) => {
+                    merged.insert(key.clone(), value);
+                }
+                Err(_) => {
+                    merged.remove(key);
+                }
+            }
+        }
+
+        if changed {
+            *metadata = Some(merged);
+        }
+    }
+
+    fn optional_value<T: Clone>(values: &Option<Vec<Option<T>>>, index: usize) -> Option<T> {
+        values
+            .as_ref()
+            .and_then(|values| values.get(index))
+            .cloned()
+            .flatten()
+    }
+
+    fn optional_ref<T>(values: &Option<Vec<Option<T>>>, index: usize) -> Option<&T> {
+        values
+            .as_ref()
+            .and_then(|values| values.get(index))
+            .and_then(|value| value.as_ref())
+    }
+
+    fn apply_add_to_records(&mut self, request: &AddCollectionRecordsRequest) {
+        for (index, id) in request.ids.iter().enumerate() {
+            if self.records.contains_key(id) {
+                continue;
+            }
+
+            let metadata = Self::optional_ref(&request.metadatas, index)
+                .and_then(Self::metadata_from_add_metadata);
+            self.records.insert(
+                id.clone(),
+                FrontendRecordState {
+                    document: Self::optional_value(&request.documents, index),
+                    metadata,
+                },
+            );
+        }
+    }
+
+    fn apply_update_to_records(&mut self, request: &UpdateCollectionRecordsRequest) {
+        for (index, id) in request.ids.iter().enumerate() {
+            let Some(record) = self.records.get_mut(id) else {
+                continue;
+            };
+
+            if let Some(document) = Self::optional_value(&request.documents, index) {
+                record.document = Some(document);
+            }
+            Self::merge_update_metadata(
+                &mut record.metadata,
+                Self::optional_ref(&request.metadatas, index),
+            );
+        }
+    }
+
+    fn apply_upsert_to_records(&mut self, request: &UpsertCollectionRecordsRequest) {
+        for (index, id) in request.ids.iter().enumerate() {
+            let update_metadata = Self::optional_ref(&request.metadatas, index);
+
+            if let Some(record) = self.records.get_mut(id) {
+                if let Some(document) = Self::optional_value(&request.documents, index) {
+                    record.document = Some(document);
+                }
+                Self::merge_update_metadata(&mut record.metadata, update_metadata);
+            } else {
+                let mut metadata = None;
+                Self::merge_update_metadata(&mut metadata, update_metadata);
+                self.records.insert(
+                    id.clone(),
+                    FrontendRecordState {
+                        document: Self::optional_value(&request.documents, index),
+                        metadata,
+                    },
+                );
+            }
+        }
+    }
+
+    fn ids_matching_delete(&self, request: &DeleteCollectionRecordsRequest) -> Vec<String> {
+        if request.r#where.is_none() {
+            return request.ids.clone().unwrap_or_default();
+        }
+
+        self.frontend
+            .as_ref()
+            .unwrap()
+            .get(
+                GetRequest::try_new(
+                    request.tenant_id.clone(),
+                    request.database_name.clone(),
+                    request.collection_id,
+                    request.ids.clone(),
+                    request.r#where.clone(),
+                    request.limit,
+                    0,
+                    IncludeList(vec![]),
+                )
+                .unwrap(),
+            )
+            .unwrap()
+            .ids
+    }
+
+    fn apply_delete_to_records(&mut self, deleted_ids: &[String]) {
+        for id in deleted_ids {
+            self.records.remove(id);
+        }
     }
 }
 
@@ -81,6 +255,7 @@ impl ReferenceStateMachine for FrontendReferenceStateMachine {
             collection: None,
             frontend: None,
             runtime,
+            records: BTreeMap::new(),
         })
         .boxed()
     }
@@ -88,15 +263,18 @@ impl ReferenceStateMachine for FrontendReferenceStateMachine {
     fn transitions(state: &Self::State) -> BoxedStrategy<Self::Transition> {
         if state.collection.is_some() {
             return proptest::arbitrary::arbitrary_with::<CollectionRequest, _, _>(
-                CollectionRequestArbitraryParams {
-                    current_state: state.clone(),
-                    ..Default::default()
-                },
+                CollectionRequestArbitraryParams::new(state.generation_state()),
             )
             .boxed();
         }
 
-        (3..=100usize)
+        let dimension_range = if crate::frontend_deep_profile_enabled() {
+            3..=100usize
+        } else {
+            3..=32usize
+        };
+
+        dimension_range
             .prop_map(|dimension| CollectionRequest::Init { dimension })
             .boxed()
     }
@@ -110,8 +288,7 @@ impl ReferenceStateMachine for FrontendReferenceStateMachine {
         // ID filtering on query requests can only include existing IDs
         if let CollectionRequest::Query(request) = transition {
             if let Some(ids) = &request.ids {
-                let known_ids = state.get_known_ids();
-                if !ids.iter().all(|id| known_ids.contains(id)) {
+                if !ids.iter().all(|id| state.contains_known_id(id)) {
                     return false;
                 }
             }
@@ -143,10 +320,9 @@ impl ReferenceStateMachine for FrontendReferenceStateMachine {
             collection.dimension = Some(*dimension as i32);
             state.collection = Some(collection);
             state.frontend = Some(frontend);
+            state.records.clear();
             return state;
         }
-
-        let frontend = state.frontend.as_mut();
 
         match transition {
             CollectionRequest::Init { .. } => {
@@ -159,7 +335,13 @@ impl ReferenceStateMachine for FrontendReferenceStateMachine {
                 request.tenant_id = collection.tenant;
                 request.database_name = collection.database;
 
-                frontend.unwrap().add(request).unwrap();
+                state
+                    .frontend
+                    .as_mut()
+                    .unwrap()
+                    .add(request.clone())
+                    .unwrap();
+                state.apply_add_to_records(&request);
             }
             CollectionRequest::Update(request) => {
                 let mut request = request.clone();
@@ -168,7 +350,13 @@ impl ReferenceStateMachine for FrontendReferenceStateMachine {
                 request.tenant_id = collection.tenant;
                 request.database_name = collection.database;
 
-                frontend.unwrap().update(request).unwrap();
+                state
+                    .frontend
+                    .as_mut()
+                    .unwrap()
+                    .update(request.clone())
+                    .unwrap();
+                state.apply_update_to_records(&request);
             }
             CollectionRequest::Upsert(request) => {
                 let mut request = request.clone();
@@ -177,7 +365,13 @@ impl ReferenceStateMachine for FrontendReferenceStateMachine {
                 request.tenant_id = collection.tenant;
                 request.database_name = collection.database;
 
-                frontend.unwrap().upsert(request).unwrap();
+                state
+                    .frontend
+                    .as_mut()
+                    .unwrap()
+                    .upsert(request.clone())
+                    .unwrap();
+                state.apply_upsert_to_records(&request);
             }
             CollectionRequest::Delete(request) => {
                 let mut request = request.clone();
@@ -186,7 +380,14 @@ impl ReferenceStateMachine for FrontendReferenceStateMachine {
                 request.tenant_id = collection.tenant.clone();
                 request.database_name = collection.database.clone();
 
-                frontend.unwrap().delete(request).unwrap();
+                let deleted_ids = state.ids_matching_delete(&request);
+                state
+                    .frontend
+                    .as_mut()
+                    .unwrap()
+                    .delete(request.clone())
+                    .unwrap();
+                state.apply_delete_to_records(&deleted_ids);
             }
             CollectionRequest::Get(_) => {
                 // (handled by the frontend under test)

--- a/rust/frontend/tests/proptest_helpers/frontend_under_test.rs
+++ b/rust/frontend/tests/proptest_helpers/frontend_under_test.rs
@@ -9,7 +9,9 @@ use chroma_types::{
     IncludeList,
 };
 use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
+use std::cell::Cell;
 use std::sync::Arc;
+use std::time::Instant;
 
 define_thread_local_stats!(STATS);
 
@@ -17,6 +19,9 @@ pub(crate) struct FrontendUnderTest {
     collection: Option<Collection>,
     frontend: Frontend,
     runtime: Arc<tokio::runtime::Runtime>,
+    case_started_at: Instant,
+    applied_transitions: usize,
+    full_sweep_pending: Cell<bool>,
 }
 
 impl StateMachineTest for FrontendUnderTest {
@@ -26,6 +31,8 @@ impl StateMachineTest for FrontendUnderTest {
     fn init_test(
         ref_state: &<Self::Reference as ReferenceStateMachine>::State,
     ) -> Self::SystemUnderTest {
+        STATS.with_borrow_mut(|stats| stats.start_run());
+
         let runtime = ref_state.runtime.clone();
         let frontend = runtime.block_on(async {
             let system = System::new();
@@ -45,6 +52,9 @@ impl StateMachineTest for FrontendUnderTest {
             collection: None,
             frontend,
             runtime,
+            case_started_at: Instant::now(),
+            applied_transitions: 0,
+            full_sweep_pending: Cell::new(false),
         }
     }
 
@@ -53,6 +63,8 @@ impl StateMachineTest for FrontendUnderTest {
         ref_state: &<Self::Reference as ReferenceStateMachine>::State,
         transition: <Self::Reference as ReferenceStateMachine>::Transition,
     ) -> Self::SystemUnderTest {
+        state.applied_transitions += 1;
+
         state.runtime.block_on(async {
             match transition {
                 CollectionRequest::Init { .. } => {
@@ -75,6 +87,7 @@ impl StateMachineTest for FrontendUnderTest {
                         .await
                         .unwrap();
                     state.collection = Some(collection);
+                    state.full_sweep_pending.set(true);
                 }
                 CollectionRequest::Add(mut request) => {
                     let collection = state.collection.clone().unwrap();
@@ -85,6 +98,7 @@ impl StateMachineTest for FrontendUnderTest {
                     STATS.with_borrow_mut(|stats| stats.num_log_operations += request.ids.len());
 
                     state.frontend.add(request).await.unwrap();
+                    state.full_sweep_pending.set(true);
                 }
                 CollectionRequest::Update(mut request) => {
                     let collection = state.collection.clone().unwrap();
@@ -95,6 +109,7 @@ impl StateMachineTest for FrontendUnderTest {
                     STATS.with_borrow_mut(|stats| stats.num_log_operations += request.ids.len());
 
                     state.frontend.update(request).await.unwrap();
+                    state.full_sweep_pending.set(true);
                 }
                 CollectionRequest::Upsert(mut request) => {
                     let collection = state.collection.clone().unwrap();
@@ -105,6 +120,7 @@ impl StateMachineTest for FrontendUnderTest {
                     STATS.with_borrow_mut(|stats| stats.num_log_operations += request.ids.len());
 
                     state.frontend.upsert(request).await.unwrap();
+                    state.full_sweep_pending.set(true);
                 }
                 CollectionRequest::Delete(mut request) => {
                     let collection = state.collection.clone().unwrap();
@@ -146,6 +162,7 @@ impl StateMachineTest for FrontendUnderTest {
                     Box::pin(state.frontend.delete(request.clone(), String::new()))
                         .await
                         .unwrap();
+                    state.full_sweep_pending.set(true);
                 }
                 CollectionRequest::Get(mut request) => {
                     let expected_result = {
@@ -156,29 +173,13 @@ impl StateMachineTest for FrontendUnderTest {
 
                         ref_state
                             .frontend
-                            .clone()
+                            .as_ref()
                             .unwrap()
                             .get(request.clone())
                             .unwrap()
                     };
 
-                    let count = {
-                        let collection = ref_state.collection.clone().unwrap();
-                        ref_state
-                            .frontend
-                            .clone()
-                            .unwrap()
-                            .count(
-                                CountRequest::try_new(
-                                    collection.tenant,
-                                    collection.database,
-                                    collection.collection_id,
-                                    ReadLevel::default(),
-                                )
-                                .unwrap(),
-                            )
-                            .unwrap()
-                    };
+                    let count = ref_state.current_count();
 
                     if count > 0 {
                         let selectivity = expected_result.ids.len() as f64 / count as f64;
@@ -226,23 +227,7 @@ impl StateMachineTest for FrontendUnderTest {
                             .unwrap()
                     };
 
-                    let count = {
-                        let collection = ref_state.collection.clone().unwrap();
-                        ref_state
-                            .frontend
-                            .clone()
-                            .unwrap()
-                            .count(
-                                CountRequest::try_new(
-                                    collection.tenant,
-                                    collection.database,
-                                    collection.collection_id,
-                                    ReadLevel::default(),
-                                )
-                                .unwrap(),
-                            )
-                            .unwrap()
-                    };
+                    let count = ref_state.current_count();
 
                     if count > 0 {
                         let selectivity = expected_result.ids.len() as f64 / count as f64;
@@ -276,44 +261,37 @@ impl StateMachineTest for FrontendUnderTest {
         state
     }
 
+    fn teardown(state: Self::SystemUnderTest) {
+        STATS.with_borrow_mut(|stats| {
+            stats.record_case(state.case_started_at.elapsed(), state.applied_transitions)
+        });
+    }
+
     fn check_invariants(
         state: &Self::SystemUnderTest,
         ref_state: &<Self::Reference as ReferenceStateMachine>::State,
     ) {
-        let reference_frontend = match ref_state.frontend.as_ref() {
-            Some(frontend) => frontend,
-            None => return,
-        };
-
         let reference_collection = match ref_state.collection.as_ref() {
             Some(collection) => collection.clone(),
             None => return,
         };
 
-        let mut frontend_under_test = state.frontend.clone();
         let collection_under_test = match state.collection.clone() {
             Some(collection) => collection,
             None => return,
         };
 
+        let mut frontend_under_test = state.frontend.clone();
+        let count_collection_under_test = collection_under_test.clone();
+        let expected_count = ref_state.current_count();
+
         state.runtime.block_on(async move {
-            let expected_count = reference_frontend
-                .count(
-                    CountRequest::try_new(
-                        reference_collection.tenant.clone(),
-                        reference_collection.database.clone(),
-                        reference_collection.collection_id,
-                        ReadLevel::default(),
-                    )
-                    .unwrap(),
-                )
-                .unwrap();
             let received_count = frontend_under_test
                 .count(
                     CountRequest::try_new(
-                        collection_under_test.tenant.clone(),
-                        collection_under_test.database.clone(),
-                        collection_under_test.collection_id,
+                        count_collection_under_test.tenant.clone(),
+                        count_collection_under_test.database.clone(),
+                        count_collection_under_test.collection_id,
                         ReadLevel::default(),
                     )
                     .unwrap(),
@@ -325,23 +303,31 @@ impl StateMachineTest for FrontendUnderTest {
                 "Expected {:?} to be equal to {:?}",
                 expected_count, received_count
             );
+        });
 
-            let expected_results = reference_frontend
-                .get(
-                    GetRequest::try_new(
-                        reference_collection.tenant.clone(),
-                        reference_collection.database.clone(),
-                        reference_collection.collection_id,
-                        None,
-                        None,
-                        None,
-                        0,
-                        IncludeList::default_get(),
-                    )
-                    .unwrap(),
+        if !state.full_sweep_pending.replace(false) {
+            return;
+        }
+
+        let reference_frontend = ref_state.frontend.as_ref().unwrap();
+        let expected_results = reference_frontend
+            .get(
+                GetRequest::try_new(
+                    reference_collection.tenant.clone(),
+                    reference_collection.database.clone(),
+                    reference_collection.collection_id,
+                    None,
+                    None,
+                    None,
+                    0,
+                    IncludeList::default_get(),
                 )
-                .unwrap();
+                .unwrap(),
+            )
+            .unwrap();
 
+        let mut frontend_under_test = state.frontend.clone();
+        state.runtime.block_on(async move {
             let received_results = Box::pin(
                 frontend_under_test.get(
                     GetRequest::try_new(

--- a/rust/frontend/tests/proptest_helpers/stats.rs
+++ b/rust/frontend/tests/proptest_helpers/stats.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 pub(crate) struct GetRequestSelectivity {
     pub where_clause_only: Vec<f64>,
     pub where_clause_and_ids: Vec<f64>,
@@ -16,11 +18,55 @@ pub(crate) struct Stats {
     pub get_request_selectivity: GetRequestSelectivity,
     pub query_request_selectivity: QueryRequestSelectivity,
     pub num_log_operations: usize,
+    pub run_started_at: Option<Instant>,
+    pub case_durations: Vec<Duration>,
+    pub transition_counts: Vec<usize>,
+}
+
+impl Stats {
+    pub fn start_run(&mut self) {
+        self.run_started_at.get_or_insert_with(Instant::now);
+    }
+
+    pub fn record_case(&mut self, duration: Duration, transitions: usize) {
+        self.case_durations.push(duration);
+        self.transition_counts.push(transitions);
+    }
 }
 
 impl Drop for Stats {
     fn drop(&mut self) {
+        fn average(values: &[f64]) -> f64 {
+            if values.is_empty() {
+                0.0
+            } else {
+                values.iter().sum::<f64>() / values.len() as f64
+            }
+        }
+
+        fn p50(values: &mut [f64]) -> f64 {
+            if values.is_empty() {
+                return 0.0;
+            }
+
+            values.sort_by(f64::total_cmp);
+            values[values.len() / 2]
+        }
+
+        fn percent(part: usize, total: usize) -> f64 {
+            if total == 0 {
+                0.0
+            } else {
+                part as f64 / total as f64 * 100.0
+            }
+        }
+
         fn print_selectivity(selectivity: &[f64]) {
+            if selectivity.is_empty() {
+                println!("      no requests generated");
+                return;
+            }
+
             let partial_results = selectivity
                 .iter()
                 .filter(|x| **x != 0.0 && **x != 1.0)
@@ -43,6 +89,52 @@ impl Drop for Stats {
         }
 
         println!("Statistics:");
+        let total_cases = self.case_durations.len();
+        let total_transitions = self.transition_counts.iter().sum::<usize>();
+        let total_wall_clock = self
+            .run_started_at
+            .map(|started_at| started_at.elapsed().as_secs_f64())
+            .unwrap_or_default();
+        let mut case_durations = self
+            .case_durations
+            .iter()
+            .map(|duration| duration.as_secs_f64())
+            .collect::<Vec<_>>();
+        let transition_times = self
+            .case_durations
+            .iter()
+            .zip(self.transition_counts.iter())
+            .filter(|(_, transitions)| **transitions > 0)
+            .map(|(duration, transitions)| duration.as_secs_f64() / *transitions as f64)
+            .collect::<Vec<_>>();
+        let mut transition_times_for_p50 = transition_times.clone();
+        let mut transition_counts = self
+            .transition_counts
+            .iter()
+            .map(|count| *count as f64)
+            .collect::<Vec<_>>();
+
+        println!(
+            "  Total frontend state-machine wall-clock time: {:.2}s",
+            total_wall_clock
+        );
+        println!("  Test cases generated: {}", total_cases);
+        println!(
+            "  Transitions generated: {} total, {:.2} average/case, {:.0} p50/case",
+            total_transitions,
+            average(&transition_counts),
+            p50(&mut transition_counts)
+        );
+        println!(
+            "  Case duration: {:.4}s average, {:.4}s p50",
+            average(&case_durations),
+            p50(&mut case_durations)
+        );
+        println!(
+            "  Transition duration: {:.4}s average, {:.4}s p50",
+            average(&transition_times),
+            p50(&mut transition_times_for_p50)
+        );
         println!(
             "  A total of {} log operations were created.",
             self.num_log_operations
@@ -58,22 +150,28 @@ impl Drop for Stats {
         );
         println!(
             "    .get() with a where clause only ({:2.2}%):",
-            self.get_request_selectivity.where_clause_only.len() as f64 / total_get_requests as f64
-                * 100.0
+            percent(
+                self.get_request_selectivity.where_clause_only.len(),
+                total_get_requests
+            )
         );
         print_selectivity(&self.get_request_selectivity.where_clause_only);
 
         println!(
             "    .get() with a where clause & IDs ({:2.2}%):",
-            self.get_request_selectivity.where_clause_and_ids.len() as f64
-                / total_get_requests as f64
-                * 100.0
+            percent(
+                self.get_request_selectivity.where_clause_and_ids.len(),
+                total_get_requests
+            )
         );
         print_selectivity(&self.get_request_selectivity.where_clause_and_ids);
 
         println!(
             "    .get() with IDs only ({:2.2}%):",
-            self.get_request_selectivity.ids_only.len() as f64 / total_get_requests as f64 * 100.0
+            percent(
+                self.get_request_selectivity.ids_only.len(),
+                total_get_requests
+            )
         );
         print_selectivity(&self.get_request_selectivity.ids_only);
 
@@ -88,32 +186,37 @@ impl Drop for Stats {
         );
         println!(
             "    .query() with a where clause & embeddings ({:2.2}%):",
-            self.query_request_selectivity.where_clause_only.len() as f64
-                / total_query_requests as f64
-                * 100.0
+            percent(
+                self.query_request_selectivity.where_clause_only.len(),
+                total_query_requests
+            )
         );
         print_selectivity(&self.query_request_selectivity.where_clause_only);
 
         println!(
             "    .query() with a where clause & IDs & embeddings ({:2.2}%):",
-            self.query_request_selectivity.where_clause_and_ids.len() as f64
-                / total_query_requests as f64
-                * 100.0
+            percent(
+                self.query_request_selectivity.where_clause_and_ids.len(),
+                total_query_requests
+            )
         );
         print_selectivity(&self.query_request_selectivity.where_clause_and_ids);
 
         println!(
             "    .query() with IDs & embeddings ({:2.2}%):",
-            self.query_request_selectivity.ids_only.len() as f64 / total_query_requests as f64
-                * 100.0
+            percent(
+                self.query_request_selectivity.ids_only.len(),
+                total_query_requests
+            )
         );
         print_selectivity(&self.query_request_selectivity.ids_only);
 
         println!(
             "    .query() with embeddings only ({:2.2}%):",
-            self.query_request_selectivity.embeddings_only.len() as f64
-                / total_query_requests as f64
-                * 100.0
+            percent(
+                self.query_request_selectivity.embeddings_only.len(),
+                total_query_requests
+            )
         );
         print_selectivity(&self.query_request_selectivity.embeddings_only);
     }
@@ -138,6 +241,9 @@ macro_rules! define_thread_local_stats {
                             ids_only: vec![],
                             embeddings_only: vec![],
                         },
+                        run_started_at: None,
+                        case_durations: vec![],
+                        transition_counts: vec![],
                     }
                 )
             };

--- a/rust/frontend/tests/test_collection.rs
+++ b/rust/frontend/tests/test_collection.rs
@@ -1,17 +1,42 @@
+use proptest::test_runner::Config;
 use proptest_helpers::{
-    frontend_reference::{FrontendReferenceState, FrontendReferenceStateMachine},
-    frontend_under_test::FrontendUnderTest,
+    frontend_reference::FrontendReferenceStateMachine, frontend_under_test::FrontendUnderTest,
     proptest_types::CollectionRequest,
 };
 use proptest_state_machine::prop_state_machine;
 mod proptest_helpers;
 
+const FRONTEND_PROPTEST_PROFILE_ENV: &str = "CHROMA_FRONTEND_PROPTEST_PROFILE";
+
+fn frontend_deep_profile_enabled() -> bool {
+    match std::env::var(FRONTEND_PROPTEST_PROFILE_ENV) {
+        Ok(profile) => profile.eq_ignore_ascii_case("deep"),
+        Err(_) => false,
+    }
+}
+
+fn frontend_proptest_config() -> Config {
+    let deep_profile = frontend_deep_profile_enabled();
+
+    Config {
+        fork: false,
+        cases: if deep_profile { 256 } else { 64 },
+        max_shrink_iters: if deep_profile { u32::MAX } else { 1024 },
+        // verbose: 2,
+        ..Config::default()
+    }
+}
+
+fn frontend_transition_range() -> std::ops::Range<usize> {
+    if frontend_deep_profile_enabled() {
+        1..30usize
+    } else {
+        1..16usize
+    }
+}
+
 prop_state_machine! {
-     #![proptest_config(proptest::test_runner::Config {
-            fork: false,
-            // verbose: 2,
-            ..proptest::test_runner::Config::default()
-        })]
+     #![proptest_config(frontend_proptest_config())]
     #[test]
-    fn test_collection_sqlite(sequential 1..30usize => FrontendUnderTest);
+    fn test_collection_sqlite(sequential frontend_transition_range() => FrontendUnderTest);
 }


### PR DESCRIPTION
## Description of changes

Maintain record state (IDs, documents, metadata) directly in
FrontendReferenceState via a BTreeMap instead of querying the
in-memory frontend during strategy generation and invariant
checks. This decouples proptest Arbitrary generation from runtime
state, avoiding frontend calls inside strategy closures.

Key changes:
- Add FrontendGenerationState for strategy-time data
- Track adds/updates/upserts/deletes in BTreeMap<String, FrontendRecordState>
- Merge update metadata with proper chroma-key filtering
- Defer full-sweep invariant checks via full_sweep_pending flag
- Add per-case timing stats (p50, average, wall-clock)
- Add CHROMA_FRONTEND_PROPTEST_PROFILE env var (deep vs default)
- Reduce default dimension range and transition count for speed

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
