### PR TITLE
[ENH] Forge EF

### DIFF
--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -59,6 +59,7 @@ def test_get_builtins_holds() -> None:
         "ChromaCloudSpladeEmbeddingFunction",
         "ChromaBm25EmbeddingFunction",
         "PerplexityEmbeddingFunction",
+        "ForgeEmbeddingFunction",
     }
 
     assert expected_builtins == embedding_functions.get_builtins()

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -95,6 +95,9 @@ from chromadb.utils.embedding_functions.chroma_bm25_embedding_function import (
 from chromadb.utils.embedding_functions.perplexity_embedding_function import (
     PerplexityEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.forge_embedding_function import (
+    ForgeEmbeddingFunction,
+)
 
 
 # Get all the class names for backward compatibility
@@ -132,7 +135,8 @@ _all_classes: Set[str] = {
     "ChromaCloudQwenEmbeddingFunction",
     "ChromaCloudSpladeEmbeddingFunction",
     "ChromaBm25EmbeddingFunction",
-    "PerplexityEmbeddingFunction"
+    "PerplexityEmbeddingFunction",
+    "ForgeEmbeddingFunction",
 }
 
 
@@ -171,6 +175,7 @@ known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignor
     "together_ai": TogetherAIEmbeddingFunction,
     "chroma-cloud-qwen": ChromaCloudQwenEmbeddingFunction,
     "perplexity": PerplexityEmbeddingFunction,
+    "forge": ForgeEmbeddingFunction,
 }
 
 sparse_known_embedding_functions: Dict[str, Type[SparseEmbeddingFunction]] = {  # type: ignore
@@ -301,6 +306,7 @@ __all__ = [
     "ChromaCloudSpladeEmbeddingFunction",
     "ChromaBm25EmbeddingFunction",
     "PerplexityEmbeddingFunction",
+    "ForgeEmbeddingFunction",
     "register_embedding_function",
     "config_to_embedding_function",
     "known_embedding_functions",

--- a/chromadb/utils/embedding_functions/forge_embedding_function.py
+++ b/chromadb/utils/embedding_functions/forge_embedding_function.py
@@ -1,0 +1,148 @@
+from chromadb.api.types import EmbeddingFunction, Space, Embeddings, Documents
+from chromadb.utils.embedding_functions.schemas import validate_config_schema
+from typing import List, Dict, Any, Optional
+import os
+import numpy as np
+import warnings
+
+
+class ForgeEmbeddingFunction(EmbeddingFunction[Documents]):
+    """
+    This class is used to generate embeddings for a list of texts using the
+    Forge API (https://voxell.ai).
+
+    Forge exposes an OpenAI-compatible embeddings endpoint, so this function
+    uses the ``openai`` client configured with the Forge base URL.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model_name: str = "forge-pro",
+        api_key_env_var: str = "FORGE_API_KEY",
+        api_base: str = "https://api.voxell.ai/v1",
+        dimensions: Optional[int] = None,
+    ):
+        """
+        Initialize the ForgeEmbeddingFunction.
+
+        Args:
+            api_key (str, optional): API key for the Forge API. If not provided,
+                will look for it in the environment variable.
+            model_name (str, optional): The name of the model to use for text
+                embeddings. Defaults to "forge-pro". Available models:
+                "forge-turbo" (1024d), "forge-pro" (2560d), "forge-ultra-4k" (4096d).
+            api_key_env_var (str, optional): Environment variable name that contains
+                your API key for the Forge API. Defaults to "FORGE_API_KEY".
+            api_base (str, optional): The base URL for the Forge API.
+                Defaults to "https://api.voxell.ai/v1".
+            dimensions (int, optional): Forge embeddings support Matryoshka
+                representation learning, allowing you to reduce embedding dimensions
+                while maintaining quality.
+        """
+        try:
+            import openai
+        except ImportError:
+            raise ValueError(
+                "The openai python package is not installed. Please install it with `pip install openai`"
+            )
+
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
+
+        self.api_key_env_var = api_key_env_var
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
+        if not self.api_key:
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
+
+        self.model_name = model_name
+        self.api_base = api_base
+        self.dimensions = dimensions
+        self.client = openai.OpenAI(api_key=self.api_key, base_url=self.api_base)
+
+    def __call__(self, input: Documents) -> Embeddings:
+        """
+        Generate embeddings for the given documents.
+
+        Args:
+            input: Documents to generate embeddings for.
+
+        Returns:
+            Embeddings for the documents.
+        """
+        if not input:
+            return []
+
+        embedding_params: Dict[str, Any] = {
+            "model": self.model_name,
+            "input": input,
+        }
+
+        if self.dimensions is not None:
+            embedding_params["dimensions"] = self.dimensions
+
+        response = self.client.embeddings.create(**embedding_params)
+
+        return [np.array(data.embedding, dtype=np.float32) for data in response.data]
+
+    @staticmethod
+    def name() -> str:
+        return "forge"
+
+    def default_space(self) -> Space:
+        return "cosine"
+
+    def supported_spaces(self) -> List[Space]:
+        return ["cosine", "l2", "ip"]
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+        api_key_env_var = config.get("api_key_env_var")
+        model_name = config.get("model_name")
+        api_base = config.get("api_base") or "https://api.voxell.ai/v1"
+        dimensions = config.get("dimensions")
+
+        if api_key_env_var is None or model_name is None:
+            assert False, "This code should not be reached"
+
+        return ForgeEmbeddingFunction(
+            api_key_env_var=api_key_env_var,
+            model_name=model_name,
+            api_base=api_base,
+            dimensions=dimensions,
+        )
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "api_key_env_var": self.api_key_env_var,
+            "model_name": self.model_name,
+            "api_base": self.api_base,
+            "dimensions": self.dimensions,
+        }
+
+    def validate_config_update(
+        self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+    ) -> None:
+        if "model_name" in new_config:
+            raise ValueError(
+                "The model name cannot be changed after the embedding function has been initialized."
+            )
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        """
+        Validate the configuration using the JSON schema.
+
+        Args:
+            config: Configuration to validate
+
+        Raises:
+            ValidationError: If the configuration does not match the schema
+        """
+        validate_config_schema(config, "forge")

--- a/clients/new-js/packages/ai-embeddings/all/package.json
+++ b/clients/new-js/packages/ai-embeddings/all/package.json
@@ -52,7 +52,8 @@
     "@chroma-core/chroma-cloud-qwen": "workspace:^",
     "@chroma-core/chroma-cloud-splade": "workspace:^",
     "@chroma-core/sentence-transformer": "workspace:^",
-    "@chroma-core/perplexity": "workspace:^"
+    "@chroma-core/perplexity": "workspace:^",
+    "@chroma-core/forge": "workspace:^"
   },
   "engines": {
     "node": ">=20"

--- a/clients/new-js/packages/ai-embeddings/all/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/all/src/index.ts
@@ -14,3 +14,4 @@ export * from "@chroma-core/chroma-cloud-qwen";
 export * from "@chroma-core/chroma-cloud-splade";
 export * from "@chroma-core/chroma-bm25";
 export * from "@chroma-core/perplexity";
+export * from "@chroma-core/forge";

--- a/clients/new-js/packages/ai-embeddings/common/src/schema-utils.ts
+++ b/clients/new-js/packages/ai-embeddings/common/src/schema-utils.ts
@@ -29,6 +29,7 @@ import chromaCloudQwenSchema from "../../../../../../schemas/embedding_functions
 import chromaCloudSpladeSchema from "../../../../../../schemas/embedding_functions/chroma-cloud-splade.json";
 import chromaBm25Schema from "../../../../../../schemas/embedding_functions/chroma_bm25.json";
 import perplexitySchema from "../../../../../../schemas/embedding_functions/perplexity.json";
+import forgeSchema from "../../../../../../schemas/embedding_functions/forge.json";
 import Ajv from "ajv";
 
 // Define a common interface for all schemas
@@ -82,6 +83,7 @@ const schemaMap = {
 	"chroma-cloud-splade": chromaCloudSpladeSchema as Schema,
 	chroma_bm25: chromaBm25Schema as Schema,
 	perplexity: perplexitySchema as Schema,
+	forge: forgeSchema as Schema,
 };
 
 /**

--- a/clients/new-js/packages/ai-embeddings/forge/README.md
+++ b/clients/new-js/packages/ai-embeddings/forge/README.md
@@ -1,0 +1,78 @@
+# Forge Embedding Function for Chroma
+
+This package provides a Forge embedding provider for Chroma. Forge exposes an
+OpenAI-compatible embeddings endpoint, so this provider uses the `openai` client
+configured with the Forge base URL.
+
+## Installation
+
+```bash
+npm install @chroma-core/forge
+```
+
+## Usage
+
+```typescript
+import { ChromaClient } from 'chromadb';
+import { ForgeEmbeddingFunction } from '@chroma-core/forge';
+
+// Initialize the embedder
+const embedder = new ForgeEmbeddingFunction({
+  apiKey: 'your-api-key', // Or set FORGE_API_KEY env var
+  modelName: 'forge-pro',
+});
+
+// Create a new ChromaClient
+const client = new ChromaClient({
+  path: 'http://localhost:8000',
+});
+
+// Create a collection with the embedder
+const collection = await client.createCollection({
+  name: 'my-collection',
+  embeddingFunction: embedder,
+});
+
+// Add documents
+await collection.add({
+  ids: ["1", "2", "3"],
+  documents: ["Document 1", "Document 2", "Document 3"],
+});
+
+// Query documents
+const results = await collection.query({
+  queryTexts: ["Sample query"],
+  nResults: 2,
+});
+```
+
+## Configuration
+
+Set your Forge API key as an environment variable:
+
+```bash
+export FORGE_API_KEY=your-api-key
+```
+
+Get your API key from [Voxell](https://voxell.ai).
+
+## Configuration Options
+
+- **apiKey**: Your Forge API key (or set via environment variable)
+- **apiKeyEnvVar**: Environment variable name for API key (default: `FORGE_API_KEY`)
+- **modelName**: Model to use for embeddings (default: `forge-pro`)
+- **apiBase**: Base URL for the Forge API (default: `https://api.voxell.ai/v1`)
+- **dimensions**: Optional dimension reduction using Matryoshka representation learning
+
+## Supported Models
+
+Forge offers the following embedding models:
+
+- `forge-turbo` - 1024 dimensions
+- `forge-pro` - 2560 dimensions (default)
+- `forge-ultra-4k` - 4096 dimensions
+
+## Features
+
+- **OpenAI-Compatible API**: Uses the standard `openai` client with the Forge base URL.
+- **Matryoshka Embeddings**: Support for dimension reduction while maintaining quality.

--- a/clients/new-js/packages/ai-embeddings/forge/jest.config.ts
+++ b/clients/new-js/packages/ai-embeddings/forge/jest.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+      },
+    ],
+  },
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  setupFiles: ["./jest.setup.ts"],
+};
+
+export default config;

--- a/clients/new-js/packages/ai-embeddings/forge/jest.setup.ts
+++ b/clients/new-js/packages/ai-embeddings/forge/jest.setup.ts
@@ -1,0 +1,3 @@
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: "../../../.env" });

--- a/clients/new-js/packages/ai-embeddings/forge/package.json
+++ b/clients/new-js/packages/ai-embeddings/forge/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@chroma-core/forge",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Forge embedding provider for Chroma",
+  "main": "dist/cjs/forge.cjs",
+  "types": "dist/forge.d.ts",
+  "module": "dist/forge.legacy-esm.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/forge.d.ts",
+        "default": "./dist/forge.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/forge.d.cts",
+        "default": "./dist/cjs/forge.cjs"
+      }
+    }
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rimraf dist",
+    "prebuild": "rimraf dist",
+    "build": "tsup",
+    "watch": "tsup --watch",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "dotenv": "^16.3.1",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.0",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "tsup": "^8.3.5"
+  },
+  "peerDependencies": {
+    "chromadb": "workspace:^"
+  },
+  "dependencies": {
+    "@chroma-core/ai-embeddings-common": "workspace:^",
+    "openai": "^4.102.0"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/clients/new-js/packages/ai-embeddings/forge/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/forge/src/index.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { ForgeEmbeddingFunction } from "./index";
+
+describe("ForgeEmbeddingFunction", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const MODEL = "forge-pro";
+
+  it("should initialize with default parameters", () => {
+    const embedder = new ForgeEmbeddingFunction({ apiKey: "test-api-key" });
+    expect(embedder.name).toBe("forge");
+
+    const config = embedder.getConfig();
+    expect(config.model_name).toBe(MODEL);
+    expect(config.api_key_env_var).toBe("FORGE_API_KEY");
+    expect(config.api_base).toBe("https://api.voxell.ai/v1");
+  });
+
+  it("should initialize with custom parameters", () => {
+    const embedder = new ForgeEmbeddingFunction({
+      apiKey: "test-api-key",
+      modelName: "forge-ultra-4k",
+      dimensions: 512,
+    });
+
+    const config = embedder.getConfig();
+    expect(config.model_name).toBe("forge-ultra-4k");
+    expect(config.dimensions).toBe(512);
+  });
+
+  it("should use custom API key environment variable", () => {
+    process.env.CUSTOM_FORGE_API_KEY = "test-api-key";
+
+    try {
+      const embedder = new ForgeEmbeddingFunction({
+        apiKeyEnvVar: "CUSTOM_FORGE_API_KEY",
+      });
+
+      expect(embedder.getConfig().api_key_env_var).toBe("CUSTOM_FORGE_API_KEY");
+    } finally {
+      delete process.env.CUSTOM_FORGE_API_KEY;
+    }
+  });
+
+  it("should build from config", () => {
+    const config = {
+      api_key_env_var: "FORGE_API_KEY",
+      model_name: "forge-turbo",
+      api_base: "https://api.voxell.ai/v1",
+    };
+
+    process.env.FORGE_API_KEY = "test-api-key";
+    try {
+      const embedder = ForgeEmbeddingFunction.buildFromConfig(config);
+
+      expect(embedder.getConfig().model_name).toBe(config.model_name);
+      expect(embedder.getConfig().api_key_env_var).toBe(config.api_key_env_var);
+      expect(embedder.getConfig().api_base).toBe(config.api_base);
+    } finally {
+      delete process.env.FORGE_API_KEY;
+    }
+  });
+
+  const generateEmbeddingsTest = "should generate embeddings";
+  if (!process.env.FORGE_API_KEY) {
+    it.skip(generateEmbeddingsTest, () => {});
+  } else {
+    it(generateEmbeddingsTest, async () => {
+      const embedder = new ForgeEmbeddingFunction({});
+      const texts = ["Hello world", "Test text"];
+      const embeddings = await embedder.generate(texts);
+
+      expect(embeddings.length).toBe(texts.length);
+
+      embeddings.forEach((embedding) => {
+        expect(embedding.length).toBeGreaterThan(0);
+      });
+
+      expect(embeddings[0]).not.toEqual(embeddings[1]);
+    });
+  }
+});

--- a/clients/new-js/packages/ai-embeddings/forge/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/forge/src/index.ts
@@ -1,0 +1,106 @@
+import {
+  ChromaValueError,
+  EmbeddingFunction,
+  EmbeddingFunctionSpace,
+  registerEmbeddingFunction,
+} from "chromadb";
+import OpenAI from "openai";
+import { validateConfigSchema } from "@chroma-core/ai-embeddings-common";
+
+const NAME = "forge";
+const DEFAULT_API_BASE = "https://api.voxell.ai/v1";
+
+export interface ForgeConfig {
+  api_key_env_var: string;
+  model_name: string;
+  api_base?: string;
+  dimensions?: number;
+}
+
+export interface ForgeArgs {
+  modelName?: string;
+  apiKeyEnvVar?: string;
+  apiKey?: string;
+  apiBase?: string;
+  dimensions?: number;
+}
+
+export class ForgeEmbeddingFunction implements EmbeddingFunction {
+  public readonly name = NAME;
+  private readonly apiKeyEnvVar: string;
+  private readonly modelName: string;
+  private readonly apiBase: string;
+  private readonly dimensions?: number;
+  private client: OpenAI;
+
+  constructor(args: ForgeArgs = {}) {
+    const {
+      apiKeyEnvVar = "FORGE_API_KEY",
+      modelName = "forge-pro",
+      apiBase = DEFAULT_API_BASE,
+      dimensions,
+    } = args;
+
+    const apiKey = args.apiKey || process.env[apiKeyEnvVar];
+
+    if (!apiKey) {
+      console.warn(
+        `Forge API key is not set. Please provide it in the constructor or set the environment variable ${apiKeyEnvVar}.`,
+      );
+    }
+
+    this.modelName = modelName;
+    this.apiKeyEnvVar = apiKeyEnvVar;
+    this.apiBase = apiBase;
+    this.dimensions = dimensions;
+    this.client = new OpenAI({ apiKey, baseURL: apiBase });
+  }
+
+  public async generate(texts: string[]): Promise<number[][]> {
+    const response = await this.client.embeddings.create({
+      input: texts,
+      model: this.modelName,
+      ...(this.dimensions !== undefined && { dimensions: this.dimensions }),
+    });
+
+    return response.data.map((e) => e.embedding);
+  }
+
+  public static buildFromConfig(config: ForgeConfig): ForgeEmbeddingFunction {
+    return new ForgeEmbeddingFunction({
+      modelName: config.model_name,
+      apiKeyEnvVar: config.api_key_env_var,
+      apiBase: config.api_base,
+      dimensions: config.dimensions,
+    });
+  }
+
+  public defaultSpace(): EmbeddingFunctionSpace {
+    return "cosine";
+  }
+
+  public supportedSpaces(): EmbeddingFunctionSpace[] {
+    return ["cosine", "l2", "ip"];
+  }
+
+  public getConfig(): ForgeConfig {
+    return {
+      api_key_env_var: this.apiKeyEnvVar,
+      model_name: this.modelName,
+      api_base: this.apiBase,
+      dimensions: this.dimensions,
+    };
+  }
+
+  public validateConfigUpdate(newConfig: Record<string, unknown>): void {
+    if (this.getConfig().model_name !== newConfig.model_name) {
+      throw new ChromaValueError("Model name cannot be updated");
+    }
+  }
+
+  public static validateConfig(config: ForgeConfig): void {
+    validateConfigSchema(config, NAME);
+  }
+}
+
+registerEmbeddingFunction(NAME, ForgeEmbeddingFunction);

--- a/clients/new-js/packages/ai-embeddings/forge/tsconfig.json
+++ b/clients/new-js/packages/ai-embeddings/forge/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./src",
+    "stripInternal": true,
+    "composite": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test",
+    "**/*.test.ts"
+  ],
+  "references": [
+    {
+      "path": "../common"
+    },
+    {
+      "path": "../../chromadb"
+    }
+  ]
+}

--- a/clients/new-js/packages/ai-embeddings/forge/tsup.config.ts
+++ b/clients/new-js/packages/ai-embeddings/forge/tsup.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, Options } from "tsup";
+import * as fs from "fs";
+
+export default defineConfig((options: Options) => {
+  const commonOptions: Partial<Options> = {
+    entry: {
+      forge: "src/index.ts",
+    },
+    sourcemap: true,
+    dts: {
+      compilerOptions: {
+        composite: false,
+        declaration: true,
+        emitDeclarationOnly: false,
+      },
+    },
+    ...options,
+  };
+
+  return [
+    {
+      ...commonOptions,
+      format: ["esm"],
+      outExtension: () => ({ js: ".mjs" }),
+      clean: true,
+      async onSuccess() {
+        // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
+        fs.copyFileSync("dist/forge.mjs", "dist/forge.legacy-esm.js");
+      },
+    },
+    {
+      ...commonOptions,
+      format: "cjs",
+      outDir: "./dist/cjs/",
+      outExtension: () => ({ js: ".cjs" }),
+    },
+  ];
+});

--- a/clients/new-js/pnpm-lock.yaml
+++ b/clients/new-js/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@chroma-core/default-embed':
         specifier: workspace:^
         version: link:../default-embed
+      '@chroma-core/forge':
+        specifier: workspace:^
+        version: link:../forge
       '@chroma-core/google-gemini':
         specifier: workspace:^
         version: link:../google-gemini
@@ -289,6 +292,40 @@ importers:
       ts-jest:
         specifier: ^29.1.0
         version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3)
+      tsup:
+        specifier: ^8.3.5
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+
+  packages/ai-embeddings/forge:
+    dependencies:
+      '@chroma-core/ai-embeddings-common':
+        specifier: workspace:^
+        version: link:../common
+      chromadb:
+        specifier: workspace:^
+        version: link:../../chromadb
+      openai:
+        specifier: ^4.102.0
+        version: 4.102.0(ws@8.18.2)(zod@3.24.4)
+    devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.5.0
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3))
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.46)(typescript@5.8.3)
       tsup:
         specifier: ^8.3.5
         version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
@@ -744,20 +781,20 @@ importers:
         version: 8.0.3
     optionalDependencies:
       chromadb-js-bindings-darwin-arm64:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
       chromadb-js-bindings-darwin-x64:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
       chromadb-js-bindings-linux-arm64-gnu:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
       chromadb-js-bindings-linux-x64-gnu:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
       chromadb-js-bindings-win32-x64-msvc:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
 
   packages/integration-test:
     dependencies:
@@ -2406,34 +2443,34 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  chromadb-js-bindings-darwin-arm64@1.3.3:
-    resolution: {integrity: sha512-fygMqw+Qsnc7zlh59tYAUfW5g859ZVLnA5cG0tyO7NZG2lQz1QKZCTqG49TVU7vfmeC7LzjIZvEQ0jrTqFKaMQ==}
+  chromadb-js-bindings-darwin-arm64@1.3.4:
+    resolution: {integrity: sha512-pDdWCcR0hCz3pSDiIijBito7YG6FumewfzYE2mIjSwjrO1CKSfQKLwDdTVK4ZNpVGQa16ePoMX+pg7ShSUARJg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  chromadb-js-bindings-darwin-x64@1.3.3:
-    resolution: {integrity: sha512-OwaNmkEo8gYp5inp88pa0vLUSNYs9nBouvumbt+YI1JYShpDs6cnBKAOfNCFbljjBunqCsv70PPxQqZmkyEzlQ==}
+  chromadb-js-bindings-darwin-x64@1.3.4:
+    resolution: {integrity: sha512-5vKVFXSFo+S9qC9by/7oofjcXqQK4IGHiUnPrvTfc7B52gNlPSKeyDO1wha556COc3KtXSZjICEH0nYBJ8UXng==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  chromadb-js-bindings-linux-arm64-gnu@1.3.3:
-    resolution: {integrity: sha512-98O7kBw2z9kLCbQqElebrV9SAcKf5QKDI9yD144ooLz+jOgj39ccF6q0R13FB3AwYxVvHhKiIKMjO3hOFCx5iw==}
+  chromadb-js-bindings-linux-arm64-gnu@1.3.4:
+    resolution: {integrity: sha512-ELiqDZzU5mZd1BvZugGrhoMkVeNyQaa+PGizd06WIpIJVoHY+S+9ZBjdeM6ZkRnL3vTxD79XBrosxNWhzqy/kg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  chromadb-js-bindings-linux-x64-gnu@1.3.3:
-    resolution: {integrity: sha512-yqJRHDiLNQFfNcCDm/iILdf5gCBR0BxG1d+esX4ViHAP41h4WqbWq9MIAla+OKHKlyMpSq9BiqSfHBaL8rr5nQ==}
+  chromadb-js-bindings-linux-x64-gnu@1.3.4:
+    resolution: {integrity: sha512-HmTUe7PEIaBngCQ70Yyle81z2wYyg9OMgJYyRUNBYCBp4ED6zTmdaOro41Vs/c/h2UyQeBXFIKNmHDeD2Nr2fw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  chromadb-js-bindings-win32-x64-msvc@1.3.3:
-    resolution: {integrity: sha512-X5zuolLBqh3+2GFh9BbjkBPFhPsmezc/HkYAk/rQvYayBqD39e/BT0JwYVbGr+gcqsZI3QO87xZ2FyHL8g8f9Q==}
+  chromadb-js-bindings-win32-x64-msvc@1.3.4:
+    resolution: {integrity: sha512-punrofQRzKspNMxHmv24qoPeRycV2T3KfedekGV4lOuPPG14i6qggS4x/OWLSAK7ozPfBbrzCejvCa5wfvujhQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -6822,19 +6859,19 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  chromadb-js-bindings-darwin-arm64@1.3.3:
+  chromadb-js-bindings-darwin-arm64@1.3.4:
     optional: true
 
-  chromadb-js-bindings-darwin-x64@1.3.3:
+  chromadb-js-bindings-darwin-x64@1.3.4:
     optional: true
 
-  chromadb-js-bindings-linux-arm64-gnu@1.3.3:
+  chromadb-js-bindings-linux-arm64-gnu@1.3.4:
     optional: true
 
-  chromadb-js-bindings-linux-x64-gnu@1.3.3:
+  chromadb-js-bindings-linux-x64-gnu@1.3.4:
     optional: true
 
-  chromadb-js-bindings-win32-x64-msvc@1.3.3:
+  chromadb-js-bindings-win32-x64-msvc@1.3.4:
     optional: true
 
   ci-info@3.9.0: {}

--- a/docs/mintlify/docs.json
+++ b/docs/mintlify/docs.json
@@ -208,6 +208,7 @@
               "integrations/embedding-models/google-gemini",
               "integrations/embedding-models/hugging-face",
               "integrations/embedding-models/hugging-face-server",
+              "integrations/embedding-models/forge",
               "integrations/embedding-models/instructor",
               "integrations/embedding-models/jina-ai",
               "integrations/embedding-models/mistral",

--- a/docs/mintlify/docs/embeddings/embedding-functions.mdx
+++ b/docs/mintlify/docs/embeddings/embedding-functions.mdx
@@ -276,6 +276,7 @@ For TypeScript users, Chroma provides packages for a number of embedding model p
 | All (installs all packages) | [@chroma-core/all](https://www.npmjs.com/package/@chroma-core/all)
 | Cloudflare Workers AI       | [@chroma-core/cloudflare-worker-ai](https://www.npmjs.com/package/@chroma-core/cloudflare-worker-ai)
 | Cohere                      | [@chroma-core/cohere](https://www.npmjs.com/package/@chroma-core/cohere)
+| Forge                       | [@chroma-core/forge](https://www.npmjs.com/package/@chroma-core/forge)
 | Google Gemini               | [@chroma-core/google-gemini](https://www.npmjs.com/package/@chroma-core/google-gemini)
 | Hugging Face Server         | [@chroma-core/huggingface-server](https://www.npmjs.com/package/@chroma-core/huggingface-server)
 | Jina                        | [@chroma-core/jina](https://www.npmjs.com/package/@chroma-core/jina)

--- a/docs/mintlify/integrations/embedding-models/forge.mdx
+++ b/docs/mintlify/integrations/embedding-models/forge.mdx
@@ -1,0 +1,102 @@
+---
+title: Forge
+---
+
+Chroma provides a convenient wrapper around Forge's embedding API. Forge exposes an OpenAI-compatible embeddings endpoint, so this embedding function uses the OpenAI client configured with the Forge base URL. This embedding function runs remotely on Forge's servers, and requires an API key. You can get an API key by signing up for an account at [Voxell](https://voxell.ai).
+
+<Tabs>
+<Tab title="Python" icon="python">
+
+This embedding function relies on the `openai` python package, which you can install with `pip install openai`.
+
+```python
+import chromadb.utils.embedding_functions as embedding_functions
+
+forge_ef = embedding_functions.ForgeEmbeddingFunction(
+    api_key="YOUR_API_KEY",
+    model_name="forge-pro"
+)
+
+forge_ef(input=["document1", "document2"])
+```
+
+</Tab>
+<Tab title="TypeScript" icon="js">
+
+```typescript
+// npm install @chroma-core/forge
+
+import { ForgeEmbeddingFunction } from "@chroma-core/forge";
+
+const embedder = new ForgeEmbeddingFunction({
+    apiKey: "YOUR_API_KEY",
+    modelName: "forge-pro",
+});
+
+// use directly
+const embeddings = await embedder.generate(["document1", "document2"]);
+
+// pass documents to query for .add and .query
+const collection = await client.createCollection({
+    name: "name",
+    embeddingFunction: embedder,
+});
+const collectionGet = await client.getCollection({
+    name: "name",
+    embeddingFunction: embedder,
+});
+```
+
+</Tab>
+</Tabs>
+
+## Available Models
+
+Forge offers the following embedding models:
+
+| Model | Dimensions |
+|-------|------------|
+| `forge-turbo` | 1024 |
+| `forge-pro` | 2560 |
+| `forge-ultra-4k` | 4096 |
+
+The default model is `forge-pro`. OpenAI model aliases are also accepted by the API.
+
+## Matryoshka Dimensions
+
+Forge models support [Matryoshka Representation Learning](https://arxiv.org/abs/2205.13147), allowing you to reduce embedding dimensions while maintaining quality. This is useful for reducing storage costs and improving search speed.
+
+<Tabs>
+<Tab title="Python" icon="python">
+
+```python
+# Reduce dimensions to 512 for the forge-pro model
+forge_ef = embedding_functions.ForgeEmbeddingFunction(
+    api_key="YOUR_API_KEY",
+    model_name="forge-pro",
+    dimensions=512
+)
+
+embeddings = forge_ef(input=["document1", "document2"])
+print(len(embeddings[0]))  # 512
+```
+
+</Tab>
+<Tab title="TypeScript" icon="js">
+
+```typescript
+// Reduce dimensions to 512 for the forge-pro model
+const embedder = new ForgeEmbeddingFunction({
+    apiKey: "YOUR_API_KEY",
+    modelName: "forge-pro",
+    dimensions: 512,
+});
+
+const embeddings = await embedder.generate(["document1", "document2"]);
+console.log(embeddings[0].length);  // 512
+```
+
+</Tab>
+</Tabs>
+
+For more details on Forge's embedding models, check the [documentation](https://voxell.ai).

--- a/schemas/embedding_functions/forge.json
+++ b/schemas/embedding_functions/forge.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Forge Embedding Function Schema",
+  "description": "Schema for the forge embedding function configuration",
+  "version": "1.0.0",
+  "type": "object",
+  "properties": {
+    "model_name": {
+      "type": "string",
+      "description": "Parameter model_name for the forge embedding function"
+    },
+    "api_key_env_var": {
+      "type": "string",
+      "description": "Parameter api_key_env_var for the forge embedding function"
+    },
+    "api_base": {
+      "type": "string",
+      "description": "The base URL for the Forge API"
+    },
+    "dimensions": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Matryoshka dimension (forge-turbo 1024, forge-pro 2560, forge-ultra-4k 4096)"
+    }
+  },
+  "required": [
+    "api_key_env_var",
+    "model_name"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Adds a Forge embedding function for both the Python package and the new-js `ai-embeddings` monorepo. Mirrors the existing provider EFs (e.g. Perplexity, #6511).

Forge exposes an OpenAI-compatible embeddings endpoint, so the EF wraps the `openai` client configured with the Forge base URL (`https://api.voxell.ai/v1`). It is a standalone `EmbeddingFunction` (not a subclass of `OpenAIEmbeddingFunction`) so `name()` returns `"forge"` and the config round-trips correctly.

Models: `forge-turbo` (1024), `forge-pro` (2560, default), `forge-ultra-4k` (4096). Supports the `dimensions` param (Matryoshka). API key via `FORGE_API_KEY` (override with `api_key_env_var`); `api_base` is configurable.

**Python**
- New `chromadb/utils/embedding_functions/forge_embedding_function.py`
- Registered in `embedding_functions/__init__.py` (`known_embedding_functions`, `_all_classes`, `__all__`)
- New `schemas/embedding_functions/forge.json`
- `ForgeEmbeddingFunction` added to `test_get_builtins_holds`

**TypeScript (new-js)**
- New package `clients/new-js/packages/ai-embeddings/forge/` (`@chroma-core/forge`), mirroring the perplexity package layout
- Schema wired into `common/src/schema-utils.ts`
- Re-exported from the `all` package; `pnpm-lock.yaml` regenerated

**Docs**
- New provider page `docs/mintlify/integrations/embedding-models/forge.mdx`, nav entry in `docs.json`, table row in `embedding-functions.mdx`

**How tested**
- Python: `test_get_builtins_holds` and `test_ef_imports` pass; verified `get_config`/`build_from_config` round-trip via `collection_configuration` serialize→deserialize, schema validation (incl. `dimensions=None`), the model-name-change guard, and that an omitted `api_base` defaults to the Forge endpoint (no fallback to `api.openai.com`).
- TypeScript: `@chroma-core/forge` builds (tsup ESM/CJS/DTS); its jest suite passes; schema load/validation verified through `@chroma-core/ai-embeddings-common`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)