### PR TITLE
Add flake8 check for relative imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,11 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-tidy-imports
         args:
-          - "--extend-ignore=E203,E501,E503"
+          - "--extend-ignore=E203,E501,E503,I250"
+          - "--ban-relative-imports=true"
           - "--max-line-length=88"
 
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -8,7 +8,8 @@ It can be used to get information about available schemas and their versions.
 from typing import Dict, List, Set
 import os
 import json
-from .schema_utils import SCHEMAS_DIR
+
+from chromadb.utils.embedding_functions.schemas.schema_utils import SCHEMAS_DIR
 
 
 def get_available_schemas() -> List[str]:


### PR DESCRIPTION
## Summary
- add `flake8-tidy-imports` to the flake8 pre-commit hook
- enable flake8's relative-import ban for Python files
- convert the remaining relative import in the schema registry to an absolute import

## Why
Issue #2334 asks for a flake8 rule that bans relative imports. This wires the rule into the existing lint hook without also turning on the plugin's unrelated alias warning (`I250`), which would otherwise create a much larger cleanup.

## Validation
- `python -m flake8 --select=TID252 --ban-relative-imports=true chromadb`
- `python -m compileall chromadb/utils/embedding_functions/schemas/registry.py`
