### PR TITLE
[BLD](tilt): Persist postgres state across restarts + bump CPU cap

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -85,6 +85,14 @@ jobs:
               - 'bin/**'
               - '**/docker-compose*.yml'
               - 'Makefile'
+              # The Tilt-stack test manifests (postgres, minio, otel, etc.)
+              # are the harness every k8s integration test runs against.
+              # A change here is invisible to the rust/python/go path
+              # filters, so without this line a manifest-only PR skips the
+              # very suites that exercise it (and the breakage surfaces
+              # later on an unrelated PR). Excludes k8s/distributed-chroma,
+              # which is the Helm chart and has its own filter.
+              - 'k8s/test/**'
 
       - name: Determine tests to run
         id: determine-tests

--- a/k8s/test/postgres.yaml
+++ b/k8s/test/postgres.yaml
@@ -45,22 +45,26 @@ spec:
           # 100m / 100m was too tight once the dev stack grew to ~20
           # parallel clients (sync-frontend + indexer + cron + change-
           # notifier + dashboard-api + foundation-server + hosted-
-          # frontend-db-migration + various test pods). With that
-          # ceiling postgres' auth path can't keep up: clients see
-          # `canceling authentication due to timeout`, the
-          # `pg_isready -U chroma` readiness probe with its 1s deadline
-          # starts failing, the pod flaps 0/1, and downstream initContainers
-          # CrashLoopBackOff with `ECONNREFUSED`. The 200m request is the
-          # guaranteed share that actually protects the auth path under
-          # contention; the 500m limit is burst headroom. Capped at 500m
-          # (not a full core) so two of these fit a single CI runner when
-          # MULTI_REGION/MCMR brings up a second stack in `chroma2` — keep
-          # this in sync with k8s/test/postgres2.yaml.
+          # frontend-db-migration + various test pods): postgres' auth
+          # path couldn't keep up, clients saw `canceling authentication
+          # due to timeout`, the `pg_isready -U chroma` readiness probe
+          # (1s deadline) flapped the pod 0/1, and downstream
+          # initContainers CrashLoopBackOff'd with `ECONNREFUSED`.
+          #
+          # The binding constraint there was the *ceiling*, not the floor:
+          # the 100m limit hard-capped postgres even with idle cores. So
+          # raise the limit (1000m = burst into idle CPU during the startup
+          # connection storm) while keeping the request small. The small
+          # request is deliberate: scheduling bin-packs on requests only
+          # (no ResourceQuota/LimitRange in k8s/), so 100m x 2 regions =
+          # 200m lets both this and chroma2's postgres fit the ~4 vCPU
+          # MULTI_REGION/MCMR cluster with room for ~30 other pods. Keep in
+          # sync with k8s/test/postgres2.yaml.
           resources:
             requests:
-              cpu: "200m"
+              cpu: "100m"
             limits:
-              cpu: "500m"
+              cpu: "1000m"
           env:
             - name: POSTGRES_MULTIPLE_DATABASES
               value: "sysdb,log"

--- a/k8s/test/postgres.yaml
+++ b/k8s/test/postgres.yaml
@@ -50,13 +50,17 @@ spec:
           # `canceling authentication due to timeout`, the
           # `pg_isready -U chroma` readiness probe with its 1s deadline
           # starts failing, the pod flaps 0/1, and downstream initContainers
-          # CrashLoopBackOff with `ECONNREFUSED`. Bumping the limit
-          # restores headroom without changing the image.
+          # CrashLoopBackOff with `ECONNREFUSED`. The 200m request is the
+          # guaranteed share that actually protects the auth path under
+          # contention; the 500m limit is burst headroom. Capped at 500m
+          # (not a full core) so two of these fit a single CI runner when
+          # MULTI_REGION/MCMR brings up a second stack in `chroma2` — keep
+          # this in sync with k8s/test/postgres2.yaml.
           resources:
             requests:
               cpu: "200m"
             limits:
-              cpu: "1"
+              cpu: "500m"
           env:
             - name: POSTGRES_MULTIPLE_DATABASES
               value: "sysdb,log"

--- a/k8s/test/postgres.yaml
+++ b/k8s/test/postgres.yaml
@@ -1,3 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: chroma
+spec:
+  # `ReadWriteOnce` (single-writer) is fine because we pair this with
+  # `strategy: Recreate` on the Deployment below — a PVC can only be
+  # mounted by one pod at a time on most cluster types.
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # 5 GiB covers the sysdb + log databases for typical Tilt-stack
+      # development. The PVC's StorageClass-default is left implicit so
+      # it works on k3d / kind / OrbStack / minikube without per-cluster
+      # tweaks.
+      storage: 5Gi
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,6 +28,12 @@ spec:
   selector:
     matchLabels:
       app: postgres
+  # PVCs with `ReadWriteOnce` can only be mounted by one pod at a
+  # time. Default `RollingUpdate` would try to bring up the new pod
+  # before tearing the old one down → the new pod would be Pending
+  # forever waiting for the volume. `Recreate` does the right thing.
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -16,11 +42,21 @@ spec:
       containers:
         - name: postgres
           image: chroma-postgres
