### PR TITLE
[TST] make default EF SHA256 tests self-contained

### DIFF
--- a/chromadb/test/ef/test_default_ef.py
+++ b/chromadb/test/ef/test_default_ef.py
@@ -1,11 +1,16 @@
+import hashlib
+import io
 import shutil
 import os
+import tarfile
+from pathlib import Path
 from typing import List, Hashable
 
 import hypothesis.strategies as st
 import onnxruntime
 import pytest
 from hypothesis import given, settings
+from onnxruntime.datasets import get_example
 
 from chromadb.utils.embedding_functions.onnx_mini_lm_l6_v2 import (
     ONNXMiniLM_L6_V2,
@@ -16,6 +21,56 @@ from chromadb.utils.embedding_functions.onnx_mini_lm_l6_v2 import _verify_sha256
 
 def unique_by(x: Hashable) -> Hashable:
     return x
+
+
+ONNX_FILES = [
+    "config.json",
+    "model.onnx",
+    "special_tokens_map.json",
+    "tokenizer_config.json",
+    "tokenizer.json",
+    "vocab.txt",
+]
+
+
+def _write_tiny_onnx_archive(path: Path) -> str:
+    model_bytes = Path(get_example("mul_1.onnx")).read_bytes()
+    archive_files = {
+        "config.json": b"{}",
+        "model.onnx": model_bytes,
+        "special_tokens_map.json": b"{}",
+        "tokenizer_config.json": b"{}",
+        "tokenizer.json": b"{}",
+        "vocab.txt": b"",
+    }
+
+    with tarfile.open(path, "w:gz") as tar:
+        for filename, contents in archive_files.items():
+            tarinfo = tarfile.TarInfo(f"onnx/{filename}")
+            tarinfo.size = len(contents)
+            tar.addfile(tarinfo, io.BytesIO(contents))
+
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _use_tiny_model_download(
+    ef: ONNXMiniLM_L6_V2, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    archive = tmp_path / "onnx.tar.gz"
+    expected_sha256 = _write_tiny_onnx_archive(archive)
+    download_path = tmp_path / "model-cache"
+    monkeypatch.setattr(ef, "DOWNLOAD_PATH", download_path)
+
+    def download(url: str, fname: str, chunk_size: int = 1024) -> None:
+        shutil.copyfile(archive, fname)
+        if not _verify_sha256(fname, ef._MODEL_SHA256):
+            os.remove(fname)
+            raise ValueError(
+                f"Downloaded file {fname} does not match expected SHA256 hash. Corrupted download or malicious file."
+            )
+
+    monkeypatch.setattr(ef, "_download", download)
+    return expected_sha256
 
 
 @settings(deadline=None)
@@ -65,18 +120,18 @@ def test_provider_repeating(providers: List[str]) -> None:
     assert "Preferred providers must be unique" in str(e.value)
 
 
-def test_invalid_sha256() -> None:
+def test_invalid_sha256(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     ef = ONNXMiniLM_L6_V2()
-    shutil.rmtree(ef.DOWNLOAD_PATH)  # clean up any existing models
+    _use_tiny_model_download(ef, tmp_path, monkeypatch)
     with pytest.raises(ValueError) as e:
         ef._MODEL_SHA256 = "invalid"
-        ef(["test"])
+        ef._download_model_if_not_exists()
     assert "does not match expected SHA256 hash" in str(e.value)
 
 
-def test_partial_download() -> None:
+def test_partial_download(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     ef = ONNXMiniLM_L6_V2()
-    shutil.rmtree(ef.DOWNLOAD_PATH, ignore_errors=True)  # clean up any existing models
+    ef._MODEL_SHA256 = _use_tiny_model_download(ef, tmp_path, monkeypatch)
     os.makedirs(ef.DOWNLOAD_PATH, exist_ok=True)
     path = os.path.join(ef.DOWNLOAD_PATH, ef.ARCHIVE_FILENAME)
     with open(path, "wb") as f:  # create invalid file to simulate partial download
@@ -87,4 +142,7 @@ def test_partial_download() -> None:
         str(os.path.join(ef.DOWNLOAD_PATH, ef.ARCHIVE_FILENAME)),
         ef._MODEL_SHA256,
     )
-    assert len(ef(["test"])) == 1
+    for filename in ONNX_FILES:
+        assert os.path.exists(
+            os.path.join(ef.DOWNLOAD_PATH, ef.EXTRACTED_FOLDER_NAME, filename)
+        )


### PR DESCRIPTION
## Description of changes

Replace real model downloads in test_invalid_sha256 and
test_partial_download with a tiny ONNX archive built from
onnxruntime's bundled example model. This eliminates network
dependencies and speeds up the tests.

Changes:
- Add _write_tiny_onnx_archive helper that creates a minimal tar.gz
  with the expected directory layout and returns its SHA256 hash
- Add _use_tiny_model_download to monkeypatch the download path and
  download function on an ONNXMiniLM_L6_V2 instance
- Rewrite test_invalid_sha256 to use the tiny archive, verifying the
  SHA256 mismatch error without a real download
- Rewrite test_partial_download to use the tiny archive, verifying
  extraction after a corrupt file is replaced
- Assert extracted files exist instead of calling ef(["test"]), which
  requires the real tokenizer and model weights

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
