### PR TITLE
[CHORE](ci) bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/actions/export-tilt-logs/action.yaml
+++ b/.github/actions/export-tilt-logs/action.yaml
@@ -13,7 +13,7 @@ runs:
         bin/get-logs.sh ${{ inputs.artifact-name }}.zip
       shell: bash
     - name: Upload logs as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
         path: "${{ inputs.artifact-name }}.zip"

--- a/.github/actions/go/action.yaml
+++ b/.github/actions/go/action.yaml
@@ -3,7 +3,7 @@ description: "This action sets up Go"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         cache-dependency-path: go/go.sum
 

--- a/.github/actions/python/action.yaml
+++ b/.github/actions/python/action.yaml
@@ -9,11 +9,11 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
     - name: Set up Python 3.9 for protos
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.9"
 
@@ -34,7 +34,7 @@ runs:
         uv pip uninstall --system grpcio grpcio-tools
       shell: bash
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
     - name: Install dependencies

--- a/.github/actions/runtime-report/action.yaml
+++ b/.github/actions/runtime-report/action.yaml
@@ -25,7 +25,7 @@ runs:
           --max-step-rows "${{ inputs.max-step-rows }}"
         cat "${{ inputs.out-dir }}/gha-runtime-report.md" >> "$GITHUB_STEP_SUMMARY"
     - name: Upload runtime report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: gha-runtime-report
         path: ${{ inputs.out-dir }}/

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -27,7 +27,7 @@ runs:
       run: |
         rustup default $(grep -m1 '^channel' rust-toolchain.toml | cut -d'"' -f2)
     - name: Install Protoc
-      uses: chroma-core/setup-protoc@v4a
+      uses: chroma-core/setup-protoc@v4b
       with:
         repo-token: ${{ inputs.github-token }}
         version: v35.0

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Cache Rust toolchain
       id: cache-rustup
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       if: ${{ runner.os != 'windows' }}
       with:
         path: ~/.rustup
@@ -27,7 +27,7 @@ runs:
       run: |
         rustup default $(grep -m1 '^channel' rust-toolchain.toml | cut -d'"' -f2)
     - name: Install Protoc
-      uses: chroma-core/setup-protoc@v3
+      uses: chroma-core/setup-protoc@v4a
       with:
         repo-token: ${{ inputs.github-token }}
         version: v35.0

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -1,5 +1,6 @@
 name: JS Bindings CI
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   DEBUG: napi:*
   APP_NAME: "chromadb-js-bindings"
   MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -17,14 +18,14 @@ jobs:
       run:
         working-directory: rust/js_bindings
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -38,7 +39,7 @@ jobs:
           rustup target add x86_64-apple-darwin
           rustup target add aarch64-apple-darwin
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -56,13 +57,13 @@ jobs:
         run: pnpm build --target x86_64-apple-darwin
         shell: bash
       - name: Upload ARM64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-aarch64-apple-darwin
           path: rust/js_bindings/chromadb-js-bindings.darwin-arm64.node
           if-no-files-found: error
       - name: Upload x86_64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-x86_64-apple-darwin
           path: rust/js_bindings/chromadb-js-bindings.darwin-x64.node
@@ -75,14 +76,14 @@ jobs:
       run:
         working-directory: rust/js_bindings
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -95,7 +96,7 @@ jobs:
         run: rustup target add x86_64-pc-windows-msvc
         shell: bash
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -110,7 +111,7 @@ jobs:
         run: pnpm build --target x86_64-pc-windows-msvc
         shell: bash
       - name: Upload x86_64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-x86_64-pc-windows-msvc
           path: rust/js_bindings/chromadb-js-bindings.win32-x64-msvc.node
@@ -123,14 +124,14 @@ jobs:
       run:
         working-directory: rust/js_bindings
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -151,7 +152,7 @@ jobs:
             g++-aarch64-linux-gnu \
             libc6-dev-arm64-cross
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -177,13 +178,13 @@ jobs:
         run: pnpm build --target x86_64-unknown-linux-gnu
         shell: bash
       - name: Upload ARM64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-aarch64-unknown-linux-gnu
           path: rust/js_bindings/chromadb-js-bindings.linux-arm64-gnu.node
           if-no-files-found: error
       - name: Upload x86_64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-x86_64-unknown-linux-gnu
           path: rust/js_bindings/chromadb-js-bindings.linux-x64-gnu.node
@@ -199,14 +200,14 @@ jobs:
       - build-windows
       - build-linux
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -214,7 +215,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: rust/js_bindings/artifacts
       - name: List downloads

--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -41,6 +41,7 @@ permissions:
   packages: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   GHCR_IMAGE_NAME: "ghcr.io/chroma-core/chroma"
   DOCKERHUB_IMAGE_NAME: "chromadb/chroma"
 
