### PR TITLE
[CHORE] Bump setup-protoc action to v4c

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Protoc
-      uses: chroma-core/setup-protoc@v4b
+      uses: chroma-core/setup-protoc@v4c
       with:
         repo-token: ${{ inputs.github-token }}
         version: v35.0


### PR DESCRIPTION
## Description of changes

This action uses a module that doesn't have security warnings, which
cleans up a warning that v4b emitted.

## Test plan

CI

## Migration plan

CI

## Observability plan

N/A

## Documentation Changes

N/A
