### PR TITLE
[CHORE](ci) harden Tilt install in tilt-setup-prebuild action

### DIFF
--- a/.github/actions/tilt-setup-prebuild/action.yaml
+++ b/.github/actions/tilt-setup-prebuild/action.yaml
@@ -13,8 +13,27 @@ runs:
       env:
         TILT_VERSION: "0.34.2"
       run: |
+        install_tilt() (
+          set -euo pipefail
+
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "${tmp_dir}"' EXIT
+
+          tilt_archive="${tmp_dir}/tilt.${TILT_VERSION}.linux.x86_64.tar.gz"
+          tilt_url="https://github.com/tilt-dev/tilt/releases/download/v${TILT_VERSION}/tilt.${TILT_VERSION}.linux.x86_64.tar.gz"
+
+          echo "Downloading Tilt ${TILT_VERSION} from ${tilt_url}"
+          curl --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
+            --output "${tilt_archive}" \
+            "${tilt_url}"
+          tar -xzf "${tilt_archive}" -C "${tmp_dir}" tilt
+          install -m 0755 "${tmp_dir}/tilt" /usr/local/bin/tilt
+          tilt version
+        )
+        export -f install_tilt
+
         parallel --tag --linebuffer ::: \
-          "bash -c 'curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v${TILT_VERSION}/tilt.${TILT_VERSION}.linux.x86_64.tar.gz | tar -xzv -C /usr/local/bin tilt'" \
+          "bash -c install_tilt" \
           "docker buildx bake -f ${{ github.action_path }}/docker-bake.hcl --load" \
           "bash ${{ github.action_path }}/pull_external_images.sh"
       working-directory: ${{ github.action_path }}/../../../ # this allows other repos to reuse this workflow when this repo may not be the current working directory


### PR DESCRIPTION
## Description of changes

Replace fragile one-liner that pipes curl directly into tar with a
robust install_tilt function that:
- Uses a temp directory with trap-based cleanup
- Retries curl up to 5 times with --retry-all-errors and backoff
- Fails fast on download errors via --fail and set -euo pipefail
- Verifies installation by running tilt version

This addresses intermittent CI failures where the Tilt download would
silently fail or produce a corrupt archive, causing the tar extraction
to error out and the entire prebuild step to fail.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