@@ -61,7 +62,7 @@ jobs:
             docker_platform: linux/arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -123,7 +124,7 @@ jobs:
       - build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Docker
         uses: ./.github/actions/docker
         with:

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -38,6 +38,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   version:
     name: Resolve version
@@ -46,7 +49,7 @@ jobs:
       version: ${{ steps.resolve_version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Resolve version
         shell: bash
         id: resolve_version
@@ -72,14 +75,14 @@ jobs:
           - { os: macos, runner: macos-14, target: aarch64 }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Rust
         uses: ./.github/actions/rust
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 
@@ -110,7 +113,7 @@ jobs:
           container: "off"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.platform.os }}-${{ matrix.platform.target }}
           path: dist
@@ -120,7 +123,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: version
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Rust
         uses: ./.github/actions/rust
         with:
@@ -153,7 +156,7 @@ jobs:
           pip install dist/*.tar.gz
           python -c "import chromadb; api = chromadb.Client(); print(api.heartbeat())"
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: dist
@@ -171,10 +174,10 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: 'wheels-*/*'
 

--- a/.github/workflows/_build_release_service_images.yml
+++ b/.github/workflows/_build_release_service_images.yml
@@ -64,6 +64,7 @@ on:
         value: ${{ jobs.build.outputs.commit_short_sha }}
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   AWS_REGION: us-east-1
 
 # Avoid two concurrent runs building the same commit. A second trigger
@@ -84,7 +85,7 @@ jobs:
       commit_short_sha: ${{ steps.bake.outputs.commit_short_sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.commit-sha || github.sha }}
 

--- a/.github/workflows/_check_rust_release.yml
+++ b/.github/workflows/_check_rust_release.yml
@@ -3,6 +3,9 @@ name: Rust tests
 on:
   workflow_call:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     strategy:
@@ -15,7 +18,7 @@ jobs:
       RUST_MIN_STACK_SIZE: 8388608
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/rust
         with:

--- a/.github/workflows/_check_spanner_migrations.yml
+++ b/.github/workflows/_check_spanner_migrations.yml
@@ -3,6 +3,9 @@ name: Check Spanner migrations
 on:
   workflow_call:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   check-migrations:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -10,7 +13,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/rust
         with:

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -9,13 +9,16 @@ on:
         default: false
         type: boolean
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   deploy:
     name: Deploy all -- staging
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Deploy all -- staging
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN}}
           script: |

--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -3,6 +3,9 @@ name: Go tests
 on:
   workflow_call:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   cluster-test:
     runs-on: "blacksmith-16vcpu-ubuntu-2404"
@@ -12,7 +15,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/go
       - name: Set up Docker

--- a/.github/workflows/_javascript-client-tests.yml
+++ b/.github/workflows/_javascript-client-tests.yml
@@ -3,12 +3,15 @@ name: JavaScript client tests
 on:
   workflow_call:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust
         uses: ./.github/actions/rust
         with:

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -19,6 +19,7 @@ on:
         type: string
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   CHROMA_HYPOTHESIS_CI_REPRODUCE_ONLY: "1"
   CHROMA_HYPOTHESIS_COMPACTION_WAITS: "auto"
 
@@ -39,7 +40,7 @@ jobs:
 
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Python
         uses: ./.github/actions/python
         with:
@@ -81,7 +82,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Setup Python (${{ matrix.python }})
       uses: ./.github/actions/python
     - name: Setup Rust
@@ -108,7 +109,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Python (${{ matrix.python }})
         uses: ./.github/actions/python
         with:
@@ -166,7 +167,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Python (${{ matrix.python }})
         uses: ./.github/actions/python
         with:
@@ -201,7 +202,7 @@ jobs:
     needs: test-cluster-rust-frontend
     steps:
       - name: Merge
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: cluster_test_logs
           pattern: cluster_logs_*
@@ -215,7 +216,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Python (${{ matrix.python }})
         uses: ./.github/actions/python
         with:
@@ -246,7 +247,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Setup Python (${{ matrix.python }})
       uses: ./.github/actions/python
     - name: Setup Rust
@@ -279,7 +280,7 @@ jobs:
     runs-on: 8core-32gb-windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Python
         uses: ./.github/actions/python
         with:

--- a/.github/workflows/_python-vulnerability-scan.yml
+++ b/.github/workflows/_python-vulnerability-scan.yml
@@ -3,11 +3,14 @@ name: Scan for Python Vulnerabilities
 on:
   workflow_call:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   bandit-scan:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/python
       - uses: ./.github/actions/bandit-scan/
