### PR TITLE
[ENH](quota): Include schema in quota enforcement for add/update/upsert

### DIFF
--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use chroma_error::ChromaError;
-use chroma_types::{plan::SearchPayload, CollectionUuid, Metadata, UpdateMetadata, Where};
+use chroma_types::{plan::SearchPayload, CollectionUuid, Metadata, Schema, UpdateMetadata, Where};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 use thiserror::Error;
@@ -98,6 +98,7 @@ pub struct QuotaPayload<'other> {
     pub query_ids: Option<&'other [String]>,
     pub collection_uuid: Option<CollectionUuid>,
     pub search_payloads: &'other [SearchPayload],
+    pub schema: Option<&'other Schema>,
 }
 
 impl<'other> QuotaPayload<'other> {
@@ -125,6 +126,7 @@ impl<'other> QuotaPayload<'other> {
             query_ids: None,
             collection_uuid: None,
             search_payloads: &[],
+            schema: None,
         }
     }
 
@@ -232,6 +234,11 @@ impl<'other> QuotaPayload<'other> {
 
     pub fn with_search_payloads(mut self, payloads: &'other [SearchPayload]) -> Self {
         self.search_payloads = payloads;
+        self
+    }
+
+    pub fn with_schema(mut self, schema: &'other Schema) -> Self {
+        self.schema = Some(schema);
         self
     }
 }

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -2017,6 +2017,15 @@ async fn collection_add(
         .get("x-chroma-token")
         .map(|val| val.to_str().unwrap_or_default())
         .map(|val| val.to_string());
+
+    let database_name = DatabaseName::new(&database).ok_or_else(|| {
+        ValidationError::InvalidArgument("database name must be at least 3 characters".to_string())
+    })?;
+    let collection = server
+        .frontend
+        .get_cached_collection(database_name, collection_id)
+        .await?;
+
     let mut quota_payload = QuotaPayload::new(Action::Add, tenant.clone(), api_token);
     quota_payload = quota_payload.with_ids(&payload.ids);
 
@@ -2032,6 +2041,9 @@ async fn collection_add(
         quota_payload = quota_payload.with_uris(uris);
     }
     quota_payload = quota_payload.with_collection_uuid(collection_id);
+    if let Some(ref schema) = collection.schema {
+        quota_payload = quota_payload.with_schema(schema);
+    }
     let _ = server.quota_enforcer.enforce(&quota_payload).await?;
 
     // Create a metering context
@@ -2151,6 +2163,15 @@ async fn collection_update(
         .get("x-chroma-token")
         .map(|val| val.to_str().unwrap_or_default())
         .map(|val| val.to_string());
+
+    let database_name = DatabaseName::new(&database).ok_or_else(|| {
+        ValidationError::InvalidArgument("database name must be at least 3 characters".to_string())
+    })?;
+    let collection = server
+        .frontend
+        .get_cached_collection(database_name, collection_id)
+        .await?;
+
     let mut quota_payload = QuotaPayload::new(Action::Update, tenant.clone(), api_token);
     quota_payload = quota_payload.with_ids(&payload.ids);
     let payload_embeddings: Option<Vec<Option<Vec<f32>>>> =
@@ -2166,6 +2187,9 @@ async fn collection_update(
     }
     if let Some(uris) = &payload.uris {
         quota_payload = quota_payload.with_uris(uris);
+    }
+    if let Some(ref schema) = collection.schema {
+        quota_payload = quota_payload.with_schema(schema);
     }
     let _ = server.quota_enforcer.enforce(&quota_payload).await?;
 
@@ -2288,6 +2312,15 @@ async fn collection_upsert(
         .get("x-chroma-token")
         .map(|val| val.to_str().unwrap_or_default())
         .map(|val| val.to_string());
+
+    let database_name = DatabaseName::new(&database).ok_or_else(|| {
+        ValidationError::InvalidArgument("database name must be at least 3 characters".to_string())
+    })?;
+    let collection = server
+        .frontend
+        .get_cached_collection(database_name, collection_id)
+        .await?;
+
     let mut quota_payload = QuotaPayload::new(Action::Upsert, tenant.clone(), api_token);
     quota_payload = quota_payload.with_ids(&payload.ids);
     let payload_embeddings: Vec<Vec<f32>> = decode_embeddings(payload.embeddings)?;
@@ -2302,6 +2335,9 @@ async fn collection_upsert(
         quota_payload = quota_payload.with_uris(uris);
     }
     quota_payload = quota_payload.with_collection_uuid(collection_id);
+    if let Some(ref schema) = collection.schema {
+        quota_payload = quota_payload.with_schema(schema);
+    }
     let _ = server.quota_enforcer.enforce(&quota_payload).await?;
 
     // Create a metering context

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -2239,6 +2239,15 @@ impl Schema {
         }
     }
 
+    /// Returns true if the inverted index is disabled for the given key and value type.
+    /// Used to determine if the larger document size quota should apply for unindexed fields.
+    pub fn is_metadata_key_unindexed(&self, key: &str, value_type: MetadataValueType) -> bool {
+        match self.is_metadata_type_index_enabled(key, value_type) {
+            Ok(enabled) => !enabled,
+            Err(_) => false,
+        }
+    }
+
     pub fn is_metadata_where_indexing_enabled(
         &self,
         where_clause: &Where,
@@ -3310,6 +3319,58 @@ mod tests {
         // Check that other defaults are still present
         assert!(result.defaults.float.is_some());
         assert!(result.defaults.int.is_some());
+    }
+
+    #[test]
+    fn test_is_metadata_key_unindexed() {
+        // Create a schema with string index disabled by default
+        let mut schema = Schema::new_default(KnnIndex::Spann);
+        schema.defaults.string = Some(StringValueType {
+            string_inverted_index: Some(StringInvertedIndexType {
+                enabled: false,
+                config: StringInvertedIndexConfig {},
+            }),
+            fts_index: None,
+        });
+
+        // Key not in schema.keys should use defaults (disabled = unindexed)
+        assert!(schema.is_metadata_key_unindexed("some_key", MetadataValueType::Str));
+
+        // Create a key-specific override with enabled index
+        schema.keys.insert(
+            "indexed_key".to_string(),
+            ValueTypes {
+                string: Some(StringValueType {
+                    string_inverted_index: Some(StringInvertedIndexType {
+                        enabled: true,
+                        config: StringInvertedIndexConfig {},
+                    }),
+                    fts_index: None,
+                }),
+                ..Default::default()
+            },
+        );
+
+        // Key with explicit enabled=true should NOT be unindexed
+        assert!(!schema.is_metadata_key_unindexed("indexed_key", MetadataValueType::Str));
+
+        // Other value types should also work
+        schema.defaults.int = Some(IntValueType {
+            int_inverted_index: Some(IntInvertedIndexType {
+                enabled: false,
+                config: IntInvertedIndexConfig {},
+            }),
+        });
+        assert!(schema.is_metadata_key_unindexed("some_key", MetadataValueType::Int));
+
+        // Enabled int index should not be unindexed
+        schema.defaults.int = Some(IntValueType {
+            int_inverted_index: Some(IntInvertedIndexType {
+                enabled: true,
+                config: IntInvertedIndexConfig {},
+            }),
+        });
+        assert!(!schema.is_metadata_key_unindexed("some_key", MetadataValueType::Int));
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

This PR enhances quota enforcement to account for schema information when validating document operations, enabling more accurate quota calculations based on whether fields are indexed.

- Improvements & Bug fixes
  - Added `is_metadata_key_unindexed()` method to `Schema` to determine if inverted indexing is disabled for a given key and value type
  - Updated `collection_add`, `collection_update`, and `collection_upsert` endpoints to fetch the collection schema and pass it to quota enforcement
  - Extended `QuotaPayload` to include optional schema reference for quota calculations

- New functionality
  - Schema is now available during quota enforcement, allowing quota logic to apply different size limits for unindexed vs indexed fields

## Test plan

- [x] Added unit test `test_is_metadata_key_unindexed()` covering schema indexing checks for string and int value types
- [x] Existing quota and collection operation tests pass

## Migration plan

No migrations required. The schema field in `QuotaPayload` is optional and backwards compatible.

## Observability plan

Quota enforcement will now have access to schema information, enabling better tracking of quota usage patterns based on field indexing configuration.

## Documentation Changes

Added docstring for `is_metadata_key_unindexed()` method explaining its purpose in determining document size quotas for unindexed fields.

https://claude.ai/code/session_012sxmuvA9ToB852BUj4UL6u