### PR TITLE
DOC: Add custom 404 page to fix confusing not found page

### DIFF
--- a/docs/mintlify/404.mdx
+++ b/docs/mintlify/404.mdx
@@ -1,0 +1,9 @@
+﻿---
+title: "Page Not Found"
+---
+
+# 404 — Page Not Found
+
+The page you're looking for doesn't exist or may have been moved.
+
+[Go back to the Chroma documentation home](https://docs.trychroma.com)


### PR DESCRIPTION
Fixes #3546

## Problem
The 404 page on Chroma docs was showing a confusing code fragment 
that users mistook for actual documentation.

## Fix
Added a custom 404.mdx file to docs/mintlify that shows a clear 
"Page Not Found" message with a link back to the Chroma docs homepage.

## Changes
- Added docs/mintlify/404.mdx