### PR TITLE
[ENH] Add foundation wiki client to talk to FE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3638,6 +3638,7 @@ version = "1.0.0"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
+ "chroma",
  "chroma-api-types",
  "chroma-config",
  "chroma-error",
@@ -3649,6 +3650,7 @@ dependencies = [
  "frontend-core",
  "mdac",
  "opentelemetry",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/rust/chroma/src/client/chroma_http_client.rs
+++ b/rust/chroma/src/client/chroma_http_client.rs
@@ -9,6 +9,7 @@ use chroma_types::WhereError;
 use failsafe::futures::CircuitBreaker as _;
 use failsafe::FailurePredicate;
 use parking_lot::Mutex;
+use reqwest::header::HeaderMap;
 use reqwest::Method;
 use reqwest::StatusCode;
 use serde::{de::DeserializeOwned, Serialize};
@@ -22,6 +23,7 @@ use chroma_types::{
 };
 
 use crate::attached_function::ChromaAttachedFunction;
+use crate::client::ChromaAuthMethod;
 use crate::client::ChromaHttpClientOptions;
 use crate::client::ChromaHttpClientOptionsError;
 use crate::collection::ChromaCollection;
@@ -191,7 +193,7 @@ pub struct ChromaHttpClient {
     tenant_id: Arc<Mutex<Option<String>>>,
     database_name: Arc<Mutex<Option<String>>>,
     resolve_tenant_or_database_lock: Arc<tokio::sync::Mutex<()>>,
-    chroma_cloud_api_key: Option<String>,
+    auth_method: ChromaAuthMethod,
 }
 
 impl Default for ChromaHttpClient {
@@ -209,7 +211,7 @@ impl Clone for ChromaHttpClient {
             tenant_id: Arc::new(Mutex::new(self.tenant_id.lock().clone())),
             database_name: Arc::new(Mutex::new(self.database_name.lock().clone())),
             resolve_tenant_or_database_lock: Arc::new(tokio::sync::Mutex::new(())),
-            chroma_cloud_api_key: self.chroma_cloud_api_key.clone(),
+            auth_method: self.auth_method.clone(),
         }
     }
 }
