### PR TITLE
[CHORE] add parallel test profile for tilt integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,6 @@
 [test-groups]
 against-tilt = { max-threads = 1 }
+against-tilt-parallel = { max-threads = 16 }
 
 [profile.default]
 default-filter = "not test(/test_k8s_integration_/) and not test(/test_k8s_mcmr_integration_/) and not test(/test_long_running_/) and not test(/test_gcs_/)"
@@ -18,11 +19,18 @@ test-group = "against-tilt"
 path = "junit.xml"
 
 [profile.ci_k8s_integration]
-default-filter = "test(/test_k8s_integration_/) and not test(test_k8s_mcmr_integration) and not test(test_k8s_integration_garbage_collection) and not package(rust-sysdb)"
+default-filter = "test(/test_k8s_integration_/) and not test(test_k8s_mcmr_integration) and not test(test_k8s_integration_garbage_collection) and not package(rust-sysdb) and not package(wal3) and not package(s3heap) and not package(s3heap-service)"
 
 [[profile.ci_k8s_integration.overrides]]
 filter = "all()"
 test-group = "against-tilt"
+
+[profile.ci_k8s_integration_tilt_parallel]
+default-filter = "test(/test_k8s_integration_/) and (package(wal3) or package(s3heap) or package(s3heap-service))"
+
+[[profile.ci_k8s_integration_tilt_parallel.overrides]]
+filter = "all()"
+test-group = "against-tilt-parallel"
 
 # This one test is extremely slow in CI and difficult to speed up.
 # TODO(@codetheweb): after all collection files are stored under a prefix, test_k8s_integration_* tests can be run in parallel and we can remove this profile.

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -70,14 +70,32 @@ jobs:
   test-integration:
     strategy:
       matrix:
-        platform: [blacksmith-16vcpu-ubuntu-2404]
-        nextest_profile: [ci_k8s_integration, ci_k8s_integration_slow]
-        partition: [1, 2]
         include:
           - nextest_profile: ci_k8s_integration
+            platform: blacksmith-16vcpu-ubuntu-2404
             partition_method: hash
+            partition: 1
+            partition_total: 2
+          - nextest_profile: ci_k8s_integration
+            platform: blacksmith-16vcpu-ubuntu-2404
+            partition_method: hash
+            partition: 2
+            partition_total: 2
           - nextest_profile: ci_k8s_integration_slow
+            platform: blacksmith-16vcpu-ubuntu-2404
             partition_method: count
+            partition: 1
+            partition_total: 2
+          - nextest_profile: ci_k8s_integration_slow
+            platform: blacksmith-16vcpu-ubuntu-2404
+            partition_method: count
+            partition: 2
+            partition_total: 2
+          - nextest_profile: ci_k8s_integration_tilt_parallel
+            platform: blacksmith-16vcpu-ubuntu-2404
+            partition_method: count
+            partition: 1
+            partition_total: 1
     runs-on: ${{ matrix.platform }}
     name: Integration test ${{ matrix.nextest_profile }} ${{ matrix.partition }}
     # OIDC token auth for AWS
@@ -104,7 +122,7 @@ jobs:
       - name: Build CLI
         run: cargo build --bin chroma
       - name: Run tests
-        run: cargo nextest run --profile ${{ matrix.nextest_profile }} --partition ${{ matrix.partition_method }}:${{ matrix.partition }}/2 --no-tests warn
+        run: cargo nextest run --profile ${{ matrix.nextest_profile }} --partition ${{ matrix.partition_method }}:${{ matrix.partition }}/${{ matrix.partition_total }} --no-tests warn
       - name: Save service logs to artifact
         if: always()
         uses: ./.github/actions/export-tilt-logs


### PR DESCRIPTION
## Description of changes

Add a new nextest profile ci_k8s_integration_tilt_parallel that runs
wal3, s3heap, and s3heap-service integration tests with up to 16
threads in parallel, separate from the serial against-tilt group.

Changes:
- Add against-tilt-parallel test group with max-threads of 16
- Exclude parallel-safe packages from ci_k8s_integration profile
- Create ci_k8s_integration_tilt_parallel profile for those packages
- Expand CI matrix to explicit includes with per-entry partition_total
- Parameterize partition denominator instead of hardcoding /2

## Test plan

cargo nextest list to confirm things moved

CI as the ultimate check

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
