### PR TITLE
[ENH](ci): shard pytest and cache builds

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -14,22 +14,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Cache Rust toolchain
-      id: cache-rustup
-      uses: actions/cache@v5
-      if: ${{ runner.os != 'windows' }}
-      with:
-        path: ~/.rustup
-        key: toolchain-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}
-    - name: Install Rust toolchain
-      if: ${{ steps.cache-rustup.outputs.cache-hit != 'true' }}
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        cache: false
-    - name: Set channel in rust-toolchain.toml as default
-      shell: bash
-      run: |
-        rustup default $(grep -m1 '^channel' rust-toolchain.toml | cut -d'"' -f2)
     - name: Install Protoc
       uses: chroma-core/setup-protoc@v4b
       with:

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -26,20 +26,12 @@ env:
   CHROMA_TEST_INVENTORY_RUNNER: ${{ inputs.runner }}
 
 jobs:
-  test-rust-bindings:
+  build-rust-bindings:
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
-        test-glob:
-          - "chromadb/test --ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*' --ignore-glob 'chromadb/test/test_cli.py'"
-          - "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py --ignore chromadb/test/property/test_add_mcmr.py"
-          - "chromadb/test/property/test_cross_version_persist.py"
-        include:
-          - test-glob: "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py --ignore chromadb/test/property/test_add_mcmr.py"
-            parallelized: false  # Disabled to fix INTERNALERROR crashes in CI
-
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v5
@@ -55,11 +47,160 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
+      - name: Upload wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-bindings-${{ runner.os }}-py${{ matrix.python }}
+          path: target/wheels/*.whl
+          if-no-files-found: error
+
+  build-rust-cli:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Rust
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+          install-nextest: "false"
+      - name: Build CLI
+        run: cargo build --bin chroma
+      - name: Upload CLI
+        uses: actions/upload-artifact@v7
+        with:
+          name: chroma-cli-${{ runner.os }}
+          path: target/debug/chroma${{ runner.os == 'Windows' && '.exe' || '' }}
+          if-no-files-found: error
+
+  test-rust-bindings:
+    timeout-minutes: 90
+    needs: build-rust-bindings
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ${{ fromJson(inputs.python_versions) }}
+        test_target:
+          - name: core-1
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore-glob 'chromadb/test/distributed/*'
+              --ignore-glob 'chromadb/test/test_cli.py'
+            shard_index: 1
+            shard_count: 6
+          - name: core-2
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore-glob 'chromadb/test/distributed/*'
+              --ignore-glob 'chromadb/test/test_cli.py'
+            shard_index: 2
+            shard_count: 6
+          - name: core-3
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore-glob 'chromadb/test/distributed/*'
+              --ignore-glob 'chromadb/test/test_cli.py'
+            shard_index: 3
+            shard_count: 6
+          - name: core-4
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore-glob 'chromadb/test/distributed/*'
+              --ignore-glob 'chromadb/test/test_cli.py'
+            shard_index: 4
+            shard_count: 6
+          - name: core-5
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore-glob 'chromadb/test/distributed/*'
+              --ignore-glob 'chromadb/test/test_cli.py'
+            shard_index: 5
+            shard_count: 6
+          - name: core-6
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore-glob 'chromadb/test/distributed/*'
+              --ignore-glob 'chromadb/test/test_cli.py'
+            shard_index: 6
+            shard_count: 6
+          - name: property-1
+            args: >-
+              chromadb/test/property
+              --ignore-glob chromadb/test/property/test_cross_version_persist.py
+              --ignore chromadb/test/property/test_add_mcmr.py
+            shard_index: 1
+            shard_count: 4
+          - name: property-2
+            args: >-
+              chromadb/test/property
+              --ignore-glob chromadb/test/property/test_cross_version_persist.py
+              --ignore chromadb/test/property/test_add_mcmr.py
+            shard_index: 2
+            shard_count: 4
+          - name: property-3
+            args: >-
+              chromadb/test/property
+              --ignore-glob chromadb/test/property/test_cross_version_persist.py
+              --ignore chromadb/test/property/test_add_mcmr.py
+            shard_index: 3
+            shard_count: 4
+          - name: property-4
+            args: >-
+              chromadb/test/property
+              --ignore-glob chromadb/test/property/test_cross_version_persist.py
+              --ignore chromadb/test/property/test_add_mcmr.py
+            shard_index: 4
+            shard_count: 4
+          - name: cross-version-1
+            args: chromadb/test/property/test_cross_version_persist.py
+            shard_index: 1
+            shard_count: 3
+          - name: cross-version-2
+            args: chromadb/test/property/test_cross_version_persist.py
+            shard_index: 2
+            shard_count: 3
+          - name: cross-version-3
+            args: chromadb/test/property/test_cross_version_persist.py
+            shard_index: 3
+            shard_count: 3
+    runs-on: ${{ inputs.runner }}
+    name: test-rust-bindings (${{ matrix.python }}, ${{ matrix.test_target.name }})
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Python
+        uses: ./.github/actions/python
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Download wheel
+        uses: actions/download-artifact@v7
+        with:
+          name: rust-bindings-${{ runner.os }}-py${{ matrix.python }}
+          path: target/wheels
       - name: Install built wheel
         shell: bash
         run: pip install --no-index --find-links target/wheels/ chromadb
       - name: Test
-        run: python -m pytest -x ${{ matrix.test-glob }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v --color=yes --durations 10
+        run: >-
+          python bin/ci/pytest-shard.py
+          --shard-index ${{ matrix.test_target.shard_index }}
+          --shard-count ${{ matrix.test_target.shard_count }}
+          --pytest-arg=-x
+          --pytest-arg=-v
+          --pytest-arg=--color=yes
+          --pytest-arg=--durations
+          --pytest-arg=10
+          -- ${{ matrix.test_target.args }}
         shell: bash
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
@@ -78,40 +219,149 @@ jobs:
           if-no-files-found: warn
 
   test-rust-single-node-integration:
+    needs: build-rust-cli
     strategy:
       fail-fast: false
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
-        test-glob:
-          - "chromadb/test --ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*'"
-          - "chromadb/test/property/test_add.py"
-          - "chromadb/test/property/test_collections.py"
-          - "chromadb/test/property/test_collections_with_database_tenant.py"
-          - "chromadb/test/property/test_cross_version_persist.py"
-          - "chromadb/test/property/test_embeddings.py"
-          - "chromadb/test/property/test_filtering.py"
-          - "chromadb/test/property/test_persist.py"
-          - "chromadb/test/stress"
+        test_target:
+          - name: core-1
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore='chromadb/test/test_cli.py'
+              --ignore-glob 'chromadb/test/distributed/*'
+            shard_index: 1
+            shard_count: 6
+          - name: core-2
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore='chromadb/test/test_cli.py'
+              --ignore-glob 'chromadb/test/distributed/*'
+            shard_index: 2
+            shard_count: 6
+          - name: core-3
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore='chromadb/test/test_cli.py'
+              --ignore-glob 'chromadb/test/distributed/*'
+            shard_index: 3
+            shard_count: 6
+          - name: core-4
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore='chromadb/test/test_cli.py'
+              --ignore-glob 'chromadb/test/distributed/*'
+            shard_index: 4
+            shard_count: 6
+          - name: core-5
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore='chromadb/test/test_cli.py'
+              --ignore-glob 'chromadb/test/distributed/*'
+            shard_index: 5
+            shard_count: 6
+          - name: core-6
+            args: >-
+              chromadb/test
+              --ignore-glob 'chromadb/test/property/*'
+              --ignore-glob 'chromadb/test/stress/*'
+              --ignore='chromadb/test/test_cli.py'
+              --ignore-glob 'chromadb/test/distributed/*'
+            shard_index: 6
+            shard_count: 6
+          - name: add
+            args: chromadb/test/property/test_add.py
+            shard_index: 1
+            shard_count: 1
+          - name: collections
+            args: chromadb/test/property/test_collections.py
+            shard_index: 1
+            shard_count: 1
+          - name: collections-db-tenant-1
+            args: chromadb/test/property/test_collections_with_database_tenant.py
+            shard_index: 1
+            shard_count: 2
+          - name: collections-db-tenant-2
+            args: chromadb/test/property/test_collections_with_database_tenant.py
+            shard_index: 2
+            shard_count: 2
+          - name: cross-version-1
+            args: chromadb/test/property/test_cross_version_persist.py
+            shard_index: 1
+            shard_count: 3
+          - name: cross-version-2
+            args: chromadb/test/property/test_cross_version_persist.py
+            shard_index: 2
+            shard_count: 3
+          - name: cross-version-3
+            args: chromadb/test/property/test_cross_version_persist.py
+            shard_index: 3
+            shard_count: 3
+          - name: embeddings
+            args: chromadb/test/property/test_embeddings.py
+            shard_index: 1
+            shard_count: 1
+          - name: filtering
+            args: chromadb/test/property/test_filtering.py
+            shard_index: 1
+            shard_count: 1
+          - name: persist-1
+            args: chromadb/test/property/test_persist.py
+            shard_index: 1
+            shard_count: 3
+          - name: persist-2
+            args: chromadb/test/property/test_persist.py
+            shard_index: 2
+            shard_count: 3
+          - name: persist-3
+            args: chromadb/test/property/test_persist.py
+            shard_index: 3
+            shard_count: 3
+          - name: stress
+            args: chromadb/test/stress
+            shard_index: 1
+            shard_count: 1
     runs-on: ${{ inputs.runner }}
+    name: test-rust-single-node-integration (${{ matrix.python }}, ${{ matrix.test_target.name }})
     steps:
     - name: Checkout
       uses: actions/checkout@v5
     - name: Setup Python (${{ matrix.python }})
       uses: ./.github/actions/python
-    - name: Setup Rust
-      uses: ./.github/actions/rust
       with:
-          github-token: ${{ github.token }}
+        python-version: ${{ matrix.python }}
+    - name: Download CLI
+      uses: actions/download-artifact@v7
+      with:
+        name: chroma-cli-${{ runner.os }}
+        path: target/debug
+    - name: Make CLI executable
+      if: runner.os != 'Windows'
+      run: chmod +x target/debug/chroma
+      shell: bash
     - name: Rust Integration Test
-      run: bin/rust-integration-test.sh -x ${{ matrix.test-glob }}
+      run: bin/rust-integration-test.sh -x ${{ matrix.test_target.args }}
       shell: bash
       env:
+        CHROMA_BIN: ${{ runner.os == 'Windows' && 'target/debug/chroma.exe' || './target/debug/chroma' }}
         ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
         CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
         CHROMA_TEST_INVENTORY_JOB: test-rust-single-node-integration
         CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
         CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test-glob }}
+        PYTEST_SHARD_INDEX: ${{ matrix.test_target.shard_index }}
+        PYTEST_SHARD_COUNT: ${{ matrix.test_target.shard_count }}
     - name: Upload test inventory shard
       if: always()
       uses: actions/upload-artifact@v7
@@ -121,16 +371,37 @@ jobs:
         if-no-files-found: warn
 
   test-rust-thin-client:
+    needs: build-rust-cli
     strategy:
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
-        test-glob:
-          - "chromadb/test/property/test_add.py"
-          - "chromadb/test/property/test_collections.py"
-          - "chromadb/test/property/test_collections_with_database_tenant.py"
-          - "chromadb/test/property/test_embeddings.py"
-          - "chromadb/test/property/test_filtering.py"
+        test_target:
+          - name: add
+            args: chromadb/test/property/test_add.py
+            shard_index: 1
+            shard_count: 1
+          - name: collections
+            args: chromadb/test/property/test_collections.py
+            shard_index: 1
+            shard_count: 1
+          - name: collections-db-tenant-1
+            args: chromadb/test/property/test_collections_with_database_tenant.py
+            shard_index: 1
+            shard_count: 2
+          - name: collections-db-tenant-2
+            args: chromadb/test/property/test_collections_with_database_tenant.py
+            shard_index: 2
+            shard_count: 2
+          - name: embeddings
+            args: chromadb/test/property/test_embeddings.py
+            shard_index: 1
+            shard_count: 1
+          - name: filtering
+            args: chromadb/test/property/test_filtering.py
+            shard_index: 1
+            shard_count: 1
     runs-on: ${{ inputs.runner }}
+    name: test-rust-thin-client (${{ matrix.python }}, ${{ matrix.test_target.name }})
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -138,14 +409,20 @@ jobs:
         uses: ./.github/actions/python
         with:
           python-version: ${{ matrix.python }}
-      - name: Setup Rust
-        uses: ./.github/actions/rust
+      - name: Download CLI
+        uses: actions/download-artifact@v7
         with:
-          github-token: ${{ github.token }}
+          name: chroma-cli-${{ runner.os }}
+          path: target/debug
+      - name: Make CLI executable
+        if: runner.os != 'Windows'
+        run: chmod +x target/debug/chroma
+        shell: bash
       - name: Test
-        run: bin/rust-integration-test.sh -x ${{ matrix.test-glob }}
+        run: bin/rust-integration-test.sh -x ${{ matrix.test_target.args }}
         shell: bash
         env:
+          CHROMA_BIN: ${{ runner.os == 'Windows' && 'target/debug/chroma.exe' || './target/debug/chroma' }}
           CHROMA_THIN_CLIENT: "1"
           ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
@@ -153,6 +430,8 @@ jobs:
           CHROMA_TEST_INVENTORY_JOB: test-rust-thin-client
           CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
           CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test-glob }}
+          PYTEST_SHARD_INDEX: ${{ matrix.test_target.shard_index }}
+          PYTEST_SHARD_COUNT: ${{ matrix.test_target.shard_count }}
       - name: Upload test inventory shard
         if: always()
         uses: actions/upload-artifact@v7
@@ -262,6 +541,7 @@ jobs:
 
   test-rust-bindings-stress:
     timeout-minutes: 90
+    needs: build-rust-bindings
     strategy:
       fail-fast: false
       matrix:
@@ -274,14 +554,11 @@ jobs:
         uses: ./.github/actions/python
         with:
           python-version: ${{ matrix.python }}
-      - name: Setup Rust
-        uses: ./.github/actions/rust
+      - name: Download wheel
+        uses: actions/download-artifact@v7
         with:
-          github-token: ${{ github.token }}
-      - name: Build Rust bindings
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
+          name: rust-bindings-${{ runner.os }}-py${{ matrix.python }}
+          path: target/wheels
       - name: Install built wheel
         shell: bash
         run: pip install --no-index --find-links target/wheels/ chromadb
@@ -304,6 +581,7 @@ jobs:
           if-no-files-found: warn
 
   test-python-cli:
+    needs: build-rust-bindings
     strategy:
       fail-fast: false
       matrix:
@@ -314,14 +592,13 @@ jobs:
       uses: actions/checkout@v5
     - name: Setup Python (${{ matrix.python }})
       uses: ./.github/actions/python
-    - name: Setup Rust
-      uses: ./.github/actions/rust
       with:
-        github-token: ${{ github.token }}
-    - name: Build Rust bindings
-      uses: PyO3/maturin-action@v1
+        python-version: ${{ matrix.python }}
+    - name: Download wheel
+      uses: actions/download-artifact@v7
       with:
-        command: build
+        name: rust-bindings-${{ runner.os }}-py${{ matrix.python }}
+        path: target/wheels
     - name: Install built wheel
       shell: bash
       run: pip install --no-index --find-links target/wheels/ chromadb
@@ -344,9 +621,8 @@ jobs:
         if-no-files-found: warn
 
   test-windows-smoke:
-    # only run windows smoke tests when the runner isn't already windows,
-    # also only run the smoke tests on PRs (ie not main and not tags) since
-    # we are already running the full suite on Windows in those cases
+    # Keep a Windows smoke signal on PRs. Main/tag release CI stays on the
+    # fast Linux path; Windows package builds are covered by release builders.
     if: ${{ !contains(inputs.runner, 'windows') && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false

--- a/bin/ci/pytest-shard.py
+++ b/bin/ci/pytest-shard.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Run a deterministic shard of a pytest selection."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from typing import Sequence
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shard-index", type=int, default=1)
+    parser.add_argument("--shard-count", type=int, default=1)
+    parser.add_argument(
+        "--pytest-arg",
+        action="append",
+        default=[],
+        help="Argument to pass to the pytest run command. Repeat as needed.",
+    )
+    parser.add_argument("pytest_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if args.pytest_args[:1] == ["--"]:
+        args.pytest_args = args.pytest_args[1:]
+    if args.shard_count < 1:
+        parser.error("--shard-count must be >= 1")
+    if args.shard_index < 1 or args.shard_index > args.shard_count:
+        parser.error("--shard-index must be between 1 and --shard-count")
+    return args
+
+
+def run(cmd: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    print("+ " + " ".join(cmd), flush=True)
+    return subprocess.run(cmd, text=True)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.shard_count == 1:
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            *args.pytest_arg,
+            *args.pytest_args,
+        ]
+        return run(cmd).returncode
+
+    plugin_dir = None
+    try:
+        plugin_dir = tempfile.TemporaryDirectory(prefix="pytest-shard-")
+        with open(
+            os.path.join(plugin_dir.name, "pytest_shard_plugin.py"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write(
+                """
+import os
+
+
+def pytest_collection_modifyitems(config, items):
+    shard_index = int(os.environ["PYTEST_SHARD_INDEX"]) - 1
+    shard_count = int(os.environ["PYTEST_SHARD_COUNT"])
+    selected = []
+    deselected = []
+    for offset, item in enumerate(items):
+        if offset % shard_count == shard_index:
+            selected.append(item)
+        else:
+            deselected.append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected
+
+    print(
+        f"selected {len(selected)} of {len(selected) + len(deselected)} tests "
+        f"for shard {shard_index + 1}/{shard_count}",
+        flush=True,
+    )
+"""
+            )
+
+        env = os.environ.copy()
+        env["PYTEST_SHARD_INDEX"] = str(args.shard_index)
+        env["PYTEST_SHARD_COUNT"] = str(args.shard_count)
+        env["PYTHONPATH"] = (
+            plugin_dir.name
+            if not env.get("PYTHONPATH")
+            else plugin_dir.name + os.pathsep + env["PYTHONPATH"]
+        )
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "pytest_shard_plugin",
+            *args.pytest_arg,
+            *args.pytest_args,
+        ]
+        print("+ " + " ".join(cmd), flush=True)
+        return subprocess.run(cmd, env=env, text=True).returncode
+    finally:
+        if plugin_dir is not None:
+            plugin_dir.cleanup()
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    raise SystemExit(main())

--- a/bin/rust-integration-test.sh
+++ b/bin/rust-integration-test.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+server_pid=""
+
+function cleanup {
+    if [[ -n "$server_pid" ]]; then
+        kill "$server_pid" 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
+
 if [[ $CHROMA_THIN_CLIENT -eq 1 ]]; then
     echo "Using thin client"
     is_thin_client_py="clients/python/is_thin_client.py"
@@ -11,8 +21,13 @@ else
     echo "Using normal client"
 fi
 
-cargo build --bin chroma
-cargo run --bin chroma -- run bin/rust_single_node_integration_test_config.yaml &
+if [[ -n "${CHROMA_BIN:-}" ]]; then
+    "$CHROMA_BIN" run bin/rust_single_node_integration_test_config.yaml &
+else
+    cargo build --bin chroma
+    cargo run --bin chroma -- run bin/rust_single_node_integration_test_config.yaml &
+fi
+server_pid="$!"
 
 echo "Waiting for Chroma server to be available..."
 for i in {1..30}; do
@@ -33,5 +48,14 @@ export CHROMA_INTEGRATION_TEST_ONLY=1
 export CHROMA_SERVER_HOST=localhost
 export CHROMA_SERVER_HTTP_PORT=8000
 
-echo testing: python -m pytest "$@"
-python -m pytest "$@"
+if [[ "${PYTEST_SHARD_COUNT:-1}" -gt 1 ]]; then
+    echo testing: python bin/ci/pytest-shard.py --shard-index "${PYTEST_SHARD_INDEX:-1}" --shard-count "${PYTEST_SHARD_COUNT}" --pytest-arg=-x -- "$@"
+    python bin/ci/pytest-shard.py \
+        --shard-index "${PYTEST_SHARD_INDEX:-1}" \
+        --shard-count "${PYTEST_SHARD_COUNT}" \
+        --pytest-arg=-x \
+        -- "$@"
+else
+    echo testing: python -m pytest "$@"
+    python -m pytest "$@"
+fi

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -34,6 +34,8 @@ from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
 import numpy as np
 import tempfile
 
+from chromadb.api.shared_system_client import SharedSystemClient
+
 CreatePersistAPI = Callable[[], ServerAPI]
 
 configurations = (
@@ -68,6 +70,14 @@ configurations = (
 @pytest.fixture(scope="module", params=configurations)
 def settings(request: pytest.FixtureRequest) -> Generator[Settings, None, None]:
     yield request.param
+
+
+@pytest.fixture(autouse=True)
+def clear_shared_system_cache() -> Generator[None, None, None]:
+    """Keep item-level sharding from reusing a stopped System."""
+    SharedSystemClient.clear_system_cache()
+    yield
+    SharedSystemClient.clear_system_cache()
 
 
 collection_st = st.shared(


### PR DESCRIPTION
## Description of changes

Split the monolithic test-glob matrix entries into fine-grained
shards driven by a new pytest-shard.py helper. Each shard runs a
deterministic slice of the collected tests via a tiny inline pytest
plugin (pytest_shard_plugin.py written to a tempdir).

Build steps are separated from test steps so artifacts (wheels, CLI
binary) are built once and downloaded by every test runner:

- build-rust-bindings: wheels uploaded per OS/Python version
- build-rust-cli: chroma binary uploaded per OS

Other improvements:
- rust-integration-test.sh uses pre-built CHROMA_BIN when set
- rust-integration-test.sh gains a cleanup trap for the server pid
- Remove dedicated Windows CI job from release-chromadb.yml
  (covered by the cross-platform matrix already)

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
