### PR TITLE
refactor: replace ValueError with InvalidArgumentError in collection_configuration

### DIFF
--- a/chromadb/api/collection_configuration.py
+++ b/chromadb/api/collection_configuration.py
@@ -349,7 +349,7 @@ def create_collection_configuration_to_json(
             raise InvalidArgumentError(f"not a valid spann config: {e}")
 
     if hnsw_config is not None and spann_config is not None:
-        raise ValueError("hnsw and spann cannot both be provided")
+        raise InvalidArgumentError("hnsw and spann cannot both be provided")
 
     if config.get("embedding_function") is None:
         ef = None
@@ -565,13 +565,13 @@ def update_collection_configuration_to_json(
         try:
             hnsw_config = cast(UpdateHNSWConfiguration, hnsw_config)
         except Exception as e:
-            raise ValueError(f"not a valid hnsw config: {e}")
+            raise InvalidArgumentError(f"not a valid hnsw config: {e}")
 
     if spann_config is not None:
         try:
             spann_config = cast(UpdateSpannConfiguration, spann_config)
         except Exception as e:
-            raise ValueError(f"not a valid spann config: {e}")
+            raise InvalidArgumentError(f"not a valid spann config: {e}")
 
     ef_config: Dict[str, Any] | None = None
     if ef is not None:
@@ -692,7 +692,7 @@ def overwrite_embedding_function(
 
     # Validate function compatibility
     if existing_embedding_function.name() != update_embedding_function.name():
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Cannot update embedding function: incompatible types "
             f"({existing_embedding_function.name()} vs {update_embedding_function.name()})"
         )
@@ -712,7 +712,7 @@ def overwrite_collection_configuration(
     update_spann = update_config.get("spann")
     update_hnsw = update_config.get("hnsw")
     if update_spann is not None and update_hnsw is not None:
-        raise ValueError("hnsw and spann cannot both be provided")
+        raise InvalidArgumentError("hnsw and spann cannot both be provided")
 
     # Handle HNSW configuration update
 
@@ -770,7 +770,7 @@ def validate_embedding_function_conflict_on_create(
             embedding_function.name() != "default"
             and embedding_function.name() != configuration_ef.name()
         ):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Multiple embedding functions provided. Please provide only one. Embedding function conflict: {embedding_function.name()} vs {configuration_ef.name()}"
             )
     return None
@@ -793,7 +793,7 @@ def validate_embedding_function_conflict_on_get(
             and persisted_ef_config.get("name") is not None
             and persisted_ef_config.get("name") != embedding_function.name()
         ):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"An embedding function already exists in the collection configuration, and a new one is provided. If this is intentional, please embed documents separately. Embedding function conflict: new: {embedding_function.name()} vs persisted: {persisted_ef_config.get('name')}"
             )
     return None
@@ -819,18 +819,18 @@ def update_schema_from_collection_configuration(
         schema.defaults.float_list is None
         or schema.defaults.float_list.vector_index is None
     ):
-        raise ValueError("Schema is missing defaults.float_list.vector_index")
+        raise InvalidArgumentError("Schema is missing defaults.float_list.vector_index")
 
     embedding_key = "#embedding"
     if embedding_key not in schema.keys:
-        raise ValueError(f"Schema is missing keys[{embedding_key}]")
+        raise InvalidArgumentError(f"Schema is missing keys[{embedding_key}]")
 
     embedding_value_types = schema.keys[embedding_key]
     if (
         embedding_value_types.float_list is None
         or embedding_value_types.float_list.vector_index is None
     ):
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Schema is missing keys[{embedding_key}].float_list.vector_index"
         )
 
