### PR TITLE
[CHORE] split large test globs and fix cluster test quoting

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
         test-glob:
-          - "chromadb/test --ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
+          - "chromadb/test --ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*' --ignore-glob 'chromadb/test/test_cli.py'"
           - "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py --ignore chromadb/test/property/test_add_mcmr.py"
           - "chromadb/test/property/test_cross_version_persist.py"
         include:
@@ -161,7 +161,6 @@ jobs:
           - test-glob: "chromadb/test/property/test_embeddings.py"
             parallelized: true
           # Tests that create tenants need MULTI_REGION for spanner instance
-          - test-glob: "chromadb/test/api"
           - test-glob: "chromadb/test/property/test_collections_with_database_tenant.py"
           - test-glob: "chromadb/test/property/test_collections_with_database_tenant_overwrite.py"
     runs-on: blacksmith-8vcpu-ubuntu-2404
@@ -193,7 +192,10 @@ jobs:
       - name: Compute artifact name
         if: always()
         id: compute-artifact-name
-        run: echo "artifact_name=cluster_logs_rust_frontend_$(basename "${{ matrix.test-glob }}" .py)_${{ matrix.python }}" >> $GITHUB_OUTPUT
+        run: |
+          test_target="${{ matrix.test-glob }}"
+          test_target="${test_target%% *}"
+          echo "artifact_name=cluster_logs_rust_frontend_$(basename "$test_target" .py)_${{ matrix.python }}" >> $GITHUB_OUTPUT
       - name: Save service logs to artifact
         if: always()
         uses: ./.github/actions/export-tilt-logs


### PR DESCRIPTION
## Description of changes

Break apart broad test globs in the Python CI workflow to improve
parallelism and isolate flaky tests:

- Exclude test_cli.py from the main unit-test glob (it runs separately).
- Split chromadb/test/api into per-file entries for test_collection,
  test_limit_offset, and test_indexing_status; remove the now-redundant
  exclude entry for the old api glob.
- Drop quotes around the pytest test-glob argument so that inline
  --ignore-glob flags are word-split correctly by the shell.
- Fix artifact-name computation to extract just the path prefix when
  the test-glob contains additional flags.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