@@ -17,7 +20,7 @@ jobs:
           bandit-config: 'bandit.yaml'
           output-file: 'bandit-report.json'
       - name: Upload Bandit Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bandit-artifact
           path: |

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -11,6 +11,9 @@ on:
         type: boolean
         default: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     strategy:
@@ -23,7 +26,7 @@ jobs:
       RUST_MIN_STACK_SIZE: 8388608
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/rust
         with:
@@ -42,7 +45,7 @@ jobs:
       RUST_MIN_STACK_SIZE: 8388608
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/rust
         with:
@@ -58,7 +61,7 @@ jobs:
       RUST_MIN_STACK_SIZE: 8388608
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/rust
         with:
@@ -94,7 +97,7 @@ jobs:
       RUST_MIN_STACK_SIZE: 8388608
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/rust
         with:
@@ -134,7 +137,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/rust
         with:
@@ -153,7 +156,7 @@ jobs:
   #     RUST_MIN_STACK_SIZE: 8388608
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v5
   #     - name: Setup
   #       uses: ./.github/actions/rust
   #       with:
@@ -197,7 +200,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/rust
         with:

--- a/.github/workflows/apply-hotfix.yaml
+++ b/.github/workflows/apply-hotfix.yaml
@@ -8,6 +8,9 @@ on:
       branch_name:
         description: 'Name of branch (release/* or rc/*) to apply hotfix to. Defaults to latest release branch.'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   resolve-branch:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -16,7 +19,7 @@ jobs:
       branch_type: ${{ steps.resolve_branch.outputs.branch_type }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -45,7 +48,7 @@ jobs:
       - resolve-branch
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
           fetch-depth: 0
@@ -93,7 +96,7 @@ jobs:
           git push origin $BRANCH_NAME
 
       - name: Create Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
           script: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -7,6 +7,7 @@ on:
       - cron: '15 9 * * *'
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   CHROMA_HYPOTHESIS_CI_REPRODUCE_ONLY: "1"
   CHROMA_HYPOTHESIS_COMPACTION_WAITS: "always"
 
@@ -21,7 +22,7 @@ jobs:
                    "chromadb/test/property/test_embeddings.py"]
     runs-on: "blacksmith-8vcpu-ubuntu-2404"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/python
         with:
           python-version: "3.12"
@@ -54,7 +55,7 @@ jobs:
     needs: test-cluster
     steps:
       - name: Merge
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: cluster_test_logs
           pattern: cluster_logs_*
@@ -70,7 +71,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Generate runtime report
         continue-on-error: true
         uses: ./.github/actions/runtime-report

--- a/.github/workflows/pr-check-title.yml
+++ b/.github/workflows/pr-check-title.yml
@@ -11,6 +11,9 @@ on:
       - main
       - '**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   check-title:
     name: Check PR Title

