### PR TITLE
[CHORE](ci) add broad chromadb/test/api entry to cluster test matrix

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -151,6 +151,11 @@ jobs:
           - "chromadb/test/distributed/test_statistics_wrapper.py"
           - "chromadb/test/api/test_indexing_status.py"
         include:
+          - test-glob: "chromadb/test/api"
+            pytest-extra-args: >-
+              --ignore=chromadb/test/api/test_collection.py
+              --ignore=chromadb/test/api/test_indexing_status.py
+              --ignore=chromadb/test/api/test_limit_offset.py
           - test-glob: "chromadb/test/property/test_add.py"
             parallelized: false
           - test-glob: "chromadb/test/property/test_embeddings.py"
@@ -179,7 +184,7 @@ jobs:
       - name: Start Tilt services
         uses: ./.github/actions/tilt
       - name: Test
-        run: bin/cluster-test.sh bash -c 'python -m pytest -x "${{ matrix.test-glob }}" ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} --durations 10'
+        run: bin/cluster-test.sh bash -c 'python -m pytest -x "${{ matrix.test-glob }}" ${{ matrix.pytest-extra-args || '' }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} --durations 10'
         shell: bash
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}


### PR DESCRIPTION
## Description of changes

The three dedicated API test jobs (test_collection, test_indexing_status,
test_limit_offset) only cover 60 of the 518 tests under chromadb/test/api.
Add a catch-all matrix entry for the directory that --ignores those three
files so every API test runs in CI without duplication.

Full collection confirms no tests are dropped:
  chromadb/test/api (broad)        458
  test_collection.py                15
  test_indexing_status.py           40
  test_limit_offset.py               5
  total                            518

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