+          # 100m / 100m was too tight once the dev stack grew to ~20
+          # parallel clients (sync-frontend + indexer + cron + change-
+          # notifier + dashboard-api + foundation-server + hosted-
+          # frontend-db-migration + various test pods). With that
+          # ceiling postgres' auth path can't keep up: clients see
+          # `canceling authentication due to timeout`, the
+          # `pg_isready -U chroma` readiness probe with its 1s deadline
+          # starts failing, the pod flaps 0/1, and downstream initContainers
+          # CrashLoopBackOff with `ECONNREFUSED`. Bumping the limit
+          # restores headroom without changing the image.
           resources:
             requests:
-              cpu: "100m"
+              cpu: "200m"
             limits:
-              cpu: "100m"
+              cpu: "1"
           env:
             - name: POSTGRES_MULTIPLE_DATABASES
               value: "sysdb,log"
@@ -28,8 +64,18 @@ spec:
               value: chroma
             - name: POSTGRES_PASSWORD
               value: chroma
+            # The official postgres image refuses to initdb into a
+            # non-empty data dir. Using a subdir keeps the PVC root
+            # clean of `lost+found` etc. from the underlying volume
+            # and lets us share the volume across multiple databases
+            # cleanly.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           ports:
             - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
           readinessProbe:
             exec:
               command:
@@ -38,6 +84,10 @@ spec:
                 - chroma
             periodSeconds: 1
             failureThreshold: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data
 
 ---
 apiVersion: v1

--- a/k8s/test/postgres2.yaml
+++ b/k8s/test/postgres2.yaml
@@ -16,11 +16,16 @@ spec:
       containers:
         - name: postgres
           image: chroma-postgres
+          # Mirrors the chroma-namespace postgres (k8s/test/postgres.yaml):
+          # 200m guaranteed share for the auth path under contention, 500m
+          # burst. Sized so this region-2 postgres and the region-1 one
+          # both fit a single CI runner under MULTI_REGION/MCMR. Keep the
+          # two in sync.
           resources:
             requests:
-              cpu: "100m"
+              cpu: "200m"
             limits:
-              cpu: "100m"
+              cpu: "500m"
           env:
             - name: POSTGRES_MULTIPLE_DATABASES
               value: "sysdb,log"

--- a/k8s/test/postgres2.yaml
+++ b/k8s/test/postgres2.yaml
@@ -17,15 +17,16 @@ spec:
         - name: postgres
           image: chroma-postgres
           # Mirrors the chroma-namespace postgres (k8s/test/postgres.yaml):
-          # 200m guaranteed share for the auth path under contention, 500m
-          # burst. Sized so this region-2 postgres and the region-1 one
-          # both fit a single CI runner under MULTI_REGION/MCMR. Keep the
-          # two in sync.
+          # small 100m request (bin-packs region-1 + region-2 into the
+          # ~4 vCPU MULTI_REGION/MCMR cluster — scheduling counts requests,
+          # not limits) + 1000m burst limit (the original starvation was
+          # the 100m *ceiling*; the limit lets postgres use idle CPU during
+          # the startup connection storm). Keep the two in sync.
           resources:
             requests:
-              cpu: "200m"
+              cpu: "100m"
             limits:
-              cpu: "500m"
+              cpu: "1000m"
           env:
             - name: POSTGRES_MULTIPLE_DATABASES
               value: "sysdb,log"


### PR DESCRIPTION
Needed this to get foundation CLI GDrive sync working locally.

## What

Three changes, all scoped to the Tilt local-dev / CI test stack (no user, docker-compose, or `distributed-chroma` Helm impact):

1. **Persist postgres across restarts** — give the `chroma`-namespace postgres a 5 GiB `ReadWriteOnce` PVC so its data survives pod restarts instead of living in the ephemeral pod filesystem.
2. **Right-size postgres CPU** — move both the `chroma` and `chroma2` (MULTI_REGION) postgres pods off the starved `100m`/`100m` to a small request + generous burst limit (`100m` request / `1000m` limit).
3. **Make the test harness self-testing** — a change to `k8s/test/**` now triggers the integration suite, so manifest-only PRs like this one are actually exercised instead of skipped.

## Why

### Persistence
Without a volume, every postgres restart (rolling deploy, OOM, crash, `kubectl delete pod`) wipes the sysdb + log + management + sync databases. The migrations that planted those tables stay `Complete` in k8s but their effects are gone — `sysdb-migration-latest`'s "ran 3 hours ago" doesn't help when postgres restarted 30 seconds ago. Downstream services then fail with `relation "..." does not exist` / `tenant not found` / `Permission denied`, and the whole local stack looks broken even though every individual service is healthy.

