### PR TITLE
Consolidate flake8 config into pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,6 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
-        args:
-          - "--extend-ignore=E203,E501,E503"
-          - "--max-line-length=88"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ dependencies = ['build >= 1.0.3', 'pydantic >= 2.0', 'pydantic-settings >= 2.0',
 [project.optional-dependencies]
 dev = ['chroma-hnswlib==0.7.6', 'fastapi>=0.115.9', 'opentelemetry-instrumentation-fastapi>=0.41b0']
 
+[tool.flake8]
+extend-ignore = ["E203", "E501", "E503"]
+max-line-length = 88
+
 [tool.black]
 line-length = 88
 required-version = "23.3.0"                 # Black will refuse to run if it's not this version.


### PR DESCRIPTION
Move flake8 settings (`extend-ignore`, `max-line-length`) from `.pre-commit-config.yaml` args to a `[tool.flake8]` section in `pyproject.toml`. This makes the config apply regardless of how flake8 is invoked — pre-commit hook, editor integration, or direct CLI — and follows the convention already established by `[tool.black]` in the same file.