### PR TITLE
[ENH] Add upsert skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,6 +3651,7 @@ dependencies = [
  "httpmock",
  "mdac",
  "opentelemetry",
+ "regex",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -3661,6 +3662,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-md",
  "uuid",
+ "validator",
 ]
 
 [[package]]

--- a/plans/foundation_edit-page_command_0a3a0511.plan.md
+++ b/plans/foundation_edit-page_command_0a3a0511.plan.md
@@ -13,7 +13,7 @@ todos:
     status: completed
   - id: pr4-authz-route-skeleton
     content: "PR 4 - Add AuthzAction::UpsertFoundation; add routes/upsert_page.rs request/response + auth + validation (slug/categories/source_ids), register POST /api/upsert-page returning a stub."
-    status: pending
+    status: completed
   - id: pr5-upsert-flow
     content: "PR 5 - Wire full flow via the SDK: resolve wiki collection + chunking config, get {slug}-0, delete where slug, re-chunk + embed, batched add with full metadata incl sparse_embedding; integration tests."
     status: pending

--- a/rust/foundation-api/Cargo.toml
+++ b/rust/foundation-api/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = { workspace = true }
 axum = { workspace = true }
 figment = { workspace = true }
 opentelemetry = { workspace = true }
+regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -22,6 +23,7 @@ tracing = { workspace = true }
 tree-sitter = "0.26"
 tree-sitter-md = "0.5"
 uuid = { workspace = true }
+validator = { workspace = true }
 
 chroma = { workspace = true }
 chroma-api-types = { workspace = true }

--- a/rust/foundation-api/src/routes/mod.rs
+++ b/rust/foundation-api/src/routes/mod.rs
@@ -2,8 +2,14 @@ use crate::server::FoundationApiServer;
 use axum::{routing::post, Router};
 
 pub(crate) mod init;
+pub(crate) mod upsert_page;
 pub(super) mod whoami;
 
 pub(crate) fn router() -> Router<FoundationApiServer> {
-    Router::new().route("/api/init", post(init::foundation_init))
+    Router::new()
+        .route("/api/init", post(init::foundation_init))
+        .route(
+            "/api/upsert-page",
+            post(upsert_page::foundation_upsert_page),
+        )
 }

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -118,12 +118,14 @@ fn validate_source_ids(source_ids: &[String]) -> Result<(), ValidationError> {
     for source_id in source_ids {
         match source_id.split_once(':') {
             Some((collection, _record_id)) if !collection.is_empty() => {}
-            _ => return Err(ValidationError::new("source_ids").with_message(
-                format!(
+            _ => {
+                return Err(ValidationError::new("source_ids").with_message(
+                    format!(
                     "invalid source id '{source_id}': expected format '<collection>:<record_id>'"
                 )
-                .into(),
-            )),
+                    .into(),
+                ))
+            }
         }
     }
     Ok(())

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -1,8 +1,7 @@
 //! `POST /api/upsert-page` — replace a wiki page's chunks.
 //!
 //! This module currently implements the request/response contract, coarse
-//! foundation authorization, and input validation ported from
-//! `foundation-research`'s `WikiStore`/`WikiTool`. The replace flow itself
+//! foundation authorization, and input validation. The replace flow itself
 //! (resolve the wiki collection, read `{slug}-0`, delete-by-slug, re-chunk +
 //! embed, batched add) lands in a later change; until then the handler returns
 //! a stub response after authorizing and validating the request.
@@ -18,15 +17,14 @@ use std::sync::LazyLock;
 use validator::{Validate, ValidationError};
 
 /// `^(?:[a-z0-9][a-z0-9-]*|category:[a-z0-9][a-z0-9-]*|)$` — the wiki slug
-/// shape from `WikiStore.SLUG_RE` (empty root, lowercase alnum/hyphen, or a
-/// `category:<slug>`). The empty alternative makes the root slug valid.
+/// shape (empty root, lowercase alnum/hyphen, or a `category:<slug>`). The
+/// empty alternative makes the root slug valid.
 static SLUG_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(?:[a-z0-9][a-z0-9-]*|category:[a-z0-9][a-z0-9-]*|)$")
         .expect("the wiki slug regex should be valid")
 });
 
