### PR TITLE
[CHORE](ci) speed up release-mode CI check

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -7,6 +7,10 @@ inputs:
   workspaces:
     description: "Workspace paths to cache (see documentation on Swatinem/rust-cache for details)"
     required: false
+  install-nextest:
+    description: "Install cargo-nextest"
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -36,4 +40,5 @@ runs:
       with:
         workspaces: ${{ inputs.workspaces }}
     - name: Setup Nextest
+      if: ${{ inputs.install-nextest == 'true' }}
       uses: taiki-e/install-action@nextest

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -202,5 +202,8 @@ jobs:
         uses: ./.github/actions/rust
         with:
           github-token: ${{ github.token }}
-      - name: Build in release mode
-        run: cargo build --release
+          install-nextest: "false"
+      # PR CI only needs to catch release-profile compile errors. Release
+      # workflows still build the optimized artifacts with cargo build --release.
+      - name: Check release mode
+        run: cargo check --release


### PR DESCRIPTION
## Description of changes

Replace `cargo build --release` with `cargo check --release` in CI.
The PR job only needs to catch release-profile compile errors; actual
optimized artifacts are still built by the release workflows.

Add an `install-nextest` input (default true) to the shared Rust
setup action so jobs that do not run tests can skip the nextest install.

## Test plan

CI because it's a CI change

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
