### PR TITLE
[BLD] Add flake8 rule to ban relative imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,11 @@ repos:
       - id: flake8
         args:
           - "--extend-ignore=E203,E501,E503"
+          - "--extend-select=I252"
+          - "--ban-relative-imports=true"
           - "--max-line-length=88"
+        additional_dependencies:
+          - flake8-tidy-imports
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -8,7 +8,7 @@ It can be used to get information about available schemas and their versions.
 from typing import Dict, List, Set
 import os
 import json
-from .schema_utils import SCHEMAS_DIR
+from chromadb.utils.embedding_functions.schemas.schema_utils import SCHEMAS_DIR
 
 
 def get_available_schemas() -> List[str]:


### PR DESCRIPTION
## Summary

Adds `flake8-tidy-imports` to the flake8 configuration to ban relative imports using the `I252` rule, enforcing the project's preference for absolute imports.

## Changes
- `.pre-commit-config.yaml`: Added `flake8-tidy-imports` as an additional dependency for the flake8 hook, with `--extend-select=I252` and `--ban-relative-imports=true`
- `chromadb/utils/embedding_functions/schemas/registry.py`: Fixed the only existing relative import in the codebase (`from .schema_utils` → `from chromadb.utils.embedding_functions.schemas.schema_utils`)

## Testing
Ran `flake8` with the new config across the entire `chromadb/` directory — no `I252` violations detected after fixing the single relative import.

Closes #2334