### PR TITLE
[CHORE] replace rollup_interval Duration with rollup_interval_secs u64

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2223,7 +2223,7 @@ impl LogServer {
         }
         let s3_fut = async {
             loop {
-                tokio::time::sleep(self.config.rollup_interval).await;
+                tokio::time::sleep(Duration::from_secs(self.config.rollup_interval_secs)).await;
                 if let Err(err) = self.roll_dirty_log_s3_cycle().await {
                     tracing::error!("could not roll up dirty log (s3): {err:?}");
                 }
@@ -2231,7 +2231,7 @@ impl LogServer {
         };
         let repl_fut = async {
             loop {
-                tokio::time::sleep(self.config.rollup_interval).await;
+                tokio::time::sleep(Duration::from_secs(self.config.rollup_interval_secs)).await;
                 if let Err(err) = self.roll_dirty_log_repl_cycle().await {
                     tracing::error!("could not roll up dirty log (repl): {err:?}");
                 }
@@ -3567,8 +3567,8 @@ pub struct LogServerConfig {
     pub reinsert_threshold: u64,
     #[serde(default = "LogServerConfig::default_suggested_compaction_threshold")]
     pub suggested_compaction_threshold: u64,
-    #[serde(default = "LogServerConfig::default_rollup_interval")]
-    pub rollup_interval: Duration,
+    #[serde(default = "LogServerConfig::default_rollup_interval_secs")]
+    pub rollup_interval_secs: u64,
     #[serde(default = "LogServerConfig::default_timeout_us")]
     pub timeout_us: u64,
     #[serde(default)]
@@ -3643,8 +3643,8 @@ impl LogServerConfig {
         250
     }
     /// rollup every ten seconds
-    fn default_rollup_interval() -> Duration {
-        Duration::from_secs(10)
+    fn default_rollup_interval_secs() -> u64 {
+        10
     }
 
     /// force compaction if a candidate has been on the log for one day.
@@ -3703,7 +3703,7 @@ impl Default for LogServerConfig {
             num_records_before_backpressure: Self::default_num_records_before_backpressure(),
             reinsert_threshold: Self::default_reinsert_threshold(),
             suggested_compaction_threshold: Self::default_suggested_compaction_threshold(),
-            rollup_interval: Self::default_rollup_interval(),
+            rollup_interval_secs: Self::default_rollup_interval_secs(),
             timeout_us: Self::default_timeout_us(),
             proxy_to: None,
             max_encoding_message_size: Self::default_max_encoding_message_size(),
@@ -4708,7 +4708,7 @@ mod tests {
         assert_eq!(100, config.record_count_threshold);
         assert_eq!(1_000_000, config.num_records_before_backpressure);
         assert_eq!(10, config.reinsert_threshold);
-        assert_eq!(Duration::from_secs(10), config.rollup_interval);
+        assert_eq!(10, config.rollup_interval_secs);
         assert_eq!(86_400_000_000, config.timeout_us);
         assert!(config.proxy_to.is_none());
     }

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -177,7 +177,7 @@ compaction_service:
   compactor:
     compaction_manager_queue_size: 1000
     max_concurrent_jobs: 50
-    compaction_interval_sec: 10
+    compaction_interval_sec: 1
     min_compaction_size: 10
     max_compaction_size: 10000
     max_partition_size: 5000
@@ -268,6 +268,7 @@ log_service:
   record_count_threshold: 10
   reinsert_threshold: 0
   suggested_compaction_threshold: 10
+  rollup_interval_secs: 1
   opentelemetry:
     service_name: "rust-log-service"
     endpoint: "http://otel-collector.chroma.svc.cluster.local:4317"

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -176,7 +176,7 @@ compaction_service:
   compactor:
     compaction_manager_queue_size: 1000
     max_concurrent_jobs: 10
-    compaction_interval_sec: 10
+    compaction_interval_sec: 1
     min_compaction_size: 10
     max_compaction_size: 10000
     max_partition_size: 5000
@@ -267,6 +267,7 @@ log_service:
   record_count_threshold: 10
   reinsert_threshold: 0
   suggested_compaction_threshold: 1
+  rollup_interval_secs: 1
   opentelemetry:
     service_name: "rust-log-service"
     endpoint: "http://otel-collector.chroma.svc.cluster.local:4317"

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -176,7 +176,7 @@ compaction_service:
   compactor:
     compaction_manager_queue_size: 1000
     max_concurrent_jobs: 10
-    compaction_interval_sec: 10
+    compaction_interval_sec: 1
     min_compaction_size: 10
     max_compaction_size: 10000
     max_partition_size: 5000
@@ -267,6 +267,7 @@ log_service:
   record_count_threshold: 10
   reinsert_threshold: 0
   suggested_compaction_threshold: 1
+  rollup_interval_secs: 1
   opentelemetry:
     service_name: "rust-log-service"
     endpoint: "http://otel-collector.chroma.svc.cluster.local:4317"


### PR DESCRIPTION
## Description of changes

Change LogServerConfig.rollup_interval from Duration to a plain u64
representing seconds. This simplifies serde serialization by avoiding
Duration encoding quirks and makes the YAML configs more readable.

- Rename rollup_interval to rollup_interval_secs (u64) in LogServerConfig
- Wrap with Duration::from_secs() at the two call sites in serve()
- Add explicit rollup_interval_secs: 1 to all three worker YAML configs
- Reduce compaction_interval_sec from 10 to 1 in all worker YAML configs

The goal of these changes is to speed up CI.  No defaults change.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
