### PR TITLE
[BUG](security): block trust_remote_code in SentenceTransformer embedding function kwargs

### DIFF
--- a/chromadb/api/collection_configuration.py
+++ b/chromadb/api/collection_configuration.py
@@ -10,6 +10,9 @@ from chromadb.utils.embedding_functions import (
     known_embedding_functions,
     register_embedding_function,
 )
+from chromadb.utils.embedding_functions.config_validation import (
+    validate_embedding_function_config_is_safe,
+)
 from multiprocessing import cpu_count
 import warnings
 
@@ -96,6 +99,7 @@ def load_collection_configuration_from_json(
                     f"Embedding function {ef_name} not found. Add @register_embedding_function decorator to the class definition."
                 )
             try:
+                validate_embedding_function_config_is_safe(ef_name, ef_config["config"])
                 ef = ef.build_from_config(ef_config["config"])  # type: ignore
             except Exception as e:
                 raise ValueError(
@@ -314,6 +318,9 @@ def load_create_collection_configuration_from_json(
             )
         else:
             ef = known_embedding_functions[ef_config["name"]]
+            validate_embedding_function_config_is_safe(
+                ef_config["name"], ef_config["config"]
+            )
             result["embedding_function"] = ef.build_from_config(ef_config["config"])
 
     return result
@@ -628,6 +635,10 @@ def load_update_collection_configuration_from_json(
             )
         else:
             ef = known_embedding_functions[json_map["embedding_function"]["name"]]
+            validate_embedding_function_config_is_safe(
+                json_map["embedding_function"]["name"],
+                json_map["embedding_function"]["config"],
+            )
             result["embedding_function"] = ef.build_from_config(
                 json_map["embedding_function"]["config"]
             )

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -2912,11 +2912,15 @@ class Schema:
                 else:
                     try:
                         from chromadb.utils.embedding_functions import (
+                            config_validation,
                             known_embedding_functions,
                         )
 
                         ef_name = ef_config["name"]
                         ef = known_embedding_functions[ef_name]
+                        config_validation.validate_embedding_function_config_is_safe(
+                            ef_name, ef_config["config"]
+                        )
                         config_data["embedding_function"] = ef.build_from_config(
                             ef_config["config"]
                         )
@@ -2962,11 +2966,15 @@ class Schema:
                 else:
                     try:
                         from chromadb.utils.embedding_functions import (
+                            config_validation,
                             sparse_known_embedding_functions,
                         )
 
                         ef_name = ef_config["name"]
                         ef = sparse_known_embedding_functions[ef_name]
+                        config_validation.validate_embedding_function_config_is_safe(
+                            ef_name, ef_config["config"]
+                        )
                         config_data["embedding_function"] = ef.build_from_config(
                             ef_config["config"]
                         )

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -819,6 +819,16 @@ class FastAPI(Server):
             request: Request, tenant: str, database: str, raw_body: bytes
         ) -> CollectionModel:
             create = validate_model(CreateCollection, orjson.loads(raw_body))
+
+            # NOTE(rescrv, iron will auth):  Implemented.
+            self.sync_auth_request(
+                request.headers,
+                AuthzAction.CREATE_COLLECTION,
+                tenant,
+                database,
+                create.name,
+            )
+
             if not create.configuration:
                 if create.metadata:
                     configuration = (
@@ -832,15 +842,6 @@ class FastAPI(Server):
                 configuration = load_create_collection_configuration_from_json(
                     create.configuration
                 )
-
-            # NOTE(rescrv, iron will auth):  Implemented.
-            self.sync_auth_request(
-                request.headers,
-                AuthzAction.CREATE_COLLECTION,
-                tenant,
-                database,
-                create.name,
-            )
 
             self._set_request_context(request=request)
 
@@ -1951,13 +1952,6 @@ class FastAPI(Server):
             request: Request, tenant: str, database: str, raw_body: bytes
         ) -> CollectionModel:
             create = validate_model(CreateCollection, orjson.loads(raw_body))
