### PR TITLE
[ENH] Foundation sparse embed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3648,6 +3648,7 @@ dependencies = [
  "chroma-types",
  "figment",
  "frontend-core",
+ "httpmock",
  "mdac",
  "opentelemetry",
  "reqwest 0.13.2",

--- a/plans/foundation_edit-page_command_0a3a0511.plan.md
+++ b/plans/foundation_edit-page_command_0a3a0511.plan.md
@@ -10,7 +10,7 @@ todos:
     status: completed
   - id: pr3-embed
     content: "PR 3 - Add wiki/embed.rs: SPLADE sparse embedding via user x-chroma-token batched at 100 (dense handled by the collection's Qwen EF on add)."
-    status: pending
+    status: completed
   - id: pr4-authz-route-skeleton
     content: "PR 4 - Add AuthzAction::UpsertFoundation; add routes/upsert_page.rs request/response + auth + validation (slug/categories/source_ids), register POST /api/upsert-page returning a stub."
     status: pending

--- a/rust/foundation-api/Cargo.toml
+++ b/rust/foundation-api/Cargo.toml
@@ -33,3 +33,6 @@ chroma-tracing = { workspace = true, features = ["middleware"] }
 chroma-types = { workspace = true }
 frontend-core = { workspace = true }
 mdac = { workspace = true }
+
+[dev-dependencies]
+httpmock = "0.8.2"

--- a/rust/foundation-api/src/wiki/embed.rs
+++ b/rust/foundation-api/src/wiki/embed.rs
@@ -1,0 +1,154 @@
+//! SPLADE sparse embedding for wiki pages.
+//!
+//! `foundation-research` pre-computes a SPLADE sparse vector client-side for
+//! every chunk and stores it under the `sparse_embedding` metadata key; the
+//! dense Qwen vector is produced by the collection's schema-bound embedding
+//! function on `add`. This ports that sparse path: build a Chroma Cloud SPLADE
+//! embedding function scoped to the caller's `x-chroma-token` (so embed usage
+//! bills to the user) and embed documents in batches of
+//! [`EMBED_BATCH_SIZE`] — the limit the Chroma Cloud embedding service accepts
+//! per request — concatenating the per-batch results in input order.
+
+use chroma::embed::chroma_cloud::{ChromaCloudEmbeddingError, ChromaCloudSpladeEmbeddingFunction};
+use chroma::embed::EmbeddingFunction;
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_types::SparseVector;
+
+/// Metadata key under which the SPLADE sparse vector is stored on each chunk.
+/// Must match `foundation_research.embeddings.SPARSE_KEY`.
+pub const SPARSE_KEY: &str = "sparse_embedding";
+
+/// Maximum documents per Chroma Cloud embedding request. The service rejects
+/// larger calls with a 413, so documents are sliced into batches of this size
+/// and the resulting vectors concatenated. Matches foundation-research's
+/// `EMBED_BATCH_SIZE`.
+pub const EMBED_BATCH_SIZE: usize = 100;
+
+/// Errors raised while computing sparse embeddings.
+#[derive(Debug, thiserror::Error)]
+pub enum WikiEmbedError {
+    /// The downstream Chroma Cloud embedding service returned an error.
+    #[error("sparse embedding failed: {0}")]
+    Embedding(#[from] ChromaCloudEmbeddingError),
+}
+
+impl ChromaError for WikiEmbedError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
+}
+
+/// Builds per-request SPLADE sparse embedders scoped to the caller's token.
+#[derive(Clone, Debug, Default)]
+pub struct WikiEmbedder {
+    embed_url: Option<String>,
+}
+
+impl WikiEmbedder {
+    /// Creates an embedder.
+    ///
+    /// `embed_url` overrides the Chroma Cloud embedding endpoint; `None` uses
+    /// the SDK default (`CHROMA_EMBED_URL` env var, else
+    /// `https://embed.trychroma.com`).
+    pub fn new(embed_url: Option<String>) -> Self {
+        Self { embed_url }
+    }
+
+    /// Computes a SPLADE sparse vector for each document, in input order.
+    ///
+    /// The embedding function is scoped to `token` so embed usage bills to the
+    /// caller. Documents are embedded in batches of [`EMBED_BATCH_SIZE`] and
+    /// the per-batch results concatenated; an empty input issues no request.
+    pub async fn embed_sparse(
+        &self,
+        token: &str,
+        documents: &[&str],
+    ) -> Result<Vec<SparseVector>, WikiEmbedError> {
+        if documents.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Default builder => model `prithivida/Splade_PP_en_v1`, tokens not
+        // included — matching foundation-research's `make_sparse_ef`.
+        let mut builder = ChromaCloudSpladeEmbeddingFunction::builder().api_key(token);
+        if let Some(embed_url) = &self.embed_url {
+            builder = builder.embed_url(embed_url.clone());
+        }
+        let embedding_function = builder.build()?;
+
+        let mut embeddings = Vec::with_capacity(documents.len());
+        for batch in documents.chunks(EMBED_BATCH_SIZE) {
+            embeddings.extend(embedding_function.embed_strs(batch).await?);
+        }
+        Ok(embeddings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::MockServer;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn embed_sparse_forwards_token_and_parses_sorted_vectors() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST")
+                    .path("/embed_sparse")
+                    .header("x-chroma-token", "user-token")
+                    .header("x-chroma-embedding-model", "prithivida/Splade_PP_en_v1");
+                then.status(200).json_body(json!({
+                    "embeddings": [{ "indices": [3, 1], "values": [0.3, 0.1] }]
+                }));
+            })
+            .await;
+
+        let embedder = WikiEmbedder::new(Some(server.base_url()));
+        let embeddings = embedder.embed_sparse("user-token", &["doc"]).await.unwrap();
+
+        assert_eq!(embeddings.len(), 1);
+        assert_eq!(embeddings[0].indices, vec![1, 3]);
+        assert_eq!(embeddings[0].values, vec![0.1, 0.3]);
+        assert_eq!(mock.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn embed_sparse_empty_docs_makes_no_request() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST").path("/embed_sparse");
+                then.status(200).json_body(json!({ "embeddings": [] }));
+            })
+            .await;
+
+        let embedder = WikiEmbedder::new(Some(server.base_url()));
+        let embeddings = embedder.embed_sparse("user-token", &[]).await.unwrap();
+
+        assert!(embeddings.is_empty());
+        assert_eq!(mock.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn embed_sparse_slices_into_batches_of_100() {
+        let server = MockServer::start_async().await;
+        // Each call returns a single vector regardless of how many texts it
+        // received; we assert only the call count, which pins the 100-doc
+        // batch boundary (250 docs => ceil(250 / 100) == 3 requests).
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST").path("/embed_sparse");
+                then.status(200).json_body(json!({
+                    "embeddings": [{ "indices": [0], "values": [1.0] }]
+                }));
+            })
+            .await;
+
+        let embedder = WikiEmbedder::new(Some(server.base_url()));
+        let docs = vec!["x"; 250];
+        embedder.embed_sparse("user-token", &docs).await.unwrap();
+
+        assert_eq!(mock.calls(), 3);
+    }
+}

