### PR TITLE
[BUG](api): Harden EF config loading

### DIFF
--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -201,6 +201,16 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         if embedding_function is not None and configuration_ef is None:
             configuration["embedding_function"] = embedding_function
 
+        collection_embedding_function = embedding_function
+        if (
+            configuration_ef is not None
+            and (
+                embedding_function is None
+                or isinstance(embedding_function, DefaultEmbeddingFunction)
+            )
+        ):
+            collection_embedding_function = configuration_ef
+
         model = await self._server.create_collection(
             name=name,
             schema=schema,
@@ -213,7 +223,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         return AsyncCollection(
             client=self._server,
             model=model,
-            embedding_function=embedding_function,
+            embedding_function=collection_embedding_function,
             data_loader=data_loader,
         )
 
@@ -307,6 +317,17 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
 
         if embedding_function is not None and configuration_ef is None:
             configuration["embedding_function"] = embedding_function
+
+        collection_embedding_function = embedding_function
+        if (
+            configuration_ef is not None
+            and (
+                embedding_function is None
+                or isinstance(embedding_function, DefaultEmbeddingFunction)
+            )
+        ):
+            collection_embedding_function = configuration_ef
+
         model = await self._server.get_or_create_collection(
             name=name,
             schema=schema,
@@ -319,13 +340,13 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         persisted_ef_config = model.configuration_json.get("embedding_function")
 
         validate_embedding_function_conflict_on_get(
-            embedding_function, persisted_ef_config
+            collection_embedding_function, persisted_ef_config
         )
 
         return AsyncCollection(
             client=self._server,
             model=model,
-            embedding_function=embedding_function,
+            embedding_function=collection_embedding_function,
             data_loader=data_loader,
         )
 

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -219,6 +219,16 @@ class Client(SharedSystemClient, ClientAPI):
         if embedding_function is not None and configuration_ef is None:
             configuration["embedding_function"] = embedding_function
 
+        collection_embedding_function = embedding_function
+        if (
+            configuration_ef is not None
+            and (
+                embedding_function is None
+                or isinstance(embedding_function, DefaultEmbeddingFunction)
+            )
+        ):
+            collection_embedding_function = configuration_ef
+
         model = self._server.create_collection(
             name=name,
             schema=schema,
@@ -231,7 +241,7 @@ class Client(SharedSystemClient, ClientAPI):
         return Collection(
             client=self._server,
             model=model,
-            embedding_function=embedding_function,
+            embedding_function=collection_embedding_function,
             data_loader=data_loader,
         )
 
@@ -358,6 +368,17 @@ class Client(SharedSystemClient, ClientAPI):
 
         if embedding_function is not None and configuration_ef is None:
             configuration["embedding_function"] = embedding_function
+
+        collection_embedding_function = embedding_function
+        if (
+            configuration_ef is not None
+            and (
+                embedding_function is None
+                or isinstance(embedding_function, DefaultEmbeddingFunction)
+            )
+        ):
+            collection_embedding_function = configuration_ef
+
         model = self._server.get_or_create_collection(
             name=name,
             schema=schema,
@@ -370,13 +391,13 @@ class Client(SharedSystemClient, ClientAPI):
         persisted_ef_config = model.configuration_json.get("embedding_function")
 
         validate_embedding_function_conflict_on_get(
-            embedding_function, persisted_ef_config
+            collection_embedding_function, persisted_ef_config
         )
 
         return Collection(
             client=self._server,
             model=model,
-            embedding_function=embedding_function,
+            embedding_function=collection_embedding_function,
             data_loader=data_loader,
         )
 

--- a/chromadb/api/collection_configuration.py
+++ b/chromadb/api/collection_configuration.py
@@ -10,6 +10,9 @@ from chromadb.utils.embedding_functions import (
     known_embedding_functions,
     register_embedding_function,
 )
+from chromadb.utils.embedding_functions.config_validation import (
+    validate_embedding_function_config_is_safe,
+)
 from multiprocessing import cpu_count
 import warnings
 
@@ -96,6 +99,7 @@ def load_collection_configuration_from_json(
                     f"Embedding function {ef_name} not found. Add @register_embedding_function decorator to the class definition."
                 )
             try:
+                validate_embedding_function_config_is_safe(ef_name, ef_config["config"])
                 ef = ef.build_from_config(ef_config["config"])  # type: ignore
             except Exception as e:
                 raise ValueError(
@@ -314,6 +318,9 @@ def load_create_collection_configuration_from_json(
             )
         else:
             ef = known_embedding_functions[ef_config["name"]]
+            validate_embedding_function_config_is_safe(
+                ef_config["name"], ef_config["config"]
+            )
             result["embedding_function"] = ef.build_from_config(ef_config["config"])
 
     return result
@@ -628,6 +635,10 @@ def load_update_collection_configuration_from_json(
             )
         else:
             ef = known_embedding_functions[json_map["embedding_function"]["name"]]
+            validate_embedding_function_config_is_safe(
+                json_map["embedding_function"]["name"],
+                json_map["embedding_function"]["config"],
+            )
             result["embedding_function"] = ef.build_from_config(
                 json_map["embedding_function"]["config"]
             )

--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -752,6 +752,19 @@ class CollectionCommon(Generic[ClientT]):
             else:
                 return self._embedding_function(input=input)
 
+        persisted_ef_config = self.configuration_json.get("embedding_function")
+        if (
+            persisted_ef_config is not None
+            and persisted_ef_config.get("type") != "legacy"
+            and persisted_ef_config.get("name") not in (None, "default")
+        ):
+            raise ValueError(
+                "An explicit embedding function is required to compute embeddings "
+                "for collections with a non-default embedding function in their "
+                "configuration. Provide an embedding_function when retrieving the "
+                "collection, or provide embeddings directly."
+            )
+
         config_ef = self.configuration.get("embedding_function")
         if config_ef is not None:
             if is_query:

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -2912,11 +2912,15 @@ class Schema:
                 else:
                     try:
                         from chromadb.utils.embedding_functions import (
+                            config_validation,
                             known_embedding_functions,
                         )
 
                         ef_name = ef_config["name"]
                         ef = known_embedding_functions[ef_name]
+                        config_validation.validate_embedding_function_config_is_safe(
+                            ef_name, ef_config["config"]
+                        )
                         config_data["embedding_function"] = ef.build_from_config(
                             ef_config["config"]
                         )
@@ -2962,11 +2966,15 @@ class Schema:
                 else:
                     try:
                         from chromadb.utils.embedding_functions import (
+                            config_validation,
                             sparse_known_embedding_functions,
                         )
 
                         ef_name = ef_config["name"]
                         ef = sparse_known_embedding_functions[ef_name]
+                        config_validation.validate_embedding_function_config_is_safe(
+                            ef_name, ef_config["config"]
+                        )
                         config_data["embedding_function"] = ef.build_from_config(
                             ef_config["config"]
                         )

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -819,6 +819,16 @@ class FastAPI(Server):
             request: Request, tenant: str, database: str, raw_body: bytes
         ) -> CollectionModel:
             create = validate_model(CreateCollection, orjson.loads(raw_body))
+
+            # NOTE(rescrv, iron will auth):  Implemented.
+            self.sync_auth_request(
+                request.headers,
+                AuthzAction.CREATE_COLLECTION,
+                tenant,
+                database,
+                create.name,
+            )
+
             if not create.configuration:
                 if create.metadata:
                     configuration = (
@@ -832,15 +842,6 @@ class FastAPI(Server):
                 configuration = load_create_collection_configuration_from_json(
                     create.configuration
                 )
-
-            # NOTE(rescrv, iron will auth):  Implemented.
-            self.sync_auth_request(
-                request.headers,
-                AuthzAction.CREATE_COLLECTION,
-                tenant,
-                database,
-                create.name,
-            )
 
             self._set_request_context(request=request)
 
@@ -1951,13 +1952,6 @@ class FastAPI(Server):
             request: Request, tenant: str, database: str, raw_body: bytes
         ) -> CollectionModel:
             create = validate_model(CreateCollection, orjson.loads(raw_body))
-            configuration = (
-                CreateCollectionConfiguration()
-                if not create.configuration
-                else load_create_collection_configuration_from_json(
-                    create.configuration
-                )
-            )
 
             (
                 maybe_tenant,
@@ -1974,6 +1968,14 @@ class FastAPI(Server):
                 tenant = maybe_tenant
             if maybe_database:
                 database = maybe_database
+
+            configuration = (
+                CreateCollectionConfiguration()
+                if not create.configuration
+                else load_create_collection_configuration_from_json(
+                    create.configuration
+                )
+            )
 
             return self._api.create_collection(
                 name=create.name,

--- a/chromadb/test/api/test_schema.py
+++ b/chromadb/test/api/test_schema.py
@@ -20,6 +20,10 @@ from chromadb.execution.expression.operator import Key
 from typing import List, Dict, Any
 from pydantic import ValidationError
 import pytest
+from chromadb.utils.embedding_functions import (
+    known_embedding_functions,
+    sparse_known_embedding_functions,
+)
 
 
 class MockSparseEmbeddingFunction(SparseEmbeddingFunction[List[str]]):
@@ -73,8 +77,128 @@ class MockEmbeddingFunction(EmbeddingFunction[List[str]]):
         return ["cosine", "l2", "ip"]
 
 
+class ExplodingVectorEmbeddingFunction(EmbeddingFunction[List[str]]):
+    build_calls = 0
+
+    def __call__(self, input: List[str]) -> Embeddings:
+        raise AssertionError("unsafe embedding function should not be called")
+
+    @staticmethod
+    def name() -> str:
+        return "sentence_transformer"
+
+    @staticmethod
+    def build_from_config(
+        config: Dict[str, Any]
+    ) -> "ExplodingVectorEmbeddingFunction":
+        ExplodingVectorEmbeddingFunction.build_calls += 1
+        raise AssertionError("unsafe embedding function should not be built")
+
+
+class ExplodingSparseEmbeddingFunction(SparseEmbeddingFunction[List[str]]):
+    build_calls = 0
+
+    def __call__(self, input: List[str]) -> List[SparseVector]:
+        raise AssertionError("unsafe sparse embedding function should not be called")
+
+    @staticmethod
+    def name() -> str:
+        return "huggingface_sparse"
+
+    @staticmethod
+    def build_from_config(
+        config: Dict[str, Any]
+    ) -> "ExplodingSparseEmbeddingFunction":
+        ExplodingSparseEmbeddingFunction.build_calls += 1
+        raise AssertionError("unsafe sparse embedding function should not be built")
+
+
 class TestNewSchema:
     """Test cases for the new Schema class."""
+
+    def test_unsafe_vector_embedding_kwargs_are_not_deserialized(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ExplodingVectorEmbeddingFunction.build_calls = 0
+        monkeypatch.setitem(
+            known_embedding_functions,
+            "sentence_transformer",
+            ExplodingVectorEmbeddingFunction,
+        )
+
+        schema = Schema.deserialize_from_json(
+            {
+                "defaults": {
+                    "float_list": {
+                        "vector_index": {
+                            "enabled": True,
+                            "config": {
+                                "embedding_function": {
+                                    "name": "sentence_transformer",
+                                    "type": "known",
+                                    "config": {
+                                        "model_name": "attacker/model",
+                                        "device": "cpu",
+                                        "normalize_embeddings": False,
+                                        "kwargs": {"trust_remote_code": True},
+                                    },
+                                }
+                            },
+                        }
+                    }
+                },
+                "keys": {},
+            }
+        )
+
+        assert ExplodingVectorEmbeddingFunction.build_calls == 0
+        assert schema.defaults.float_list is not None
+        assert schema.defaults.float_list.vector_index is not None
+        assert (
+            schema.defaults.float_list.vector_index.config.embedding_function is None
+        )
+
+    def test_unsafe_sparse_embedding_kwargs_are_not_deserialized(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ExplodingSparseEmbeddingFunction.build_calls = 0
+        monkeypatch.setitem(
+            sparse_known_embedding_functions,
+            "huggingface_sparse",
+            ExplodingSparseEmbeddingFunction,
+        )
+
+        schema = Schema.deserialize_from_json(
+            {
+                "defaults": {
+                    "sparse_vector": {
+                        "sparse_vector_index": {
+                            "enabled": True,
+                            "config": {
+                                "embedding_function": {
+                                    "name": "huggingface_sparse",
+                                    "type": "known",
+                                    "config": {
+                                        "model_name": "attacker/model",
+                                        "device": "cpu",
+                                        "kwargs": {"trust_remote_code": True},
+                                    },
+                                }
+                            },
+                        }
+                    }
+                },
+                "keys": {},
+            }
+        )
+
+        assert ExplodingSparseEmbeddingFunction.build_calls == 0
+        assert schema.defaults.sparse_vector is not None
+        assert schema.defaults.sparse_vector.sparse_vector_index is not None
+        assert (
+            schema.defaults.sparse_vector.sparse_vector_index.config.embedding_function
+            is None
+        )
 
     def test_default_schema_initialization(self) -> None:
         """Test that Schema() initializes with correct defaults."""

--- a/chromadb/test/configurations/test_collection_configuration.py
+++ b/chromadb/test/configurations/test_collection_configuration.py
@@ -7,6 +7,7 @@ from chromadb.api.types import (
     Embeddings,
     Space,
     Embeddable,
+    DefaultEmbeddingFunction,
 )
 from chromadb.api import ClientAPI
 from chromadb.api.collection_configuration import (
@@ -19,13 +20,20 @@ from chromadb.api.collection_configuration import (
     UpdateSpannConfiguration,
     SpannConfiguration,
     overwrite_spann_configuration,
+    load_create_collection_configuration_from_json,
+    load_update_collection_configuration_from_json,
 )
 import json
-from chromadb.utils.embedding_functions import register_embedding_function
+from chromadb.utils.embedding_functions import (
+    known_embedding_functions,
+    register_embedding_function,
+)
 from chromadb.test.conftest import ClientFactories
 from chromadb.test.conftest import is_spann_disabled_mode, skip_reason_spann_disabled
 from chromadb.types import Collection as CollectionModel
+from chromadb.api.models.Collection import Collection
 from typing import Optional, TypedDict
+from uuid import uuid4
 
 
 class LegacyEmbeddingFunction(EmbeddingFunction[Embeddable]):
@@ -92,6 +100,94 @@ class CustomEmbeddingFunction2(EmbeddingFunction[Embeddable]):
 
     def default_space(self) -> Space:
         return "l2"
+
+
+class ExplodingEmbeddingFunction(EmbeddingFunction[Embeddable]):
+    build_calls = 0
+
+    def __call__(self, input: Embeddable) -> Embeddings:
+        raise AssertionError("unsafe embedding function should not be called")
+
+    @staticmethod
+    def name() -> str:
+        return "sentence_transformer"
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "ExplodingEmbeddingFunction":
+        ExplodingEmbeddingFunction.build_calls += 1
+        raise AssertionError("unsafe embedding function should not be built")
+
+
+def malicious_sentence_transformer_config() -> Dict[str, Any]:
+    return {
+        "embedding_function": {
+            "name": "sentence_transformer",
+            "type": "known",
+            "config": {
+                "model_name": "attacker/model",
+                "device": "cpu",
+                "normalize_embeddings": False,
+                "kwargs": {"trust_remote_code": True},
+            },
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "loader",
+    [
+        load_create_collection_configuration_from_json,
+        load_update_collection_configuration_from_json,
+        load_collection_configuration_from_json,
+    ],
+)
+def test_unsafe_embedding_function_kwargs_are_rejected_before_build(
+    monkeypatch: pytest.MonkeyPatch, loader: Any
+) -> None:
+    ExplodingEmbeddingFunction.build_calls = 0
+    monkeypatch.setitem(
+        known_embedding_functions,
+        "sentence_transformer",
+        ExplodingEmbeddingFunction,
+    )
+
+    with pytest.raises(ValueError, match="kwargs"):
+        loader(malicious_sentence_transformer_config())
+
+    assert ExplodingEmbeddingFunction.build_calls == 0
+
+
+def test_default_client_embedding_does_not_execute_persisted_non_default_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ExplodingEmbeddingFunction.build_calls = 0
+    monkeypatch.setitem(
+        known_embedding_functions,
+        "sentence_transformer",
+        ExplodingEmbeddingFunction,
+    )
+
+    model = CollectionModel(
+        id=uuid4(),
+        name="poisoned_collection",
+        configuration_json=malicious_sentence_transformer_config(),
+        serialized_schema=None,
+        metadata=None,
+        dimension=None,
+        tenant="default_tenant",
+        database="default_database",
+    )
+    collection = Collection(
+        client=cast(Any, object()),
+        model=model,
+        embedding_function=DefaultEmbeddingFunction(),
+        data_loader=None,
+    )
+
+    with pytest.raises(ValueError, match="explicit embedding function"):
+        collection._embed(["test"])
+
+    assert ExplodingEmbeddingFunction.build_calls == 0
 
 
 def test_legacy_embedding_function(client: ClientAPI) -> None:

--- a/chromadb/test/server/test_fastapi_security.py
+++ b/chromadb/test/server/test_fastapi_security.py
@@ -1,0 +1,129 @@
+from typing import Any, Callable, Dict, List
+
+import orjson
+import pytest
+
+import chromadb.server.fastapi as fastapi_server
+from chromadb.server.fastapi import FastAPI
+
+
+class FakeRequest:
+    headers: Dict[str, str] = {}
+
+    def __init__(self, body: Dict[str, Any]) -> None:
+        self._body = orjson.dumps(body)
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+class ExplodingApi:
+    def create_collection(self, **_kwargs: Any) -> None:
+        raise AssertionError("collection creation should not be reached")
+
+
+class NoopRateLimitEnforcer:
+    def rate_limit(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        return func
+
+
+async def run_sync_immediately(
+    func: Callable[..., Any], *args: Any, limiter: Any = None
+) -> Any:
+    del limiter
+    return func(*args)
+
+
+def create_collection_body() -> Dict[str, Any]:
+    return {
+        "name": "poisoned",
+        "configuration": {
+            "embedding_function": {
+                "name": "sentence_transformer",
+                "type": "known",
+                "config": {
+                    "model_name": "attacker/model",
+                    "device": "cpu",
+                    "normalize_embeddings": False,
+                    "kwargs": {"trust_remote_code": True},
+                },
+            }
+        },
+    }
+
+
+def make_uninitialized_fastapi() -> FastAPI:
+    server = FastAPI.__new__(FastAPI)
+    server._api = ExplodingApi()
+    server._capacity_limiter = None
+    server._async_rate_limit_enforcer = NoopRateLimitEnforcer()
+    server._set_request_context = lambda request: None
+    return server
+
+
+@pytest.mark.asyncio
+async def test_v2_create_collection_authenticates_before_loading_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[str] = []
+    server = make_uninitialized_fastapi()
+
+    def fail_auth(*_args: Any, **_kwargs: Any) -> None:
+        calls.append("auth")
+        raise RuntimeError("unauthorized")
+
+    def load_configuration(config: Dict[str, Any]) -> Dict[str, Any]:
+        del config
+        calls.append("load_configuration")
+        return {}
+
+    server.sync_auth_request = fail_auth
+    monkeypatch.setattr(fastapi_server.to_thread, "run_sync", run_sync_immediately)
+    monkeypatch.setattr(
+        fastapi_server,
+        "load_create_collection_configuration_from_json",
+        load_configuration,
+    )
+
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        await server.create_collection(
+            FakeRequest(create_collection_body()),
+            tenant="default_tenant",
+            database_name="default_database",
+        )
+
+    assert calls == ["auth"]
+
+
+@pytest.mark.asyncio
+async def test_v1_create_collection_authenticates_before_loading_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[str] = []
+    server = make_uninitialized_fastapi()
+
+    def fail_auth(*_args: Any, **_kwargs: Any) -> None:
+        calls.append("auth")
+        raise RuntimeError("unauthorized")
+
+    def load_configuration(config: Dict[str, Any]) -> Dict[str, Any]:
+        del config
+        calls.append("load_configuration")
+        return {}
+
+    server.sync_auth_and_get_tenant_and_database_for_request = fail_auth
+    monkeypatch.setattr(fastapi_server.to_thread, "run_sync", run_sync_immediately)
+    monkeypatch.setattr(
+        fastapi_server,
+        "load_create_collection_configuration_from_json",
+        load_configuration,
+    )
+
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        await server.create_collection_v1(
+            FakeRequest(create_collection_body()),
+            tenant="default_tenant",
+            database="default_database",
+        )
+
+    assert calls == ["auth"]

--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -32,6 +32,41 @@ def get_embedding_function_names() -> List[str]:
 class TestEmbeddingFunctionSchemas:
     """Test class for embedding function schemas"""
 
+    @pytest.mark.parametrize(
+        "schema_name,config",
+        [
+            (
+                "sentence_transformer",
+                {
+                    "model_name": "attacker/model",
+                    "device": "cpu",
+                    "normalize_embeddings": False,
+                    "kwargs": {"trust_remote_code": True},
+                },
+            ),
+            (
+                "huggingface_sparse",
+                {
+                    "model_name": "attacker/model",
+                    "device": "cpu",
+                    "kwargs": {"trust_remote_code": True},
+                },
+            ),
+            (
+                "fastembed_sparse",
+                {
+                    "model_name": "attacker/model",
+                    "kwargs": {"trust_remote_code": True},
+                },
+            ),
+        ],
+    )
+    def test_local_model_loader_schemas_reject_non_empty_kwargs(
+        self, schema_name: str, config: Dict[str, Any]
+    ) -> None:
+        with pytest.raises(ValidationError):
+            validate_config_schema(config, schema_name)
+
     @pytest.mark.parametrize("ef_name", get_embedding_function_names())
     def test_embedding_function_config_roundtrip(
         self,

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -4,6 +4,9 @@ from chromadb.api.types import (
     DefaultEmbeddingFunction,
     SparseEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.config_validation import (
+    validate_embedding_function_config_is_safe,
+)
 
 # Import all embedding functions
 from chromadb.utils.embedding_functions.cohere_embedding_function import (
@@ -260,6 +263,7 @@ def config_to_embedding_function(config: Dict[str, Any]) -> EmbeddingFunction:  
     if known_embedding_functions[name] is None:
         raise ValueError(f"Unsupported embedding function: {name}")
 
+    validate_embedding_function_config_is_safe(name, ef_config)
     return known_embedding_functions[name].build_from_config(ef_config)
 
 

--- a/chromadb/utils/embedding_functions/config_validation.py
+++ b/chromadb/utils/embedding_functions/config_validation.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict
+
+
+_LOCAL_MODEL_LOADERS_WITH_UNSAFE_KWARGS = {
+    "fastembed_sparse",
+    "huggingface_sparse",
+    "sentence_transformer",
+}
+
+
+def validate_embedding_function_config_is_safe(
+    name: str, config: Dict[str, Any]
+) -> None:
+    if name in _LOCAL_MODEL_LOADERS_WITH_UNSAFE_KWARGS and config.get("kwargs"):
+        raise ValueError(
+            f"Embedding function {name} does not allow non-empty kwargs in "
+            "serialized configuration"
+        )

--- a/schemas/embedding_functions/fastembed_sparse.json
+++ b/schemas/embedding_functions/fastembed_sparse.json
@@ -73,16 +73,7 @@
         "kwargs": {
             "type": "object",
             "description": "Additional arguments to pass to the model",
-            "additionalProperties": {
-                "type": [
-                    "string",
-                    "integer",
-                    "number",
-                    "boolean",
-                    "array",
-                    "object"
-                ]
-            }
+            "additionalProperties": false
         }
     },
     "required": [

--- a/schemas/embedding_functions/huggingface_sparse.json
+++ b/schemas/embedding_functions/huggingface_sparse.json
@@ -39,16 +39,7 @@
         "kwargs": {
             "type": "object",
             "description": "Additional arguments to pass to the Splade model",
-            "additionalProperties": {
-                "type": [
-                    "string",
-                    "integer",
-                    "number",
-                    "boolean",
-                    "array",
-                    "object"
-                ]
-            }
+            "additionalProperties": false
         }
     },
     "required": [

--- a/schemas/embedding_functions/sentence_transformer.json
+++ b/schemas/embedding_functions/sentence_transformer.json
@@ -20,16 +20,7 @@
         "kwargs": {
             "type": "object",
             "description": "Additional arguments to pass to the SentenceTransformer model",
-            "additionalProperties": {
-                "type": [
-                    "string",
-                    "integer",
-                    "number",
-                    "boolean",
-                    "array",
-                    "object"
-                ]
-            }
+            "additionalProperties": false
         }
     },
     "required": [


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Move Python FastAPI v1/v2 create-collection auth before collection configuration hydration.
  - Reject unsafe serialized embedding-function kwargs for local model-loading embedding functions.
  - Prevent default clients from implicitly executing persisted non-default embedding functions.
  - Add regression tests for server auth ordering, config/schema deserialization, client poisoning, and schema validation.
- New functionality
  - None.

## Test plan

_How are these changes tested?_

- [x] Focused CVE regression suite passes with `uvx --with-requirements requirements.txt --with-requirements requirements_dev.txt pytest ... -q`
- [x] `uvx ruff check` on changed Python files
- [x] `python3 -m py_compile` on changed Python files
- [x] `git diff --check`

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

No database migration. This is a security hardening behavior change: serialized configs for `sentence_transformer`, `huggingface_sparse`, and `fastembed_sparse` no longer accept non-empty `kwargs`.

## Observability plan

_What is the plan to instrument and monitor this change?_

No new instrumentation. Existing request/auth/error logging should surface rejected unsafe configurations.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

No user-facing API signatures changed. Schema behavior changed for security; docs can be updated separately if maintainers want to document that serialized embedding-function kwargs are rejected for local model-loading embedding functions.
