### PR TITLE
[CHORE](ci): Add pytest test inventory

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -22,6 +22,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   CHROMA_HYPOTHESIS_CI_REPRODUCE_ONLY: "1"
   CHROMA_HYPOTHESIS_COMPACTION_WAITS: "auto"
+  PYTEST_ADDOPTS: "-p chromadb.test.pytest_inventory"
+  CHROMA_TEST_INVENTORY_RUNNER: ${{ inputs.runner }}
 
 jobs:
   test-rust-bindings:
@@ -63,6 +65,17 @@ jobs:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
           CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
           RUST_BACKTRACE: 1
+          CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
+          CHROMA_TEST_INVENTORY_JOB: test-rust-bindings
+          CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
+          CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test-glob }}
+      - name: Upload test inventory shard
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-test-inventory-shard-${{ inputs.runner }}-test-rust-bindings-${{ runner.os }}-${{ matrix.python }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/python-test-inventory/shard.json
+          if-no-files-found: warn
 
   test-rust-single-node-integration:
     strategy:
@@ -95,6 +108,17 @@ jobs:
       env:
         ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+        CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
+        CHROMA_TEST_INVENTORY_JOB: test-rust-single-node-integration
+        CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
+        CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test-glob }}
+    - name: Upload test inventory shard
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: python-test-inventory-shard-${{ inputs.runner }}-test-rust-single-node-integration-${{ runner.os }}-${{ matrix.python }}-${{ strategy.job-index }}
+        path: ${{ runner.temp }}/python-test-inventory/shard.json
+        if-no-files-found: warn
 
   test-rust-thin-client:
     strategy:
@@ -125,6 +149,17 @@ jobs:
           CHROMA_THIN_CLIENT: "1"
           ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+          CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