@@ -842,7 +842,7 @@ def update_schema_from_collection_configuration(
         if "hnsw" in configuration and configuration["hnsw"] is not None:
             # Update HNSW config
             if vector_index.config.hnsw is None:
-                raise ValueError("Trying to update HNSW config but schema has SPANN")
+                raise InvalidArgumentError("Trying to update HNSW config but schema has SPANN")
 
             hnsw_config = vector_index.config.hnsw
             update_hnsw = configuration["hnsw"]
@@ -862,7 +862,7 @@ def update_schema_from_collection_configuration(
         elif "spann" in configuration and configuration["spann"] is not None:
             # Update SPANN config
             if vector_index.config.spann is None:
-                raise ValueError("Trying to update SPANN config but schema has HNSW")
+                raise InvalidArgumentError("Trying to update SPANN config but schema has HNSW")
 
             spann_config = vector_index.config.spann
             update_spann = configuration["spann"]

--- a/chromadb/api/collection_configuration.py
+++ b/chromadb/api/collection_configuration.py
@@ -6,6 +6,7 @@ from chromadb.api.types import (
     UpdateMetadata,
     EmbeddingFunction,
 )
+from chromadb.errors import InvalidArgumentError
 from chromadb.utils.embedding_functions import (
     known_embedding_functions,
     register_embedding_function,
@@ -60,7 +61,7 @@ def load_collection_configuration_from_json(
         config_json_map.get("spann") is not None
         and config_json_map.get("hnsw") is not None
     ):
-        raise ValueError("hnsw and spann cannot both be provided")
+        raise InvalidArgumentError("hnsw and spann cannot both be provided")
 
     hnsw_config = None
     spann_config = None
@@ -86,19 +87,19 @@ def load_collection_configuration_from_json(
             try:
                 ef_name = ef_config["name"]
             except KeyError:
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"Embedding function name not found in config: {ef_config}"
                 )
             try:
                 ef = known_embedding_functions[ef_name]
             except KeyError:
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"Embedding function {ef_name} not found. Add @register_embedding_function decorator to the class definition."
                 )
             try:
                 ef = ef.build_from_config(ef_config["config"])  # type: ignore
             except Exception as e:
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"Could not build embedding function {ef_config['name']} from config {ef_config['config']}: {e}"
                 )
     else:
@@ -139,12 +140,12 @@ def collection_configuration_to_json(config: CollectionConfiguration) -> Dict[st
         try:
             hnsw_config = cast(HNSWConfiguration, hnsw_config)
         except Exception as e:
-            raise ValueError(f"not a valid hnsw config: {e}")
+            raise InvalidArgumentError(f"not a valid hnsw config: {e}")
     if spann_config is not None:
         try:
             spann_config = cast(SpannConfiguration, spann_config)
         except Exception as e:
-            raise ValueError(f"not a valid spann config: {e}")
+            raise InvalidArgumentError(f"not a valid spann config: {e}")
 
     if ef is None:
         ef = None
@@ -197,7 +198,7 @@ def json_to_create_hnsw_configuration(
         if space_value in get_args(Space):
             config["space"] = space_value
         else:
-            raise ValueError(f"not a valid space: {space_value}")
+            raise InvalidArgumentError(f"not a valid space: {space_value}")
     if "ef_construction" in json_map:
         config["ef_construction"] = json_map["ef_construction"]
     if "max_neighbors" in json_map:
@@ -240,7 +241,7 @@ def json_to_create_spann_configuration(
         if space_value in get_args(Space):
             config["space"] = space_value
         else:
-            raise ValueError(f"not a valid space: {space_value}")
+            raise InvalidArgumentError(f"not a valid space: {space_value}")
     if "ef_construction" in json_map:
         config["ef_construction"] = json_map["ef_construction"]
     if "ef_search" in json_map:
@@ -292,7 +293,7 @@ def load_create_collection_configuration_from_json(
     json_map: Dict[str, Any]
 ) -> CreateCollectionConfiguration:
     if json_map.get("hnsw") is not None and json_map.get("spann") is not None:
-        raise ValueError("hnsw and spann cannot both be provided")
+        raise InvalidArgumentError("hnsw and spann cannot both be provided")
 
     result = CreateCollectionConfiguration()
 
@@ -340,12 +341,12 @@ def create_collection_configuration_to_json(
         try:
             hnsw_config = cast(CreateHNSWConfiguration, hnsw_config)
         except Exception as e:
-            raise ValueError(f"not a valid hnsw config: {e}")
+            raise InvalidArgumentError(f"not a valid hnsw config: {e}")
     if spann_config is not None:
         try:
             spann_config = cast(CreateSpannConfiguration, spann_config)
         except Exception as e:
-            raise ValueError(f"not a valid spann config: {e}")
+            raise InvalidArgumentError(f"not a valid spann config: {e}")
 
     if hnsw_config is not None and spann_config is not None:
         raise ValueError("hnsw and spann cannot both be provided")
@@ -607,7 +608,7 @@ def load_update_collection_configuration_from_json(
 ) -> UpdateCollectionConfiguration:
     """Convert a JSON dict to an UpdateCollectionConfiguration"""
     if json_map.get("hnsw") is not None and json_map.get("spann") is not None:
-        raise ValueError("hnsw and spann cannot both be provided")
+        raise InvalidArgumentError("hnsw and spann cannot both be provided")
 
     result = UpdateCollectionConfiguration()
 


### PR DESCRIPTION
Replace ValueError with InvalidArgumentError in collection_configuration.py for better error handling and consistency with the chroma error system.

Changes:
- Import InvalidArgumentError from chromadb.errors
- Replace ValueError with InvalidArgumentError for invalid space values, invalid hnsw/spann configurations, invalid embedding function configurations, and conflicting hnsw and spann configurations

Fixes #3026