### PR TITLE
[CHORE](garbage_collector): speed up GC property tests

### DIFF
--- a/rust/garbage_collector/tests/prop_test_garbage_collection.rs
+++ b/rust/garbage_collector/tests/prop_test_garbage_collection.rs
@@ -10,7 +10,7 @@ mod proptest_helpers;
 #[cfg(test)]
 mod tests {
     use crate::proptest_helpers::garbage_collector_under_test::GarbageCollectorUnderTest;
-    use proptest::test_runner::Config;
+    use proptest::test_runner::{Config, FileFailurePersistence};
     use proptest_state_machine::prop_state_machine;
     use std::ops::Range;
 
@@ -18,7 +18,6 @@ mod tests {
         cases: u32,
         max_shrink_iters: u32,
         transition_range: Range<usize>,
-        replay_regressions: bool,
     }
 
     fn garbage_collector_proptest_profile() -> GarbageCollectorProptestProfile {
@@ -27,13 +26,11 @@ mod tests {
                 cases: 256,
                 max_shrink_iters: 1024,
                 transition_range: 1..50,
-                replay_regressions: true,
             },
             _ => GarbageCollectorProptestProfile {
                 cases: 32,
                 max_shrink_iters: 256,
                 transition_range: 1..25,
-                replay_regressions: false,
             },
         }
     }
