### PR TITLE
Read embedding schema JSON files as UTF-8

### DIFF
--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -35,7 +35,7 @@ def get_schema_info() -> Dict[str, Dict[str, str]]:
     schema_info = {}
     for schema_name in get_available_schemas():
         schema_path = os.path.join(SCHEMAS_DIR, f"{schema_name}.json")
-        with open(schema_path, "r") as f:
+        with open(schema_path, "r", encoding="utf-8") as f:
             schema = json.load(f)
             schema_info[schema_name] = {
                 "version": schema.get("version", "1.0.0"),

--- a/chromadb/utils/embedding_functions/schemas/schema_utils.py
+++ b/chromadb/utils/embedding_functions/schemas/schema_utils.py
@@ -33,7 +33,7 @@ def load_schema(schema_name: str) -> Dict[str, Any]:
     if schema_name in cached_schemas:
         return cached_schemas[schema_name]
     schema_path = os.path.join(SCHEMAS_DIR, f"{schema_name}.json")
-    with open(schema_path, "r") as f:
+    with open(schema_path, "r", encoding="utf-8") as f:
         schema = cast(Dict[str, Any], json.load(f))
         cached_schemas[schema_name] = schema
         return schema


### PR DESCRIPTION
## Description
- Adds explicit UTF-8 encoding when loading embedding-function schema JSON files in `schema_utils.py` and `registry.py`.

## Why
These schema files are repository text fixtures. Passing an explicit encoding avoids relying on the platform default when Chroma loads schema metadata or validates embedding function configs.

## Verification
- `python -m py_compile chromadb/utils/embedding_functions/schemas/schema_utils.py chromadb/utils/embedding_functions/schemas/registry.py`

I also attempted the focused schema test file locally, but this environment is missing project dependencies (`overrides` during test collection), so I could not complete pytest here.