### PR TITLE
[ENH](foundation-api): Add gdrive to source-collections

### DIFF
--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -80,7 +80,17 @@ impl FoundationConfig {
         "agent_sessions".to_string()
     }
     fn default_source_collections() -> Vec<String> {
-        vec!["slack".to_string(), "notion".to_string()]
+        vec![
+            "slack".to_string(),
+            "notion".to_string(),
+            // Lands as part of hosted-chroma's GDrive sync stack
+            // (chroma-core/hosted-chroma#7675…#7702). /init flags
+            // `CHROMA_GROUP_CHUNK_SIBLINGS_KEY` on this collection
+            // so chroma's end-of-job marker orders correctly across
+            // the multi-chunk-per-file outputs that the gdrive
+            // worker produces via process_bytes.
+            "gdrive".to_string(),
+        ]
     }
     fn default_function_name() -> String {
         "http_generate".to_string()


### PR DESCRIPTION
## What

Adds \`\"gdrive\"\` to \`FoundationConfig::default_source_collections\` so foundation-api's \`/init\` endpoint flags \`CHROMA_GROUP_CHUNK_SIBLINGS_KEY\` on the \`gdrive\` collection.

## Why

The chunk-sibling-grouping flag (PRs #7133 / #7134) tells \`PartitionOperator\` to strip a trailing \`-{idx}\` suffix from record IDs before partitioning. Without it, the end-of-job marker on a multi-chunk-per-file source can order incorrectly — chunks of the same file split across partitions, and the trailing \`{base}-0\` update lands on the wrong segment.

The hosted-chroma GDrive sync source (PRs [#7675](https://github.com/chroma-core/hosted-chroma/pull/7675) ... [#7702](https://github.com/chroma-core/hosted-chroma/pull/7702)) writes records into the \`gdrive\` collection via \`sync_source_to_chroma\` and produces many chunks per Drive file. With this flag, the existing chroma end-of-job-marker machinery advances each \`foundation_job_id\` from \`uploaded\` → \`indexed\` → \`synthesized\` correctly.

## Companion

hosted-chroma side: [#7702](https://github.com/chroma-core/hosted-chroma/pull/7702) — the connect handler enqueues \`GDriveListFilesJob\` after upsert, kicking off the per-file sync that produces the chunks this flag handles.

## Checks

- \`cargo check -p foundation-api\` ✓
- \`cargo clippy -p foundation-api --all-targets -- -D warnings\` ✓
- \`cargo fmt --check -p foundation-api\` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)