--- a/.github/workflows/pr-review-checklist.yml
+++ b/.github/workflows/pr-review-checklist.yml
@@ -5,16 +5,19 @@ on:
     types:
       - opened
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   PR-Comment:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: PR Comment
-      uses: actions/github-script@v2
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.createComment({
+          await github.rest.issues.createComment({
             issue_number: ${{ github.event.number }},
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # This job detects what changed and determines which tests to run
   change-detection:
@@ -22,7 +25,7 @@ jobs:
       # Helm version check
       helm-version-changed: ${{ steps.helm-version.outputs.version_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
@@ -121,7 +124,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Comment warning
         if: needs.change-detection.outputs.helm-version-changed == 'false'
         uses: marocchino/sticky-pull-request-comment@v2
@@ -166,7 +169,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Blacksmith builder
         uses: useblacksmith/setup-docker-builder@v1
       - name: Build all CI images (warms BuildKit cache on sticky disk)
@@ -235,7 +238,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: ./.github/actions/python
         with:
           python-version: "3.11"
@@ -304,7 +307,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Generate runtime report
         continue-on-error: true
         uses: ./.github/actions/runtime-report

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   check-tag:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -29,11 +32,11 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
       - name: Install setuptools_scm
@@ -119,7 +122,7 @@ jobs:
       - go-tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python
@@ -156,11 +159,11 @@ jobs:
       - release-thin-pypi
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: wheels-*
           path: dist
@@ -226,7 +229,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Generate runtime report
         continue-on-error: true
         uses: ./.github/actions/runtime-report

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -10,13 +10,16 @@ on:
     tags:
       - 'cli_release_[0-9]*.[0-9]*.[0-9]*'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-linux:
     name: Build Linux binary
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: ./.github/actions/rust
@@ -30,7 +33,7 @@ jobs:
         run: mv target/release/chroma ./chroma-linux
 
       - name: Upload Linux binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chroma-linux
           path: chroma-linux
@@ -40,7 +43,7 @@ jobs:
     runs-on: 8core-32gb-windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: ./.github/actions/rust
@@ -58,7 +61,7 @@ jobs:
           Get-ChildItem -Path ..
 
       - name: Upload Windows binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chroma-windows
           path: chroma-windows.exe
@@ -68,7 +71,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: ./.github/actions/rust
@@ -95,13 +98,13 @@ jobs:
           chmod +x ./chroma-macos-intel ./chroma-macos-arm64
 
       - name: Upload macOS Intel binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chroma-macos-intel
           path: chroma-macos-intel
 
       - name: Upload macOS ARM64 binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chroma-macos-arm64
           path: chroma-macos-arm64
@@ -110,12 +113,14 @@ jobs:
     name: Create GitHub Release and Attach Assets
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [ build-linux, build-windows, build-macos ]
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 
@@ -140,54 +145,15 @@ jobs:
             echo "tag_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Create GitHub release and upload assets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.release_info.outputs.tag_name }}
-          release_name: ${{ steps.release_info.outputs.release_name }}
-          body: "CLI release."
-          draft: false
-          prerelease: false
-
-      - name: Upload Linux binary to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/chroma-linux/chroma-linux
-          asset_name: chroma-linux
-          asset_content_type: application/octet-stream
-
-      - name: Upload Windows binary to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/chroma-windows/chroma-windows.exe
-          asset_name: chroma-windows.exe
-          asset_content_type: application/octet-stream
-
-      - name: Upload macOS Intel binary to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/chroma-macos-intel/chroma-macos-intel
-          asset_name: chroma-macos-intel
-          asset_content_type: application/octet-stream
-
-      - name: Upload macOS ARM64 binary to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/chroma-macos-arm64/chroma-macos-arm64
-          asset_name: chroma-macos-arm64
-          asset_content_type: application/octet-stream
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.release_info.outputs.tag_name }}" \
+            "artifacts/chroma-linux/chroma-linux#chroma-linux" \
+            "artifacts/chroma-windows/chroma-windows.exe#chroma-windows.exe" \
+            "artifacts/chroma-macos-intel/chroma-macos-intel#chroma-macos-intel" \
+            "artifacts/chroma-macos-arm64/chroma-macos-arm64#chroma-macos-arm64" \
+            --target "${{ github.sha }}" \
+            --title "${{ steps.release_info.outputs.release_name }}" \
+            --notes "CLI release."

--- a/.github/workflows/release-dev-javascript-client.yml
+++ b/.github/workflows/release-dev-javascript-client.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     name: JavaScript client tests
@@ -29,7 +32,7 @@ jobs:
             exit 1
           fi
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -40,7 +43,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "18.x"
           registry-url: ${{ matrix.registry }}
@@ -115,7 +118,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Generate runtime report
         continue-on-error: true
         uses: ./.github/actions/runtime-report

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   detect-version-change:
     name: Detect if version in Chart.yaml was changed
@@ -16,7 +19,7 @@ jobs:
       version_changed: ${{ steps.detect-version-change.outputs.version_changed }}
       version: ${{ steps.detect-version-change.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
       - name: Detect if version field in Chart.yaml was changed
@@ -50,7 +53,7 @@ jobs:
       AWS_REGION: us-east-1
     if: ${{ needs.detect-version-change.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:

--- a/.github/workflows/release-javascript-client.yml
+++ b/.github/workflows/release-javascript-client.yml
@@ -11,6 +11,7 @@ on:
         description: 'Tag to release'
         required: true
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   PNPM_CACHE_FOLDER: .cache/pnpm
 jobs:
   release:
@@ -46,7 +47,7 @@ jobs:
           exit 1
         fi
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Install pnpm
@@ -55,7 +56,7 @@ jobs:
         version: 9
         run_install: false
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "18.x"
         registry-url: ${{ matrix.registry }}


### PR DESCRIPTION
## Description of changes

Update all GitHub Actions across workflows and composite actions to
versions that support the Node 24 runtime:

- actions/checkout v3/v4 -> v5
- actions/upload-artifact v4 -> v7
- actions/download-artifact v4 -> v7
- actions/cache v4 -> v5
- actions/setup-node v4 -> v6
- actions/setup-python v5 -> v6
- actions/setup-go v5 -> v6
- actions/github-script v2/v6/v7 -> v8
- actions/attest-build-provenance v1 -> v4
- actions/upload-artifact/merge v4 -> v7
- astral-sh/setup-uv v6 -> v8.1.0
- chroma-core/setup-protoc v3 -> v4a

Replace deprecated actions/create-release and actions/upload-release-asset
in release-cli.yml with gh CLI, adding contents:write permission.

Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env var in all workflows.

## Test plan

CI as it's all CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
