### PR TITLE
[CHORE] simplify test_log_backpressure test

### DIFF
--- a/chromadb/test/distributed/test_log_backpressure.py
+++ b/chromadb/test/distributed/test_log_backpressure.py
@@ -1,54 +1,45 @@
-# Add up to 200k records until the log-is-full message is seen.
+# Add up to 2M records until the log-is-full message is seen.
 
-import grpc
-import math
-import random
-import time
-
-import numpy as np
+import pytest
 
 from chromadb.api import ClientAPI
-from chromadb.proto.logservice_pb2 import SealLogRequest, MigrateLogRequest
-from chromadb.proto.logservice_pb2_grpc import LogServiceStub
 from chromadb.test.conftest import (
     reset,
     skip_if_not_cluster,
 )
-from chromadb.test.property import invariants
-from chromadb.test.utils.wait_for_version_increase import wait_for_version_increase
 
-RECORDS = 2000000
+EXPECTED_BACKPRESSURE_ERROR = (
+    "log needs compaction before accepting more writes; "
+    "please backoff exponentially and retry"
+)
+RECORDS = 2_000_000
 BATCH_SIZE = 100
+EMBEDDING = [0.0, 0.0, 0.0]
+
 
 @skip_if_not_cluster()
 def test_log_backpressure(
     client: ClientAPI,
 ) -> None:
-    seed = time.time()
-    random.seed(seed)
-    print("Generating data with seed ", seed)
     reset(client)
     collection = client.create_collection(
         name="test",
         metadata={"hnsw:construction_ef": 128, "hnsw:search_ef": 128, "hnsw:M": 128},
     )
 
-    time.sleep(1)
+    print("backpressuring for", collection.id)
 
-    print('backpressuring for', collection.id)
-
-    excepted = False
-    # Add RECORDS records, where each embedding has 3 dimensions randomly generated between 0 and 1
+    # RECORDS is intentionally high to guarantee backpressure, but the test
+    # succeeds as soon as that condition is observed.
     for i in range(0, RECORDS, BATCH_SIZE):
-        ids = []
-        embeddings = []
-        ids.extend([str(x) for x in range(i, i + BATCH_SIZE)])
-        embeddings.extend([np.random.rand(1, 3)[0] for x in range(i, i + BATCH_SIZE)])
+        ids = [str(x) for x in range(i, i + BATCH_SIZE)]
+        embeddings = [EMBEDDING] * BATCH_SIZE
         try:
             collection.add(ids=ids, embeddings=embeddings)
-        except Exception as x:
-            print(f"Caught exception:\n{x}")
-            if 'log needs compaction before accepting more writes; please backoff exponentially and retry' in str(x):
-                excepted = True
-                break
-    assert excepted, "Expected an exception to be thrown."
+        except Exception as exc:
+            print(f"Caught exception:\n{exc}")
+            if EXPECTED_BACKPRESSURE_ERROR in str(exc):
+                return
+            raise
+
+    pytest.fail("Expected log backpressure to be triggered.")


### PR DESCRIPTION
## Description of changes

Remove unused imports (grpc, math, random, time, numpy, proto stubs,
invariants, wait_for_version_increase) and streamline the test:

- Extract expected error message into a module-level constant
- Replace random numpy embeddings with a fixed constant vector
- Return early on backpressure instead of tracking a boolean flag
- Use pytest.fail for a clear message when backpressure is not triggered
- Use thousands separator for RECORDS literal (2_000_000)

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