-/// `^[a-z0-9][a-z0-9-]*$` — the category-name shape from
-/// `WikiStore.CATEGORY_NAME_RE`.
+/// `^[a-z0-9][a-z0-9-]*$` — the category-name shape.
 static CATEGORY_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^[a-z0-9][a-z0-9-]*$").expect("the category-name regex should be valid")
 });
@@ -99,7 +97,7 @@ pub async fn foundation_upsert_page(
     }))
 }
 
-/// Validates the slug against [`SLUG_RE`] (mirrors `WikiStore.validate_slug`).
+/// Validates the slug against [`SLUG_RE`].
 fn validate_slug(slug: &str) -> Result<(), ValidationError> {
     if SLUG_RE.is_match(slug) {
         Ok(())
@@ -112,8 +110,8 @@ fn validate_slug(slug: &str) -> Result<(), ValidationError> {
 }
 
 /// Validates each source id is `<collection>:<record_id>` with a non-empty
-/// collection, mirroring `citations.parse_source_id`. The record id (after the
-/// first `:`) may be empty (the wiki root's citation id).
+/// collection. The record id (after the first `:`) may be empty (the wiki
+/// root's citation id).
 fn validate_source_ids(source_ids: &[String]) -> Result<(), ValidationError> {
     for source_id in source_ids {
         match source_id.split_once(':') {
@@ -145,7 +143,7 @@ fn validate_categories(categories: &[String]) -> Result<(), ValidationError> {
 }
 
 /// Deduplicates and lexicographically sorts the (already-validated) category
-/// list, mirroring `sorted(set(categories or []))` in `WikiStore.upsert_file`.
+/// list.
 fn normalize_categories(categories: &[String]) -> Vec<String> {
     categories
         .iter()

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -1,0 +1,251 @@
+//! `POST /api/upsert-page` — replace a wiki page's chunks.
+//!
+//! This module currently implements the request/response contract, coarse
+//! foundation authorization, and input validation ported from
+//! `foundation-research`'s `WikiStore`/`WikiTool`. The replace flow itself
+//! (resolve the wiki collection, read `{slug}-0`, delete-by-slug, re-chunk +
+//! embed, batched add) lands in a later change; until then the handler returns
+//! a stub response after authorizing and validating the request.
+
+use super::whoami::whoami_and_authorize;
+use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
+use axum::{extract::State, http::HeaderMap, Json};
+use chroma_error::ChromaValidationError;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::sync::LazyLock;
+use validator::{Validate, ValidationError};
+
+/// `^(?:[a-z0-9][a-z0-9-]*|category:[a-z0-9][a-z0-9-]*|)$` — the wiki slug
+/// shape from `WikiStore.SLUG_RE` (empty root, lowercase alnum/hyphen, or a
+/// `category:<slug>`). The empty alternative makes the root slug valid.
+static SLUG_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:[a-z0-9][a-z0-9-]*|category:[a-z0-9][a-z0-9-]*|)$")
+        .expect("the wiki slug regex should be valid")
+});
+
+/// `^[a-z0-9][a-z0-9-]*$` — the category-name shape from
+/// `WikiStore.CATEGORY_NAME_RE`.
+static CATEGORY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[a-z0-9][a-z0-9-]*$").expect("the category-name regex should be valid")
+});
+
+/// Request body for `POST /api/upsert-page`.
+#[derive(Debug, Deserialize, Validate)]
+pub struct UpsertPageRequest {
+    /// Page slug. Empty string is the wiki root; otherwise lowercase
+    /// alnum/hyphen, or `category:<slug>`.
+    #[validate(custom(function = "validate_slug"))]
+    pub slug: String,
+    /// Full markdown content. The first non-blank line is the title.
+    #[validate(length(min = 1, message = "content must not be empty"))]
+    pub content: String,
+    /// Citation ids (`<collection>:<record_id>`) for every source whose
+    /// information appears in `content`. May be empty.
+    #[validate(custom(function = "validate_source_ids"))]
+    pub source_ids: Vec<String>,
+    /// Optional category tags (lowercase alnum/hyphen); deduplicated and
+    /// sorted before they are stamped onto the page.
+    #[serde(default)]
+    #[validate(custom(function = "validate_categories"))]
+    pub categories: Vec<String>,
+}
+
+/// Response body for `POST /api/upsert-page`.
+#[derive(Debug, Serialize)]
+pub struct UpsertPageResponse {
+    /// The page slug that was written.
+    pub slug: String,
+    /// `"added"` for a new page or `"updated"` for an existing one (the stub
+    /// returns `"stub"` until the replace flow is wired up).
+    pub op: String,
+    /// Monotonic page version (1 for a new page, previous + 1 on update).
+    pub version: u32,
+    /// Page creation time, unix seconds.
+    pub created_at: i64,
+    /// Last write time, unix seconds.
+    pub updated_at: i64,
+    /// Number of chunks written for the page.
+    pub num_chunks: usize,
+}
+
+/// `POST /api/upsert-page` handler.
+pub async fn foundation_upsert_page(
+    headers: HeaderMap,
+    State(server): State<FoundationApiServer>,
+    Json(request): Json<UpsertPageRequest>,
+) -> Result<Json<UpsertPageResponse>, ServerError> {
+    let identity =
+        whoami_and_authorize(&*server.auth, &headers, AuthzAction::UpsertFoundation).await?;
+    let tenant = identity.tenant;
+
+    let _guard =
+        server.scorecard_request(&["op:foundation_upsert_page", &format!("tenant:{tenant}")])?;
+
+    request.validate().map_err(ChromaValidationError::from)?;
+
+    // Normalize now so the replace flow (added later) can rely on a well-formed
+    // request; `_categories` is the deduped/sorted list it stamps onto chunks.
+    let _categories = normalize_categories(&request.categories);
+
+    Ok(Json(UpsertPageResponse {
+        slug: request.slug,
+        op: "stub".to_string(),
+        version: 0,
+        created_at: 0,
+        updated_at: 0,
+        num_chunks: 0,
+    }))
+}
+
+/// Validates the slug against [`SLUG_RE`] (mirrors `WikiStore.validate_slug`).
+fn validate_slug(slug: &str) -> Result<(), ValidationError> {
+    if SLUG_RE.is_match(slug) {
+        Ok(())
+    } else {
+        Err(ValidationError::new("slug").with_message(
+            format!("invalid slug '{slug}': must be lowercase alnum/hyphen, or 'category:<slug>'")
+                .into(),
+        ))
+    }
+}
+
+/// Validates each source id is `<collection>:<record_id>` with a non-empty
+/// collection, mirroring `citations.parse_source_id`. The record id (after the
+/// first `:`) may be empty (the wiki root's citation id).
+fn validate_source_ids(source_ids: &[String]) -> Result<(), ValidationError> {
+    for source_id in source_ids {
+        match source_id.split_once(':') {
+            Some((collection, _record_id)) if !collection.is_empty() => {}
+            _ => return Err(ValidationError::new("source_ids").with_message(
+                format!(
+                    "invalid source id '{source_id}': expected format '<collection>:<record_id>'"
+                )
+                .into(),
+            )),
+        }
+    }
+    Ok(())
+}
+
+/// Validates each category against [`CATEGORY_RE`].
+fn validate_categories(categories: &[String]) -> Result<(), ValidationError> {
+    for category in categories {
+        if !CATEGORY_RE.is_match(category) {
+            return Err(ValidationError::new("categories").with_message(
+                format!("invalid category name '{category}': must be lowercase alnum/hyphen")
+                    .into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Deduplicates and lexicographically sorts the (already-validated) category
+/// list, mirroring `sorted(set(categories or []))` in `WikiStore.upsert_file`.
+fn normalize_categories(categories: &[String]) -> Vec<String> {
+    categories
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(
+        slug: &str,
+        content: &str,
+        source_ids: &[&str],
+        categories: &[&str],
+    ) -> UpsertPageRequest {
+        UpsertPageRequest {
+            slug: slug.to_string(),
+            content: content.to_string(),
+            source_ids: source_ids.iter().map(|s| s.to_string()).collect(),
+            categories: categories.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn validate_slug_accepts_root_and_well_formed_slugs() {
+        validate_slug("").unwrap();
+        validate_slug("foo").unwrap();
+        validate_slug("foo-bar-1").unwrap();
+        validate_slug("category:foo-bar").unwrap();
+        validate_slug("0").unwrap();
+    }
+
+    #[test]
+    fn validate_slug_rejects_malformed_slugs() {
+        for slug in [
+            "Foo",          // uppercase
+            "foo_bar",      // underscore
+            "-foo",         // leading hyphen
+            "foo:bar",      // colon outside category prefix
+            "category:",    // empty category body
+            "category:Foo", // uppercase category body
+            " foo",         // leading space
+        ] {
+            assert!(
+                validate_slug(slug).is_err(),
+                "expected {slug:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_source_ids_checks_collection_and_separator() {
+        validate_source_ids(&[]).unwrap();
+        validate_source_ids(&["slack_master:C094_177.992".to_string()]).unwrap();
+        // Empty record id is allowed (root page citation id).
+        validate_source_ids(&["wiki_master:".to_string()]).unwrap();
+
+        assert!(validate_source_ids(&["norecord".to_string()]).is_err());
+        assert!(validate_source_ids(&[":record".to_string()]).is_err());
+    }
+
+    #[test]
+    fn validate_categories_rejects_malformed_names() {
+        validate_categories(&[]).unwrap();
+        validate_categories(&["foo".to_string(), "bar-1".to_string()]).unwrap();
+        assert!(validate_categories(&["Archive".to_string()]).is_err());
+    }
+
+    #[test]
+    fn normalize_categories_dedups_and_sorts() {
+        assert_eq!(
+            normalize_categories(&["b".to_string(), "a".to_string(), "a".to_string()]),
+            vec!["a".to_string(), "b".to_string()]
+        );
+        assert_eq!(normalize_categories(&[]), Vec::<String>::new());
+    }
+
+    #[test]
+    fn request_validate_rejects_empty_content() {
+        assert!(request("foo", "", &["c:r"], &[]).validate().is_err());
+    }
+
+    #[test]
+    fn request_validate_rejects_bad_fields() {
+        assert!(request("Foo", "body", &[], &[]).validate().is_err());
+        assert!(request("foo", "body", &["norecord"], &[])
+            .validate()
+            .is_err());
+        assert!(request("foo", "body", &[], &["Archive"])
+            .validate()
+            .is_err());
+    }
+
+    #[test]
+    fn request_validate_accepts_well_formed_request() {
+        request("foo", "# Title\n\nBody", &["slack_master:abc"], &["z", "a"])
+            .validate()
+            .unwrap();
+    }
+}

--- a/rust/frontend-core/src/auth.rs
+++ b/rust/frontend-core/src/auth.rs
@@ -43,6 +43,7 @@ pub enum AuthzAction {
     RemoveAttachedFunction,
     InitFoundation,
     ViewFoundation,
+    UpsertFoundation,
 }
 
 impl Display for AuthzAction {
@@ -78,6 +79,7 @@ impl Display for AuthzAction {
             AuthzAction::RemoveAttachedFunction => write!(f, "collection:remove_attached_function"),
             AuthzAction::InitFoundation => write!(f, "foundation:init_foundation"),
             AuthzAction::ViewFoundation => write!(f, "foundation:view_foundation"),
+            AuthzAction::UpsertFoundation => write!(f, "foundation:upsert_foundation"),
         }
     }
 }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

Adds the `POST /api/upsert-page` route's contract, authorization, and input
validation. The handler authorizes + validates, then returns a stub response;
the replace flow itself lands in the next PR.

- New functionality
  - Add `AuthzAction::UpsertFoundation` (`foundation:upsert_foundation`).
  - Add `routes/upsert_page.rs`: `UpsertPageRequest` / `UpsertPageResponse`,
    coarse foundation authorization via `whoami_and_authorize`, a scorecard
    guard, and validation of `slug`, `source_ids` (`<collection>:<record_id>`),
    and `categories` (deduped + sorted). Register the route in the router.
  - Add `regex` + `validator` dependencies.
- Improvements & Bug fixes
  - None.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `cargo test`. Unit tests cover slug / source-id /
  category validation (accept + reject cases) and category normalization.

## Migration plan

Backwards compatible. The route is registered but returns a stub and performs no
record I/O; it is only reachable once `frontend_ingress_url` is configured and
the full flow is wired up.

## Observability plan

The handler emits a scorecard request tagged `op:foundation_upsert_page` and
`tenant:<tenant>`. Broader tracing for `foundation-api` is tracked separately.

## Documentation Changes

None yet — the user-facing `/api/upsert-page` request/response contract will be
documented when the flow is complete. Request/response fields carry rustdoc.