-            configuration = (
-                CreateCollectionConfiguration()
-                if not create.configuration
-                else load_create_collection_configuration_from_json(
-                    create.configuration
-                )
-            )
 
             (
                 maybe_tenant,
@@ -1974,6 +1968,14 @@ class FastAPI(Server):
                 tenant = maybe_tenant
             if maybe_database:
                 database = maybe_database
+
+            configuration = (
+                CreateCollectionConfiguration()
+                if not create.configuration
+                else load_create_collection_configuration_from_json(
+                    create.configuration
+                )
+            )
 
             return self._api.create_collection(
                 name=create.name,

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -1221,6 +1221,7 @@ def mock_common_deps(monkeypatch: MonkeyPatch) -> MonkeyPatch:
     mock_attributes = {
         "PIL.Image": MagicMock(),
         "sentence_transformers.SentenceTransformer": MagicMock(),
+        "sentence_transformers.SparseEncoder": MagicMock(),
         "ollama.Client": MagicMock(),
         "InstructorEmbedding.INSTRUCTOR": MagicMock(),
         "voyageai.Client": MagicMock(),

--- a/chromadb/test/server/test_fastapi_security.py
+++ b/chromadb/test/server/test_fastapi_security.py
@@ -1,0 +1,130 @@
+from typing import Any, Callable, Dict, List
+
+import orjson
+import pytest
+from anyio import to_thread
+
+import chromadb.server.fastapi as fastapi_server
+from chromadb.server.fastapi import FastAPI
+
+
+class FakeRequest:
+    headers: Dict[str, str] = {}
+
+    def __init__(self, body: Dict[str, Any]) -> None:
+        self._body = orjson.dumps(body)
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+class ExplodingApi:
+    def create_collection(self, **_kwargs: Any) -> None:
+        raise AssertionError("collection creation should not be reached")
+
+
+class NoopRateLimitEnforcer:
+    def rate_limit(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        return func
+
+
+async def run_sync_immediately(
+    func: Callable[..., Any], *args: Any, limiter: Any = None
+) -> Any:
+    del limiter
+    return func(*args)
+
+
+def create_collection_body() -> Dict[str, Any]:
+    return {
+        "name": "poisoned",
+        "configuration": {
+            "embedding_function": {
+                "name": "sentence_transformer",
+                "type": "known",
+                "config": {
+                    "model_name": "attacker/model",
+                    "device": "cpu",
+                    "normalize_embeddings": False,
+                    "kwargs": {"model_kwargs": {"trust_remote_code": True}},
+                },
+            }
+        },
+    }
+
+
+def make_uninitialized_fastapi() -> Any:
+    server: Any = FastAPI.__new__(FastAPI)
+    server._api = ExplodingApi()
+    server._capacity_limiter = None
+    server._async_rate_limit_enforcer = NoopRateLimitEnforcer()
+    server._set_request_context = lambda request: None
+    return server
+
+
+@pytest.mark.asyncio
+async def test_v2_create_collection_authenticates_before_loading_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[str] = []
+    server = make_uninitialized_fastapi()
+
+    def fail_auth(*_args: Any, **_kwargs: Any) -> None:
+        calls.append("auth")
+        raise RuntimeError("unauthorized")
+
+    def load_configuration(config: Dict[str, Any]) -> Dict[str, Any]:
+        del config
+        calls.append("load_configuration")
+        return {}
+
+    server.sync_auth_request = fail_auth
+    monkeypatch.setattr(to_thread, "run_sync", run_sync_immediately)
+    monkeypatch.setattr(
+        fastapi_server,
+        "load_create_collection_configuration_from_json",
+        load_configuration,
+    )
+
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        await server.create_collection(
+            FakeRequest(create_collection_body()),
+            tenant="default_tenant",
+            database_name="default_database",
+        )
+
+    assert calls == ["auth"]
+
+
+@pytest.mark.asyncio
+async def test_v1_create_collection_authenticates_before_loading_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[str] = []
+    server = make_uninitialized_fastapi()
+
+    def fail_auth(*_args: Any, **_kwargs: Any) -> None:
+        calls.append("auth")
+        raise RuntimeError("unauthorized")
+
+    def load_configuration(config: Dict[str, Any]) -> Dict[str, Any]:
+        del config
+        calls.append("load_configuration")
+        return {}
+
+    server.sync_auth_and_get_tenant_and_database_for_request = fail_auth
+    monkeypatch.setattr(to_thread, "run_sync", run_sync_immediately)
+    monkeypatch.setattr(
+        fastapi_server,
+        "load_create_collection_configuration_from_json",
+        load_configuration,
+    )
+
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        await server.create_collection_v1(
+            FakeRequest(create_collection_body()),
+            tenant="default_tenant",
+            database="default_database",
+        )
+
+    assert calls == ["auth"]

--- a/chromadb/test/utils/test_embedding_function_config_validation.py
+++ b/chromadb/test/utils/test_embedding_function_config_validation.py
@@ -1,0 +1,257 @@
+from typing import Any, Dict, List
+
+import pytest
+
+from chromadb.api.collection_configuration import (
+    load_collection_configuration_from_json,
+    load_create_collection_configuration_from_json,
+    load_update_collection_configuration_from_json,
+)
+from chromadb.api.types import (
+    Documents,
+    Embeddings,
+    EmbeddingFunction,
+    Schema,
+    SparseEmbeddingFunction,
+    SparseVector,
+)
+from chromadb.utils.embedding_functions import (
+    known_embedding_functions,
+    sparse_known_embedding_functions,
+)
+from chromadb.utils.embedding_functions.config_validation import (
+    validate_embedding_function_config_is_safe,
+    validate_embedding_function_kwargs_are_safe,
+)
+
+LOCAL_MODEL_LOADERS = [
+    "sentence_transformer",
+    "huggingface_sparse",
+    "fastembed_sparse",
+]
+
+UNSAFE_KWARGS: List[Dict[str, Any]] = [
+    {"trust_remote_code": True},
+    {"trust_remote_code": False},
+    {"model_kwargs": {"trust_remote_code": True}},
+    {"config_kwargs": {"trust_remote_code": True}},
+    {"tokenizer_kwargs": {"trust_remote_code": True}},
+    {"processor_kwargs": {"trust_remote_code": True}},
+    {"outer": {"inner": {"trust_remote_code": True}}},
+    {"listed": [{"trust_remote_code": True}]},
+    {"listed": [{"nested": ({"trust_remote_code": True},)}]},
+]
+
+BENIGN_KWARGS: List[Dict[str, Any]] = [
+    {},
+    {"cache_folder": "/tmp/models"},
+    {"revision": "main"},
+    {"token": "hf_xxx"},
+    {"backend": "onnx"},
+    {"model_kwargs": {"torch_dtype": "float16"}},
+    {"config_kwargs": {"attn_implementation": "eager"}},
+    {"model_kwargs": {"device_map": "auto"}, "revision": "refs/pr/1"},
+]
+
+
+@pytest.mark.parametrize("kwargs", UNSAFE_KWARGS)
+def test_validate_kwargs_rejects_trust_remote_code(kwargs: Dict[str, Any]) -> None:
+    with pytest.raises(ValueError, match="trust_remote_code is not allowed"):
+        validate_embedding_function_kwargs_are_safe(kwargs)
+
+
+@pytest.mark.parametrize("kwargs", BENIGN_KWARGS)
+def test_validate_kwargs_allows_benign_kwargs(kwargs: Dict[str, Any]) -> None:
+    validate_embedding_function_kwargs_are_safe(kwargs)
+
+
+def test_validate_kwargs_allows_none() -> None:
+    validate_embedding_function_kwargs_are_safe(None)
+
+
+@pytest.mark.parametrize("name", LOCAL_MODEL_LOADERS)
+@pytest.mark.parametrize("kwargs", UNSAFE_KWARGS)
+def test_validate_config_rejects_local_loader_trust_remote_code(
+    name: str, kwargs: Dict[str, Any]
+) -> None:
+    with pytest.raises(ValueError, match="trust_remote_code is not allowed"):
+        validate_embedding_function_config_is_safe(name, {"kwargs": kwargs})
+
+
+@pytest.mark.parametrize("name", LOCAL_MODEL_LOADERS)
+@pytest.mark.parametrize("kwargs", BENIGN_KWARGS)
+def test_validate_config_allows_local_loader_benign_kwargs(
+    name: str, kwargs: Dict[str, Any]
+) -> None:
+    validate_embedding_function_config_is_safe(name, {"kwargs": kwargs})
+
+
+def test_validate_config_ignores_non_local_loaders() -> None:
+    validate_embedding_function_config_is_safe(
+        "openai", {"kwargs": {"trust_remote_code": True}}
+    )
+
+
+def test_validate_config_handles_missing_kwargs() -> None:
+    validate_embedding_function_config_is_safe(
+        "sentence_transformer", {"model_name": "x"}
+    )
+
+
+class ExplodingEmbeddingFunction(EmbeddingFunction[Documents]):
+    build_calls = 0
+
+    def __call__(self, input: Documents) -> Embeddings:
+        raise AssertionError("unsafe embedding function should not be called")
+
+    @staticmethod
+    def name() -> str:
+        return "sentence_transformer"
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "ExplodingEmbeddingFunction":
+        ExplodingEmbeddingFunction.build_calls += 1
+        raise AssertionError("unsafe embedding function should not be built")
+
+
+class ExplodingSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
+    build_calls = 0
+
+    def __call__(self, input: Documents) -> List[SparseVector]:
+        raise AssertionError("unsafe sparse embedding function should not be called")
+
+    @staticmethod
+    def name() -> str:
+        return "huggingface_sparse"
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "ExplodingSparseEmbeddingFunction":
+        ExplodingSparseEmbeddingFunction.build_calls += 1
+        raise AssertionError("unsafe sparse embedding function should not be built")
+
+
+def malicious_dense_config() -> Dict[str, Any]:
+    return {
+        "embedding_function": {
+            "name": "sentence_transformer",
+            "type": "known",
+            "config": {
+                "model_name": "attacker/model",
+                "device": "cpu",
+                "normalize_embeddings": False,
+                "kwargs": {"model_kwargs": {"trust_remote_code": True}},
+            },
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "loader",
+    [
+        load_create_collection_configuration_from_json,
+        load_update_collection_configuration_from_json,
+        load_collection_configuration_from_json,
+    ],
+)
+def test_loaders_reject_nested_trust_remote_code_before_build(
+    monkeypatch: pytest.MonkeyPatch, loader: Any
+) -> None:
+    ExplodingEmbeddingFunction.build_calls = 0
+    monkeypatch.setitem(
+        known_embedding_functions,
+        "sentence_transformer",
+        ExplodingEmbeddingFunction,
+    )
+
+    with pytest.raises(ValueError, match="trust_remote_code"):
+        loader(malicious_dense_config())
+
+    assert ExplodingEmbeddingFunction.build_calls == 0
+
+
+def test_schema_deserialize_drops_dense_nested_trust_remote_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ExplodingEmbeddingFunction.build_calls = 0
+    monkeypatch.setitem(
+        known_embedding_functions,
+        "sentence_transformer",
+        ExplodingEmbeddingFunction,
+    )
+
+    schema = Schema.deserialize_from_json(
+        {
+            "defaults": {
+                "float_list": {
+                    "vector_index": {
+                        "enabled": True,
+                        "config": {
+                            "embedding_function": {
+                                "name": "sentence_transformer",
+                                "type": "known",
+                                "config": {
+                                    "model_name": "attacker/model",
+                                    "device": "cpu",
+                                    "normalize_embeddings": False,
+                                    "kwargs": {
+                                        "model_kwargs": {"trust_remote_code": True}
+                                    },
+                                },
+                            }
+                        },
+                    }
+                }
+            },
+            "keys": {},
+        }
+    )
+
+    assert ExplodingEmbeddingFunction.build_calls == 0
+    assert schema.defaults.float_list is not None
+    assert schema.defaults.float_list.vector_index is not None
+    assert schema.defaults.float_list.vector_index.config.embedding_function is None
+
+
+def test_schema_deserialize_drops_sparse_nested_trust_remote_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ExplodingSparseEmbeddingFunction.build_calls = 0
+    monkeypatch.setitem(
+        sparse_known_embedding_functions,
+        "huggingface_sparse",
+        ExplodingSparseEmbeddingFunction,
+    )
+
+    schema = Schema.deserialize_from_json(
+        {
+            "defaults": {
+                "sparse_vector": {
+                    "sparse_vector_index": {
+                        "enabled": True,
+                        "config": {
+                            "embedding_function": {
+                                "name": "huggingface_sparse",
+                                "type": "known",
+                                "config": {
+                                    "model_name": "attacker/model",
+                                    "device": "cpu",
+                                    "kwargs": {
+                                        "processor_kwargs": {"trust_remote_code": True}
+                                    },
+                                },
+                            }
+                        },
+                    }
+                }
+            },
+            "keys": {},
+        }
+    )
+
+    assert ExplodingSparseEmbeddingFunction.build_calls == 0
+    assert schema.defaults.sparse_vector is not None
+    assert schema.defaults.sparse_vector.sparse_vector_index is not None
+    assert (
+        schema.defaults.sparse_vector.sparse_vector_index.config.embedding_function
+        is None
+    )

--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -11,6 +11,12 @@ from chromadb.utils.embedding_functions import (
     known_embedding_functions,
     sparse_known_embedding_functions,
 )
+from chromadb.utils.embedding_functions.huggingface_sparse_embedding_function import (
+    HuggingFaceSparseEmbeddingFunction,
+)
+from chromadb.utils.embedding_functions.sentence_transformer_embedding_function import (
+    SentenceTransformerEmbeddingFunction,
+)
 from chromadb.api.types import Documents, Embeddings
 from pytest import MonkeyPatch
 
@@ -63,18 +69,15 @@ class TestEmbeddingFunctionSchemas:
                 "instructions": CHROMA_CLOUD_QWEN_DEFAULT_INSTRUCTIONS,
             }
 
-        # Mock the class constructor to return our mock instance
+        # Use the mock instance directly to avoid mutating __new__, which leaves
+        # constructor slots in a bad state for later tests.
+        ef_instance = mock_ef
         mock_common_deps.setattr(
-            ef_class, "__new__", lambda cls, *args, **kwargs: mock_ef
+            ef_class, "build_from_config", MagicMock(return_value=mock_ef)
         )
 
-        # Create instance with minimal args (constructor will be mocked)
-        ef_instance = ef_class()
-
-        # Get the config (this will use the real method)
+        # Keep this mock-based roundtrip test isolated from real constructors.
         config = ef_instance.get_config()
-
-        # Test recreation from config
         new_instance = ef_class.build_from_config(config)
         new_config = new_instance.get_config()
 
@@ -146,6 +149,97 @@ class TestEmbeddingFunctionSchemas:
             if schema.get("additionalProperties", True) is False:
                 with pytest.raises(ValidationError):
                     validate_config_schema(test_config, schema_name)
+
+    @pytest.mark.parametrize(
+        "ef_class,config",
+        [
+            (
+                SentenceTransformerEmbeddingFunction,
+                {
+                    "model_name": "all-MiniLM-L6-v2",
+                    "device": "cpu",
+                    "normalize_embeddings": False,
+                    "kwargs": {"trust_remote_code": True},
+                },
+            ),
+            (
+                HuggingFaceSparseEmbeddingFunction,
+                {
+                    "model_name": "naver/splade-v3",
+                    "device": "cpu",
+                    "kwargs": {"trust_remote_code": True},
+                },
+            ),
+        ],
+    )
+    def test_trust_remote_code_rejected_by_schema(
+        self, ef_class: Any, config: Dict[str, Any]
+    ) -> None:
+        """Test that schemas reject kwargs that enable arbitrary remote code."""
+        with pytest.raises(ValidationError):
+            ef_class.validate_config(config)
+
+    @pytest.mark.parametrize(
+        "ef_class,config",
+        [
+            (
+                SentenceTransformerEmbeddingFunction,
+                {
+                    "model_name": "all-MiniLM-L6-v2",
+                    "device": "cpu",
+                    "normalize_embeddings": False,
+                    "kwargs": {"trust_remote_code": True},
+                },
+            ),
+            (
+                HuggingFaceSparseEmbeddingFunction,
+                {
+                    "model_name": "naver/splade-v3",
+                    "device": "cpu",
+                    "kwargs": {"trust_remote_code": True},
+                },
+            ),
+        ],
+    )
+    def test_trust_remote_code_rejected_by_build_from_config(
+        self,
+        ef_class: Any,
+        config: Dict[str, Any],
+        mock_common_deps: MonkeyPatch,
+    ) -> None:
+        """Test config construction if schema validation is bypassed."""
+        with pytest.raises(ValueError, match="trust_remote_code is not allowed"):
+            ef_class.build_from_config(config)
+
+    def test_sentence_transformer_trust_remote_code_rejected_by_constructor(
+        self, mock_common_deps: MonkeyPatch
+    ) -> None:
+        """Test direct construction rejects trust_remote_code before model creation."""
+        import sentence_transformers
+
+        sentence_transformers.SentenceTransformer.reset_mock()
+
+        with pytest.raises(ValueError, match="trust_remote_code is not allowed"):
+            SentenceTransformerEmbeddingFunction(trust_remote_code=True)
+
+        sentence_transformers.SentenceTransformer.assert_not_called()
+
+    def test_huggingface_sparse_trust_remote_code_rejected_by_constructor(
+        self, mock_common_deps: MonkeyPatch
+    ) -> None:
+        """Test sparse construction rejects trust_remote_code before model creation."""
+        import sentence_transformers
+
+        sentence_transformers.SparseEncoder.reset_mock()
+
+        with pytest.raises(ValueError, match="trust_remote_code is not allowed"):
+            HuggingFaceSparseEmbeddingFunction(
+                model_name="naver/splade-v3",
+                device="cpu",
+                trust_remote_code=True,
+            )
+
+        sentence_transformers.SparseEncoder.assert_not_called()
 
     def _create_valid_config_from_schema(
         self, schema: Dict[str, Any]

--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -241,6 +241,110 @@ class TestEmbeddingFunctionSchemas:
 
         sentence_transformers.SparseEncoder.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "ef_class,config",
+        [
+            (
+                SentenceTransformerEmbeddingFunction,
+                {
+                    "model_name": "all-MiniLM-L6-v2",
+                    "device": "cpu",
+                    "normalize_embeddings": False,
+                    "kwargs": {"model_kwargs": {"trust_remote_code": True}},
+                },
+            ),
+            (
+                SentenceTransformerEmbeddingFunction,
+                {
+                    "model_name": "all-MiniLM-L6-v2",
+                    "device": "cpu",
+                    "normalize_embeddings": False,
+                    "kwargs": {"config_kwargs": {"trust_remote_code": True}},
+                },
+            ),
+            (
+                SentenceTransformerEmbeddingFunction,
+                {
+                    "model_name": "all-MiniLM-L6-v2",
+                    "device": "cpu",
+                    "normalize_embeddings": False,
+                    "kwargs": {"tokenizer_kwargs": {"trust_remote_code": True}},
+                },
+            ),
+            (
+                HuggingFaceSparseEmbeddingFunction,
+                {
+                    "model_name": "naver/splade-v3",
+                    "device": "cpu",
+                    "kwargs": {"model_kwargs": {"trust_remote_code": True}},
+                },
+            ),
+            (
+                HuggingFaceSparseEmbeddingFunction,
+                {
+                    "model_name": "naver/splade-v3",
+                    "device": "cpu",
+                    "kwargs": {"processor_kwargs": {"trust_remote_code": True}},
+                },
+            ),
+        ],
+    )
+    def test_nested_trust_remote_code_rejected_by_build_from_config(
+        self,
+        ef_class: Any,
+        config: Dict[str, Any],
+        mock_common_deps: MonkeyPatch,
+    ) -> None:
+        with pytest.raises(ValueError, match="trust_remote_code is not allowed"):
+            ef_class.build_from_config(config)
+
+    def test_sentence_transformer_nested_trust_remote_code_rejected(
+        self, mock_common_deps: MonkeyPatch
+    ) -> None:
+        import sentence_transformers
+
+        sentence_transformers.SentenceTransformer.reset_mock()
+
+        with pytest.raises(ValueError, match="trust_remote_code is not allowed"):
+            SentenceTransformerEmbeddingFunction(
+                model_kwargs={"trust_remote_code": True}
+            )
+
+        sentence_transformers.SentenceTransformer.assert_not_called()
+
+    def test_huggingface_sparse_nested_trust_remote_code_rejected(
+        self, mock_common_deps: MonkeyPatch
+    ) -> None:
+        import sentence_transformers
+
+        sentence_transformers.SparseEncoder.reset_mock()
+
+        with pytest.raises(ValueError, match="trust_remote_code is not allowed"):
+            HuggingFaceSparseEmbeddingFunction(
+                model_name="naver/splade-v3",
+                device="cpu",
+                config_kwargs={"trust_remote_code": True},
+            )
+
+        sentence_transformers.SparseEncoder.assert_not_called()
+
+    def test_benign_kwargs_are_preserved(self, mock_common_deps: MonkeyPatch) -> None:
+        import sentence_transformers
+
+        sentence_transformers.SentenceTransformer.reset_mock()
+
+        ef = SentenceTransformerEmbeddingFunction(
+            model_name="test-benign-st-model",
+            cache_folder="/tmp/models",
+            model_kwargs={"torch_dtype": "float16"},
+        )
+
+        assert ef.kwargs == {
+            "cache_folder": "/tmp/models",
+            "model_kwargs": {"torch_dtype": "float16"},
+        }
+        sentence_transformers.SentenceTransformer.assert_called_once()
+
     def _create_valid_config_from_schema(
         self, schema: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -4,6 +4,9 @@ from chromadb.api.types import (
     DefaultEmbeddingFunction,
     SparseEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.config_validation import (
+    validate_embedding_function_config_is_safe,
+)
 
 # Import all embedding functions
 from chromadb.utils.embedding_functions.cohere_embedding_function import (
@@ -260,6 +263,7 @@ def config_to_embedding_function(config: Dict[str, Any]) -> EmbeddingFunction:  
     if known_embedding_functions[name] is None:
         raise ValueError(f"Unsupported embedding function: {name}")
 
+    validate_embedding_function_config_is_safe(name, ef_config)
     return known_embedding_functions[name].build_from_config(ef_config)
 
 

--- a/chromadb/utils/embedding_functions/config_validation.py
+++ b/chromadb/utils/embedding_functions/config_validation.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict
+
+_UNSAFE_KWARG_KEYS = frozenset({"trust_remote_code"})
+
+_LOCAL_MODEL_LOADER_EMBEDDING_FUNCTIONS = frozenset(
+    {
+        "fastembed_sparse",
+        "huggingface_sparse",
+        "sentence_transformer",
+    }
+)
+
+
+def _contains_unsafe_kwarg(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            if key in _UNSAFE_KWARG_KEYS:
+                return True
+            if _contains_unsafe_kwarg(nested_value):
+                return True
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_contains_unsafe_kwarg(item) for item in value)
+    return False
+
+
+def validate_embedding_function_kwargs_are_safe(kwargs: Any) -> None:
+    if _contains_unsafe_kwarg(kwargs):
+        raise ValueError(
+            "trust_remote_code is not allowed as a kwarg to prevent arbitrary "
+            "remote code execution"
+        )
+
+
+def validate_embedding_function_config_is_safe(
+    name: str, config: Dict[str, Any]
+) -> None:
+    if name in _LOCAL_MODEL_LOADER_EMBEDDING_FUNCTIONS:
+        validate_embedding_function_kwargs_are_safe(config.get("kwargs"))

--- a/chromadb/utils/embedding_functions/fastembed_sparse_embedding_function.py
+++ b/chromadb/utils/embedding_functions/fastembed_sparse_embedding_function.py
@@ -5,6 +5,9 @@ from chromadb.api.types import (
 )
 from typing import Dict, Any, TypedDict, Optional
 from typing import cast, Literal
+from chromadb.utils.embedding_functions.config_validation import (
+    validate_embedding_function_kwargs_are_safe,
+)
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from chromadb.utils.sparse_embedding_utils import normalize_sparse_vector
 
@@ -57,6 +60,7 @@ class FastembedSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
         self.cuda = cuda
         self.device_ids = device_ids
         self.lazy_load = lazy_load
+        validate_embedding_function_kwargs_are_safe(kwargs)
         for key, value in kwargs.items():
             if not isinstance(value, (str, int, float, bool, list, dict, tuple)):
                 raise ValueError(f"Keyword argument {key} is not a primitive type")

--- a/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
@@ -6,6 +6,9 @@ from chromadb.api.types import (
 from typing import Dict, Any, TypedDict, Optional
 import numpy as np
 from typing import cast, Literal
+from chromadb.utils.embedding_functions.config_validation import (
+    validate_embedding_function_kwargs_are_safe,
+)
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from chromadb.utils.sparse_embedding_utils import normalize_sparse_vector
 
@@ -47,10 +50,7 @@ class HuggingFaceSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
         self.device = device
         self.task = task
         self.query_config = query_config
-        if "trust_remote_code" in kwargs:
-            raise ValueError(
-                "trust_remote_code is not allowed as a kwarg to prevent arbitrary remote code execution"
-            )
+        validate_embedding_function_kwargs_are_safe(kwargs)
         for key, value in kwargs.items():
             if not isinstance(value, (str, int, float, bool, list, dict, tuple)):
                 raise ValueError(f"Keyword argument {key} is not a primitive type")

--- a/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
@@ -47,6 +47,10 @@ class HuggingFaceSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
         self.device = device
         self.task = task
         self.query_config = query_config
+        if "trust_remote_code" in kwargs:
+            raise ValueError(
+                "trust_remote_code is not allowed as a kwarg to prevent arbitrary remote code execution"
+            )
         for key, value in kwargs.items():
             if not isinstance(value, (str, int, float, bool, list, dict, tuple)):
                 raise ValueError(f"Keyword argument {key} is not a primitive type")

--- a/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
+++ b/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
@@ -35,6 +35,10 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         self.model_name = model_name
         self.device = device
         self.normalize_embeddings = normalize_embeddings
+        if "trust_remote_code" in kwargs:
+            raise ValueError(
+                "trust_remote_code is not allowed as a kwarg to prevent arbitrary remote code execution"
+            )
         for key, value in kwargs.items():
             if not isinstance(value, (str, int, float, bool, list, dict, tuple)):
                 raise ValueError(f"Keyword argument {key} is not a primitive type")

--- a/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
+++ b/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
@@ -1,6 +1,9 @@
 from chromadb.api.types import EmbeddingFunction, Space, Embeddings, Documents
 from typing import List, Dict, Any
 import numpy as np
+from chromadb.utils.embedding_functions.config_validation import (
+    validate_embedding_function_kwargs_are_safe,
+)
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 
 
@@ -35,10 +38,7 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         self.model_name = model_name
         self.device = device
         self.normalize_embeddings = normalize_embeddings
-        if "trust_remote_code" in kwargs:
-            raise ValueError(
-                "trust_remote_code is not allowed as a kwarg to prevent arbitrary remote code execution"
-            )
+        validate_embedding_function_kwargs_are_safe(kwargs)
         for key, value in kwargs.items():
             if not isinstance(value, (str, int, float, bool, list, dict, tuple)):
                 raise ValueError(f"Keyword argument {key} is not a primitive type")

--- a/schemas/embedding_functions/fastembed_sparse.json
+++ b/schemas/embedding_functions/fastembed_sparse.json
@@ -73,6 +73,9 @@
         "kwargs": {
             "type": "object",
             "description": "Additional arguments to pass to the model",
+            "properties": {
+                "trust_remote_code": false
+            },
             "additionalProperties": {
                 "type": [
                     "string",

--- a/schemas/embedding_functions/huggingface_sparse.json
+++ b/schemas/embedding_functions/huggingface_sparse.json
@@ -39,6 +39,9 @@
         "kwargs": {
             "type": "object",
             "description": "Additional arguments to pass to the Splade model",
+            "properties": {
+                "trust_remote_code": false
+            },
             "additionalProperties": {
                 "type": [
                     "string",

--- a/schemas/embedding_functions/sentence_transformer.json
+++ b/schemas/embedding_functions/sentence_transformer.json
@@ -20,6 +20,9 @@
         "kwargs": {
             "type": "object",
             "description": "Additional arguments to pass to the SentenceTransformer model",
+            "properties": {
+                "trust_remote_code": false
+            },
             "additionalProperties": {
                 "type": [
                     "string",


### PR DESCRIPTION
## Summary

- Rejects `trust_remote_code` in `kwargs` for `SentenceTransformerEmbeddingFunction` and `HuggingFaceSparseEmbeddingFunction` by raising a `ValueError` before any model loading occurs.
- Adds a `false` schema constraint on `trust_remote_code` inside the `kwargs` object in both `sentence_transformer.json` and `huggingface_sparse.json`, so the check is also enforced at the config-deserialization layer via `validate_config_schema`.

## Background

Both embedding functions accept `**kwargs` and pass them directly to `SentenceTransformer` / `SparseEncoder`. Because the collection configuration API endpoint (`/api/v2/tenants/{tenant}/databases/{db}/collections`) accepts arbitrary JSON and deserializes it into these kwargs without restriction, an unauthenticated attacker could supply `{"kwargs": {"trust_remote_code": true}}` alongside a malicious model path and achieve arbitrary code execution on the server.

Fixes #7226 (CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c).

## Test plan

- [ ] Unit test: constructing `SentenceTransformerEmbeddingFunction(trust_remote_code=True)` raises `ValueError`
- [ ] Unit test: constructing `HuggingFaceSparseEmbeddingFunction(..., trust_remote_code=True)` raises `ValueError`
- [ ] Unit test: `validate_config_schema({"model_name": "x", "device": "cpu", "normalize_embeddings": False, "kwargs": {"trust_remote_code": True}}, "sentence_transformer")` raises `ValidationError`
- [ ] Regression: existing kwargs (e.g. `cache_folder`) still work as before