@@ -250,15 +252,11 @@ impl ChromaHttpClient {
     /// # }
     /// ```
     pub fn new(options: ChromaHttpClientOptions) -> Self {
-        let chroma_cloud_api_key = options
-            .auth_method
-            .chroma_cloud_api_key()
-            .map(ToOwned::to_owned);
-        let mut headers = options.headers();
-        headers.append("user-agent", USER_AGENT.try_into().unwrap());
+        let mut default_headers = HeaderMap::new();
+        default_headers.append("user-agent", USER_AGENT.try_into().unwrap());
 
         let client = reqwest::Client::builder()
-            .default_headers(headers)
+            .default_headers(default_headers)
             // Set a pool idle timeout to prevent the client from using connections that are
             // about to be closed by the server (which often have a 60s timeout).
             // Ref: https://github.com/hyperium/hyper/issues/2136#issuecomment-589488526
@@ -285,12 +283,37 @@ impl ChromaHttpClient {
             tenant_id: Arc::new(Mutex::new(options.tenant_id)),
             database_name: Arc::new(Mutex::new(options.database_name)),
             resolve_tenant_or_database_lock: Arc::new(tokio::sync::Mutex::new(())),
-            chroma_cloud_api_key,
+            auth_method: options.auth_method,
         }
     }
 
+    /// Returns a clone of this client that shares the same underlying HTTP
+    /// connection pool but is re-scoped to `auth_method`, `tenant_id`, and
+    /// `database_name`.
+    ///
+    /// This is the cheap way to fan a single long-lived client out across many
+    /// credentials (for example, a server forwarding each caller's token): the
+    /// reqwest connection pool, retry policy, and endpoint configuration are
+    /// reused; only the auth method, tenant, and database are swapped. Setting
+    /// all three together means a re-scoped credential can't be accidentally
+    /// paired with an inherited tenant or database, and setting the tenant
+    /// explicitly avoids the identity lookup that resolving it would otherwise
+    /// require.
+    pub fn with_scope(
+        &self,
+        auth_method: ChromaAuthMethod,
+        tenant_id: impl AsRef<str>,
+        database_name: impl AsRef<str>,
+    ) -> Self {
+        let mut cloned = self.clone();
+        cloned.auth_method = auth_method;
+        cloned.set_tenant_id(tenant_id);
+        cloned.set_database_name(database_name);
+        cloned
+    }
+
     pub(crate) fn chroma_cloud_api_key(&self) -> Option<&str> {
-        self.chroma_cloud_api_key.as_deref()
+        self.auth_method.chroma_cloud_api_key()
     }
 
     /// Constructs a client from environment variables.
@@ -357,6 +380,24 @@ impl ChromaHttpClient {
     pub fn set_database_name(&self, database_name: impl AsRef<str>) {
         let mut lock = self.database_name.lock();
         *lock = Some(database_name.as_ref().to_string());
+    }
+
+    /// Assigns the tenant to use for subsequent operations.
+    ///
+    /// Overrides any previously cached or configured tenant ID, skipping the
+    /// identity lookup that would otherwise be needed to resolve it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chroma::ChromaHttpClient;
+    /// # fn example(client: ChromaHttpClient) {
+    /// client.set_tenant_id("my-tenant");
+    /// # }
+    /// ```
+    pub fn set_tenant_id(&self, tenant_id: impl AsRef<str>) {
+        let mut lock = self.tenant_id.lock();
+        *lock = Some(tenant_id.as_ref().to_string());
     }
 
     /// Resolves the database name for collection operations.
@@ -1224,7 +1265,9 @@ impl ChromaHttpClient {
         );
 
         let attempt = || async {
-            let mut request = backend.client.request(method.clone(), url.clone());
+            let mut request = self
+                .auth_method
+                .apply(backend.client.request(method.clone(), url.clone()));
             if let Some(body) = body {
                 request = request.json(body);
             }
@@ -1472,6 +1515,69 @@ mod tests {
 
         assert_eq!(response, serde_json::json!({"status": "ok"}));
         assert_eq!(mock.calls(), 2);
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_auth_token_is_sent_as_request_header() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("GET")
+                    .path("/with-auth")
+                    .header("x-chroma-token", "secret-token");
+                then.status(200).body(r#"{"value": "ok"}"#);
+            })
+            .await;
+
+        let client = ChromaHttpClient::new(ChromaHttpClientOptions {
+            endpoint: server.base_url().parse().unwrap(),
+            auth_method: ChromaAuthMethod::cloud_api_key("secret-token").unwrap(),
+            ..Default::default()
+        });
+
+        let response: serde_json::Value = client
+            .send::<(), (), serde_json::Value>("with_auth", Method::GET, "/with-auth", None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(response, serde_json::json!({"value": "ok"}));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_with_scope_sets_auth_tenant_and_database() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("GET")
+                    .path("/scoped")
+                    .header("x-chroma-token", "scoped-token");
+                then.status(200).body(r#"{"value": "ok"}"#);
+            })
+            .await;
+
+        let base = ChromaHttpClient::new(ChromaHttpClientOptions {
+            endpoint: server.base_url().parse().unwrap(),
+            ..Default::default()
+        });
+        let scoped = base.with_scope(
+            ChromaAuthMethod::cloud_api_key("scoped-token").unwrap(),
+            "my-tenant",
+            "my-database",
+        );
+
+        // Tenant and database are set without any identity-resolution request.
+        assert_eq!(scoped.get_tenant_id().await.unwrap(), "my-tenant");
+        assert_eq!(scoped.get_database_name().await.unwrap(), "my-database");
+
+        let response: serde_json::Value = scoped
+            .send::<(), (), serde_json::Value>("scoped", Method::GET, "/scoped", None, None)
+            .await
+            .unwrap();
+        assert_eq!(response, serde_json::json!({"value": "ok"}));
+        mock.assert();
     }
 
     #[tokio::test]

--- a/rust/chroma/src/client/options.rs
+++ b/rust/chroma/src/client/options.rs
@@ -7,7 +7,7 @@
 use std::time::Duration;
 
 use backon::ExponentialBuilder;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, InvalidHeaderValue};
+use reqwest::header::{HeaderName, HeaderValue, InvalidHeaderValue};
 
 /// Configuration for automatic retry behavior when requests fail.
 ///
@@ -100,6 +100,16 @@ impl ChromaAuthMethod {
                 value.to_str().ok()
             }
             ChromaAuthMethod::HeaderAuth { .. } | ChromaAuthMethod::None => None,
+        }
+    }
+
+    /// Applies this authentication method to an outgoing request.
+    pub(crate) fn apply(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match self {
+            ChromaAuthMethod::HeaderAuth { header, value } => {
+                request.header(header.clone(), value.clone())
+            }
+            ChromaAuthMethod::None => request,
         }
     }
 }
