### PR TITLE
[TST] parallelize log backpressure test for faster execution

### DIFF
--- a/chromadb/test/distributed/test_log_backpressure.py
+++ b/chromadb/test/distributed/test_log_backpressure.py
@@ -1,5 +1,8 @@
 # Add up to 2M records until the log-is-full message is seen.
 
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
 import pytest
 
 from chromadb.api import ClientAPI
@@ -13,7 +16,8 @@ EXPECTED_BACKPRESSURE_ERROR = (
     "please backoff exponentially and retry"
 )
 RECORDS = 2_000_000
-BATCH_SIZE = 100
+BATCH_SIZE = 300
+PARALLELISM = 4
 EMBEDDING = [0.0, 0.0, 0.0]
 
 
@@ -29,17 +33,42 @@ def test_log_backpressure(
 
     print("backpressuring for", collection.id)
 
-    # RECORDS is intentionally high to guarantee backpressure, but the test
-    # succeeds as soon as that condition is observed.
-    for i in range(0, RECORDS, BATCH_SIZE):
-        ids = [str(x) for x in range(i, i + BATCH_SIZE)]
-        embeddings = [EMBEDDING] * BATCH_SIZE
-        try:
-            collection.add(ids=ids, embeddings=embeddings)
-        except Exception as exc:
-            print(f"Caught exception:\n{exc}")
-            if EXPECTED_BACKPRESSURE_ERROR in str(exc):
-                return
-            raise
+    stop_event = threading.Event()
+
+    def add_batches(worker: int) -> bool:
+        # RECORDS is intentionally high to guarantee backpressure, but the test
+        # succeeds as soon as that condition is observed.
+        for batch in range(worker, RECORDS // BATCH_SIZE, PARALLELISM):
+            if stop_event.is_set():
+                return False
+
+            i = batch * BATCH_SIZE
+            ids = [str(x) for x in range(i, i + BATCH_SIZE)]
+            embeddings = [EMBEDDING] * BATCH_SIZE
+            try:
+                collection.add(ids=ids, embeddings=embeddings)
+            except Exception as exc:
+                print(f"Caught exception:\n{exc}")
+                if EXPECTED_BACKPRESSURE_ERROR in str(exc):
+                    stop_event.set()
+                    return True
+                stop_event.set()
+                raise
+        return False
+
+    with ThreadPoolExecutor(max_workers=PARALLELISM) as executor:
+        futures = [
+            executor.submit(add_batches, worker) for worker in range(PARALLELISM)
+        ]
+        found_backpressure = False
+        for future in as_completed(futures):
+            found_backpressure = future.result() or found_backpressure
+            if found_backpressure:
+                break
+
+        if found_backpressure:
+            for future in futures:
+                future.result()
+            return
 
     pytest.fail("Expected log backpressure to be triggered.")

--- a/chromadb/test/distributed/test_log_backpressure.py
+++ b/chromadb/test/distributed/test_log_backpressure.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import pytest
 
 from chromadb.api import ClientAPI
+from chromadb.errors import RateLimitError
 from chromadb.test.conftest import (
     reset,
     skip_if_not_cluster,
@@ -15,10 +16,22 @@ EXPECTED_BACKPRESSURE_ERROR = (
     "log needs compaction before accepting more writes; "
     "please backoff exponentially and retry"
 )
+EXPECTED_RATE_LIMIT_ERRORS = (
+    "Too many requests; backoff and try again",
+    "Rate limit exceeded.",
+)
 RECORDS = 2_000_000
 BATCH_SIZE = 300
 PARALLELISM = 4
 EMBEDDING = [0.0, 0.0, 0.0]
+INITIAL_RATE_LIMIT_BACKOFF_SECONDS = 0.1
+MAX_RATE_LIMIT_BACKOFF_SECONDS = 1.0
+
+
+def is_rate_limit_error(exc: Exception) -> bool:
+    return isinstance(exc, RateLimitError) or any(
+        error in str(exc) for error in EXPECTED_RATE_LIMIT_ERRORS
+    )
 
 
 @skip_if_not_cluster()
@@ -45,15 +58,28 @@ def test_log_backpressure(
             i = batch * BATCH_SIZE
             ids = [str(x) for x in range(i, i + BATCH_SIZE)]
             embeddings = [EMBEDDING] * BATCH_SIZE
-            try:
-                collection.add(ids=ids, embeddings=embeddings)
-            except Exception as exc:
-                print(f"Caught exception:\n{exc}")
-                if EXPECTED_BACKPRESSURE_ERROR in str(exc):
+            backoff = INITIAL_RATE_LIMIT_BACKOFF_SECONDS
+            while not stop_event.is_set():
+                try:
+                    collection.add(ids=ids, embeddings=embeddings)
+                    break
+                except Exception as exc:
+                    if EXPECTED_BACKPRESSURE_ERROR in str(exc):
+                        print(f"Caught exception:\n{exc}")
+                        stop_event.set()
+                        return True
+                    if is_rate_limit_error(exc):
+                        if stop_event.wait(backoff):
+                            return False
+                        backoff = min(
+                            backoff * 2,
+                            MAX_RATE_LIMIT_BACKOFF_SECONDS,
+                        )
+                        continue
+
+                    print(f"Caught exception:\n{exc}")
                     stop_event.set()
-                    return True
-                stop_event.set()
-                raise
+                    raise
         return False
 
     with ThreadPoolExecutor(max_workers=PARALLELISM) as executor:


### PR DESCRIPTION
## Description of changes

Replace serial batch adds with a ThreadPoolExecutor (4 workers) so the
log fills faster and backpressure is triggered sooner. A shared
threading.Event coordinates early stop across workers once the expected
error is observed.

Other changes:
- Increase BATCH_SIZE from 100 to 300
- Workers interleave batch ranges to avoid ID collisions

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
