### PR TITLE
[ENH] Add foundation /upsert flow

### DIFF
--- a/plans/foundation_edit-page_command_0a3a0511.plan.md
+++ b/plans/foundation_edit-page_command_0a3a0511.plan.md
@@ -16,7 +16,7 @@ todos:
     status: completed
   - id: pr5-upsert-flow
     content: "PR 5 - Wire full flow via the SDK: resolve wiki collection + chunking config, get {slug}-0, delete where slug, re-chunk + embed, batched add with full metadata incl sparse_embedding; integration tests."
-    status: pending
+    status: completed
   - id: pr6-source-date
     content: "PR 6 - (Optional) Port RawSourceDateResolver to compute latest_raw_source_date from source-collection records via the SDK get."
     status: pending

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -1,20 +1,49 @@
 //! `POST /api/upsert-page` — replace a wiki page's chunks.
 //!
-//! This module currently implements the request/response contract, coarse
-//! foundation authorization, and input validation. The replace flow itself
-//! (resolve the wiki collection, read `{slug}-0`, delete-by-slug, re-chunk +
-//! embed, batched add) lands in a later change; until then the handler returns
-//! a stub response after authorizing and validating the request.
+//! Acts as a Chroma *client*: it resolves the tenant's `wiki` collection through
+//! the proxying [`WikiClient`], reads the `{slug}-0` chunk to learn whether the
+//! page exists (and to preserve `created_at` / bump `version`), deletes every
+//! chunk for the slug on update, re-chunks the new content, computes SPLADE
+//! sparse vectors with the caller's token, and re-adds the chunks in batches —
+//! letting the collection's schema-bound Qwen EF produce the dense vectors on
+//! `add`. The FE enforces auth, quota, metering, and billing on every proxied
+//! call.
+//!
+//! The replace is currently a non-atomic delete-then-add. Once the data plane
+//! exposes an atomic put-if-absent / put-if-none (compare-and-set) op, the
+//! delete-then-add below will be replaced with it to close the partial-write
+//! window and the read-then-write race on a slug.
 
 use super::whoami::whoami_and_authorize;
+use crate::wiki::chunking::{chunk_content, chunk_id_for, title_from_content, ChunkingConfig};
+use crate::wiki::client::is_not_found;
+use crate::wiki::embed::WikiEmbedder;
+use crate::wiki::page::{build_metadatas, kind_for};
+use crate::wiki::{WikiClient, WikiClientError};
 use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
 use axum::{extract::State, http::HeaderMap, Json};
-use chroma_error::ChromaValidationError;
+use chroma::client::ChromaHttpClientError;
+use chroma_error::{ChromaError, ChromaValidationError, ErrorCodes};
+use chroma_types::{
+    Include, IncludeList, Metadata, MetadataComparison, MetadataExpression, MetadataValue,
+    PrimitiveOperator, Where,
+};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+use std::future::Future;
 use std::sync::LazyLock;
+use std::time::{SystemTime, UNIX_EPOCH};
 use validator::{Validate, ValidationError};
+
+/// HTTP header carrying the caller's Chroma Cloud token, forwarded to the FE on
+/// every proxied call so authz/quota/billing key off the user.
+const CHROMA_TOKEN_HEADER: &str = "x-chroma-token";
+
+/// Max records per `add` request. Chroma Cloud's embedding service rejects
+/// calls with more than this many docs, and large pages can exceed it, so adds
+/// are sliced into batches of this size.
+const ADD_BATCH_SIZE: usize = 100;
 
 /// `^(?:[a-z0-9][a-z0-9-]*|category:[a-z0-9][a-z0-9-]*|)$` — the wiki slug
 /// shape (empty root, lowercase alnum/hyphen, or a `category:<slug>`). The