@@ -347,18 +357,6 @@ impl ChromaHttpClientOptions {
             }
         }
         endpoints
-    }
-
-    /// Constructs HTTP headers from the authentication method.
-    pub(crate) fn headers(&self) -> HeaderMap {
-        let mut headers = HeaderMap::new();
-        match &self.auth_method {
-            ChromaAuthMethod::HeaderAuth { header, value } => {
-                headers.insert(header.clone(), value.clone());
-            }
-            ChromaAuthMethod::None => {}
-        }
-        headers
     }
 }
 

--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -211,6 +211,28 @@ impl ChromaCollection {
         }
     }
 
+    /// Builds a collection handle from an already-resolved [`Collection`]
+    /// model without performing a network lookup.
+    ///
+    /// This is useful when the collection identity (id, schema, metadata) has
+    /// been cached out of band and only needs to be re-bound to a fresh client
+    /// (for example, one carrying a per-request authentication token). The
+    /// dense embedding function is re-derived from the collection schema,
+    /// mirroring [`ChromaHttpClient::get_collection`](crate::ChromaHttpClient::get_collection).
+    pub fn from_collection_model(client: ChromaHttpClient, collection: Collection) -> Self {
+        Self::new(client, collection)
+    }
+
+    /// Returns a clone of the underlying [`Collection`] model (id, name,
+    /// schema, metadata, ...).
+    ///
+    /// Useful for caching the collection identity so a handle can later be
+    /// rebuilt with [`ChromaCollection::from_collection_model`] without another
+    /// network round trip.
+    pub fn to_collection_model(&self) -> Collection {
+        (*self.collection).clone()
+    }
+
     /// Sets the embedding function used when record embeddings are omitted.
     ///
     /// Passing `None` clears the callback. When set, [`add`](Self::add),

--- a/rust/foundation-api/Cargo.toml
+++ b/rust/foundation-api/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = { workspace = true }
 axum = { workspace = true }
 figment = { workspace = true }
 opentelemetry = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -20,6 +21,7 @@ tower-http = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
+chroma = { workspace = true }
 chroma-api-types = { workspace = true }
 chroma-config = { workspace = true }
 chroma-error = { workspace = true, features = ["validator", "http"] }