+          CHROMA_TEST_INVENTORY_JOB: test-rust-thin-client
+          CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
+          CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test-glob }}
+      - name: Upload test inventory shard
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-test-inventory-shard-${{ inputs.runner }}-test-rust-thin-client-${{ runner.os }}-${{ matrix.python }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/python-test-inventory/shard.json
+          if-no-files-found: warn
 
   test-cluster-rust-frontend:
     if: ${{ contains(inputs.runner, 'ubuntu') }}
@@ -190,6 +225,17 @@ jobs:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
           CHROMA_RUST_FRONTEND_TEST_ONLY: "1"
           CHROMA_SERVER_HOST: "localhost:8000"
+          CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
+          CHROMA_TEST_INVENTORY_JOB: test-cluster-rust-frontend
+          CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
+          CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test-glob }}
+      - name: Upload test inventory shard
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-test-inventory-shard-${{ inputs.runner }}-test-cluster-rust-frontend-${{ runner.os }}-${{ matrix.python }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/python-test-inventory/shard.json
+          if-no-files-found: warn
       - name: Compute artifact name
         if: always()
         id: compute-artifact-name
@@ -245,6 +291,17 @@ jobs:
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
           CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
+          CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
+          CHROMA_TEST_INVENTORY_JOB: test-rust-bindings-stress
+          CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
+          CHROMA_TEST_INVENTORY_TARGET: chromadb/test/stress
+      - name: Upload test inventory shard
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-test-inventory-shard-${{ inputs.runner }}-test-rust-bindings-stress-${{ runner.os }}-${{ matrix.python }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/python-test-inventory/shard.json
+          if-no-files-found: warn
 
   test-python-cli:
     strategy:
@@ -274,6 +331,17 @@ jobs:
       env:
         ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+        CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
+        CHROMA_TEST_INVENTORY_JOB: test-python-cli
+        CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
+        CHROMA_TEST_INVENTORY_TARGET: chromadb/test/test_cli.py
+    - name: Upload test inventory shard
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: python-test-inventory-shard-${{ inputs.runner }}-test-python-cli-${{ runner.os }}-${{ matrix.python }}-${{ strategy.job-index }}
+        path: ${{ runner.temp }}/python-test-inventory/shard.json
+        if-no-files-found: warn
 
   test-windows-smoke:
     # only run windows smoke tests when the runner isn't already windows,
@@ -309,3 +377,45 @@ jobs:
         env:
           CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
           RUST_BACKTRACE: 1
+          CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
+          CHROMA_TEST_INVENTORY_JOB: test-windows-smoke
+          CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
+          CHROMA_TEST_INVENTORY_TARGET: chromadb/test/test_api.py
+      - name: Upload test inventory shard
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-test-inventory-shard-${{ inputs.runner }}-test-windows-smoke-${{ runner.os }}-${{ matrix.python }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/python-test-inventory/shard.json
+          if-no-files-found: warn
+
+  merge-python-test-inventory:
+    if: always()
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - test-rust-bindings
+      - test-rust-single-node-integration
+      - test-rust-thin-client
+      - test-cluster-rust-frontend
+      - test-rust-bindings-stress
+      - test-python-cli
+      - test-windows-smoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Download test inventory shards
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          pattern: python-test-inventory-shard-${{ inputs.runner }}-*
+          path: python-test-inventory-shards
+      - name: Merge test inventory shards
+        run: python3 bin/ci/merge_python_test_inventory.py python-test-inventory-shards python-test-inventory/python-test-inventory.json
+        shell: bash
+      - name: Upload test inventory
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-test-inventory-${{ inputs.runner }}
+          path: python-test-inventory/python-test-inventory.json
+          if-no-files-found: error

--- a/bin/ci/merge_python_test_inventory.py
+++ b/bin/ci/merge_python_test_inventory.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import copy
+import datetime
+import hashlib
+import json
+import pathlib
+from typing import Any, Dict, List, Sequence, Tuple
+
+
+SHARD_KIND = "chroma-python-test-inventory-shard"
+MERGED_KIND = "chroma-python-test-inventory"
+
+
+def main() -> None:
+    args = parse_args()
+    input_dir = pathlib.Path(args.input_dir)
+    output_path = pathlib.Path(args.output_json)
+
+    shards, errors = read_shards(input_dir)
+    payload = merged_payload(shards, errors)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = output_path.with_name(f"{output_path.name}.tmp")
+    with tmp_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+    tmp_path.replace(output_path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Merge Chroma Python pytest inventory shard artifacts."
+    )
+    parser.add_argument("input_dir", help="Directory containing shard artifacts")
+    parser.add_argument("output_json", help="Merged inventory JSON output path")
+    return parser.parse_args()
+
+
+def read_shards(input_dir: pathlib.Path) -> Tuple[List[Dict[str, Any]], List[str]]:
+    shards: List[Dict[str, Any]] = []
+    errors: List[str] = []
+
+    if not input_dir.exists():
+        errors.append(f"input directory does not exist: {input_dir}")
+        return shards, errors
+
+    for path in sorted(input_dir.rglob("*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except Exception as e:
+            errors.append(f"{path}: failed to read JSON: {e}")
+            continue
+
+        if not isinstance(payload, dict):
+            errors.append(f"{path}: shard is not a JSON object")
+            continue
+
+        if payload.get("kind") != SHARD_KIND:
+            errors.append(f"{path}: unexpected kind {payload.get('kind')!r}")
+            continue
+
+        shard = copy.deepcopy(payload)
+        shard["source"] = {
+            "path": str(path),
+            "artifact": artifact_name(input_dir, path),
+        }
+        shards.append(shard)
+
+    return shards, errors
+
+
+def merged_payload(
+    shards: Sequence[Dict[str, Any]], errors: Sequence[str]
+) -> Dict[str, Any]:
+    collected_count = 0
+    unique_nodeids = set()
+    shard_hashes: List[str] = []
+
+    for shard in shards:
+        collection = shard.get("collection", {})
+        tests = collection.get("tests", [])
+        if isinstance(tests, list):
+            collected_count += len(tests)
+            unique_nodeids.update(str(test) for test in tests)
+
+        sha256 = collection.get("sha256")
+        if isinstance(sha256, str):
+            shard_hashes.append(sha256)
+
+    return {
+        "schema_version": 1,
+        "kind": MERGED_KIND,
+        "generated_at": utc_now(),
+        "summary": {
+            "shard_count": len(shards),
+            "collected_count": collected_count,
+            "unique_nodeid_count": len(unique_nodeids),
+            "sha256": aggregate_sha256(shard_hashes),
+        },
+        "errors": list(errors),
+        "shards": list(shards),
+    }
+
+
+def artifact_name(input_dir: pathlib.Path, path: pathlib.Path) -> str:
+    try:
+        relative = path.relative_to(input_dir)
+    except ValueError:
+        return ""
+
+    if len(relative.parts) > 1:
+        return relative.parts[0]
+    return ""
+
+
+def aggregate_sha256(shard_hashes: Sequence[str]) -> str:
+    hasher = hashlib.sha256()
+    for shard_hash in sorted(shard_hashes):
+        hasher.update(shard_hash.encode("utf-8"))
+        hasher.update(b"\0")
+    return hasher.hexdigest()
+
+
+def utc_now() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/chromadb/test/pytest_inventory.py
+++ b/chromadb/test/pytest_inventory.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+import platform
+import sys
+from typing import Any, Dict, List, Optional, Sequence
+
+import pytest
+
+
+_local_nodeids: List[str] = []
+_xdist_nodeids_by_worker: Dict[str, List[str]] = {}
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("chroma-test-inventory")
+    group.addoption(
+        "--chroma-test-inventory-json",
+        action="store",
+        default=None,
+        help="Write a JSON inventory of collected pytest node IDs.",
+    )
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    if _is_xdist_worker(session.config):
+        return
+
+    global _local_nodeids
+    _local_nodeids = [item.nodeid for item in session.items]
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_xdist_node_collection_finished(node: Any, ids: Sequence[str]) -> None:
+    worker_id = _worker_id(node)
+    _xdist_nodeids_by_worker[worker_id] = list(ids)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if _is_xdist_worker(session.config):
+        return
+
+    output_path = _output_path(session.config)
+    if output_path is None:
+        return
+
+    nodeids, xdist = _collection()
+    payload = {
+        "schema_version": 1,
+        "kind": "chroma-python-test-inventory-shard",
+        "generated_at": _utc_now(),
+        "shard": _shard_metadata(),
+        "pytest": {
+            "args": sys.argv[1:],
+            "exitstatus": int(exitstatus),
+        },
+        "collection": {
+            "count": len(nodeids),
+            "sha256": _nodeids_sha256(nodeids),
+            "tests": nodeids,
+        },
+        "xdist": xdist,
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = output_path.with_name(f"{output_path.name}.tmp")
+    with tmp_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+    tmp_path.replace(output_path)
+
+
+def _output_path(config: pytest.Config) -> Optional[pathlib.Path]:
+    option_path = config.getoption("--chroma-test-inventory-json")
+    path = option_path or os.getenv("CHROMA_TEST_INVENTORY_JSON")
+    if not path:
+        return None
+    return pathlib.Path(path)
+
+
+def _is_xdist_worker(config: pytest.Config) -> bool:
+    return hasattr(config, "workerinput")
+
+
+def _collection() -> tuple[List[str], Dict[str, Any]]:
+    if not _xdist_nodeids_by_worker:
+        return list(_local_nodeids), {
+            "enabled": False,
+            "worker_count": 0,
+            "collections_consistent": True,
+            "worker_collection_counts": {},
+        }
+
+    worker_ids = sorted(_xdist_nodeids_by_worker)
+    first_worker = worker_ids[0]
+    first_collection = _xdist_nodeids_by_worker[first_worker]
+    collections_consistent = all(
+        _xdist_nodeids_by_worker[worker_id] == first_collection
+        for worker_id in worker_ids
+    )
+
+    if collections_consistent:
+        nodeids = list(first_collection)
+    else:
+        nodeids = sorted(
+            {
+                nodeid
+                for worker_nodeids in _xdist_nodeids_by_worker.values()
+                for nodeid in worker_nodeids
+            }
+        )
+
+    return nodeids, {
+        "enabled": True,
+        "worker_count": len(worker_ids),
+        "collections_consistent": collections_consistent,
+        "worker_collection_counts": {
+            worker_id: len(_xdist_nodeids_by_worker[worker_id])
+            for worker_id in worker_ids
+        },
+    }
+
+
+def _worker_id(node: Any) -> str:
+    workerinput = getattr(node, "workerinput", None)
+    if isinstance(workerinput, dict):
+        worker_id = workerinput.get("workerid")
+        if worker_id:
+            return str(worker_id)
+
+    gateway = getattr(node, "gateway", None)
+    gateway_id = getattr(gateway, "id", None)
+    if gateway_id:
+        return str(gateway_id)
+
+    return f"worker-{len(_xdist_nodeids_by_worker)}"
+
+
+def _shard_metadata() -> Dict[str, Optional[str]]:
+    return {
+        "job": os.getenv("CHROMA_TEST_INVENTORY_JOB") or os.getenv("GITHUB_JOB"),
+        "python": os.getenv("CHROMA_TEST_INVENTORY_PYTHON")
+        or f"{sys.version_info.major}.{sys.version_info.minor}",
+        "runner_os": os.getenv("RUNNER_OS"),
+        "runner_name": os.getenv("RUNNER_NAME"),
+        "runner_input": os.getenv("CHROMA_TEST_INVENTORY_RUNNER"),
+        "test_target": os.getenv("CHROMA_TEST_INVENTORY_TARGET"),
+        "workflow": os.getenv("GITHUB_WORKFLOW"),
+        "run_id": os.getenv("GITHUB_RUN_ID"),
+        "run_attempt": os.getenv("GITHUB_RUN_ATTEMPT"),
+        "sha": os.getenv("GITHUB_SHA"),
+        "ref": os.getenv("GITHUB_REF"),
+        "platform": platform.platform(),
+    }
+
+
+def _nodeids_sha256(nodeids: Sequence[str]) -> str:
+    hasher = hashlib.sha256()
+    for nodeid in nodeids:
+        hasher.update(nodeid.encode("utf-8"))
+        hasher.update(b"\0")
+    return hasher.hexdigest()
+
+
+def _utc_now() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    )


### PR DESCRIPTION
## Description of changes

Add a pytest plugin and CI plumbing to produce a JSON inventory
of every collected test node ID across all Python test jobs.

- chromadb/test/pytest_inventory.py: pytest plugin that records
  collected node IDs (local and xdist) and writes a JSON shard
- bin/ci/merge_python_test_inventory.py: merges per-job shard
  artifacts into a single unified inventory
- _python-tests.yml: enable the plugin via PYTEST_ADDOPTS, upload
  per-job shard artifacts, add a merge-python-test-inventory job

## Test plan

Locally the script seems to build the right output.

I'm going to run in CI and download the artifacts.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