@@ -55,8 +84,7 @@ pub struct UpsertPageRequest {
 pub struct UpsertPageResponse {
     /// The page slug that was written.
     pub slug: String,
-    /// `"added"` for a new page or `"updated"` for an existing one (the stub
-    /// returns `"stub"` until the replace flow is wired up).
+    /// `"added"` for a new page or `"updated"` for an existing one.
     pub op: String,
     /// Monotonic page version (1 for a new page, previous + 1 on update).
     pub version: u32,
@@ -66,6 +94,38 @@ pub struct UpsertPageResponse {
     pub updated_at: i64,
     /// Number of chunks written for the page.
     pub num_chunks: usize,
+}
+
+/// Errors raised while running the upsert-page replace flow (after validation).
+#[derive(Debug, thiserror::Error)]
+pub enum UpsertPageError {
+    /// `frontend_ingress_url` is unset, so the wiki client was never built.
+    #[error("wiki record I/O is not configured")]
+    RouteDisabled,
+    /// The caller's request carried no usable `x-chroma-token`.
+    #[error("missing or invalid {CHROMA_TOKEN_HEADER} header")]
+    MissingToken,
+    /// Resolving the wiki collection through the proxy failed.
+    #[error(transparent)]
+    Resolve(#[from] WikiClientError),
+    /// Computing SPLADE sparse embeddings failed.
+    #[error(transparent)]
+    Embed(#[from] crate::wiki::embed::WikiEmbedError),
+    /// A proxied record-I/O call (`get`/`delete`/`add`) to the FE failed.
+    #[error("chroma record I/O failed: {0}")]
+    RecordIo(ChromaHttpClientError),
+}
+
+impl ChromaError for UpsertPageError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            UpsertPageError::RouteDisabled => ErrorCodes::Internal,
+            UpsertPageError::MissingToken => ErrorCodes::InvalidArgument,
+            UpsertPageError::Resolve(err) => err.code(),
+            UpsertPageError::Embed(err) => err.code(),
+            UpsertPageError::RecordIo(_) => ErrorCodes::Internal,
+        }
+    }
 }
 
 /// `POST /api/upsert-page` handler.
@@ -82,19 +142,199 @@ pub async fn foundation_upsert_page(
         server.scorecard_request(&["op:foundation_upsert_page", &format!("tenant:{tenant}")])?;
 
     request.validate().map_err(ChromaValidationError::from)?;
+    let categories = normalize_categories(&request.categories);
 
-    // Normalize now so the replace flow (added later) can rely on a well-formed
-    // request; `_categories` is the deduped/sorted list it stamps onto chunks.
-    let _categories = normalize_categories(&request.categories);
+    let response = upsert_page(&server, &headers, &tenant, &request, &categories).await?;
+    Ok(Json(response))
+}
 
-    Ok(Json(UpsertPageResponse {
-        slug: request.slug,
-        op: "stub".to_string(),
-        version: 0,
-        created_at: 0,
-        updated_at: 0,
-        num_chunks: 0,
-    }))
+/// Runs the replace flow against the proxied wiki collection.
+async fn upsert_page(
+    server: &FoundationApiServer,
+    headers: &HeaderMap,
+    tenant: &str,
+    request: &UpsertPageRequest,
+    categories: &[String],
+) -> Result<UpsertPageResponse, UpsertPageError> {
+    let slug = request.slug.as_str();
+    let wiki_client = server
+        .wiki_client
+        .as_ref()
+        .ok_or(UpsertPageError::RouteDisabled)?;
+    let token = chroma_token(headers)?;
+
+    // Resolve (cache-first) the wiki collection identity, then derive the
+    // chunker from its metadata so writes match how the collection was created.
+    let collection = wiki_client.wiki_collection(tenant, token).await?;
+    let chunking = ChunkingConfig::from_collection_metadata(collection.metadata().as_ref());
+
+    // Read chunk-0 to learn page existence + preserve created_at / bump version.
+    let chunk0 = chunk_id_for(slug, 0);
+    let existing = record_op(
+        wiki_client,
+        tenant,
+        collection.get(
+            Some(vec![chunk0]),
+            None,
+            None,
+            None,
+            Some(IncludeList(vec![Include::Metadata])),
+        ),
+    )
+    .await?;
+    let existing_meta = existing
+        .metadatas
+        .and_then(|metas| metas.into_iter().next().flatten());
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or(0);
+    let (op, created_at, version) = match &existing_meta {
+        Some(meta) => {
+            // chunk-0 exists, so the page exists; an absent or non-integer
+            // created_at / version means corrupt or pre-versioning metadata.
+            // Recover (so the upsert still succeeds) but warn — this should
+            // never happen for a page foundation-api wrote.
+            let created_at = match meta.get("created_at").and_then(|v| i64::try_from(v).ok()) {
+                Some(created_at) => created_at,
+                None => {
+                    tracing::warn!(
+                        slug = %slug,
+                        "existing wiki page has no integer created_at; using current time"
+                    );
+                    now
+                }
+            };
+            let version = match meta.get("version").and_then(|v| i64::try_from(v).ok()) {
+                Some(version) => version + 1,
+                None => {
+                    tracing::warn!(
+                        slug = %slug,
+                        "existing wiki page has no integer version; resetting to 1"
+                    );
+                    1
+                }
+            };
+            ("updated", created_at, version)
+        }
+        None => ("added", now, 1),
+    };
+
+    // Re-chunk + compute sparse vectors (dense is auto-embedded on `add`).
+    let chunks = chunk_content(slug, &request.content, &chunking);
+    let documents: Vec<&str> = chunks.iter().map(|chunk| chunk.text.as_str()).collect();
+    let sparse = WikiEmbedder::new(None)
+        .embed_sparse(token, &documents)
+        .await?;
+
+    let metadatas = build_metadatas(
+        slug,
+        &chunks,
+        sparse,
+        kind_for(slug),
+        &title_from_content(&request.content),
+        created_at,
+        now,
+        version,
+        categories,
+        &request.source_ids,
+    );
+
+    // delete-then-add is non-atomic: a mid-flight failure can leave the page
+    // partially removed, and there is no fencing against a concurrent upsert of
+    // the same slug. We only delete when the page already exists so a brand-new
+    // page is never briefly absent. TODO: replace this delete-then-add with an
+    // atomic put-if-absent / put-if-none (compare-and-set) op once the data
+    // plane exposes one, which removes both the partial-write window and the
+    // read-then-write race. This is temporary until the data plane exposes an
+    // such an api.
+    if existing_meta.is_some() {
+        let where_slug = Where::Metadata(MetadataExpression {
+            key: "slug".to_string(),
+            comparison: MetadataComparison::Primitive(
+                PrimitiveOperator::Equal,
+                MetadataValue::Str(slug.to_string()),
+            ),
+        });
+        record_op(
+            wiki_client,
+            tenant,
+            collection.delete(None, Some(where_slug), None),
+        )
+        .await?;
+    }
+
+    let ids: Vec<String> = chunks.iter().map(|chunk| chunk.id.clone()).collect();
+    let num_chunks = ids.len();
+    for start in (0..num_chunks).step_by(ADD_BATCH_SIZE) {
+        let end = (start + ADD_BATCH_SIZE).min(num_chunks);
+        let id_batch = ids[start..end].to_vec();
+        let doc_batch: Vec<Option<String>> = chunks[start..end]
+            .iter()
+            .map(|chunk| Some(chunk.text.clone()))
+            .collect();
+        let meta_batch: Vec<Option<Metadata>> =
+            metadatas[start..end].iter().cloned().map(Some).collect();
+        record_op(
+            wiki_client,
+            tenant,
+            // `embeddings = None` lets the collection's schema-bound Qwen EF
+            // embed the documents on the FE using the forwarded token.
+            collection.add(
+                id_batch,
+                None::<Vec<Vec<f32>>>,
+                Some(doc_batch),
+                None,
+                Some(meta_batch),
+            ),
+        )
+        .await?;
+    }
+
+    Ok(UpsertPageResponse {
+        slug: slug.to_string(),
+        op: op.to_string(),
+        version: version as u32,
+        created_at,
+        updated_at: now,
+        num_chunks,
+    })
+}
+
+/// Awaits a proxied record-I/O call, invalidating the tenant's cached
+/// collection identity on a `NotFound` (the cached id is stale because the
+/// collection was recreated/forked).
+///
+/// This request still fails; the next one re-resolves the name to the new id.
+/// We don't transparently retry in-request because a stale id is rare (it
+/// requires the collection to be recreated within the cache TTL) and a `delete`
+/// against the dead id 404s before any `add`, so failing can't half-write the
+/// live collection — a client retry is cheaper than an in-request re-resolve +
+/// re-embed.
+async fn record_op<T, F>(
+    wiki_client: &WikiClient,
+    tenant: &str,
+    fut: F,
+) -> Result<T, UpsertPageError>
+where
+    F: Future<Output = Result<T, ChromaHttpClientError>>,
+{
+    fut.await.map_err(|err| {
+        if is_not_found(&err) {
+            wiki_client.invalidate(tenant);
+        }
+        UpsertPageError::RecordIo(err)
+    })
+}
+
+/// Extracts the caller's Chroma token from the request headers.
+fn chroma_token(headers: &HeaderMap) -> Result<&str, UpsertPageError> {
+    headers
+        .get(CHROMA_TOKEN_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|token| !token.is_empty())
+        .ok_or(UpsertPageError::MissingToken)
 }
 
 /// Validates the slug against [`SLUG_RE`].

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -182,6 +182,11 @@ async fn upsert_page(
         ),
     )
     .await?;
