### PR TITLE
[BLD] Add safety pre-commit hooks (check-ast, check-toml, detect-private-key, debug-statements, and more)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,11 @@ repos:
       - id: flake8
         args:
           - "--extend-ignore=E203,E501,E503"
+          - "--extend-select=I252"
+          - "--ban-relative-imports=true"
           - "--max-line-length=88"
+        additional_dependencies:
+          - flake8-tidy-imports
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,12 @@ repos:
       - id: check-merge-conflict
       - id: check-case-conflict
       - id: check-docstring-first
+      - id: check-ast
+      - id: check-added-large-files
+      - id: check-json
+      - id: check-toml
+      - id: detect-private-key
+      - id: debug-statements
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     # https://github.com/psf/black/issues/2493
@@ -30,11 +36,7 @@ repos:
       - id: flake8
         args:
           - "--extend-ignore=E203,E501,E503"
-          - "--extend-select=I252"
-          - "--ban-relative-imports=true"
           - "--max-line-length=88"
-        additional_dependencies:
-          - flake8-tidy-imports
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -8,7 +8,7 @@ It can be used to get information about available schemas and their versions.
 from typing import Dict, List, Set
 import os
 import json
-from .schema_utils import SCHEMAS_DIR
+from chromadb.utils.embedding_functions.schemas.schema_utils import SCHEMAS_DIR
 
 
 def get_available_schemas() -> List[str]:

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -8,7 +8,7 @@ It can be used to get information about available schemas and their versions.
 from typing import Dict, List, Set
 import os
 import json
-from chromadb.utils.embedding_functions.schemas.schema_utils import SCHEMAS_DIR
+from .schema_utils import SCHEMAS_DIR
 
 
 def get_available_schemas() -> List[str]:


### PR DESCRIPTION
## Description of changes

Adds 6 new pre-commit hooks from the existing `pre-commit-hooks` repo (zero new dependencies):

| Hook | Purpose |
|------|---------|
| `check-ast` | Parses Python files to catch syntax errors |
| `check-added-large-files` | Prevents accidentally committing large/binary files |
| `check-json` | Validates JSON files |
| `check-toml` | Validates TOML files (`pyproject.toml`, etc.) |
| `detect-private-key` | Prevents accidental private key commits |
| `debug-statements` | Catches `pdb.set_trace()`, `print()`, etc. |

## Why

These are common safety nets that catch issues before they reach review. Chroma already uses the same `pre-commit-hooks` repo (v4.6.0), so there are no new dependencies or configuration needed.