### PR TITLE
Add CI check to sync requirements.txt with pyproject.toml (#2361)

### DIFF
--- a/bin/ci/check-requirements-sync.py
+++ b/bin/ci/check-requirements-sync.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Check that requirements.txt is in sync with pyproject.toml dependencies.
+
+Usage:
+    python bin/ci/check-requirements-sync.py          # checks root
+    python bin/ci/check-requirements-sync.py clients/python  # checks thin client
+"""
+
+import os
+import re
+import sys
+import tomllib
+
+
+def parse_pyproject_deps(pyproject_path):
+    """Extract dependency specs from pyproject.toml [project] dependencies."""
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+    raw_deps = data["project"].get("dependencies", [])
+    deps = {}
+    for dep in raw_deps:
+        dep = dep.strip()
+        # Remove environment markers after ;
+        dep = dep.split(";")[0].strip()
+        # Parse name + version spec; handle extras like [standard] and complex constraints
+        m = re.match(r"^([\w\-_.\[\]]+)\s*([>=<!~]+\s*\S+(?:\s*,\s*[>=<!]+\s*\S+)*)?", dep)
+        if m:
+            name = m.group(1).lower()
+            spec = m.group(2)
+            spec = "".join(spec.split()) if spec else ""
+            deps[name] = spec
+    return deps
+
+
+def parse_requirements(req_path):
+    """Extract dependency specs from a requirements.txt file."""
+    deps = {}
+    with open(req_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith("--"):
+                continue
+            # Remove environment markers
+            line = line.split(";")[0].strip()
+            m = re.match(r"^([\w\-_.\[\]]+)\s*([>=<!~]+\s*\S+(?:\s*,\s*[>=<!]+\s*\S+)*)?", line)
+            if m:
+                name = m.group(1).lower()
+                spec = m.group(2)
+                spec = "".join(spec.split()) if spec else ""
+                deps[name] = spec
+    return deps
+
+def main():
+    if len(sys.argv) > 1:
+        subdir = sys.argv[1].strip("/")
+    else:
+        subdir = ""
+
+    repo_root = os.path.join(os.path.dirname(__file__), "..", "..")
+    pyproject = os.path.join(repo_root, subdir, "pyproject.toml")
+    req_txt = os.path.join(repo_root, subdir, "requirements.txt")
+
+    if not os.path.exists(pyproject):
+        print(f"No pyproject.toml found at {pyproject}")
+        sys.exit(0)
+    if not os.path.exists(req_txt):
+        print(f"No requirements.txt found at {req_txt}")
+        sys.exit(0)
+
+    pyproject_deps = parse_pyproject_deps(pyproject)
+    req_deps = parse_requirements(req_txt)
+
+    # Build-time only deps in pyproject.toml that don't need to be in requirements.txt
+    build_only = {"build", "setuptools", "setuptools-scm", "wheel", "maturin"}
+
+    errors = []
+
+    # Check each pyproject dep is in requirements.txt (unless build-only)
+    for name, spec in pyproject_deps.items():
+        if name in build_only:
+            continue
+        if name not in req_deps:
+            errors.append(f"Missing: {name}{spec or ''} is in pyproject.toml but not in requirements.txt")
+        elif req_deps[name] != spec:
+            errors.append(
+                f"Version mismatch: {name}: pyproject.toml has {spec or '(any)'}, "
+                f"requirements.txt has {req_deps[name] or '(any)'}"
+            )
+
+    # Check each requirements.txt entry is in pyproject.toml
+    for name, spec in req_deps.items():
+        if name not in pyproject_deps:
+            errors.append(f"Extra: {name}{spec or ''} is in requirements.txt but not in pyproject.toml")
+
+    if errors:
+        print(f"ERROR: Dependency drift detected in {subdir or 'root'}:" if subdir else "ERROR: Dependency drift detected:")
+        for e in errors:
+            print(f"  {e}")
+        sys.exit(1)
+    else:
+        label = subdir if subdir else "root"
+        print(f"OK: {label} requirements.txt is in sync with pyproject.toml")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "Chroma."
 readme = "README.md"
 requires-python = ">=3.9"
 classifiers = ["Programming Language :: Python :: 3", "License :: OSI Approved :: Apache Software License", "Operating System :: OS Independent"]
-dependencies = ['build >= 1.0.3', 'pydantic >= 2.0', 'pydantic-settings >= 2.0', 'pybase64>=1.4.1', 'uvicorn[standard] >= 0.18.3', 'numpy >= 1.22.5', 'typing_extensions >= 4.5.0', 'onnxruntime >= 1.14.1', 'opentelemetry-api>=1.2.0', 'opentelemetry-exporter-otlp-proto-grpc>=1.2.0', 'opentelemetry-sdk>=1.2.0', 'tokenizers >= 0.13.2', 'pypika >= 0.48.9', 'tqdm >= 4.65.0', 'overrides >= 7.3.1', 'importlib-resources', 'graphlib_backport >= 1.0.3; python_version < "3.9"', 'grpcio >= 1.58.0', 'bcrypt >= 4.0.1', 'typer >= 0.9.0', 'kubernetes>=28.1.0', 'tenacity>=8.2.3', 'PyYAML>=6.0.0', 'mmh3>=4.0.1', 'orjson>=3.9.12', 'httpx>=0.27.0', 'rich>=10.11.0', 'jsonschema>=4.19.0']
+dependencies = ['build >= 1.0.3', 'pydantic >= 2.0', 'pydantic-settings >= 2.0', 'pybase64>=1.4.1', 'uvicorn[standard] >= 0.18.3', 'numpy >= 1.22.5', 'typing_extensions >= 4.5.0', 'onnxruntime >= 1.14.1', 'opentelemetry-api>=1.24.0', 'opentelemetry-exporter-otlp-proto-grpc>=1.24.0', 'opentelemetry-sdk>=1.24.0', 'tokenizers >= 0.13.2', 'pypika >= 0.48.9', 'tqdm >= 4.65.0', 'overrides >= 7.3.1', 'importlib-resources', 'graphlib_backport >= 1.0.3; python_version < "3.9"', 'grpcio >= 1.58.0', 'bcrypt >= 4.0.1', 'typer >= 0.9.0', 'kubernetes>=28.1.0', 'tenacity>=8.2.3', 'PyYAML>=6.0.0', 'mmh3>=4.0.1', 'orjson>=3.9.12', 'httpx>=0.27.0', 'rich>=10.11.0', 'jsonschema>=4.19.0']
 
 [project.optional-dependencies]
 dev = ['chroma-hnswlib==0.7.6', 'fastapi>=0.115.9', 'opentelemetry-instrumentation-fastapi>=0.41b0']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bcrypt>=4.0.1
-graphlib_backport==1.0.3; python_version < '3.9'
+graphlib_backport>=1.0.3; python_version < '3.9'
 grpcio>=1.58.0
 httpx>=0.27.0
 importlib-resources


### PR DESCRIPTION
Closes #2361

**Summary**
Adds a CI script () that validates all dependencies in  match the  in . The script checks for:

1. **Missing deps**: a dependency is in pyproject.toml but not in requirements.txt (build-only deps like `build` are skipped).
2. **Extra deps**: a dependency is in requirements.txt but not in pyproject.toml.
3. **Version drift**: the version specifiers differ between the two files.

The  environment marker (`; python_version < "3.9"`) is already present in requirements.txt and is preserved.

**Fixes made**
- pyproject.toml: `opentelemetry-api>=1.2.0` → `>=1.24.0`, `opentelemetry-exporter-otlp-proto-grpc>=1.2.0` → `>=1.24.0`, `opentelemetry-sdk>=1.2.0` → `>=1.24.0` (requirements.txt already used 1.24)
- requirements.txt: `graphlib_backport==1.0.3` → `>=1.0.3` (pyproject.toml used `>=`)

**Usage**
```
python bin/ci/check-requirements-sync.py          # root
python bin/ci/check-requirements-sync.py clients/python  # thin client
```