### PR TITLE
fix(types): normalize bool before int in validate_where list homogeneity check

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1268,14 +1268,23 @@ def validate_where(where: Where) -> None:
                     raise ValueError(
                         f"Expected where operand value to be a str, int, float, bool, or list of those type, got {operand}"
                     )
-                if isinstance(operand, list) and (
-                    len(operand) == 0
-                    or not all(isinstance(x, type(operand[0])) for x in operand)
-                ):
-                    raise ValueError(
-                        f"Expected where operand value to be a non-empty list, and all values to be of the same type "
-                        f"got {operand}"
-                    )
+                if isinstance(operand, list):
+                    if len(operand) == 0:
+                        raise ValueError(
+                            f"Expected where operand value to be a non-empty list, and all values to be of the same type "
+                            f"got {operand}"
+                        )
+                    # Normalize types: bool must be checked before int because
+                    # isinstance(True, int) is True, making the check order-dependent.
+                    def _norm_type(v: object) -> type:
+                        return bool if isinstance(v, bool) else type(v)
+
+                    first_type = _norm_type(operand[0])
+                    if not all(_norm_type(x) is first_type for x in operand):
+                        raise ValueError(
+                            f"Expected where operand value to be a non-empty list, and all values to be of the same type "
+                            f"got {operand}"
+                        )
 
 
 def validate_where_document(where_document: WhereDocument) -> None:

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -2276,6 +2276,19 @@ def test_where_contains_validation():
     )
 
 
+def test_where_in_operand_bool_int_ordering():
+    """$in/$nin with mixed bool/int must raise regardless of element order (bool is subclass of int)."""
+    from chromadb.api.types import validate_where
+
+    with pytest.raises(ValueError, match="same type"):
+        validate_where({"field": {"$in": [True, 1]}})
+    with pytest.raises(ValueError, match="same type"):
+        validate_where({"field": {"$in": [1, True]}})
+    # Homogeneous lists must still pass
+    validate_where({"field": {"$in": [True, False]}})
+    validate_where({"field": {"$in": [1, 2, 3]}})
+
+
 def _is_python_local_segment(client):
     """Return True when the client is backed by the Python local segment API
     (which does not yet support array metadata)."""


### PR DESCRIPTION
## What's broken

`validate_where` accepts `{"field": {"$in": [1, True]}}` but rejects `{"field": {"$in": [True, 1]}}`, even though both represent the same mixed bool/int list. Callers get inconsistent validation errors depending on element order.

## Why it happens

The check on line 1273 uses `isinstance(x, type(operand[0]))` to verify all list elements share a type. Because `bool` is a subclass of `int`, `isinstance(True, int)` is `True` but `isinstance(1, bool)` is `False`. Whichever type appears first determines whether the check passes or fails.

## Fix

Replace the order-dependent expression with a `_norm_type` helper that maps `bool` to `bool` before falling back to `type(v)`. This mirrors the approach already used correctly in `_validate_metadata_list_value` (lines 1049–1059 of the same file).

## Test

Added `test_where_in_operand_bool_int_ordering` which asserts that both `[True, 1]` and `[1, True]` raise `ValueError`, while `[True, False]` and `[1, 2, 3]` pass.

Fixes #7181