### PR TITLE
[CHORE] replace a busted gha.

### DIFF
--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -182,13 +182,11 @@ jobs:
           prerelease: false
           makeLatest: true
           generateReleaseNotes: true
-      - name: Update Tag
-        uses: richardsimko/update-tag@v1.0.5
+      - name: Update latest tag
         if: ${{ needs.check-tag.outputs.tag_matches != 'true' }}
-        with:
-          tag_name: latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag --force latest
+          git push --force origin refs/tags/latest
       - name: Release Latest
         uses: ncipollo/release-action@v1.14.0
         if: ${{ needs.check-tag.outputs.tag_matches != 'true' }}


### PR DESCRIPTION
## Description of changes

This gha is no longer compatible with the config we have.  I don't trust
it.  Move off it.  Ironically, the replacement is raw git and shorter.

## Test plan

I know git.  This should work.

## Migration plan

N/A

## Observability plan

Watch merge queue.

## Documentation Changes

N/A