--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -29,8 +29,8 @@ pub struct FoundationConfig {
     /// Base URL of the Chroma frontend (FE) ingress that record-I/O routes
     /// proxy to (e.g. `https://foundation-fe.internal`). This must point at the
     /// HAProxy ingress rather than the internal ClusterIP so the ingress can
-    /// consistent-hash on the collection id in the request path. Required for
-    /// `/upsert-page`; absent in config -> `None`, which disables that route.
+    /// consistent-hash on the collection id in the request path.
+    /// absent in config -> `None` should disable dependent routes.
     #[serde(default)]
     pub frontend_ingress_url: Option<String>,
     // TODO(hammadb): collection identities should move onto Chroma collection

--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -26,6 +26,13 @@ pub struct FoundationApiConfig {
 pub struct FoundationConfig {
     #[serde(default = "FoundationConfig::default_database_name")]
     pub database_name: String,
+    /// Base URL of the Chroma frontend (FE) ingress that record-I/O routes
+    /// proxy to (e.g. `https://foundation-fe.internal`). This must point at the
+    /// HAProxy ingress rather than the internal ClusterIP so the ingress can
+    /// consistent-hash on the collection id in the request path. Required for
+    /// `/upsert-page`; absent in config -> `None`, which disables that route.
+    #[serde(default)]
+    pub frontend_ingress_url: Option<String>,
     // TODO(hammadb): collection identities should move onto Chroma collection
     // metadata rather than living as a deployment-side config field.
     #[serde(default = "FoundationConfig::default_wiki_collection")]
@@ -94,6 +101,7 @@ impl Default for FoundationConfig {
     fn default() -> Self {
         Self {
             database_name: Self::default_database_name(),
+            frontend_ingress_url: None,
             wiki_collection: Self::default_wiki_collection(),
             wiki_revisions_collection: Self::default_wiki_revisions_collection(),
             file_uploads_collection: Self::default_file_uploads_collection(),

--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 pub mod config;
 pub(crate) mod routes;
 pub mod server;
+pub(crate) mod wiki;
 
 pub use frontend_core::{ac, auth, errors, middleware as server_middleware, traced_json};
 

--- a/rust/foundation-api/src/server.rs
+++ b/rust/foundation-api/src/server.rs
@@ -27,6 +27,7 @@ use crate::{
     errors::ServerError,
     routes,
     server_middleware::{always_json_errors_middleware, default_json_content_type_middleware},
+    wiki::{WikiClient, WikiClientError},
 };
 
 /// Placeholder batch limit reported by `/api/v2/pre-flight-checks`.
@@ -53,6 +54,12 @@ pub struct FoundationApiServer {
     pub(crate) scorecard: Arc<Scorecard<'static>>,
     pub(crate) system: System,
     pub(crate) metrics: Arc<SystemMetrics>,
+    /// Proxying Chroma client for wiki record I/O, shared across requests so
+    /// its per-tenant collection cache persists. `None` when
+    /// `frontend_ingress_url` is unset or invalid, which disables wiki routes.
+    // Read by the wiki record-I/O routes added later in the stack.
+    #[allow(dead_code)]
+    pub(crate) wiki_client: Option<WikiClient>,
 }
 
 impl FoundationApiServer {
@@ -70,6 +77,22 @@ impl FoundationApiServer {
         // SAFETY(rescrv): This is safe because 128 is non-zero.
         let scorecard = Arc::new(Scorecard::new(&(), rules, 128.try_into().unwrap()));
         let metrics = Arc::new(SystemMetrics::new(&global::meter("foundation-api")));
+        let wiki_client = match WikiClient::from_config(&config.foundation) {
+            Ok(client) => Some(client),
+            Err(WikiClientError::MissingIngressUrl) => {
+                tracing::info!(
+                    "foundation frontend_ingress_url unset; wiki record-I/O routes disabled",
+                );
+                None
+            }
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    "invalid foundation frontend_ingress_url; wiki record-I/O routes disabled",
+                );
+                None
+            }
+        };
         FoundationApiServer {
             config,
             auth,
@@ -78,6 +101,7 @@ impl FoundationApiServer {
             scorecard,
             system,
             metrics,
+            wiki_client,
         }
     }
 

--- a/rust/foundation-api/src/wiki/client.rs
+++ b/rust/foundation-api/src/wiki/client.rs
@@ -2,10 +2,11 @@
 //!
 //! A single long-lived [`ChromaHttpClient`] (one shared connection pool to the
 //! FE ingress) is built once at startup. Each request cheaply re-scopes it via
-//! [`ChromaHttpClient::with_auth_method`] to forward the caller's
-//! `x-chroma-token` and tenant against the `FOUNDATION` database, so the FE
-//! remains the single point that enforces auth, quota, metering, and billing
-//! while connections stay pooled across requests and tenants.
+//! [`ChromaHttpClient::with_scope`], which swaps the caller's auth method
+//! (forwarding their `x-chroma-token`), tenant, and the `FOUNDATION` database
+//! in one call, so the FE remains the single point that enforces auth, quota,
+//! metering, and billing while connections stay pooled across requests and
+//! tenants.
 //!
 //! Requests target the FE's HAProxy ingress URL (not the internal ClusterIP)
 //! so the ingress can consistent-hash on the collection id in the request

--- a/rust/foundation-api/src/wiki/client.rs
+++ b/rust/foundation-api/src/wiki/client.rs
@@ -1,0 +1,312 @@
+//! Chroma client used by wiki routes to proxy record I/O to the FE.
+//!
+//! A single long-lived [`ChromaHttpClient`] (one shared connection pool to the
+//! FE ingress) is built once at startup. Each request cheaply re-scopes it via
+//! [`ChromaHttpClient::with_auth_method`] to forward the caller's
+//! `x-chroma-token` and tenant against the `FOUNDATION` database, so the FE
+//! remains the single point that enforces auth, quota, metering, and billing
+//! while connections stay pooled across requests and tenants.
+//!
+//! Requests target the FE's HAProxy ingress URL (not the internal ClusterIP)
+//! so the ingress can consistent-hash on the collection id in the request
+//! path. The one call the ingress cannot hash to the right replica is the
+//! initial get-collection-by-name lookup, so the resolved wiki collection
+//! identity (id + schema + metadata) is cached per tenant and used to rebuild
+//! a handle on subsequent requests.
+
+use chroma::client::{ChromaAuthMethod, ChromaHttpClientError, ChromaHttpClientOptions};
+use chroma::{ChromaCollection, ChromaHttpClient};
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_types::Collection;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::config::FoundationConfig;
+
+/// How long a resolved wiki collection identity is reused before it is
+/// re-fetched from the FE. Short enough that schema/metadata edits propagate
+/// quickly, long enough to keep the unhashable name lookup off the hot path.
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// Errors raised while resolving or building the proxying Chroma client.
+#[derive(Debug, thiserror::Error)]
+pub enum WikiClientError {
+    /// `frontend_ingress_url` was not set in config, so the route is disabled.
+    #[error("foundation frontend_ingress_url is not configured")]
+    MissingIngressUrl,
+    /// `frontend_ingress_url` was set but is not a valid URL.
+    #[error("invalid frontend_ingress_url '{url}': {message}")]
+    InvalidIngressUrl {
+        /// The offending configured value.
+        url: String,
+        /// The underlying parse error rendered as a string.
+        message: String,
+    },
+    /// The caller's `x-chroma-token` is not a valid HTTP header value.
+    #[error("invalid x-chroma-token header value: {0}")]
+    InvalidToken(String),
+    /// The downstream Chroma client/FE returned an error.
+    #[error("chroma client error: {0}")]
+    Client(#[from] ChromaHttpClientError),
+}
+
+impl ChromaError for WikiClientError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            WikiClientError::MissingIngressUrl | WikiClientError::InvalidIngressUrl { .. } => {
+                ErrorCodes::Internal
+            }
+            WikiClientError::InvalidToken(_) => ErrorCodes::InvalidArgument,
+            WikiClientError::Client(_) => ErrorCodes::Internal,
+        }
+    }
+}
+
+/// A cheaply-cloneable factory for per-request Chroma collection handles that
+/// proxy to the FE. Holds one long-lived client (shared connection pool) plus
+/// a tenant-scoped cache of the wiki collection identity.
+#[derive(Clone, Debug)]
+pub struct WikiClient {
+    base_client: ChromaHttpClient,
+    database_name: String,
+    wiki_collection_name: String,
+    cache: Arc<WikiCollectionCache>,
+}
+
+impl WikiClient {
+    /// Builds a [`WikiClient`] from foundation config.
+    ///
+    /// Returns [`WikiClientError::MissingIngressUrl`] when no ingress URL is
+    /// configured (the caller should treat the route as disabled), or
+    /// [`WikiClientError::InvalidIngressUrl`] when it cannot be parsed.
+    pub fn from_config(foundation: &FoundationConfig) -> Result<Self, WikiClientError> {
+        let ingress_url = foundation
+            .frontend_ingress_url
+            .as_ref()
+            .ok_or(WikiClientError::MissingIngressUrl)?;
+        let endpoint: reqwest::Url =
+            ingress_url
+                .parse()
+                .map_err(|err| WikiClientError::InvalidIngressUrl {
+                    url: ingress_url.clone(),
+                    message: format!("{err}"),
+                })?;
+        // One process-wide client/connection pool, with no credential or tenant
+        // of its own. Per request we re-scope it to the caller's token, tenant,
+        // and the FOUNDATION database via `scoped_client`, which shares this
+        // pool rather than opening a new one.
+        let base_client = ChromaHttpClient::new(ChromaHttpClientOptions {
+            endpoint,
+            auth_method: ChromaAuthMethod::None,
+            tenant_id: None,
+            database_name: None,
+            ..Default::default()
+        });
+        Ok(Self {
+            base_client,
+            database_name: foundation.database_name.clone(),
+            wiki_collection_name: foundation.wiki_collection.clone(),
+            cache: Arc::new(WikiCollectionCache::new(DEFAULT_CACHE_TTL)),
+        })
+    }
+
+    /// Re-scopes the shared base client to the caller's token, `tenant`, and
+    /// the FOUNDATION database in one shot, reusing the existing connection
+    /// pool. Setting the tenant explicitly also avoids an identity lookup round
+    /// trip.
+    fn scoped_client(
+        &self,
+        tenant: &str,
+        token: &str,
+    ) -> Result<ChromaHttpClient, WikiClientError> {
+        let auth_method = ChromaAuthMethod::cloud_api_key(token)
+            .map_err(|err| WikiClientError::InvalidToken(err.to_string()))?;
+        Ok(self
+            .base_client
+            .with_scope(auth_method, tenant, &self.database_name))
+    }
+
+    /// Resolves a handle to the foundation `wiki` collection for this request,
+    /// reusing the cached collection identity when available so the
+    /// unhashable get-collection-by-name lookup stays off the hot path.
+    pub async fn wiki_collection(
+        &self,
+        tenant: &str,
+        token: &str,
+    ) -> Result<ChromaCollection, WikiClientError> {
+        let client = self.scoped_client(tenant, token)?;
+        if let Some(collection) = self.cache.get(tenant) {
+            return Ok(ChromaCollection::from_collection_model(client, collection));
+        }
+        let collection = client.get_collection(&self.wiki_collection_name).await?;
+        self.cache
+            .put(tenant.to_string(), collection.to_collection_model());
+        Ok(collection)
+    }
+
+    /// Drops the cached wiki collection identity for `tenant`. Call this after
+    /// a `NotFound` from the FE, since the collection may have been recreated
+    /// with a new id.
+    pub fn invalidate(&self, tenant: &str) {
+        self.cache.invalidate(tenant);
+    }
+}
+
+/// A tenant-keyed, TTL-bounded cache of resolved wiki collection identities.
+#[derive(Debug)]
+struct WikiCollectionCache {
+    ttl: Duration,
+    entries: Mutex<HashMap<String, CacheEntry>>,
+}
+
+#[derive(Debug)]
+struct CacheEntry {
+    collection: Collection,
+    inserted_at: Instant,
+}
+
+impl WikiCollectionCache {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn get(&self, tenant: &str) -> Option<Collection> {
+        self.get_at(tenant, Instant::now())
+    }
+
+    fn get_at(&self, tenant: &str, now: Instant) -> Option<Collection> {
+        let mut entries = self.lock();
+        match entries.get(tenant) {
+            Some(entry) if now.duration_since(entry.inserted_at) < self.ttl => {
+                Some(entry.collection.clone())
+            }
+            Some(_) => {
+                entries.remove(tenant);
+                None
+            }
+            None => None,
+        }
+    }
+
+    fn put(&self, tenant: String, collection: Collection) {
+        self.put_at(tenant, collection, Instant::now());
+    }
+
+    fn put_at(&self, tenant: String, collection: Collection, now: Instant) {
+        self.lock().insert(
+            tenant,
+            CacheEntry {
+                collection,
+                inserted_at: now,
+            },
+        );
+    }
+
+    fn invalidate(&self, tenant: &str) {
+        self.lock().remove(tenant);
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, CacheEntry>> {
+        // A poisoned lock means a prior holder panicked while mutating the map.
+        // The cache is rebuildable from the FE, so recover the guard rather than
+        // propagating the panic.
+        self.entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn collection_named(name: &str) -> Collection {
+        Collection {
+            name: name.to_string(),
+            tenant: "tenant".to_string(),
+            database: "FOUNDATION".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn cache_returns_entry_within_ttl() {
+        let cache = WikiCollectionCache::new(Duration::from_secs(300));
+        let start = Instant::now();
+        let collection = collection_named("wiki");
+        let id = collection.collection_id;
+
+        cache.put_at("t1".to_string(), collection, start);
+
+        let hit = cache
+            .get_at("t1", start + Duration::from_secs(299))
+            .expect("entry should be live within ttl");
+        assert_eq!(hit.collection_id, id);
+        assert_eq!(hit.name, "wiki");
+    }
+
+    #[test]
+    fn cache_expires_entry_after_ttl() {
+        let cache = WikiCollectionCache::new(Duration::from_secs(300));
+        let start = Instant::now();
+        cache.put_at("t1".to_string(), collection_named("wiki"), start);
+
+        assert!(cache
+            .get_at("t1", start + Duration::from_secs(300))
+            .is_none());
+        // Expired entries are evicted, not just hidden.
+        assert!(cache.entries.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn cache_is_keyed_per_tenant() {
+        let cache = WikiCollectionCache::new(Duration::from_secs(300));
+        let start = Instant::now();
+        cache.put_at("t1".to_string(), collection_named("wiki"), start);
+
+        assert!(cache.get_at("t1", start).is_some());
+        assert!(cache.get_at("t2", start).is_none());
+    }
+
+    #[test]
+    fn invalidate_drops_cached_entry() {
+        let cache = WikiCollectionCache::new(Duration::from_secs(300));
+        let start = Instant::now();
+        cache.put_at("t1".to_string(), collection_named("wiki"), start);
+
+        cache.invalidate("t1");
+        assert!(cache.get_at("t1", start).is_none());
+    }
+
+    #[test]
+    fn from_config_requires_ingress_url() {
+        let config = FoundationConfig::default();
+        let err = WikiClient::from_config(&config).unwrap_err();
+        assert!(matches!(err, WikiClientError::MissingIngressUrl));
+    }
+
+    #[test]
+    fn from_config_rejects_invalid_ingress_url() {
+        let config = FoundationConfig {
+            frontend_ingress_url: Some("not a url".to_string()),
+            ..FoundationConfig::default()
+        };
+        let err = WikiClient::from_config(&config).unwrap_err();
+        assert!(matches!(err, WikiClientError::InvalidIngressUrl { .. }));
+    }
+
+    #[test]
+    fn from_config_accepts_valid_ingress_url() {
+        let config = FoundationConfig {
+            frontend_ingress_url: Some("https://foundation-fe.internal".to_string()),
+            ..FoundationConfig::default()
+        };
+        let client = WikiClient::from_config(&config).expect("valid url");
+        assert_eq!(client.database_name, "FOUNDATION");
+        assert_eq!(client.wiki_collection_name, "wiki");
+    }
+}

--- a/rust/foundation-api/src/wiki/mod.rs
+++ b/rust/foundation-api/src/wiki/mod.rs
@@ -1,0 +1,13 @@
+//! Wiki-domain helpers for foundation-api.
+//!
+//! foundation-api does not embed the Chroma data plane. Instead it acts as a
+//! Chroma client and proxies record I/O to the frontend (FE), letting the FE
+//! enforce auth, quota, metering, and billing against the caller's
+//! `x-chroma-token`. This module hosts that client surface; chunking and
+//! embedding helpers land here in later changes.
+
+// Wired into the server in this change but not yet exercised end to end; the
+// resolve/cache surface is consumed once the wiki record-I/O routes land.
+#[allow(dead_code)]
+pub(crate) mod client;
+pub(crate) use client::{WikiClient, WikiClientError};


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

First PR in the `foundation-api` `/upsert-page` stack. Makes `foundation-api` a
Chroma client that proxies record I/O to the frontend (FE) instead of embedding
the data plane, so the FE keeps enforcing auth, quota, metering, and billing
against the caller's `x-chroma-token`.

- New functionality
  - Add a `WikiClient` (`wiki/client.rs`): one long-lived `ChromaHttpClient`
    (shared connection pool) pointed at the FE HAProxy ingress, cheaply
    re-scoped per request to the caller's token + tenant + `FOUNDATION` db.
  - Cache the resolved `wiki` collection identity per tenant (TTL-bounded, with
    explicit invalidation) so the un-hashable get-collection-by-name lookup
    stays off the hot path.
  - Add `frontend_ingress_url` to `FoundationConfig` and wire an optional
    `wiki_client` into the server (absent/invalid URL disables wiki routes).
- Improvements & Bug fixes
  - `ChromaHttpClient` now stores the full `ChromaAuthMethod` and applies it
    per request, adding `with_scope` / `set_tenant_id` so one client can fan out
    across credentials without re-opening pools or doing identity lookups.
  - `ChromaCollection` gains `from_collection_model` / `to_collection_model` to
    rebind a cached collection identity to a fresh client without a network
    round trip.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `cargo test` (SDK auth/scope unit tests +
  `WikiCollectionCache` TTL/per-tenant/invalidation tests + config parsing).

## Migration plan

Backwards compatible. `frontend_ingress_url` defaults to `None`; when unset the
wiki client is not built and dependent routes (added later in the stack) stay
disabled, so existing deployments are unaffected.

## Observability plan

Server startup logs whether the wiki client was built (info when the ingress
URL is unset, error when it is invalid). No new routes are exercised yet.

## Documentation Changes

None — no user-facing API yet. New public SDK methods (`with_scope`,
`from_collection_model`, etc.) carry rustdoc.