@@ -44,11 +41,11 @@ mod tests {
         Config {
             cases: profile.cases,
             max_shrink_iters: profile.max_shrink_iters,
-            failure_persistence: if profile.replay_regressions {
-                Config::default().failure_persistence
-            } else {
-                None
-            },
+            // Integration tests live outside src/, so SourceParallel cannot
+            // find a crate root. Keep using this test's checked-in sidecar.
+            failure_persistence: Some(Box::new(FileFailurePersistence::WithSource(
+                "proptest-regressions",
+            ))),
             fork: false,
             ..Config::default()
         }

--- a/rust/garbage_collector/tests/prop_test_garbage_collection.rs
+++ b/rust/garbage_collector/tests/prop_test_garbage_collection.rs
@@ -1,15 +1,68 @@
 mod proptest_helpers;
 
 // Tip: run with `RUST_LOG=prop_test_garbage_collection=debug,garbage_collector=trace`
+//
+// Fast/default timing:
+// /usr/bin/time -p cargo test -p garbage_collector --test prop_test_garbage_collection -- --exact tests::test_k8s_integration_garbage_collection --nocapture
+//
+// Deep timing:
+// env CHROMA_GC_PROPTEST_PROFILE=deep /usr/bin/time -p cargo test -p garbage_collector --test prop_test_garbage_collection -- --exact tests::test_k8s_integration_garbage_collection --nocapture
 #[cfg(test)]
 mod tests {
     use crate::proptest_helpers::garbage_collector_under_test::GarbageCollectorUnderTest;
+    use proptest::test_runner::Config;
     use proptest_state_machine::prop_state_machine;
+    use std::ops::Range;
+
+    struct GarbageCollectorProptestProfile {
+        cases: u32,
+        max_shrink_iters: u32,
+        transition_range: Range<usize>,
+        replay_regressions: bool,
+    }
+
+    fn garbage_collector_proptest_profile() -> GarbageCollectorProptestProfile {
+        match std::env::var("CHROMA_GC_PROPTEST_PROFILE").as_deref() {
+            Ok("deep") => GarbageCollectorProptestProfile {
+                cases: 256,
+                max_shrink_iters: 1024,
+                transition_range: 1..50,
+                replay_regressions: true,
+            },
+            _ => GarbageCollectorProptestProfile {
+                cases: 32,
+                max_shrink_iters: 256,
+                transition_range: 1..25,
+                replay_regressions: false,
+            },
+        }
+    }
+
+    fn garbage_collector_proptest_config() -> Config {
+        let profile = garbage_collector_proptest_profile();
+
+        Config {
+            cases: profile.cases,
+            max_shrink_iters: profile.max_shrink_iters,
+            failure_persistence: if profile.replay_regressions {
+                Config::default().failure_persistence
+            } else {
+                None
+            },
+            fork: false,
+            ..Config::default()
+        }
+    }
+
+    fn garbage_collector_transition_range() -> Range<usize> {
+        garbage_collector_proptest_profile().transition_range
+    }
 
     prop_state_machine! {
+        #![proptest_config(garbage_collector_proptest_config())]
         fn run_test(
             sequential
-            1..50
+            garbage_collector_transition_range()
             =>
           GarbageCollectorUnderTest
         );

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_reference.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_reference.rs
@@ -79,6 +79,11 @@ pub struct ReferenceState {
     pub db_id: DatabaseUuid,
     version_graph: DiGraph<CollectionVersionGraphNode, ()>,
     root_collection_id: Option<CollectionUuid>,
+    latest_node_by_collection: HashMap<CollectionUuid, NodeIndex>,
+    versions_by_collection: HashMap<CollectionUuid, Vec<NodeIndex>>,
+    alive_collection_ids: HashSet<CollectionUuid>,
+    node_depth: HashMap<NodeIndex, usize>,
+    graph_depth: usize,
 }
 
 impl ReferenceState {
@@ -131,59 +136,80 @@ impl ReferenceState {
     }
 
     pub fn max_version_for_collection(&self, collection_id: CollectionUuid) -> Option<u64> {
-        self.version_graph
-            .node_indices()
-            .filter_map(|idx| {
-                let node = &self.version_graph[idx];
-                if node.collection_id == collection_id && !node.is_deleted {
-                    return Some(node);
-                }
-
-                None
-            })
-            .max_by_key(|node| node.version)
+        self.latest_live_node_for_collection(collection_id)
             .map(|node| node.version)
     }
 
     pub fn expected_versions_by_collection(&self) -> HashMap<CollectionUuid, Vec<u64>> {
         let mut expected_alive_collection_versions = HashMap::new();
 
-        // Iterate over the nodes in the graph
-        for node in self.version_graph.node_indices() {
-            let node_data = &self.version_graph[node];
-            let status = &self.collection_status[&node_data.collection_id];
-            if !node_data.is_deleted && *status == CollectionStatus::Alive {
+        for collection_id in self.alive_collection_ids.iter() {
+            if let Some(version_nodes) = self.versions_by_collection.get(collection_id) {
                 let versions = expected_alive_collection_versions
-                    .entry(node_data.collection_id)
+                    .entry(*collection_id)
                     .or_insert_with(Vec::new);
-                versions.push(node_data.version);
+                versions.extend(version_nodes.iter().filter_map(|node_index| {
+                    let node = &self.version_graph[*node_index];
+                    if node.is_deleted {
+                        None
+                    } else {
+                        Some(node.version)
+                    }
+                }));
             }
-        }
-        // Sort the versions for each collection
-        for versions in expected_alive_collection_versions.values_mut() {
-            versions.sort();
         }
 
         expected_alive_collection_versions
     }
 
     pub fn get_graph_depth(&self) -> usize {
-        let dist =
-            petgraph::algo::dijkstra(&self.version_graph, NodeIndex::from(0), None, |_| 1usize);
-        *dist.values().max().unwrap_or(&0)
+        self.graph_depth
     }
 
     fn get_collection_ids(&self) -> HashSet<CollectionUuid> {
-        self.collection_status
+        self.alive_collection_ids.clone()
+    }
+
+    fn insert_version_node(
+        &mut self,
+        collection_id: CollectionUuid,
+        node_index: NodeIndex,
+        depth: usize,
+    ) {
+        self.latest_node_by_collection
+            .insert(collection_id, node_index);
+        self.versions_by_collection
+            .entry(collection_id)
+            .or_default()
+            .push(node_index);
+        self.node_depth.insert(node_index, depth);
+        self.graph_depth = self.graph_depth.max(depth);
+    }
+
+    fn latest_live_node_index_for_collection(
+        &self,
+        collection_id: CollectionUuid,
+    ) -> Option<NodeIndex> {
+        if let Some(node_index) = self.latest_node_by_collection.get(&collection_id) {
+            if !self.version_graph[*node_index].is_deleted {
+                return Some(*node_index);
+            }
+        }
+
+        self.versions_by_collection
+            .get(&collection_id)?
             .iter()
-            .filter_map(|(collection_id, status)| {
-                if *status == CollectionStatus::Alive {
-                    Some(*collection_id)
-                } else {
-                    None
-                }
-            })
-            .collect()
+            .rev()
+            .copied()
+            .find(|node_index| !self.version_graph[*node_index].is_deleted)
+    }
+
+    fn latest_live_node_for_collection(
+        &self,
+        collection_id: CollectionUuid,
+    ) -> Option<&CollectionVersionGraphNode> {
+        self.latest_live_node_index_for_collection(collection_id)
+            .map(|node_index| &self.version_graph[node_index])
     }
 }
 
@@ -213,21 +239,20 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
             db_id: DatabaseUuid(database_id),
             collection_status: HashMap::new(),
             root_collection_id: None,
+            latest_node_by_collection: HashMap::new(),
+            versions_by_collection: HashMap::new(),
+            alive_collection_ids: HashSet::new(),
+            node_depth: HashMap::new(),
+            graph_depth: 0,
         })
         .boxed()
     }
 
     fn transitions(state: &Self::State) -> proptest::prelude::BoxedStrategy<Self::Transition> {
         let alive_collection_ids = state
-            .collection_status
+            .alive_collection_ids
             .iter()
-            .filter_map(|(collection_id, status)| {
-                if matches!(status, CollectionStatus::Alive) {
-                    Some(*collection_id)
-                } else {
-                    None
-                }
-            })
+            .copied()
             .collect::<Vec<_>>();
 
         let alive_collection_id_strategy = any::<proptest::sample::Index>().prop_map({
@@ -260,20 +285,17 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
         let increment_collection_version_transition = alive_collection_id_strategy
             .clone()
             .prop_flat_map({
-                let version_graph = state.version_graph.clone();
+                let latest_live_nodes = alive_collection_ids
+                    .iter()
+                    .filter_map(|collection_id| {
+                        state
+                            .latest_live_node_for_collection(*collection_id)
+                            .map(|node| (*collection_id, node.clone()))
+                    })
+                    .collect::<HashMap<_, _>>();
 
                 move |collection_id| {
-                    let parent = version_graph
-                        .node_indices()
-                        .filter_map(|idx| {
-                            if version_graph[idx].collection_id == collection_id {
-                                return Some(version_graph[idx].clone());
-                            }
-
-                            None
-                        })
-                        .max_by_key(|node| node.version)
-                        .unwrap();
+                    let parent = latest_live_nodes.get(&collection_id).cloned().unwrap();
 
                     parent.next_version_strategy()
                 }
@@ -360,30 +382,27 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
                     segments: segments.clone(),
                     is_deleted: false,
                 };
-                state.version_graph.add_node(new_node);
+                let node_index = state.version_graph.add_node(new_node);
+                state.insert_version_node(*collection_id, node_index, 0);
                 state.root_collection_id = Some(*collection_id);
                 state
                     .collection_status
                     .insert(*collection_id, CollectionStatus::Alive);
+                state.alive_collection_ids.insert(*collection_id);
             }
             Self::Transition::IncrementCollectionVersion {
                 collection_id,
                 next_segments,
             } => {
                 let parent_node_index = state
-                    .version_graph
-                    .node_indices()
-                    .filter(|&idx| state.version_graph[idx].collection_id == *collection_id)
-                    .max_by_key(|node_index| {
-                        let node = &state.version_graph[*node_index];
-                        node.version
-                    })
+                    .latest_live_node_index_for_collection(*collection_id)
                     .unwrap();
 
                 let parent_node = &state.version_graph[parent_node_index];
+                let parent_version = parent_node.version;
                 let new_node = CollectionVersionGraphNode {
                     collection_id: *collection_id,
-                    version: parent_node.version + 1,
+                    version: parent_version + 1,
                     segments: next_segments.clone(),
                     is_deleted: false,
                 };
@@ -391,22 +410,15 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
                 state
                     .version_graph
                     .add_edge(parent_node_index, new_node_index, ());
+                let parent_depth = state.node_depth[&parent_node_index];
+                state.insert_version_node(*collection_id, new_node_index, parent_depth + 1);
             }
             Self::Transition::ForkCollection {
                 source_collection_id,
                 new_collection_id,
             } => {
                 let parent_node_index = state
-                    .version_graph
-                    .node_indices()
-                    .filter(|idx| {
-                        let node = &state.version_graph[*idx];
-                        node.collection_id == *source_collection_id && !node.is_deleted
-                    })
-                    .max_by_key(|node_index| {
-                        let node = &state.version_graph[*node_index];
-                        node.version
-                    })
+                    .latest_live_node_index_for_collection(*source_collection_id)
                     .unwrap();
                 let parent_node = &state.version_graph[parent_node_index];
 
@@ -420,9 +432,12 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
                 state
                     .version_graph
                     .add_edge(parent_node_index, new_node_index, ());
+                let parent_depth = state.node_depth[&parent_node_index];
+                state.insert_version_node(*new_collection_id, new_node_index, parent_depth + 1);
                 state
                     .collection_status
                     .insert(*new_collection_id, CollectionStatus::Alive);
+                state.alive_collection_ids.insert(*new_collection_id);
             }
             Self::Transition::GarbageCollect {
                 min_versions_to_keep,
@@ -433,26 +448,9 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
                 for (collection_id, status) in state.collection_status.iter() {
                     if *status == CollectionStatus::SoftDeleted {
                         let first_collection_node = state
-                            .version_graph
-                            .node_indices()
-                            .filter(|&n| {
-                                let node = state
-                                    .version_graph
-                                    .node_weight(n)
-                                    .expect("Node should exist");
-                                node.collection_id == *collection_id
-                            })
-                            .max_by(|a, b| {
-                                let a_node = state
-                                    .version_graph
-                                    .node_weight(*a)
-                                    .expect("Node should exist");
-                                let b_node = state
-                                    .version_graph
-                                    .node_weight(*b)
-                                    .expect("Node should exist");
-                                b_node.version.cmp(&a_node.version)
-                            })
+                            .versions_by_collection
+                            .get(collection_id)
+                            .and_then(|versions| versions.first().copied())
                             .expect("collection should have at least one version node");
 
                         let mut dfs =
@@ -504,17 +502,9 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
                 }
 
                 for collection_id in state.get_collection_ids() {
-                    let mut versions_for_collection = vec![];
-                    for node in state.version_graph.node_indices() {
-                        let node_data = &state.version_graph[node];
-                        if node_data.collection_id == collection_id {
-                            versions_for_collection.push(node_data);
-                        }
-                    }
-                    versions_for_collection.sort_by_key(|n| n.version);
-
-                    let versions_to_delete = versions_for_collection
-                        .into_iter()
+                    let versions_to_delete = state.versions_by_collection[&collection_id]
+                        .iter()
+                        .map(|node_index| &state.version_graph[*node_index])
                         .rev()
                         .skip(*min_versions_to_keep)
                         .map(|v| v.version)
@@ -535,6 +525,7 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
                 state
                     .collection_status
                     .insert(*collection_id, CollectionStatus::SoftDeleted);
+                state.alive_collection_ids.remove(collection_id);
             }
             Self::Transition::NoOp => {}
         }

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -563,8 +563,12 @@ impl StateMachineTest for GarbageCollectorUnderTest {
             }
 
             let check_expensive = matches!(
-                transition,
-                Transition::DeleteCollection(_) | Transition::GarbageCollect { .. }
+                &transition,
+                Transition::CreateCollection { .. }
+                    | Transition::IncrementCollectionVersion { .. }
+                    | Transition::ForkCollection { .. }
+                    | Transition::DeleteCollection(_)
+                    | Transition::GarbageCollect { .. }
             );
 
             ref_state = <Self::Reference as ReferenceStateMachine>::apply(ref_state, &transition);

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -1,4 +1,6 @@
-use super::garbage_collector_reference::{CollectionStatus, ReferenceGarbageCollector};
+use super::garbage_collector_reference::{
+    CollectionStatus, ReferenceGarbageCollector, ReferenceState,
+};
 use super::proptest_types::SegmentIds;
 use crate::define_thread_local_stats;
 use crate::proptest_helpers::proptest_types::Transition;
@@ -19,11 +21,13 @@ use chrono::DateTime;
 use futures::StreamExt;
 use garbage_collector_library::garbage_collector_orchestrator_v2::GarbageCollectorOrchestrator;
 use garbage_collector_library::types::CleanupMode;
+use proptest::test_runner::Config;
 use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
 use prost::Message;
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{self, AtomicUsize};
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Instant, SystemTime};
 use tokio::sync::OnceCell;
 use tracing::{Instrument, Span};
 use uuid::Uuid;
@@ -37,6 +41,8 @@ pub struct GarbageCollectorUnderTest {
     logs: Log,
     root_manager: RootManager,
     collection_id_to_segment_ids: HashMap<CollectionUuid, SegmentIds>,
+    tenant_prefix: String,
+    written_files: HashSet<String>,
 }
 
 impl Drop for GarbageCollectorUnderTest {
@@ -50,7 +56,7 @@ impl Drop for GarbageCollectorUnderTest {
 
             let files = self
                 .storage
-                .list_prefix("", GetOptions::default())
+                .list_prefix(&self.tenant_prefix, GetOptions::default())
                 .await
                 .unwrap();
             if files.is_empty() {
@@ -76,6 +82,162 @@ impl Drop for GarbageCollectorUnderTest {
 // The S3 client is a bit expensive to construct, so we cache it since the config is identical across all test cases.
 static STORAGE_ONCE: OnceCell<Storage> = OnceCell::const_new();
 
+impl GarbageCollectorUnderTest {
+    fn check_expensive_invariants(state: &Self, ref_state: &ReferenceState) {
+        ref_state.check_invariants();
+
+        let expected_versions_by_collection = ref_state.expected_versions_by_collection();
+
+        ref_state.runtime.block_on({
+            let mut sysdb = state.sysdb.clone();
+            let storage = state.storage.clone();
+
+            async move {
+                let collection_statuses = sysdb
+                    .batch_get_collection_soft_delete_status(
+                        None,
+                        ref_state.collection_status.keys().cloned().collect(),
+                    )
+                    .await
+                    .unwrap();
+                for (collection_id, status) in ref_state.collection_status.iter() {
+                    match status {
+                        CollectionStatus::Deleted => {
+                            assert!(
+                                !collection_statuses.contains_key(collection_id),
+                                "Collection {} is supposed to be hard deleted, but still exists in the sysdb. Is soft deleted: {:?}",
+                                collection_id,
+                                collection_statuses.get(collection_id)
+                            );
+                        }
+                        CollectionStatus::Alive => match collection_statuses.get(collection_id) {
+                            Some(&true) => {
+                                panic!("Collection {} is supposed to be alive, but is marked as soft deleted in the sysdb.", collection_id);
+                            }
+                            Some(&false) => {
+                                // Expected case
+                            }
+                            None => {
+                                panic!("Collection {} is supposed to be alive, but does not exist in the sysdb.", collection_id);
+                            }
+                        },
+                        CollectionStatus::SoftDeleted => {
+                            match collection_statuses.get(collection_id) {
+                                Some(&true) => {
+                                    // Expected case
+                                }
+                                Some(&false) => {
+                                    panic!("Collection {} is supposed to be soft deleted, but is marked as alive in the sysdb.", collection_id);
+                                }
+                                None => {
+                                    panic!("Collection {} is supposed to be soft deleted, but does not exist in the sysdb.", collection_id);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                futures::stream::iter(expected_versions_by_collection)
+                    .map(move |(collection_id, expected_versions)| {
+                        let mut sysdb = sysdb.clone();
+                        let storage = storage.clone();
+
+                        async move {
+                            let collections = sysdb
+                                .get_collections(GetCollectionsOptions {
+                                    collection_id: Some(collection_id),
+                                    ..Default::default()
+                                })
+                                .await
+                                .unwrap();
+
+                            let collection = collections.first().unwrap_or_else(|| {
+                                panic!(
+                                    "Collection {} is expected to be alive with versions {:?}, but does not exist in sysdb.",
+                                    collection_id, expected_versions
+                                )
+                            });
+                            let version_file_path = collection.version_file_path.as_ref().unwrap();
+                            tracing::trace!(
+                                "Version file path for collection {}: {}",
+                                collection_id,
+                                version_file_path
+                            );
+
+                            let version_file = storage
+                                .get(version_file_path, GetOptions::default())
+                                .await
+                                .unwrap();
+                            let version_file =
+                                CollectionVersionFile::decode(version_file.as_slice()).unwrap();
+
+                            let versions = version_file
+                                .version_history
+                                .as_ref()
+                                .unwrap()
+                                .versions
+                                .iter()
+                                .map(|v| v.version as u64)
+                                .collect::<Vec<_>>();
+
+                            let versions_marked_for_deletion = version_file
+                                .version_history
+                                .unwrap()
+                                .versions
+                                .iter()
+                                .filter_map(|v| {
+                                    if v.marked_for_deletion {
+                                        Some(v.version as u64)
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect::<Vec<_>>();
+
+                            assert_eq!(
+                                versions, expected_versions,
+                                "Version file for collection {} does not match expected versions. Expected: {:?}, found: {:?}. The version file has versions {:?} marked for deletion.",
+                                collection_id, expected_versions, versions,
+                                versions_marked_for_deletion
+                            );
+                        }
+                    })
+                    .buffer_unordered(32)
+                    .collect::<Vec<_>>()
+                    .await;
+            }
+        });
+
+        let file_ref_counts = ref_state.get_file_ref_counts();
+        let files_on_disk = ref_state
+            .runtime
+            .block_on(
+                state
+                    .storage
+                    .list_prefix(&state.tenant_prefix, GetOptions::default()),
+            )
+            .unwrap()
+            .into_iter()
+            .collect::<HashSet<_>>();
+
+        for (file_path, refs) in file_ref_counts {
+            let on_disk = files_on_disk.contains(&file_path);
+
+            if refs.is_empty() && on_disk {
+                panic!(
+                    "Invariant violation: file {} has zero references but is still on disk.",
+                    file_path
+                );
+            } else if !refs.is_empty() && !on_disk {
+                panic!(
+                  "Invariant violation: file reference {} has a non-zero count {} but is not on disk. Referenced by: {:#?}",
+                  file_path, refs.len(), refs
+              );
+            }
+        }
+    }
+}
+
 impl StateMachineTest for GarbageCollectorUnderTest {
     type SystemUnderTest = Self;
     type Reference = ReferenceGarbageCollector;
@@ -84,6 +246,10 @@ impl StateMachineTest for GarbageCollectorUnderTest {
         ref_state: &<Self::Reference as ReferenceStateMachine>::State,
     ) -> Self::SystemUnderTest {
         tracing::debug!("Starting test");
+
+        STATS.with_borrow_mut(|stats| {
+            stats.record_test_case_start();
+        });
 
         ref_state.runtime.block_on(async {
             let registry = Registry::new();
@@ -127,6 +293,8 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                 logs,
                 root_manager,
                 collection_id_to_segment_ids: HashMap::new(),
+                tenant_prefix: format!("tenant/{}/", ref_state.tenant),
+                written_files: HashSet::new(),
             }
         })
     }
@@ -137,6 +305,7 @@ impl StateMachineTest for GarbageCollectorUnderTest {
         transition: <Self::Reference as ReferenceStateMachine>::Transition,
     ) -> Self::SystemUnderTest {
         tracing::debug!("Applying transition: {:#?}", transition);
+        let transition_start = Instant::now();
 
         STATS.with_borrow_mut(|stats| {
             stats.record_transition(&transition, ref_state);
@@ -148,7 +317,9 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                 segments,
             } => {
                 ref_state.runtime.block_on(async {
-                    segments.write_files(&state.storage).await;
+                    segments
+                        .write_files(&state.storage, &mut state.written_files)
+                        .await;
 
                     let segments = vec![
                         Segment {
@@ -228,11 +399,14 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                 let segment_ids = state
                     .collection_id_to_segment_ids
                     .get(&collection_id)
+                    .copied()
                     .unwrap();
                 ref_state.runtime.block_on(async {
-                    next_segments.write_files(&state.storage).await;
+                    next_segments
+                        .write_files(&state.storage, &mut state.written_files)
+                        .await;
 
-                    let segment_flush_info = next_segments.into_segment_flushes(segment_ids);
+                    let segment_flush_info = next_segments.into_segment_flushes(&segment_ids);
 
                     for sfi in segment_flush_info.iter() {
                         assert!(!sfi.file_paths.is_empty());
@@ -362,149 +536,60 @@ impl StateMachineTest for GarbageCollectorUnderTest {
             ref_state.get_graphviz_of_graph()
         );
 
+        STATS.with_borrow_mut(|stats| {
+            stats.record_transition_duration(transition_start.elapsed());
+        });
+
         state
+    }
+
+    fn test_sequential(
+        config: Config,
+        mut ref_state: <Self::Reference as ReferenceStateMachine>::State,
+        transitions: Vec<<Self::Reference as ReferenceStateMachine>::Transition>,
+        mut seen_counter: Option<Arc<AtomicUsize>>,
+    ) {
+        let _ = config;
+
+        let mut concrete_state = Self::init_test(&ref_state);
+
+        Self::check_invariants(&concrete_state, &ref_state);
+        Self::check_expensive_invariants(&concrete_state, &ref_state);
+        let mut full_checked_current_state = true;
+
+        for transition in transitions {
+            if let Some(seen_counter) = seen_counter.as_mut() {
+                seen_counter.fetch_add(1, atomic::Ordering::SeqCst);
+            }
+
+            let check_expensive = matches!(
+                transition,
+                Transition::DeleteCollection(_) | Transition::GarbageCollect { .. }
+            );
+
+            ref_state = <Self::Reference as ReferenceStateMachine>::apply(ref_state, &transition);
+            concrete_state = Self::apply(concrete_state, &ref_state, transition);
+
+            Self::check_invariants(&concrete_state, &ref_state);
+            full_checked_current_state = false;
+            if check_expensive {
+                Self::check_expensive_invariants(&concrete_state, &ref_state);
+                full_checked_current_state = true;
+            }
+        }
+
+        if !full_checked_current_state {
+            Self::check_expensive_invariants(&concrete_state, &ref_state);
+        }
+
+        Self::teardown(concrete_state);
     }
 
     fn check_invariants(
         state: &Self::SystemUnderTest,
         ref_state: &<Self::Reference as ReferenceStateMachine>::State,
     ) {
-        // Check invariants in the reference state
+        let _ = state;
         ref_state.check_invariants();
-
-        // Check version files
-        let expected_versions_by_collection = ref_state.expected_versions_by_collection();
-
-        ref_state.runtime.block_on({
-            let mut sysdb = state.sysdb.clone();
-            let storage = state.storage.clone();
-
-            async move {
-                let collection_statuses = sysdb.batch_get_collection_soft_delete_status(None, ref_state.collection_status.keys().cloned().collect()).await.unwrap();
-                for (collection_id, status) in ref_state.collection_status.iter() {
-                    match status {
-                        CollectionStatus::Deleted => {
-                            assert!(
-                                !collection_statuses.contains_key(collection_id),
-                                "Collection {} is supposed to be hard deleted, but still exists in the sysdb. Is soft deleted: {:?}",
-                                collection_id,
-                                collection_statuses.get(collection_id)
-                            );
-                        }
-                        CollectionStatus::Alive => {
-                            match collection_statuses.get(collection_id) {
-                                Some(&true) => {
-                                    panic!("Collection {} is supposed to be alive, but is marked as soft deleted in the sysdb.", collection_id);
-                                }
-                                Some(&false) => {
-                                    // Expected case
-                                }
-                                None => {
-                                    panic!("Collection {} is supposed to be alive, but does not exist in the sysdb.", collection_id);
-                                }
-                            }
-                        }
-                        CollectionStatus::SoftDeleted => {
-                            match collection_statuses.get(collection_id) {
-                                Some(&true) => {
-                                    // Expected case
-                                }
-                                Some(&false) => {
-                                    panic!("Collection {} is supposed to be soft deleted, but is marked as alive in the sysdb.", collection_id);
-                                }
-                                None => {
-                                    panic!("Collection {} is supposed to be soft deleted, but does not exist in the sysdb.", collection_id);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                futures::stream::iter(expected_versions_by_collection)
-                    .map(move |(collection_id, expected_versions)| {
-                        let mut sysdb = sysdb.clone();
-                        let storage = storage.clone();
-
-                        async move {
-                            let collections = sysdb
-                                .get_collections(
-                                   GetCollectionsOptions {
-                                        collection_id: Some(collection_id),
-                                        ..Default::default()
-                                })
-                                .await
-                                .unwrap();
-
-                            let collection = collections.first().unwrap();
-                            let version_file_path = collection.version_file_path.as_ref().unwrap();
-                            tracing::trace!("Version file path for collection {}: {}", collection_id, version_file_path);
-
-                            let version_file = storage
-                                .get(version_file_path, GetOptions::default())
-                                .await
-                                .unwrap();
-                            let version_file =
-                                CollectionVersionFile::decode(version_file.as_slice()).unwrap();
-
-                            let versions = version_file
-                                .version_history
-                                .as_ref()
-                                .unwrap()
-                                .versions
-                                .iter()
-                                .map(|v| v.version as u64)
-                                .collect::<Vec<_>>();
-
-                            let versions_marked_for_deletion = version_file
-                                .version_history
-                                .unwrap()
-                                .versions
-                                .iter()
-                                .filter_map(|v| {
-                                    if v.marked_for_deletion {
-                                        Some(v.version as u64)
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect::<Vec<_>>();
-
-                            assert_eq!(
-                                versions, expected_versions,
-                                "Version file for collection {} does not match expected versions. Expected: {:?}, found: {:?}. The version file has versions {:?} marked for deletion.",
-                                collection_id, expected_versions, versions,
-                                versions_marked_for_deletion
-                            );
-                        }
-                    })
-                    .buffer_unordered(32)
-                    .collect::<Vec<_>>()
-                    .await;
-            }
-        });
-
-        let file_ref_counts = ref_state.get_file_ref_counts();
-        let files_on_disk = ref_state
-            .runtime
-            .block_on(state.storage.list_prefix("", GetOptions::default()))
-            .unwrap()
-            .into_iter()
-            .collect::<HashSet<_>>();
-
-        for (file_path, refs) in file_ref_counts {
-            let on_disk = files_on_disk.contains(&file_path);
-
-            if refs.is_empty() && on_disk {
-                panic!(
-                    "Invariant violation: file {} has zero references but is still on disk.",
-                    file_path
-                );
-            } else if !refs.is_empty() && !on_disk {
-                panic!(
-                  "Invariant violation: file reference {} has a non-zero count {} but is not on disk. Referenced by: {:#?}",
-                  file_path, refs.len(), refs
-              );
-            }
-        }
     }
 }

--- a/rust/garbage_collector/tests/proptest_helpers/proptest_types.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/proptest_types.rs
@@ -23,6 +23,7 @@ pub enum Transition {
     NoOp,
 }
 
+#[derive(Clone, Copy)]
 pub struct SegmentIds {
     pub vector: SegmentUuid,
     pub metadata: SegmentUuid,

--- a/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
@@ -12,6 +12,7 @@ use chroma_types::{
 };
 use futures::StreamExt;
 use proptest::prelude::{any, any_with, Arbitrary, BoxedStrategy};
+use proptest::sample::Index;
 use proptest::strategy::Strategy;
 use proptest::{prelude::Just, prop_oneof};
 use std::collections::{HashMap, HashSet};
@@ -20,7 +21,7 @@ use uuid::Uuid;
 
 use super::proptest_types::SegmentIds;
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Default)]
 enum SegmentFileReferenceType {
     #[default]
     HNSWIndex,
@@ -98,7 +99,7 @@ struct SegmentFileReference {
     reference: FileReference,
 }
 
-fn new_hnsw_index_strategy(prefix_path: String) -> BoxedStrategy<SegmentFileReference> {
+fn new_hnsw_index(prefix_path: String) -> SegmentFileReference {
     let hnsw_index_id = Uuid::new_v4();
     let hnsw_index = FileReference::Hnsw {
         file_paths: FILES
@@ -112,26 +113,37 @@ fn new_hnsw_index_strategy(prefix_path: String) -> BoxedStrategy<SegmentFileRefe
             })
             .collect::<Vec<String>>(),
     };
-    Just(SegmentFileReference {
+    SegmentFileReference {
         reference_id: hnsw_index_id,
         reference: hnsw_index,
-    })
-    .boxed()
+    }
 }
 
-fn new_usearch_index_strategy(
-    prefix_path: String,
-    quantized: bool,
-) -> BoxedStrategy<SegmentFileReference> {
+fn new_usearch_index(prefix_path: String, quantized: bool) -> SegmentFileReference {
     let usearch_id = Uuid::new_v4();
     let file_path =
         USearchIndex::format_storage_key(&prefix_path, IndexUuid(usearch_id), quantized);
     let usearch_ref = FileReference::USearch { file_path };
-    Just(SegmentFileReference {
+    SegmentFileReference {
         reference_id: usearch_id,
         reference: usearch_ref,
-    })
-    .boxed()
+    }
+}
+
+fn new_sparse_index(prefix_path: String, num_blocks: usize) -> SegmentFileReference {
+    let block_paths = (0..num_blocks)
+        .map(|_| BlockManager::format_key(&prefix_path, &Uuid::new_v4()))
+        .collect();
+
+    let sparse_index_id = Uuid::new_v4();
+    let sparse_index = FileReference::SparseIndex {
+        path: RootManager::get_storage_key(&prefix_path, &sparse_index_id),
+        block_paths,
+    };
+    SegmentFileReference {
+        reference_id: sparse_index_id,
+        reference: sparse_index,
+    }
 }
 
 fn new_or_forked_sparse_index_strategy(
@@ -193,6 +205,49 @@ fn new_or_forked_sparse_index_strategy(
         .boxed()
 }
 
+fn fork_sparse_index_reference(
+    existing_sparse_index: SegmentFileReference,
+    prefix_path: String,
+    num_new_blocks: usize,
+    inherited_block_count: Index,
+) -> SegmentFileReference {
+    let existing_block_paths = match existing_sparse_index {
+        SegmentFileReference {
+            reference: FileReference::SparseIndex { block_paths, .. },
+            ..
+        } => block_paths,
+        _ => unreachable!(),
+    };
+
+    let min_existing_block_paths = existing_block_paths.len().min(2);
+    let num_inherited_block_paths = if existing_block_paths.is_empty() {
+        0
+    } else {
+        min_existing_block_paths
+            + inherited_block_count.index(existing_block_paths.len() - min_existing_block_paths + 1)
+    };
+
+    let mut block_paths = HashSet::new();
+    block_paths.extend(
+        existing_block_paths
+            .into_iter()
+            .take(num_inherited_block_paths),
+    );
+    for _ in 0..num_new_blocks {
+        block_paths.insert(BlockManager::format_key(&prefix_path, &Uuid::new_v4()));
+    }
+
+    let sparse_index_id = Uuid::new_v4();
+    let sparse_index = FileReference::SparseIndex {
+        path: RootManager::get_storage_key(&prefix_path, &sparse_index_id),
+        block_paths: block_paths.into_iter().collect(),
+    };
+    SegmentFileReference {
+        reference_id: sparse_index_id,
+        reference: sparse_index,
+    }
+}
+
 /// A collection of file references for a segment.
 #[derive(Clone, Debug)]
 pub struct SegmentFilePaths {
@@ -211,39 +266,47 @@ impl Arbitrary for SegmentFilePaths {
             "tenant/{}/database/{}/collection/{}/segment/{}",
             params.0, params.1, params.2, segment_id
         );
-        let prefix_path_clone = prefix_path.clone();
-        proptest::collection::vec(
-            any::<SegmentFileReferenceType>().prop_flat_map(move |segment_file_reference_type| {
-                let refs = match segment_file_reference_type.clone() {
-                    SegmentFileReferenceType::HNSWIndex => {
-                        new_hnsw_index_strategy(prefix_path.clone())
-                    }
-                    SegmentFileReferenceType::HNSWPath => {
-                        new_hnsw_index_strategy(prefix_path.clone())
-                    }
-                    SegmentFileReferenceType::SparseIndex { .. } => {
-                        new_or_forked_sparse_index_strategy(None, prefix_path.clone())
-                    }
-                    SegmentFileReferenceType::USearchRawCentroid => {
-                        new_usearch_index_strategy(prefix_path.clone(), false)
-                    }
-                    SegmentFileReferenceType::USearchQuantizedCentroid => {
-                        new_usearch_index_strategy(prefix_path.clone(), true)
-                    }
-                };
-                (Just(segment_file_reference_type), refs)
-            }),
-            1..10,
-        )
-        .prop_map(move |elements| SegmentFilePaths {
-            paths: elements
-                .into_iter()
-                .map(|(k, v)| (k, vec![v]))
-                .collect::<HashMap<_, _>>(),
-            root_segment_id: segment_id,
-            prefix_path: prefix_path_clone.clone(),
-        })
-        .boxed()
+        proptest::collection::btree_set(any::<SegmentFileReferenceType>(), 1..10)
+            .prop_flat_map(move |reference_types| {
+                let num_reference_types = reference_types.len();
+                (
+                    Just(reference_types),
+                    proptest::collection::vec(1..10usize, num_reference_types),
+                )
+            })
+            .prop_map(move |(reference_types, mut sparse_block_counts)| {
+                let paths = reference_types
+                    .into_iter()
+                    .map(|reference_type| {
+                        let reference = match &reference_type {
+                            SegmentFileReferenceType::HNSWIndex
+                            | SegmentFileReferenceType::HNSWPath => {
+                                new_hnsw_index(prefix_path.clone())
+                            }
+                            SegmentFileReferenceType::SparseIndex { .. } => new_sparse_index(
+                                prefix_path.clone(),
+                                sparse_block_counts
+                                    .pop()
+                                    .expect("sparse block count should exist"),
+                            ),
+                            SegmentFileReferenceType::USearchRawCentroid => {
+                                new_usearch_index(prefix_path.clone(), false)
+                            }
+                            SegmentFileReferenceType::USearchQuantizedCentroid => {
+                                new_usearch_index(prefix_path.clone(), true)
+                            }
+                        };
+                        (reference_type, vec![reference])
+                    })
+                    .collect::<HashMap<_, _>>();
+
+                SegmentFilePaths {
+                    paths,
+                    root_segment_id: segment_id,
+                    prefix_path: prefix_path.clone(),
+                }
+            })
+            .boxed()
     }
 }
 
@@ -423,44 +486,41 @@ impl SegmentFilePaths {
             Just(HashMap::new()).boxed()
         } else {
             let num_sparse_indices = sparse_indices.len();
-            // proptest does not yet support `Vec<BoxedStrategy<T>> -> BoxedStrategy<Vec<T>>`, so instead we first sample a subset of Vec<T> and apply the desired flat map while sampling. We then reject the generated Vec<T> if it contains duplicates.
-            proptest::collection::vec(
-                proptest::sample::select(sparse_indices).prop_flat_map(
-                    move |(sparse_index_name, sparse_index)| {
-                        let sparse_index = new_or_forked_sparse_index_strategy(
-                            Some(sparse_index),
+            proptest::sample::subsequence(sparse_indices, 1..=num_sparse_indices)
+                .prop_flat_map(move |sparse_indices| {
+                    let prefix_path = prefix_path.clone();
+                    let num_sparse_indices = sparse_indices.len();
+                    (
+                        Just(sparse_indices),
+                        Just(prefix_path),
+                        proptest::collection::vec((1..10usize, any::<Index>()), num_sparse_indices),
+                    )
+                })
+                .prop_map(|sparse_indices| {
+                    let (sparse_indices, prefix_path, mut fork_params) = sparse_indices;
+                    let mut refs: HashMap<SegmentFileReferenceType, Vec<SegmentFileReference>> =
+                        HashMap::new();
+                    for (sparse_index_name, sparse_index) in sparse_indices {
+                        let (num_new_blocks, inherited_block_count) = fork_params
+                            .pop()
+                            .expect("fork params should match sparse indices");
+                        let sparse_index = fork_sparse_index_reference(
+                            sparse_index,
                             prefix_path.clone(),
+                            num_new_blocks,
+                            inherited_block_count,
                         );
-                        (Just(sparse_index_name), sparse_index)
-                    },
-                ),
-                (1.min(num_sparse_indices))..=num_sparse_indices,
-            )
-            .prop_filter("duplicate sparse index sampled", |sparse_indices| {
-                let mut seen = HashSet::new();
-                for (sparse_index_name, _) in sparse_indices {
-                    if seen.contains(sparse_index_name) {
-                        return false;
+                        let entry = refs.entry(sparse_index_name).or_default();
+                        if !entry
+                            .iter()
+                            .any(|r| r.reference_id == sparse_index.reference_id)
+                        {
+                            entry.push(sparse_index);
+                        }
                     }
-                    seen.insert(sparse_index_name);
-                }
-                true
-            })
-            .prop_map(|sparse_indices| {
-                let mut refs: HashMap<SegmentFileReferenceType, Vec<SegmentFileReference>> =
-                    HashMap::new();
-                for (sparse_index_name, sparse_index) in sparse_indices {
-                    let entry = refs.entry(sparse_index_name).or_default();
-                    if !entry
-                        .iter()
-                        .any(|r| r.reference_id == sparse_index.reference_id)
-                    {
-                        entry.push(sparse_index);
-                    }
-                }
-                refs
-            })
-            .boxed()
+                    refs
+                })
+                .boxed()
         };
 
         let new_sparse_indices_strategy = proptest::collection::hash_map(
@@ -542,41 +602,69 @@ impl SegmentGroup {
         Arc::from([vector_flush_info, metadata_flush_info, record_flush_info])
     }
 
-    pub async fn write_files(&self, storage: &Storage) {
+    pub async fn write_files(&self, storage: &Storage, written_files: &mut HashSet<String>) {
+        let vector_new_files = mark_new_file_paths(self.vector.paths(), written_files);
+        let metadata_new_files = mark_new_file_paths(self.metadata.paths(), written_files);
+        let record_new_files = mark_new_file_paths(self.record.paths(), written_files);
+
         futures::future::join_all([
-            write_files_for_segment(storage, &self.vector),
-            write_files_for_segment(storage, &self.metadata),
-            write_files_for_segment(storage, &self.record),
+            write_files_for_segment(storage, &self.vector, vector_new_files),
+            write_files_for_segment(storage, &self.metadata, metadata_new_files),
+            write_files_for_segment(storage, &self.record, record_new_files),
         ])
         .await;
     }
 }
 
-async fn write_files_for_segment(storage: &Storage, file_paths: &SegmentFilePaths) {
+fn mark_new_file_paths(
+    file_paths: Vec<String>,
+    written_files: &mut HashSet<String>,
+) -> HashSet<String> {
+    file_paths
+        .into_iter()
+        .filter(|file_path| written_files.insert(file_path.clone()))
+        .collect()
+}
+
+async fn write_files_for_segment(
+    storage: &Storage,
+    file_paths: &SegmentFilePaths,
+    new_files: HashSet<String>,
+) {
     let prefix_path = file_paths.prefix_path.clone();
     for refs in file_paths.paths.values() {
         for file_ref in refs {
             match &file_ref.reference {
-                FileReference::SparseIndex { block_paths, .. } => {
-                    let block_ids = block_paths
+                FileReference::SparseIndex { path, block_paths } => {
+                    if new_files.contains(path) {
+                        let block_ids = block_paths
+                            .iter()
+                            .map(|block_path| {
+                                Uuid::parse_str(block_path.split('/').next_back().unwrap()).unwrap()
+                            })
+                            .collect::<Vec<_>>();
+                        create_test_sparse_index(
+                            storage,
+                            file_ref.reference_id,
+                            block_ids,
+                            None,
+                            prefix_path.clone(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+
+                    let block_paths = block_paths
                         .iter()
-                        .map(|block_path| {
-                            Uuid::parse_str(block_path.split('/').next_back().unwrap()).unwrap()
-                        })
+                        .filter(|file| new_files.contains(*file))
                         .collect::<Vec<_>>();
-                    create_test_sparse_index(
-                        storage,
-                        file_ref.reference_id,
-                        block_ids,
-                        None,
-                        prefix_path.clone(),
-                    )
-                    .await
-                    .unwrap();
+                    if block_paths.is_empty() {
+                        continue;
+                    }
 
                     // Write blocks
                     let contents = vec![0; 8];
-                    futures::stream::iter(block_paths.iter())
+                    futures::stream::iter(block_paths)
                         .map(|file| {
                             let storage = storage.clone();
                             let contents = contents.clone();
@@ -592,8 +680,16 @@ async fn write_files_for_segment(storage: &Storage, file_paths: &SegmentFilePath
                         .await
                 }
                 FileReference::Hnsw { file_paths, .. } => {
+                    let file_paths = file_paths
+                        .iter()
+                        .filter(|file| new_files.contains(*file))
+                        .collect::<Vec<_>>();
+                    if file_paths.is_empty() {
+                        continue;
+                    }
+
                     let contents = vec![0; 8];
-                    futures::stream::iter(file_paths.iter())
+                    futures::stream::iter(file_paths)
                         .map(|file| {
                             let storage = storage.clone();
                             let contents = contents.clone();
@@ -609,6 +705,10 @@ async fn write_files_for_segment(storage: &Storage, file_paths: &SegmentFilePath
                         .await
                 }
                 FileReference::USearch { file_path } => {
+                    if !new_files.contains(file_path) {
+                        continue;
+                    }
+
                     let contents = vec![0; 8];
                     storage
                         .put_bytes(file_path, contents, Default::default())

--- a/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
@@ -657,67 +657,54 @@ async fn write_files_for_segment(
                     let block_paths = block_paths
                         .iter()
                         .filter(|file| new_files.contains(*file))
+                        .map(String::as_str)
                         .collect::<Vec<_>>();
                     if block_paths.is_empty() {
                         continue;
                     }
 
-                    // Write blocks
-                    let contents = vec![0; 8];
-                    futures::stream::iter(block_paths)
-                        .map(|file| {
-                            let storage = storage.clone();
-                            let contents = contents.clone();
-                            async move {
-                                storage
-                                    .put_bytes(file, contents, Default::default())
-                                    .await
-                                    .unwrap();
-                            }
-                        })
-                        .buffer_unordered(32)
-                        .collect()
-                        .await
+                    write_placeholder_files(storage, block_paths).await;
                 }
                 FileReference::Hnsw { file_paths, .. } => {
                     let file_paths = file_paths
                         .iter()
                         .filter(|file| new_files.contains(*file))
+                        .map(String::as_str)
                         .collect::<Vec<_>>();
                     if file_paths.is_empty() {
                         continue;
                     }
 
-                    let contents = vec![0; 8];
-                    futures::stream::iter(file_paths)
-                        .map(|file| {
-                            let storage = storage.clone();
-                            let contents = contents.clone();
-                            async move {
-                                storage
-                                    .put_bytes(file, contents, Default::default())
-                                    .await
-                                    .unwrap();
-                            }
-                        })
-                        .buffer_unordered(32)
-                        .collect()
-                        .await
+                    write_placeholder_files(storage, file_paths).await;
                 }
                 FileReference::USearch { file_path } => {
                     if !new_files.contains(file_path) {
                         continue;
                     }
 
-                    let contents = vec![0; 8];
-                    storage
-                        .put_bytes(file_path, contents, Default::default())
-                        .await
-                        .unwrap();
+                    write_placeholder_files(storage, vec![file_path.as_str()]).await;
                 }
             }
         }
     }
+}
+
+async fn write_placeholder_files(storage: &Storage, file_paths: Vec<&str>) {
+    let contents = vec![0; 8];
+    futures::stream::iter(file_paths)
+        .map(|file| {
+            let storage = storage.clone();
+            let contents = contents.clone();
+            async move {
+                storage
+                    .put_bytes(file, contents, Default::default())
+                    .await
+                    .unwrap();
+            }
+        })
+        .buffer_unordered(32)
+        .collect()
+        .await
 }
 
 impl Arbitrary for SegmentGroup {

--- a/rust/garbage_collector/tests/proptest_helpers/stats.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/stats.rs
@@ -1,8 +1,15 @@
 use super::{garbage_collector_reference::ReferenceState, proptest_types::Transition};
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 #[derive(Default)]
 pub(crate) struct Stats {
+    pub case_start: Option<Instant>,
+    pub case_durations: Vec<Duration>,
+    pub transition_durations: Vec<Duration>,
+    pub transitions_per_case: Vec<usize>,
+    pub current_num_transitions: usize,
+
     /// Fork tree: file path -> # of times used in tree
     pub file_usage_counts: Vec<HashMap<String, usize>>,
     pub current_fork_tree: Option<HashMap<String, usize>>, // gets moved into file_usage_counts at end of each test case
@@ -18,7 +25,14 @@ pub(crate) struct Stats {
 }
 
 impl Stats {
+    pub fn record_test_case_start(&mut self) {
+        self.case_start = Some(Instant::now());
+        self.current_num_transitions = 0;
+    }
+
     pub fn record_transition(&mut self, transition: &Transition, ref_state: &ReferenceState) {
+        self.current_num_transitions += 1;
+
         match transition {
             Transition::CreateCollection { segments, .. } => {
                 let current_fork_tree = self.current_fork_tree.get_or_insert_with(HashMap::new);
@@ -51,7 +65,17 @@ impl Stats {
         }
     }
 
+    pub fn record_transition_duration(&mut self, duration: Duration) {
+        self.transition_durations.push(duration);
+    }
+
     pub fn record_test_case_end(&mut self) {
+        if let Some(case_start) = self.case_start.take() {
+            self.case_durations.push(case_start.elapsed());
+        }
+        self.transitions_per_case.push(self.current_num_transitions);
+        self.current_num_transitions = 0;
+
         // Move the current fork tree into the file usage counts
         let current_fork_tree = self.current_fork_tree.take().unwrap_or_default();
         self.file_usage_counts.push(current_fork_tree);
@@ -71,7 +95,63 @@ impl Stats {
 
 impl Drop for Stats {
     fn drop(&mut self) {
+        fn average_duration(durations: &[Duration]) -> Duration {
+            if durations.is_empty() {
+                return Duration::ZERO;
+            }
+
+            Duration::from_secs_f64(
+                durations.iter().map(Duration::as_secs_f64).sum::<f64>() / durations.len() as f64,
+            )
+        }
+
+        fn p50_duration(durations: &[Duration]) -> Duration {
+            if durations.is_empty() {
+                return Duration::ZERO;
+            }
+
+            let mut durations = durations.to_vec();
+            durations.sort();
+            durations[durations.len() / 2]
+        }
+
+        fn average_usize(values: &[usize]) -> f64 {
+            if values.is_empty() {
+                return 0.0;
+            }
+
+            values.iter().sum::<usize>() as f64 / values.len() as f64
+        }
+
+        fn p50_usize(values: &[usize]) -> usize {
+            if values.is_empty() {
+                return 0;
+            }
+
+            let mut values = values.to_vec();
+            values.sort();
+            values[values.len() / 2]
+        }
+
         println!("Statistics:");
+        println!("  Test cases: {}", self.case_durations.len());
+        println!(
+            "  Transitions: {} total, {:.2} average/case, {} p50/case",
+            self.transition_durations.len(),
+            average_usize(&self.transitions_per_case),
+            p50_usize(&self.transitions_per_case)
+        );
+        println!(
+            "  Case duration: {:.4}s average, {:.4}s p50",
+            average_duration(&self.case_durations).as_secs_f64(),
+            p50_duration(&self.case_durations).as_secs_f64()
+        );
+        println!(
+            "  Transition duration: {:.4}s average, {:.4}s p50",
+            average_duration(&self.transition_durations).as_secs_f64(),
+            p50_duration(&self.transition_durations).as_secs_f64()
+        );
+
         let total_num_files: usize = self
             .file_usage_counts
             .iter()
@@ -83,11 +163,19 @@ impl Drop for Stats {
             .file_usage_counts
             .iter()
             .map(|file_usage| {
+                if file_usage.is_empty() {
+                    return 0.0;
+                }
+
                 let num_reused_files = file_usage.iter().filter(|(_, count)| **count > 1).count();
                 num_reused_files as f64 / file_usage.len() as f64
             })
-            .sum::<f64>()
-            / self.file_usage_counts.len() as f64;
+            .sum::<f64>();
+        let average_file_reuse = if self.file_usage_counts.is_empty() {
+            0.0
+        } else {
+            average_file_reuse / self.file_usage_counts.len() as f64
+        };
         println!(
             "  Average file reuse: {:.2}% of files were reused at least once (per tree)",
             average_file_reuse * 100.0
@@ -104,8 +192,11 @@ impl Drop for Stats {
                     .map(|(_, count)| *count)
             })
             .collect::<Vec<usize>>();
-        let average_reuse_count: f64 =
-            reused_files_counts.iter().sum::<usize>() as f64 / reused_files_counts.len() as f64;
+        let average_reuse_count: f64 = if reused_files_counts.is_empty() {
+            0.0
+        } else {
+            reused_files_counts.iter().sum::<usize>() as f64 / reused_files_counts.len() as f64
+        };
         println!(
             "  Files that were reused were reused an average of: {:.2} times (per tree)",
             average_reuse_count
@@ -115,16 +206,24 @@ impl Drop for Stats {
             .fork_tree_depths
             .iter()
             .map(|depth| *depth as f64)
-            .sum::<f64>()
-            / self.fork_tree_depths.len() as f64;
+            .sum::<f64>();
+        let average_fork_tree_depth = if self.fork_tree_depths.is_empty() {
+            0.0
+        } else {
+            average_fork_tree_depth / self.fork_tree_depths.len() as f64
+        };
         println!("  Average tree depth: {:.2}", average_fork_tree_depth);
 
         let average_num_forks: f64 = self
             .num_forks_per_tree
             .iter()
             .map(|num_forks| *num_forks as f64)
-            .sum::<f64>()
-            / self.num_forks_per_tree.len() as f64;
+            .sum::<f64>();
+        let average_num_forks = if self.num_forks_per_tree.is_empty() {
+            0.0
+        } else {
+            average_num_forks / self.num_forks_per_tree.len() as f64
+        };
         println!(
             "  Average number of forks: {:.2} (per tree)",
             average_num_forks
@@ -134,8 +233,12 @@ impl Drop for Stats {
             .num_versions_per_tree
             .iter()
             .map(|num_versions| *num_versions as f64)
-            .sum::<f64>()
-            / self.num_versions_per_tree.len() as f64;
+            .sum::<f64>();
+        let average_num_versions = if self.num_versions_per_tree.is_empty() {
+            0.0
+        } else {
+            average_num_versions / self.num_versions_per_tree.len() as f64
+        };
         println!(
             "  Average number of versions: {:.2} (per tree)",
             average_num_versions
@@ -150,6 +253,11 @@ macro_rules! define_thread_local_stats {
             static $name: ::std::cell::RefCell<$crate::proptest_helpers::stats::Stats> = const {
                 ::std::cell::RefCell::new(
                     $crate::proptest_helpers::stats::Stats {
+                        case_start: None,
+                        case_durations: vec![],
+                        transition_durations: vec![],
+                        transitions_per_case: vec![],
+                        current_num_transitions: 0,
                         file_usage_counts: vec![],
                         current_fork_tree: None,
                         fork_tree_depths: vec![],


### PR DESCRIPTION
## Description of changes

Optimize the garbage collector proptest suite for faster execution:

- Add configurable proptest profiles (default: fast, CHROMA_GC_PROPTEST_PROFILE=deep
  for thorough runs) controlling case count, shrink iters, and transition range
- Cache collection lookups in ReferenceState with indexed maps
  (latest_node_by_collection, versions_by_collection, alive_collection_ids,
  node_depth) replacing O(n) graph scans with O(1) lookups
- Precompute graph_depth incrementally instead of running Dijkstra each time
- Override test_sequential to run expensive invariant checks (sysdb queries,
  file-on-disk verification) only after Delete/GC transitions, not every step
- Track written_files to skip redundant S3 uploads for shared/forked files
- Simplify strategies: replace prop_flat_map with prop_map for HNSW/USearch
  generation (no randomness needed), use subsequence instead of
  select+prop_filter for sparse index forking
- Scope storage list_prefix to tenant prefix instead of scanning all files
- Derive Copy for SegmentIds, Ord/PartialOrd for SegmentFileReferenceType
- Add per-case and per-transition timing to stats, fix div-by-zero on empty

## Test plan

Some tests passed locally.  Others not run.  That's why I CI.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