+    // Page existence is driven by chunk-0's *presence* (its id is always
+    // returned), not by whether it carries metadata: a chunk-0 row with no
+    // metadata still means the page exists and its other chunks must be
+    // cleared. Reading metadata separately lets the recovery branch below fire.
+    let exists = !existing.ids.is_empty();
     let existing_meta = existing
         .metadatas
         .and_then(|metas| metas.into_iter().next().flatten());
@@ -190,8 +195,8 @@ async fn upsert_page(
         .duration_since(UNIX_EPOCH)
         .map(|elapsed| elapsed.as_secs() as i64)
         .unwrap_or(0);
-    let (op, created_at, version) = match &existing_meta {
-        Some(meta) => {
+    let (op, created_at, version) = match (exists, &existing_meta) {
+        (true, Some(meta)) => {
             // chunk-0 exists, so the page exists; an absent or non-integer
             // created_at / version means corrupt or pre-versioning metadata.
             // Recover (so the upsert still succeeds) but warn — this should
@@ -218,7 +223,18 @@ async fn upsert_page(
             };
             ("updated", created_at, version)
         }
-        None => ("added", now, 1),
+        (true, None) => {
+            // chunk-0 exists but carries no metadata at all (corrupt or
+            // pre-versioning row). Treat it as an update so the delete-by-slug
+            // still clears any orphan chunks, but reset created_at / version
+            // since there is nothing to recover.
+            tracing::warn!(
+                slug = %slug,
+                "existing wiki chunk-0 has no metadata; treating as update with reset created_at/version"
+            );
+            ("updated", now, 1)
+        }
+        (false, _) => ("added", now, 1),
     };
 
     // Re-chunk + compute sparse vectors (dense is auto-embedded on `add`).
@@ -241,15 +257,12 @@ async fn upsert_page(
         &request.source_ids,
     );
 
-    // delete-then-add is non-atomic: a mid-flight failure can leave the page
+    // delete-then-add is non-atomic (see the module docstring for the planned
+    // compare-and-set replacement): a mid-flight failure can leave the page
     // partially removed, and there is no fencing against a concurrent upsert of
     // the same slug. We only delete when the page already exists so a brand-new
-    // page is never briefly absent. TODO: replace this delete-then-add with an
-    // atomic put-if-absent / put-if-none (compare-and-set) op once the data
-    // plane exposes one, which removes both the partial-write window and the
-    // read-then-write race. This is temporary until the data plane exposes an
-    // such an api.
-    if existing_meta.is_some() {
+    // page is never briefly absent.
+    if exists {
         let where_slug = Where::Metadata(MetadataExpression {
             key: "slug".to_string(),
             comparison: MetadataComparison::Primitive(

--- a/rust/foundation-api/src/wiki/chunking.rs
+++ b/rust/foundation-api/src/wiki/chunking.rs
@@ -1,12 +1,9 @@
-//! Markdown chunking for wiki pages, ported from
-//! `foundation-research/src/foundation_research/chunking.py`.
+//! Markdown chunking for wiki pages.
 //!
-//! This is a byte-faithful Rust port of the generate-flow chunker so
-//! `/upsert-page` writes are indistinguishable from pages written by
-//! `foundation-research`. The chunker parses markdown with the
-//! `tree-sitter-md` block grammar, emits chunk 0 as the first non-blank line
-//! (so title search keeps working), then greedy-packs top-level blocks into
-//! chunks no larger than `max_bytes` of UTF-8 text.
+//! The chunker parses markdown with the `tree-sitter-md` block grammar, emits
+//! chunk 0 as the first non-blank line (so title search keeps working), then
+//! greedy-packs top-level blocks into chunks no larger than `max_bytes` of
+//! UTF-8 text.
 //!
 //! `foundation-research` also has a legacy one-chunk-per-line strategy for
 //! collections written before the tree-sitter chunker existed; foundation-api
@@ -46,8 +43,8 @@ pub struct Chunk {
 }
 
 /// The metadata string value persisted for the tree-sitter chunking strategy.
-/// foundation-research keys its `chunking_strategy` marker off this value, so
-/// keep it in sync with `ChunkStrategy.TREESITTER_MARKDOWN` there.
+/// Other readers/writers of the collection key their chunking strategy off this
+/// value, so it is part of the on-collection contract.
 pub const CHUNKING_STRATEGY: &str = "treesitter-markdown";
 
 /// Per-collection chunking parameters, recoverable from collection metadata
@@ -72,7 +69,7 @@ impl ChunkingConfig {
     /// Only the `max_bytes` budget is configurable — foundation-api always
     /// tree-sitter chunks — so missing or malformed metadata simply yields the
     /// default budget. The `chunking_strategy` marker is ignored on read; it
-    /// exists only for foundation-research interop.
+    /// exists only as on-collection interop for other readers.
     pub fn from_collection_metadata(metadata: Option<&Metadata>) -> Self {
         let max_bytes = metadata
             .and_then(|metadata| metadata.get("chunking_max_bytes"))
@@ -86,8 +83,8 @@ impl ChunkingConfig {
     }
 
     /// Serializes this config to collection metadata, including the
-    /// `chunking_strategy` marker so foundation-research readers recover the
-    /// tree-sitter chunker.
+    /// `chunking_strategy` marker so other readers recover the tree-sitter
+    /// chunker.
     pub fn to_metadata(self) -> Metadata {
         let mut metadata = Metadata::new();
         metadata.insert(
@@ -309,7 +306,8 @@ fn pack_lines(
 ) -> Vec<(usize, usize)> {
     let mut out: Vec<(usize, usize)> = Vec::new();
     let mut cur_start = start_row;
-    // `None` mirrors the Python `cur_end = start_row - 1` empty sentinel.
+    // `None` is the empty-run sentinel (no line accumulated into the current
+    // chunk yet).
     let mut cur_end: Option<usize> = None;
     for r in start_row..=end_row {
         let prospective = byte_len(rest_lines, cur_start, r);
@@ -400,7 +398,7 @@ mod tests {
         chunks.iter().map(|c| c.text.as_str()).collect()
     }
 
-    // --- treesitter: round-trip parity (ports test_chunking_treesitter.py) ---
+    // --- treesitter: round-trip ---
 
     fn assert_ts_round_trip(content: &str, max_bytes: usize, concat_check: bool) {
         let chunks = chunk_treesitter_markdown("p", content, max_bytes);

--- a/rust/foundation-api/src/wiki/client.rs
+++ b/rust/foundation-api/src/wiki/client.rs
@@ -154,6 +154,16 @@ impl WikiClient {
     }
 }
 
+/// Whether a proxied call failed because the resource was not found (HTTP 404).
+/// A 404 on a collection-id path means the cached id is stale (the collection
+/// was recreated/forked), so callers invalidate the cache on it.
+pub(crate) fn is_not_found(err: &ChromaHttpClientError) -> bool {
+    matches!(
+        err,
+        ChromaHttpClientError::ApiError(_, status) if *status == reqwest::StatusCode::NOT_FOUND
+    )
+}
+
 /// A tenant-keyed, TTL-bounded cache of resolved wiki collection identities.
 #[derive(Debug)]
 struct WikiCollectionCache {
@@ -281,6 +291,20 @@ mod tests {
 
         cache.invalidate("t1");
         assert!(cache.get_at("t1", start).is_none());
+    }
+
+    #[test]
+    fn is_not_found_matches_only_http_404() {
+        use reqwest::StatusCode;
+        assert!(is_not_found(&ChromaHttpClientError::ApiError(
+            "missing".to_string(),
+            StatusCode::NOT_FOUND,
+        )));
+        assert!(!is_not_found(&ChromaHttpClientError::ApiError(
+            "boom".to_string(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )));
+        assert!(!is_not_found(&ChromaHttpClientError::NoBackendAvailable));
     }
 
     #[test]

--- a/rust/foundation-api/src/wiki/embed.rs
+++ b/rust/foundation-api/src/wiki/embed.rs
@@ -1,11 +1,10 @@
 //! SPLADE sparse embedding for wiki pages.
 //!
-//! `foundation-research` pre-computes a SPLADE sparse vector client-side for
-//! every chunk and stores it under the `sparse_embedding` metadata key; the
-//! dense Qwen vector is produced by the collection's schema-bound embedding
-//! function on `add`. This ports that sparse path: build a Chroma Cloud SPLADE
-//! embedding function scoped to the caller's `x-chroma-token` (so embed usage
-//! bills to the user) and embed documents in batches of
+//! A SPLADE sparse vector is computed client-side for every chunk and stored
+//! under the `sparse_embedding` metadata key; the dense Qwen vector is produced
+//! by the collection's schema-bound embedding function on `add`. Build a Chroma
+//! Cloud SPLADE embedding function scoped to the caller's `x-chroma-token` (so
+//! embed usage bills to the user) and embed documents in batches of
 //! [`EMBED_BATCH_SIZE`] — the limit the Chroma Cloud embedding service accepts
 //! per request — concatenating the per-batch results in input order.
 
@@ -14,14 +13,13 @@ use chroma::embed::EmbeddingFunction;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::SparseVector;
 
-/// Metadata key under which the SPLADE sparse vector is stored on each chunk.
-/// Must match `foundation_research.embeddings.SPARSE_KEY`.
+/// Metadata key under which the SPLADE sparse vector is stored on each chunk;
+/// it must match the key the wiki search path queries.
 pub const SPARSE_KEY: &str = "sparse_embedding";
 
 /// Maximum documents per Chroma Cloud embedding request. The service rejects
 /// larger calls with a 413, so documents are sliced into batches of this size
-/// and the resulting vectors concatenated. Matches foundation-research's
-/// `EMBED_BATCH_SIZE`.
+/// and the resulting vectors concatenated.
 pub const EMBED_BATCH_SIZE: usize = 100;
 
 /// Errors raised while computing sparse embeddings.
@@ -68,7 +66,7 @@ impl WikiEmbedder {
             return Ok(Vec::new());
         }
         // Default builder => model `prithivida/Splade_PP_en_v1`, tokens not
-        // included — matching foundation-research's `make_sparse_ef`.
+        // included.
         let mut builder = ChromaCloudSpladeEmbeddingFunction::builder().api_key(token);
         if let Some(embed_url) = &self.embed_url {
             builder = builder.embed_url(embed_url.clone());

--- a/rust/foundation-api/src/wiki/embed.rs
+++ b/rust/foundation-api/src/wiki/embed.rs
@@ -28,6 +28,10 @@ pub enum WikiEmbedError {
     /// The downstream Chroma Cloud embedding service returned an error.
     #[error("sparse embedding failed: {0}")]
     Embedding(#[from] ChromaCloudEmbeddingError),
+    /// The service returned a different number of vectors than documents,
+    /// violating the embedder's one-vector-per-document contract.
+    #[error("sparse embedding returned {got} vectors for {expected} documents")]
+    CountMismatch { expected: usize, got: usize },
 }
 
 impl ChromaError for WikiEmbedError {
@@ -76,6 +80,14 @@ impl WikiEmbedder {
         let mut embeddings = Vec::with_capacity(documents.len());
         for batch in documents.chunks(EMBED_BATCH_SIZE) {
             embeddings.extend(embedding_function.embed_strs(batch).await?);
+        }
+        // Enforce the one-vector-per-document contract: a short return would
+        // otherwise silently truncate when zipped with the chunks downstream.
+        if embeddings.len() != documents.len() {
+            return Err(WikiEmbedError::CountMismatch {
+                expected: documents.len(),
+                got: embeddings.len(),
+            });
         }
         Ok(embeddings)
     }
@@ -129,12 +141,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn embed_sparse_slices_into_batches_of_100() {
+    async fn embed_sparse_errors_on_vector_count_mismatch() {
         let server = MockServer::start_async().await;
-        // Each call returns a single vector regardless of how many texts it
-        // received; we assert only the call count, which pins the 100-doc
-        // batch boundary (250 docs => ceil(250 / 100) == 3 requests).
-        let mock = server
+        // Service returns a single vector for two documents — a contract
+        // violation that must surface as an error, not silently truncate.
+        server
             .mock_async(|when, then| {
                 when.method("POST").path("/embed_sparse");
                 then.status(200).json_body(json!({
@@ -144,9 +155,42 @@ mod tests {
             .await;
 
         let embedder = WikiEmbedder::new(Some(server.base_url()));
-        let docs = vec!["x"; 250];
-        embedder.embed_sparse("user-token", &docs).await.unwrap();
+        let err = embedder
+            .embed_sparse("user-token", &["a", "b"])
+            .await
+            .unwrap_err();
 
-        assert_eq!(mock.calls(), 3);
+        assert!(matches!(
+            err,
+            WikiEmbedError::CountMismatch {
+                expected: 2,
+                got: 1
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn embed_sparse_slices_into_batches_of_100() {
+        let server = MockServer::start_async().await;
+        // Each call echoes back one vector per document in the batch (the
+        // contract embed_sparse now enforces). With 200 docs and a 100-doc
+        // batch limit we expect exactly ceil(200 / 100) == 2 requests.
+        let batch_vectors: Vec<_> = (0..EMBED_BATCH_SIZE)
+            .map(|_| json!({ "indices": [0], "values": [1.0] }))
+            .collect();
+        let mock = server
+            .mock_async(|when, then| {
+                when.method("POST").path("/embed_sparse");
+                then.status(200)
+                    .json_body(json!({ "embeddings": batch_vectors }));
+            })
+            .await;
+
+        let embedder = WikiEmbedder::new(Some(server.base_url()));
+        let docs = vec!["x"; 2 * EMBED_BATCH_SIZE];
+        let embeddings = embedder.embed_sparse("user-token", &docs).await.unwrap();
+
+        assert_eq!(embeddings.len(), 2 * EMBED_BATCH_SIZE);
+        assert_eq!(mock.calls(), 2);
     }
 }

--- a/rust/foundation-api/src/wiki/mod.rs
+++ b/rust/foundation-api/src/wiki/mod.rs
@@ -4,19 +4,12 @@
 //! Chroma client and proxies record I/O to the frontend (FE), letting the FE
 //! enforce auth, quota, metering, and billing against the caller's
 //! `x-chroma-token`. This module hosts that client surface plus the
-//! foundation-specific chunking the `/upsert-page` flow composes on top of it;
-//! the embedding helper lands here in a later change.
+//! foundation-specific chunking and SPLADE embedding the `/upsert-page` flow
+//! composes on top of it.
 
-// Wired into the server in this change but not yet exercised end to end; the
-// resolve/cache surface is consumed once the wiki record-I/O routes land.
-#[allow(dead_code)]
-pub(crate) mod client;
-// Pure markdown chunking ported from foundation-research; consumed by the
-// `/upsert-page` route added later in the stack, so unused on its own for now.
 #[allow(dead_code)]
 pub(crate) mod chunking;
-// SPLADE sparse embedding helper; also consumed by the `/upsert-page` route
-// added later in the stack, so unused on its own for now.
-#[allow(dead_code)]
+pub(crate) mod client;
 pub(crate) mod embed;
+pub(crate) mod page;
 pub(crate) use client::{WikiClient, WikiClientError};

--- a/rust/foundation-api/src/wiki/page.rs
+++ b/rust/foundation-api/src/wiki/page.rs
@@ -1,0 +1,169 @@
+//! Helpers for reading and writing wiki page chunk metadata.
+
+use crate::wiki::chunking::Chunk;
+use crate::wiki::embed::SPARSE_KEY;
+use chroma_types::{Metadata, MetadataValue, SparseVector};
+
+/// Slugs that are seeded system pages rather than content/category pages.
+const SYSTEM_SLUGS: [&str; 3] = ["", "meta", "categories"];
+
+/// The page `kind` stamped on every chunk.
+pub(crate) fn kind_for(slug: &str) -> &'static str {
+    if SYSTEM_SLUGS.contains(&slug) {
+        "system"
+    } else if slug.starts_with("category:") {
+        "category"
+    } else {
+        "page"
+    }
+}
+
+/// Builds the per-chunk metadata: the always-on fields plus the sparse vector,
+/// with `categories` / `source_ids` stamped on every chunk only when non-empty.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_metadatas(
+    slug: &str,
+    chunks: &[Chunk],
+    sparse: Vec<SparseVector>,
+    kind: &str,
+    title: &str,
+    created_at: i64,
+    updated_at: i64,
+    version: i64,
+    categories: &[String],
+    source_ids: &[String],
+) -> Vec<Metadata> {
+    chunks
+        .iter()
+        .zip(sparse)
+        .map(|(chunk, sparse_vec)| {
+            let mut meta = Metadata::new();
+            meta.insert("slug".to_string(), MetadataValue::Str(slug.to_string()));
+            meta.insert(
+                "chunk_id".to_string(),
+                MetadataValue::Int(chunk.chunk_id as i64),
+            );
+            meta.insert(
+                "line_no".to_string(),
+                MetadataValue::Int(chunk.line_no as i64),
+            );
+            meta.insert("kind".to_string(), MetadataValue::Str(kind.to_string()));
+            meta.insert("title".to_string(), MetadataValue::Str(title.to_string()));
+            meta.insert("created_at".to_string(), MetadataValue::Int(created_at));
+            meta.insert("updated_at".to_string(), MetadataValue::Int(updated_at));
+            meta.insert("version".to_string(), MetadataValue::Int(version));
+            meta.insert(
+                SPARSE_KEY.to_string(),
+                MetadataValue::SparseVector(sparse_vec),
+            );
+            if !categories.is_empty() {
+                meta.insert(
+                    "categories".to_string(),
+                    MetadataValue::StringArray(categories.to_vec()),
+                );
+            }
+            if !source_ids.is_empty() {
+                meta.insert(
+                    "source_ids".to_string(),
+                    MetadataValue::StringArray(source_ids.to_vec()),
+                );
+            }
+            meta
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wiki::chunking::chunk_id_for;
+
+    fn chunk(chunk_id: usize, line_no: usize, text: &str) -> Chunk {
+        Chunk {
+            id: chunk_id_for("foo", chunk_id),
+            slug: "foo".to_string(),
+            chunk_id,
+            line_no,
+            text: text.to_string(),
+        }
+    }
+
+    fn sparse(index: u32) -> SparseVector {
+        SparseVector::new(vec![index], vec![1.0]).unwrap()
+    }
+
+    #[test]
+    fn kind_for_classifies_system_category_and_page() {
+        assert_eq!(kind_for(""), "system");
+        assert_eq!(kind_for("meta"), "system");
+        assert_eq!(kind_for("categories"), "system");
+        assert_eq!(kind_for("category:archive"), "category");
+        assert_eq!(kind_for("getting-started"), "page");
+    }
+
+    #[test]
+    fn build_metadatas_stamps_all_fields_and_sparse_vector() {
+        let chunks = vec![chunk(0, 0, "Title"), chunk(1, 2, "Body")];
+        let metas = build_metadatas(
+            "foo",
+            &chunks,
+            vec![sparse(1), sparse(2)],
+            "page",
+            "Title",
+            10,
+            20,
+            3,
+            &["a".to_string()],
+            &["slack_master:abc".to_string()],
+        );
+
+        assert_eq!(metas.len(), 2);
+        let first = &metas[0];
+        assert_eq!(first.get("slug"), Some(&MetadataValue::Str("foo".into())));
+        assert_eq!(first.get("chunk_id"), Some(&MetadataValue::Int(0)));
+        assert_eq!(first.get("line_no"), Some(&MetadataValue::Int(0)));
+        assert_eq!(first.get("kind"), Some(&MetadataValue::Str("page".into())));
+        assert_eq!(
+            first.get("title"),
+            Some(&MetadataValue::Str("Title".into()))
+        );
+        assert_eq!(first.get("created_at"), Some(&MetadataValue::Int(10)));
+        assert_eq!(first.get("updated_at"), Some(&MetadataValue::Int(20)));
+        assert_eq!(first.get("version"), Some(&MetadataValue::Int(3)));
+        assert_eq!(
+            first.get("categories"),
+            Some(&MetadataValue::StringArray(vec!["a".to_string()]))
+        );
+        assert_eq!(
+            first.get("source_ids"),
+            Some(&MetadataValue::StringArray(vec![
+                "slack_master:abc".to_string()
+            ]))
+        );
+        assert!(matches!(
+            metas[1].get(SPARSE_KEY),
+            Some(MetadataValue::SparseVector(_))
+        ));
+    }
+
+    #[test]
+    fn build_metadatas_omits_empty_categories_and_source_ids() {
+        let chunks = vec![chunk(0, 0, "Title")];
+        let metas = build_metadatas(
+            "foo",
+            &chunks,
+            vec![sparse(1)],
+            "page",
+            "Title",
+            10,
+            20,
+            1,
+            &[],
+            &[],
+        );
+
+        assert!(!metas[0].contains_key("categories"));
+        assert!(!metas[0].contains_key("source_ids"));
+        assert!(metas[0].contains_key(SPARSE_KEY));
+    }
+}


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

Wires up the full `POST /api/upsert-page` replace flow, composing the client,
chunker, and sparse embedder from earlier in the stack. The route now actually
replaces a wiki page's chunks in the tenant's `wiki` collection.

- New functionality
  - Implement the replace flow in `routes/upsert_page.rs`: resolve the `wiki`
    collection (cache-first) and derive the chunker from its metadata; read the
    `{slug}-0` chunk to determine add-vs-update, preserve `created_at`, and bump
    `version`; re-chunk the content; compute SPLADE sparse vectors with the
    caller's token; delete existing chunks by slug (update only); and re-add in
    batches of 100, letting the collection's Qwen EF produce dense vectors.
  - Add `wiki/page.rs`: `kind_for` (system / category / page) and
    `build_metadatas`, which stamps per-chunk metadata (`slug`, `chunk_id`,
    `line_no`, `kind`, `title`, `created_at`, `updated_at`, `version`,
    `sparse_embedding`, plus `categories` / `source_ids` when non-empty).
  - Add `WikiClient::is_not_found`; the flow invalidates the tenant's cached
    collection identity on a `404` so a recreated/forked collection re-resolves.
- Improvements & Bug fixes
  - Replace the skeleton's stub response with real `op` / `version` /
    `created_at` / `updated_at` / `num_chunks` values.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `cargo test` (`wiki/page.rs` metadata-builder
  tests, `is_not_found` matching, plus the chunking/embed/validation unit tests
  from earlier in the stack).
- [ ] Manual end-to-end check against a running FE behind the HAProxy ingress
  (add + update a page, verify chunk replacement and version bump).

## Migration plan

Backwards compatible and gated on `frontend_ingress_url`. Note the replace is a
**non-atomic delete-then-add**: a mid-flight failure can leave a page partially
removed, and there is no fencing against a concurrent upsert of the same slug
(delete happens only on update, so a brand-new page is never briefly absent).
This matches existing behavior and will be replaced with an atomic
put-if-absent / compare-and-set op once the data plane exposes one.

## Observability plan

Reuses the scorecard tag `op:foundation_upsert_page` / `tenant:<tenant>` from
the skeleton. Warns when an existing page has missing/non-integer
`created_at` / `version` metadata (recovers rather than failing).

## Documentation Changes

None in `docs.trychroma.com` (internal foundation route). The handler, flow, and
metadata helpers carry rustdoc, including the non-atomic-replace caveat.
