### PR TITLE
[CHORE] Remove rust-toolchain.toml.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-# Keep this version in sync with rust/Dockerfile.
-channel = "1.92.0"
-components = ["rustfmt", "clippy", "llvm-tools-preview"]

--- a/rust/blockstore/benches/blockfile_writer.rs
+++ b/rust/blockstore/benches/blockfile_writer.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use chroma_blockstore::{
     arrow::{
         config::BlockManagerConfig,

--- a/rust/blockstore/src/arrow/block/value/spann_posting_list_value.rs
+++ b/rust/blockstore/src/arrow/block/value/spann_posting_list_value.rs
@@ -109,8 +109,7 @@ impl ArrowWriteableValue for &SpannPostingList<'_> {
 
         let inner_offset_id_ref = builder.doc_offset_ids_builder.values();
         let inner_version_ref = builder.doc_versions_builder.values();
-        for (doc_offset_id, doc_version) in doc_offset_ids.into_iter().zip(doc_versions.into_iter())
-        {
+        for (doc_offset_id, doc_version) in doc_offset_ids.into_iter().zip(doc_versions) {
             inner_offset_id_ref.append_value(doc_offset_id);
             inner_version_ref.append_value(doc_version);
         }

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -870,33 +870,13 @@ impl RootManager {
     fn should_prefetch(&self, id: &Uuid) -> bool {
         let mut lock_guard = self.prefetched_roots.lock();
         let expires_at = lock_guard.get(id);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Do not deploy before UNIX epoch");
         match expires_at {
-            Some(expires_at) => {
-                if SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .expect("Do not deploy before UNIX epoch")
-                    < *expires_at
-                {
-                    false
-                } else {
-                    lock_guard.insert(
-                        *id,
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .expect("Do not deploy before UNIX epoch")
-                            + std::time::Duration::from_secs(PREFETCH_TTL_HOURS * 3600),
-                    );
-                    true
-                }
-            }
-            None => {
-                lock_guard.insert(
-                    *id,
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .expect("Do not deploy before UNIX epoch")
-                        + std::time::Duration::from_secs(PREFETCH_TTL_HOURS * 3600),
-                );
+            Some(expires_at) if now < *expires_at => false,
+            Some(_) | None => {
+                lock_guard.insert(*id, now + Duration::from_secs(PREFETCH_TTL_HOURS * 3600));
                 true
             }
         }

--- a/rust/blockstore/src/lib.rs
+++ b/rust/blockstore/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 pub mod types;
 
 pub mod arrow;

--- a/rust/blockstore/tests/blockfile_writer_test.rs
+++ b/rust/blockstore/tests/blockfile_writer_test.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! This test uses the proptest-state-machine crate to generate a sequence of transitions for a blockfile writer and compares the result after every commit with a reference implementation.
 
 #[cfg(test)]

--- a/rust/cli/src/ui_utils.rs
+++ b/rust/cli/src/ui_utils.rs
@@ -69,13 +69,11 @@ pub fn read_secret(prompt: &str) -> io::Result<String> {
                     password.push(c);
                     stdout.write_all(b"*")?;
                 }
-                KeyCode::Backspace => {
-                    if !password.is_empty() {
-                        password.pop();
-                        stdout.execute(cursor::MoveLeft(1))?;
-                        stdout.write_all(b" ")?;
-                        stdout.execute(cursor::MoveLeft(1))?;
-                    }
+                KeyCode::Backspace if !password.is_empty() => {
+                    password.pop();
+                    stdout.execute(cursor::MoveLeft(1))?;
+                    stdout.write_all(b" ")?;
+                    stdout.execute(cursor::MoveLeft(1))?;
                 }
                 _ => {}
             }

--- a/rust/garbage_collector/src/lib.rs
+++ b/rust/garbage_collector/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use chroma_config::Configurable;
 use chroma_jemalloc_pprof_server::spawn_pprof_server;
 use chroma_memberlist::memberlist_provider::CustomResourceMemberlistProvider;

--- a/rust/garbage_collector/src/log_only_orchestrator.rs
+++ b/rust/garbage_collector/src/log_only_orchestrator.rs
@@ -94,8 +94,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
         &mut self,
         ctx: &ComponentContext<Self>,
     ) -> Result<(), GarbageCollectorError> {
-        let collections_to_destroy =
-            HashSet::from_iter(vec![self.collection_to_destroy].into_iter());
+        let collections_to_destroy = HashSet::from_iter(vec![self.collection_to_destroy]);
         let collections_to_garbage_collect = HashMap::new();
         let task = wrap(
             Box::new(DeleteUnusedLogsOperator {

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -56,7 +56,7 @@ impl Drop for GarbageCollectorUnderTest {
             if files.is_empty() {
                 return;
             }
-            futures::stream::iter(files.into_iter())
+            futures::stream::iter(files)
                 .map(|file| {
                     let storage = self.storage.clone();
                     async move {

--- a/rust/index/benches/fts_regex.rs
+++ b/rust/index/benches/fts_regex.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use chroma_benchmark::datasets::wikipedia_splade::WikipediaSplade;
 use chroma_blockstore::arrow::provider::BlockfileReaderOptions;
 use chroma_blockstore::{test_arrow_blockfile_provider, BlockfileWriterOptions};

--- a/rust/index/benches/full_text.rs
+++ b/rust/index/benches/full_text.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use anyhow::Result;
 use chroma_benchmark::datasets::types::Record;
 use chroma_benchmark::datasets::{

--- a/rust/index/benches/literal.rs
+++ b/rust/index/benches/literal.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use chroma_benchmark::{
     benchmark::{bench_run, tokio_multi_thread},
     datasets::rust::TheStackDedupRust,

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -156,7 +156,7 @@ impl FullTextIndexWriter {
                             }
                         });
 
-                    token_instances.extend(trigrams_to_delete.into_iter());
+                    token_instances.extend(trigrams_to_delete);
                 }
 
                 DocumentMutation::Delete {
@@ -180,7 +180,7 @@ impl FullTextIndexWriter {
                             }
                         });
 
-                    token_instances.extend(trigrams_to_delete.into_iter());
+                    token_instances.extend(trigrams_to_delete);
                 }
             }
         }

--- a/rust/index/src/lib.rs
+++ b/rust/index/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 pub mod config;
 pub mod fulltext;
 mod hnsw;

--- a/rust/index/src/spann/fast_writer.rs
+++ b/rust/index/src/spann/fast_writer.rs
@@ -617,7 +617,7 @@ impl FastSpannIndexWriter {
         let mut nearby_ids2: Vec<usize> = Vec::with_capacity(k);
         let mut nearby_distances2: Vec<f32> = Vec::with_capacity(k);
         // Get the embeddings also for distance computation.
-        for (id, distance) in nearby_ids.into_iter().zip(nearby_distances.into_iter()) {
+        for (id, distance) in nearby_ids.into_iter().zip(nearby_distances) {
             // Skip concurrently deleted heads.
             let Some(head_data) = self.heads.get(&(id as u32)) else {
                 continue;
@@ -633,7 +633,7 @@ impl FastSpannIndexWriter {
         // Embeddings that were obtained are already normalized.
         for (id, (distance, embedding)) in nearby_ids2
             .into_iter()
-            .zip(nearby_distances2.into_iter().zip(embeddings.into_iter()))
+            .zip(nearby_distances2.into_iter().zip(embeddings))
         {
             if res_ids.len() >= replica_count {
                 break;
@@ -800,7 +800,7 @@ impl FastSpannIndexWriter {
             distances: Vec::with_capacity(k),
             embeddings: Vec::with_capacity(k),
         };
-        for (id, distance) in nearest_ids.into_iter().zip(nearest_distances.into_iter()) {
+        for (id, distance) in nearest_ids.into_iter().zip(nearest_distances) {
             // Skip heads that are too far from the nearest head.
             if let Some(limit) = limit_dist {
                 if distance > limit {
@@ -856,9 +856,8 @@ impl FastSpannIndexWriter {
         }; // guard dropped here
 
         // Append to the posting list.
-        for (nearest_head_id, nearest_head_embedding) in nearest_head_ids
-            .into_iter()
-            .zip(nearest_head_embeddings.into_iter())
+        for (nearest_head_id, nearest_head_embedding) in
+            nearest_head_ids.into_iter().zip(nearest_head_embeddings)
         {
             if self.is_outdated(doc_offset_id, next_version)? {
                 return Ok(());
@@ -1574,7 +1573,7 @@ impl FastSpannIndexWriter {
             return Ok(());
         }
         // Otherwise add to the posting list of these arrays.
-        for (head_id, head_embedding) in ids.into_iter().zip(head_embeddings.into_iter()) {
+        for (head_id, head_embedding) in ids.into_iter().zip(head_embeddings) {
             Box::pin(self.append(
                 head_id as u32,
                 id,

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -983,9 +983,8 @@ impl SpannIndexWriter {
                 .insert(doc_offset_id, next_version);
         }
         // Append to the posting list.
-        for (nearest_head_id, nearest_head_embedding) in nearest_head_ids
-            .into_iter()
-            .zip(nearest_head_embeddings.into_iter())
+        for (nearest_head_id, nearest_head_embedding) in
+            nearest_head_ids.into_iter().zip(nearest_head_embeddings)
         {
             if self.is_outdated(doc_offset_id, next_version).await? {
                 return Ok(());
@@ -1804,9 +1803,8 @@ impl SpannIndexWriter {
             let (nearest_head_ids, _, nearest_head_embeddings) = self
                 .get_nearby_heads(head_embedding, self.params.num_centers_to_merge_to as usize)
                 .await?;
-            for (nearest_head_id, nearest_head_embedding) in nearest_head_ids
-                .into_iter()
-                .zip(nearest_head_embeddings.into_iter())
+            for (nearest_head_id, nearest_head_embedding) in
+                nearest_head_ids.into_iter().zip(nearest_head_embeddings)
             {
                 // Skip if it is the current head. Can't a merge a head into itself.
                 if nearest_head_id == head_id {
@@ -4405,7 +4403,7 @@ mod tests {
                 .await
                 .expect("Error scanning spann index reader");
             assert_eq!(results.len(), 10000);
-            results.sort_by(|a, b| a.doc_offset_id.cmp(&b.doc_offset_id));
+            results.sort_by_key(|a| a.doc_offset_id);
 
             for i in 0..10000 {
                 assert_eq!(results[i].doc_offset_id, doc_offset_ids[i]);
@@ -4544,7 +4542,7 @@ mod tests {
                 .await
                 .expect("Error scanning spann index reader");
             assert_eq!(results.len(), 10000);
-            results.sort_by(|a, b| a.doc_offset_id.cmp(&b.doc_offset_id));
+            results.sort_by_key(|a| a.doc_offset_id);
 
             for i in 0..10000 {
                 assert_eq!(results[i].doc_offset_id, doc_offset_ids_arc[i]);
@@ -4671,7 +4669,7 @@ mod tests {
                 .await
                 .expect("Error scanning spann index reader");
             assert_eq!(results.len(), 10000);
-            results.sort_by(|a, b| a.doc_offset_id.cmp(&b.doc_offset_id));
+            results.sort_by_key(|a| a.doc_offset_id);
 
             for i in 0..10000 {
                 assert_eq!(results[i].doc_offset_id, doc_offset_ids[i]);
@@ -4825,7 +4823,7 @@ mod tests {
                 .await
                 .expect("Error scanning spann index reader");
             assert_eq!(results.len(), 10000);
-            results.sort_by(|a, b| a.doc_offset_id.cmp(&b.doc_offset_id));
+            results.sort_by_key(|a| a.doc_offset_id);
 
             for i in 0..10000 {
                 assert_eq!(results[i].doc_offset_id, doc_offset_ids_arc[i]);
@@ -5123,7 +5121,7 @@ mod tests {
                 .scan()
                 .await
                 .expect("Error scanning spann index reader");
-            results.sort_by(|a, b| a.doc_offset_id.cmp(&b.doc_offset_id));
+            results.sort_by_key(|a| a.doc_offset_id);
 
             let mut actual_pairs: Vec<(u32, Option<Vec<f32>>)> = doc_offset_ids
                 .iter()
@@ -5199,7 +5197,7 @@ mod tests {
                 .scan()
                 .await
                 .expect("Error scanning spann index reader");
-            results.sort_by(|a, b| a.doc_offset_id.cmp(&b.doc_offset_id));
+            results.sort_by_key(|a| a.doc_offset_id);
             let mut count = 0;
             for (id, embedding) in actual_pairs.iter() {
                 if embedding.is_none() {

--- a/rust/index/tests/hnsw_reload_repro.rs
+++ b/rust/index/tests/hnsw_reload_repro.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::{
     env,
     process::{Command, Output},

--- a/rust/index/tests/maxscore/main.rs
+++ b/rust/index/tests/maxscore/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 mod common;
 
 mod ms_01_blockfile_roundtrip;

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1960,17 +1960,21 @@ impl LogServer {
         if let Some(cache) = self.cache.as_ref() {
             let mut cache_collections_to_purge = Vec::with_capacity(after.len());
             let before = rollup.rollups;
-            // Guard against division by zero if reinsert_threshold is misconfigured to 0.
-            if self.config.reinsert_threshold > 0 {
-                for (key, after_state) in after.iter() {
-                    let Some(before_state) = before.get(key) else {
-                        continue;
-                    };
-                    if before_state.reinsert_count / self.config.reinsert_threshold
-                        != after_state.reinsert_count / self.config.reinsert_threshold
-                    {
-                        cache_collections_to_purge.push(key.1);
-                    }
+            let reinsert_threshold = self.config.reinsert_threshold;
+            for (key, after_state) in after.iter() {
+                let Some(before_state) = before.get(key) else {
+                    continue;
+                };
+                if before_state
+                    .reinsert_count
+                    .checked_div(reinsert_threshold)
+                    .unwrap_or(0)
+                    != after_state
+                        .reinsert_count
+                        .checked_div(reinsert_threshold)
+                        .unwrap_or(0)
+                {
+                    cache_collections_to_purge.push(key.1);
                 }
             }
             for collection_id in cache_collections_to_purge {

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -720,7 +720,7 @@ impl GrpcLog {
             }
         }
         if !futures.is_empty() {
-            futures::future::try_join_all(futures.into_iter()).await?;
+            futures::future::try_join_all(futures).await?;
         }
         Ok(())
     }

--- a/rust/log/src/in_memory_log.rs
+++ b/rust/log/src/in_memory_log.rs
@@ -125,7 +125,7 @@ impl InMemoryLog {
             }
 
             let mut logs = filtered_records.to_vec();
-            logs.sort_by(|a, b| a.log_offset.cmp(&b.log_offset));
+            logs.sort_by_key(|a| a.log_offset);
             collections.push(CollectionInfo {
                 collection_id: *collection_id,
                 topology_name: None,

--- a/rust/rust-sysdb/src/lib.rs
+++ b/rust/rust-sysdb/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use chroma_config::Configurable;
 
 use crate::config::RootConfig;

--- a/rust/s3heap/src/lib.rs
+++ b/rust/s3heap/src/lib.rs
@@ -788,7 +788,7 @@ impl HeapWriter {
         // Execute bucket writes in parallel with concurrency limit
         use futures::stream::{self, StreamExt, TryStreamExt};
 
-        stream::iter(buckets.into_iter())
+        stream::iter(buckets)
             .map(|(bucket, entries)| async move {
                 self.internal.merge_on_s3(bucket, &entries).await
             })

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -386,7 +386,7 @@ impl<'me> MetadataSegmentWriter<'me> {
             .shards
             .iter()
             .zip(partitions.iter())
-            .zip(shard_readers.into_iter())
+            .zip(shard_readers)
             .map(|((shard, partitioned), shard_reader)| {
                 let schema_clone = schema.clone();
                 async move {

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -151,7 +151,7 @@ impl RecordSegmentWriter {
             .shards
             .iter()
             .zip(partitions.iter())
-            .zip(shard_readers.into_iter())
+            .zip(shard_readers)
             .map(|((shard, partitioned), shard_reader)| async move {
                 shard
                     .apply_materialized_log_chunk(&shard_reader, partitioned)

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -1028,7 +1028,7 @@ mod test {
             .await
             .expect("Error gettting all data from reader")
             .collect::<Vec<_>>();
-        versions_map.sort_by(|a, b| a.1.cmp(&b.1));
+        versions_map.sort_by_key(|a| a.1);
         assert_eq!(
             versions_map
                 .into_iter()

--- a/rust/segment/src/lib.rs
+++ b/rust/segment/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 pub mod blockfile_metadata;
 pub mod blockfile_record;
 pub mod bloom_filter;

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -672,10 +672,8 @@ impl MaterializeLogsResult {
                 }
             }
             None => {
-                let mut new_offset_id = 1u32;
-                for record in other_mat_logs.iter() {
+                for (new_offset_id, record) in (1u32..).zip(other_mat_logs.iter()) {
                     record.set_offset_id(new_offset_id);
-                    new_offset_id += 1;
                 }
             }
         }
@@ -1117,7 +1115,7 @@ pub async fn materialize_logs_for_rebuild(
 
     let mut res = Vec::with_capacity(logs.len());
 
-    for ((log_record, log_index), offset_id) in logs.iter().zip(offset_ids.into_iter()) {
+    for ((log_record, log_index), offset_id) in logs.iter().zip(offset_ids) {
         if log_record.record.operation != Operation::Add {
             return Err(LogMaterializerError::UnsupportedOperationForRebuild(
                 log_record.record.operation,
@@ -1371,7 +1369,7 @@ impl VectorSegmentWriter {
             .shards
             .iter()
             .zip(partitions.iter())
-            .zip(shard_readers.into_iter())
+            .zip(shard_readers)
             .map(|((shard, partitions_logs), shard_reader)| async move {
                 shard
                     .apply_materialized_log_chunk(&shard_reader, partitions_logs)

--- a/rust/spanner-migrations/src/lib.rs
+++ b/rust/spanner-migrations/src/lib.rs
@@ -68,11 +68,9 @@ const DDL_WAIT_POLL_INTERVAL_MS: u64 = 10_000;
 /// operation is still in progress is retried.
 pub fn ddl_wait_retry_setting(admin_rpc_timeout_secs: u64) -> RetrySetting {
     let poll_interval_secs = DDL_WAIT_POLL_INTERVAL_MS / 1000;
-    let take = if poll_interval_secs == 0 {
-        0
-    } else {
-        (admin_rpc_timeout_secs / poll_interval_secs) as usize
-    };
+    let take = admin_rpc_timeout_secs
+        .checked_div(poll_interval_secs)
+        .unwrap_or(0) as usize;
     RetrySetting {
         from_millis: DDL_WAIT_POLL_INTERVAL_MS,
         max_delay: Some(Duration::from_millis(DDL_WAIT_POLL_INTERVAL_MS)),

--- a/rust/sqlite/src/migrations.rs
+++ b/rust/sqlite/src/migrations.rs
@@ -149,7 +149,7 @@ impl MigrationDir {
             ));
         }
 
-        migrations.sort_by(|a, b| a.version.cmp(&b.version));
+        migrations.sort_by_key(|a| a.version);
         Ok(migrations)
     }
 }

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -419,8 +419,7 @@ impl SqliteSysDb {
             let collections = collections.unwrap();
             let collection = collections.into_iter().next().unwrap();
             // if schema exists, update schema instead of configuration
-            if collection.schema.is_some() {
-                let mut existing_schema = collection.schema.unwrap();
+            if let Some(mut existing_schema) = collection.schema {
                 existing_schema.update(&configuration);
                 schema_str = Some(
                     serde_json::to_string(&existing_schema)

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -2581,11 +2581,11 @@ impl Schema {
                 }
                 // Falls through to dispatch
             }
-            IndexConfig::SparseVector(_) => {
+            IndexConfig::SparseVector(_) if key.is_none() => {
                 // SparseVector requires a specific key
-                if key.is_none() {
-                    return Err(SchemaBuilderError::SparseVectorRequiresKey);
-                }
+                return Err(SchemaBuilderError::SparseVectorRequiresKey);
+            }
+            IndexConfig::SparseVector(_) => {
                 // Falls through to dispatch
             }
             _ => {}

--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![doc = include_str!("../README.md")]
 
 use std::sync::Arc;

--- a/rust/wal3/src/reader.rs
+++ b/rust/wal3/src/reader.rs
@@ -323,9 +323,7 @@ impl<P: FragmentPointer, FC: FragmentConsumer, MC: ManifestConsumer<P>> LogReade
             let resolved = futures::future::try_join_all(futures).await?;
             // NOTE(rescrv):  This empties snapshots before the first loop so we can fill it
             // incrementally as we find snapshots that reference snapshots.
-            for (r, s) in
-                std::iter::zip(resolved.iter(), std::mem::take(&mut snapshots).into_iter())
-            {
+            for (r, s) in std::iter::zip(resolved.iter(), std::mem::take(&mut snapshots)) {
                 if let Some(r) = r {
                     snapshots.extend(r.snapshots.iter().cloned());
                     fragments.extend(r.fragments.iter().cloned());

--- a/rust/worker/benches/filter.rs
+++ b/rust/worker/benches/filter.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::iter::once;
 
 use chroma_benchmark::benchmark::{bench_run, tokio_multi_thread};

--- a/rust/worker/benches/get.rs
+++ b/rust/worker/benches/get.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 #[allow(dead_code)]
 mod load;
 

--- a/rust/worker/benches/limit.rs
+++ b/rust/worker/benches/limit.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use chroma_benchmark::benchmark::{bench_run, tokio_multi_thread};
 use chroma_log::test::{upsert_generator, LoadFromGenerator};
 use chroma_segment::test::TestDistributedSegment;

--- a/rust/worker/benches/query.rs
+++ b/rust/worker/benches/query.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 #[allow(dead_code)]
 mod load;
 

--- a/rust/worker/benches/regex.rs
+++ b/rust/worker/benches/regex.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::collections::HashMap;
 use std::time::Duration;
 

--- a/rust/worker/benches/spann.rs
+++ b/rust/worker/benches/spann.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::collections::HashSet;
 
 use chroma_benchmark::{

--- a/rust/worker/src/compactor/scheduler_policy.rs
+++ b/rust/worker/src/compactor/scheduler_policy.rs
@@ -37,7 +37,7 @@ impl SchedulerPolicy for LasCompactionTimeSchedulerPolicy {
         number_jobs: i32,
     ) -> Vec<CompactionJob> {
         let mut collections = collections;
-        collections.sort_by(|a, b| a.last_compaction_time.cmp(&b.last_compaction_time));
+        collections.sort_by_key(|a| a.last_compaction_time);
         let number_tasks = if number_jobs > collections.len() as i32 {
             collections.len() as i32
         } else {

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 mod compactor;
 pub mod fn_consumer;
 mod server;

--- a/rust/worker/tests/config_from_default_path.rs
+++ b/rust/worker/tests/config_from_default_path.rs
@@ -7,6 +7,7 @@ use worker::config::RootConfig;
 
 #[test]
 #[serial]
+#[allow(clippy::result_large_err)]
 fn test_config_from_default_path() {
     Jail::expect_with(|jail| {
         let _ = jail.create_file(

--- a/rust/worker/tests/config_from_specific_path.rs
+++ b/rust/worker/tests/config_from_specific_path.rs
@@ -6,6 +6,7 @@ use worker::config::RootConfig;
 
 #[test]
 #[serial]
+#[allow(clippy::result_large_err)]
 fn test_config_from_specific_path() {
     Jail::expect_with(|jail| {
         let _ = jail.create_file(

--- a/rust/worker/tests/config_missing_default_field.rs
+++ b/rust/worker/tests/config_missing_default_field.rs
@@ -3,6 +3,7 @@ use figment::Jail;
 use worker::config::RootConfig;
 
 #[test]
+#[allow(clippy::result_large_err)]
 fn test_missing_default_field() {
     Jail::expect_with(|jail| {
         let _ = jail.create_file(

--- a/rust/worker/tests/config_with_env_override.rs
+++ b/rust/worker/tests/config_with_env_override.rs
@@ -5,6 +5,7 @@ use worker::config::RootConfig;
 
 #[test]
 #[serial]
+#[allow(clippy::result_large_err)]
 fn test_config_with_env_override() {
     Jail::expect_with(|jail| {
         jail.set_env("CHROMA_QUERY_SERVICE__MY_MEMBER_ID", "query-service-0");

--- a/rust/worker/tests/config_without_cache_directive.rs
+++ b/rust/worker/tests/config_without_cache_directive.rs
@@ -4,6 +4,7 @@ use worker::config::RootConfig;
 
 #[test]
 #[serial]
+#[allow(clippy::result_large_err)]
 fn test_config_without_cache_directive() {
     Jail::expect_with(|jail| {
         let _ = jail.create_file(


### PR DESCRIPTION
## Description of changes

We ride for stable.

After removing rust-toolchain.toml, the default toolchain surfaces
new clippy lints and hits recursion limits during macro expansion.

Clippy fixes across the workspace:
- Remove redundant .into_iter() calls on iterables passed to .zip(),
  .extend(), futures::stream::iter(), and HashSet::from_iter()
- Replace .sort_by(|a, b| a.field.cmp(&b.field)) with .sort_by_key()
- Use if-let instead of .is_some() followed by .unwrap()
- Merge match arms with conditions into guarded patterns
- Replace manual zero-check with checked_div
- Enumerate with (1u32..) instead of manual counter increment
- Allow clippy::result_large_err in worker integration tests

Add #![recursion_limit = "256"] to crates and benchmarks that hit the
default limit of 128 during async macro expansion: blockstore, index,
garbage_collector, log-service, rust-sysdb, segment, wal3, and worker.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
