### PR TITLE
[CHORE] always write server logs directly to stdout/stderr

### DIFF
--- a/clients/new-js/packages/chromadb/scripts/start-chroma-common.ts
+++ b/clients/new-js/packages/chromadb/scripts/start-chroma-common.ts
@@ -107,9 +107,6 @@ export const startChromaServer = async (buildContextDir: string) => {
     process.exit(1);
   }
 
-  // jest throws an error if we use console.* after the test complete, so we use this flag to forward logs directly to stdout/stderr during shutdown
-  let is_exiting = false;
-
   console.log(chalk.blue("🚀 Starting Rust Chroma server..."));
   serverProcess = spawn(
     "cargo",
@@ -129,23 +126,19 @@ export const startChromaServer = async (buildContextDir: string) => {
   );
 
   serverProcess.stdout?.on("data", (data) => {
-    const message = chalk.magenta(`🔧 rust-server: ${data.toString().trim()}`);
-    if (is_exiting) {
-      process.stdout.write(message + "\n");
-    } else {
-      console.log(message);
-    }
+    // Jest fails the run if console.* is called after tests complete. Rust can
+    // still emit async logs while global teardown is starting, so write directly.
+    const message = chalk.magenta(
+      `🔧 rust-server: ${data.toString().trimEnd()}`,
+    );
+    process.stdout.write(message + "\n");
   });
 
   serverProcess.stderr?.on("data", (data) => {
     const message = chalk.red(
-      `🔧 rust-server-error: ${data.toString().trim()}`,
+      `🔧 rust-server-error: ${data.toString().trimEnd()}`,
     );
-    if (is_exiting) {
-      process.stderr.write(message + "\n");
-    } else {
-      console.error(message);
-    }
+    process.stderr.write(message + "\n");
   });
 
   console.log(chalk.yellow("⏳ Waiting for Chroma server heartbeat..."));
@@ -171,8 +164,6 @@ export const startChromaServer = async (buildContextDir: string) => {
           resolve();
           return;
         }
-
-        is_exiting = true;
 
         serverProcess.on("exit", () => {
           resolve();

--- a/rust/chroma/examples/embeddings.rs
+++ b/rust/chroma/examples/embeddings.rs
@@ -43,7 +43,7 @@ use serde_json::{to_string_pretty, Error as JsonError};
 const COLLECTION_NAME: &str = "rust_chroma_cloud_embeddings_example";
 const DENSE_KEY: &str = "#embedding";
 const SPARSE_KEY: &str = "sparse_embedding";
-const QUERY: &str = "How do I create embeddings with the Rust client?";
+const QUERY: &str = "How do I create embeddings with Chroma's Rust client?";
 
 struct ExampleRecord {
     id: &'static str,


### PR DESCRIPTION
## Description of changes

Jest fails the run if console.log or console.error is called after tests
complete. The previous approach used an is_exiting flag to switch from
console.* to process.stdout/stderr.write during shutdown, but Rust can
emit async logs before the flag is set, creating a race condition that
causes flaky test failures.

Remove the is_exiting flag entirely and always write through
process.stdout/stderr. Also switch from trim() to trimEnd() to preserve
leading whitespace in server log output.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
