### PR TITLE
[BUG](api): Use /heartbeat path in async client

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -171,7 +171,8 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @trace_method("AsyncFastAPI.heartbeat", OpenTelemetryGranularity.OPERATION)
     @override
     async def heartbeat(self) -> int:
-        response = await self._make_request("get", "")
+        """Returns the current server time in nanoseconds to check if the server is alive"""
+        response = await self._make_request("get", "/heartbeat")
         return int(response["nanosecond heartbeat"])
 
     @trace_method("AsyncFastAPI.create_database", OpenTelemetryGranularity.OPERATION)

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -297,3 +297,18 @@ def test_rust_bindings_api_stop_closes_bindings() -> None:
     bindings.close.assert_called_once_with()
     assert hasattr(api, "bindings") is False
     assert api._running is False
+
+
+def test_async_fastapi_heartbeat_uses_heartbeat_path() -> None:
+    """AsyncFastAPI.heartbeat() must request the /heartbeat path, matching the sync
+    FastAPI client and the server contract (regression test for issue #6870)."""
+    from unittest.mock import AsyncMock
+    from chromadb.api.async_fastapi import AsyncFastAPI
+
+    api = AsyncFastAPI.__new__(AsyncFastAPI)
+    api._make_request = AsyncMock(return_value={"nanosecond heartbeat": 123})  # type: ignore[method-assign]
+
+    result = asyncio.get_event_loop().run_until_complete(api.heartbeat())
+
+    assert result == 123
+    api._make_request.assert_awaited_once_with("get", "/heartbeat")


### PR DESCRIPTION
## Description of changes

Fixes #6870.

`AsyncFastAPI.heartbeat()` requested the empty path `""` instead of
`/heartbeat`, so `await chromadb.AsyncHttpClient(...).heartbeat()` hit the
base API URL rather than the health endpoint. The response there does not
contain the expected `"nanosecond heartbeat"` field, so the async health
check raised even when the server was healthy. The sync `FastAPI` client
already uses the correct `/heartbeat` path.

- Improvements & Bug fixes
  - `AsyncFastAPI.heartbeat()` now requests `/heartbeat`, matching the sync
    client and the server contract.
  - Added the same docstring the sync `heartbeat()` carries.
- New functionality
  - None

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Added `test_async_fastapi_heartbeat_uses_heartbeat_path` in
`chromadb/test/test_client.py`, which asserts that `heartbeat()` issues a
`GET /heartbeat` request and parses the `nanosecond heartbeat` payload.

## Migration plan

None required — this is a client-side path correction with no
forwards/backwards compatibility impact.

## Observability plan

None required. The existing `@trace_method("AsyncFastAPI.heartbeat", ...)`
span is unchanged.

## Documentation Changes

None required. The added docstring mirrors the sync client; no user-facing
API documentation changes are needed.