--- a/rust/foundation-api/src/wiki/mod.rs
+++ b/rust/foundation-api/src/wiki/mod.rs
@@ -15,4 +15,8 @@ pub(crate) mod client;
 // `/upsert-page` route added later in the stack, so unused on its own for now.
 #[allow(dead_code)]
 pub(crate) mod chunking;
+// SPLADE sparse embedding helper; also consumed by the `/upsert-page` route
+// added later in the stack, so unused on its own for now.
+#[allow(dead_code)]
+pub(crate) mod embed;
 pub(crate) use client::{WikiClient, WikiClientError};


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

Adds the SPLADE sparse-embedding helper the `/upsert-page` flow uses. Each chunk
gets a client-side SPLADE vector stored under the `sparse_embedding` metadata
key; dense Qwen vectors are still produced by the collection's schema-bound EF
on `add`.

- New functionality
  - Add `wiki/embed.rs`: `WikiEmbedder::embed_sparse` builds a Chroma Cloud
    SPLADE embedding function scoped to the caller's `x-chroma-token` (so embed
    usage bills to the user) and embeds documents in batches of 100 (the service
    per-request limit), concatenating results in input order. Empty input issues
    no request.
  - Add `httpmock` dev-dependency for mocked embedding-endpoint tests.
- Improvements & Bug fixes
  - None.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `cargo test`. Mocked-server unit tests cover token
  forwarding + sorted-vector parsing, the empty-input no-request case, and the
  100-doc batch boundary (250 docs => 3 requests).

## Migration plan

None — new internal module, no schema or config changes.

## Observability plan

None directly; embedding requests are attributed to the caller's token on the
Chroma Cloud embedding service.

## Documentation Changes

None — internal module, covered by rustdoc.
