### PR TITLE
[CHORE] pin Rust toolchain in CI actions

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -4,6 +4,10 @@ inputs:
   github-token:
     description: "GitHub token"
     required: false
+  toolchain:
+    description: "Rust toolchain to install and use"
+    required: false
+    default: "stable"
   workspaces:
     description: "Workspace paths to cache (see documentation on Swatinem/rust-cache for details)"
     required: false
@@ -14,6 +18,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Rust toolchain
+      shell: bash
+      env:
+        RUST_TOOLCHAIN: ${{ inputs.toolchain }}
+      run: |
+        rustup set profile minimal
+        rustup update "$RUST_TOOLCHAIN"
+        rustup default "$RUST_TOOLCHAIN"
+        rustc --version
+        cargo --version
     - name: Install Protoc
       uses: chroma-core/setup-protoc@v4b
       with:

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/rust
         with:
+          toolchain: stable
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
@@ -127,6 +128,7 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/rust
         with:
+          toolchain: stable
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set version in pyproject.toml
         shell: bash


### PR DESCRIPTION
## Description of changes

Add an explicit toolchain input to the shared rust action so callers
can specify which Rust version to install. The action now runs
rustup update/default before any build steps, ensuring a consistent
compiler version across all jobs.

Blacksmith runners ship varying Rust versions by default, which
became apparent after we recently removed rust-toolchain.toml.
Pinning to stable via the action input makes builds reproducible
regardless of runner image drift.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