This bit hardest for **foundation GDrive sync**, which is what surfaced it. By design the backend is the source of truth and the CLI keeps nothing recoverable: after `gdrive login` the CLI discards the OAuth tokens, so the delta cursor (`start_page_token`), the `watch_channel_*` registration, and the `gdrive_files` mirror live only in the `sync` database (the tokens themselves live in the dashboard-api credential vault — also DB-backed). A single ephemeral-postgres restart mid-session silently resets you to "no account connected" with no way back short of re-running the whole OAuth loopback flow — and the end-to-end dev loop (login → fan-out → index → webhook across ~20 services) takes long enough that a restart landing mid-test is likely. For other sources a wipe just means re-triggering a sync; for GDrive it's losing the connection itself.

### CPU
`100m` (10% of a core) was fine when ~5 services talked to postgres. The stack has grown to ~20 (sync-frontend + indexer + change-notifier + 2 gdrive crons + dashboard-api + foundation-server + hosted-frontend-db-migration + sysdb-migration + others), each holding pooled connections. Under that load postgres' auth path can't service connection attempts fast enough: clients see `FATAL: canceling authentication due to timeout`, the `pg_isready -U chroma` readiness probe (1s deadline) times out → the pod flaps 0/1 → downstream `initContainers` `CrashLoopBackOff` with `ECONNREFUSED`.

The binding constraint there was the **ceiling, not the floor**: the `100m` *limit* hard-capped postgres even when the node had idle cores. So the fix raises the limit (`1000m` — burst into idle CPU during the startup connection storm) while keeping the *request* small (`100m`). The small request is deliberate, and it's what makes this safe for MULTI_REGION/MCMR: scheduling bin-packs on requests only (there's no `ResourceQuota`/`LimitRange` in `k8s/` that would count limits), so `100m` × 2 regions = `200m` lets both postgres pods fit the ~4 vCPU MCMR cluster with room for the ~30 other pods. `postgres2.yaml` (the `chroma2` region) is moved to the same numbers — it was still on the old `100m` ceiling and would have hit the original starvation the moment MCMR is re-enabled.

(One honest caveat for whoever re-enables MCMR: under a *fully saturated* 4-core node, CFS shares CPU by request, so a `100m`-request postgres gets a thinner guaranteed slice and the `1000m` limit can't help — there's no idle CPU to burst into. That's a tuning point for the disabled MCMR path, not a problem for the active single-stack CI or for getting MCMR to schedule.)

### CI filter
PR change-detection (`.github/workflows/pr.yml`) gates the k8s integration tests on the `rust`/`python`/`go`/`ci-infra` path filters — none of which matched `k8s/test/**`. So a PR that only edits a Tilt test manifest (exactly this one) **skipped every suite that stands the manifest up via `tilt ci`**: CI went green without running anything, and a broken manifest would only surface later on an unrelated rust PR. Adding `k8s/test/**` to the `ci-infra` ("core infra → run all tests") filter fixes that going forward, and — because the commit also touches `.github/**` → `ci-infra` — makes this PR run the suite, validating the PVC and the new CPU numbers for real.

## How

```yaml
# k8s/test/postgres.yaml — chroma namespace
PersistentVolumeClaim postgres-data: { accessModes: [ReadWriteOnce], storage: 5Gi }
Deployment:
  strategy.type: Recreate                          # RWO PVC can't be mounted twice
  env.PGDATA: /var/lib/postgresql/data/pgdata      # subdir so initdb ignores lost+found
  volumeMounts/volumes: data → claim postgres-data
  resources: { requests.cpu: 100m, limits.cpu: 1000m }   # was 100m / 100m

# k8s/test/postgres2.yaml — chroma2 (MULTI_REGION) namespace
  resources: { requests.cpu: 100m, limits.cpu: 1000m }   # was 100m / 100m (no PVC — region-2 stays ephemeral)

# .github/workflows/pr.yml
ci-infra filter += 'k8s/test/**'                   # harness changes now run the integration suite
```

Note: only the `chroma`-region postgres gets the PVC; `chroma2` is MCMR-only and left ephemeral. Say the word if region-2 should persist too.

## Test plan

Manually verified on OrbStack k3d:

1. `kubectl apply -f k8s/test/postgres.yaml` → PVC `postgres-data` provisions at 5 Gi via `rancher.io/local-path`; pod boots, mounts the volume, initdb runs into the `pgdata` subdir.
2. Plant a sentinel (`INSERT INTO pvc_test ...`), `kubectl delete pod -l app=postgres` → new pod comes up, sentinel still there. ✓
3. Under load (full hosted-chroma Tilt stack + client services concurrently restarting), postgres stays 1/1 — no `canceling authentication` lines, no downstream `ECONNREFUSED` crashloop. ✓

CI: with the filter change, this PR now runs the rust k8s integration suite on minikube (the fresh-cluster path that actually stands this manifest up) — that run is the real confirmation the PVC binds and the `100m`/`1000m` postgres clears the startup connection storm.

## Migration note for existing dev environments

The first apply is **destructive** for any sysdb / log / management / sync data sitting in the ephemeral pod's filesystem. Anything depending on chroma sysdb state re-runs automatically: `sysdb-migration-latest` (when the new pod comes up) and `dashboard-seed` in hosted-chroma (via Tilt); tenants/databases created through the dashboard-api flow need recreating. Subsequent restarts preserve data normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
