### PR TITLE
[ENH] Add agent scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chroma-agent"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "chroma-api-types"
 version = "0.14.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = ["rust/benchmark", "rust/blockstore", "rust/cache", "rust/chroma", "rust/config", "rust/distance", "rust/error", "rust/faults", "rust/foundation-api", "rust/frontend", "rust/frontend-core", "rust/garbage_collector", "rust/index", "rust/load", "rust/log", "rust/log-service", "rust/memberlist", "rust/metering-macros", "rust/metering", "rust/storage", "rust/system", "rust/sysdb", "rust/types", "rust/worker", "rust/segment", "rust/python_bindings", "rust/mdac", "rust/tracing", "rust/sqlite", "rust/cli", "rust/wal3", "rust/js_bindings", "rust/jemalloc-pprof-server", "rust/s3heap", "rust/s3heap-service", "rust/api-types", "rust/rust-sysdb", "rust/spanner-migrations"]
+members = ["rust/benchmark", "rust/blockstore", "rust/cache", "rust/chroma", "rust/config", "rust/distance", "rust/error", "rust/faults", "rust/foundation-api", "rust/frontend", "rust/frontend-core", "rust/garbage_collector", "rust/index", "rust/load", "rust/log", "rust/log-service", "rust/memberlist", "rust/metering-macros", "rust/metering", "rust/storage", "rust/system", "rust/sysdb", "rust/types", "rust/worker", "rust/segment", "rust/python_bindings", "rust/mdac", "rust/tracing", "rust/sqlite", "rust/cli", "rust/wal3", "rust/js_bindings", "rust/jemalloc-pprof-server", "rust/s3heap", "rust/s3heap-service", "rust/api-types", "rust/rust-sysdb", "rust/spanner-migrations", "rust/agent"]
 
 [workspace.dependencies]
 anyhow = "1.0"
@@ -91,6 +91,7 @@ google-cloud-gax = { git = "https://github.com/yoshidan/google-cloud-rust", tag 
 google-cloud-googleapis = { git = "https://github.com/yoshidan/google-cloud-rust", tag = "v20260319", package = "gcloud-googleapis", features = ["spanner"] }
 
 chroma = { path = "rust/chroma", version = "0.14.0" }
+chroma-agent = { path = "rust/agent" }
 chroma-api-types = { path = "rust/api-types", version = "0.14.0" }
 chroma-benchmark = { path = "rust/benchmark" }
 chroma-blockstore = { path = "rust/blockstore" }

--- a/rust/agent/Cargo.toml
+++ b/rust/agent/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "chroma-agent"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/rust/agent/src/error.rs
+++ b/rust/agent/src/error.rs
@@ -1,0 +1,27 @@
+//! Error types for the agent crate.
+
+use thiserror::Error;
+
+/// Errors surfaced by the agent core, tools, and inference models.
+///
+/// This is the crate-wide error skeleton; variants are filled in as the tool,
+/// trajectory, inference, and driver layers land in subsequent milestones.
+#[derive(Debug, Error)]
+pub enum AgentError {
+    /// Failed to (de)serialize JSON, e.g. decoding model-supplied tool params.
+    #[error("invalid JSON: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+
+    /// The model referenced a tool name that is not registered in the toolset.
+    #[error("unknown tool: {0}")]
+    UnknownTool(String),
+
+    /// Harness-supplied runtime params did not downcast to the tool's declared
+    /// `RuntimeParams` type.
+    #[error("runtime params type mismatch for tool `{tool}`")]
+    ToolRuntimeParamsTypeMismatch { tool: String },
+
+    /// A requested provider format or operation is not yet supported.
+    #[error("unsupported: {0}")]
+    Unsupported(String),
+}

--- a/rust/agent/src/lib.rs
+++ b/rust/agent/src/lib.rs
@@ -1,0 +1,32 @@
+//! `chroma-agent`: a provider-agnostic agent core ported from the Python
+//! search-agent research framework.
+//!
+//! This milestone lands the crate scaffold: the [`ProviderFormat`] dispatch
+//! seam and the crate-wide [`AgentError`] type. The tool abstraction,
+//! trajectory, inference models, and the agent driver land in subsequent PRs
+//! (see `plans/`).
+
+mod error;
+mod provider;
+
+pub use error::AgentError;
+pub use provider::ProviderFormat;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_error_displays() {
+        let err = AgentError::UnknownTool("get_weather".to_string());
+        assert_eq!(err.to_string(), "unknown tool: get_weather");
+
+        let err = AgentError::ToolRuntimeParamsTypeMismatch {
+            tool: "get_weather".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "runtime params type mismatch for tool `get_weather`"
+        );
+    }
+}

--- a/rust/agent/src/provider.rs
+++ b/rust/agent/src/provider.rs
@@ -1,0 +1,15 @@
+//! Provider format dispatch.
+//!
+//! Only [`ProviderFormat::Anthropic`] exists for now, but keeping this as an
+//! enum preserves the dispatch seam so additional inference providers can slot
+//! in without churning the `to_provider_format` APIs on `ToolSchema` and
+//! `Trajectory` (added in later milestones).
+
+use serde::{Deserialize, Serialize};
+
+/// Wire format that a tool schema or trajectory is rendered into for a given
+/// inference provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ProviderFormat {
+    Anthropic,
+}


### PR DESCRIPTION
## Description of changes

PR **1/5** of the Rust agent port — porting the Python search-agent research
framework to a native Rust crate (`rust/agent`, `chroma-agent`). See
`plans/rust_agent_port_1bfabf45.plan.md`. This PR is pure scaffolding; no agent
behavior lands yet.

- New functionality
  - Create the `chroma-agent` crate and wire it into the workspace
    (`Cargo.toml` members list + `chroma-agent` workspace dependency).
  - `provider.rs`: the `ProviderFormat` enum (`Anthropic`) — the single dispatch
    seam that all provider-specific rendering goes through in later PRs.
  - `error.rs`: the crate-wide `AgentError` skeleton (`thiserror`).
  - `lib.rs`: module wiring + re-exports.

Stacked PRs layer on top: tool core → trajectory → inference → driver.

## Test plan

- [x] Tests pass locally with `cargo test -p chroma-agent` (unit test asserts
      `AgentError` variants `Display` correctly).
- [x] `cargo build -p chroma-agent`, `cargo clippy -p chroma-agent --all-targets -- -D warnings`, and `cargo fmt --check` are clean.

## Migration plan

None. New, self-contained crate that is not yet referenced by any binary or
service, so nothing it contains is deployed.

## Observability plan

N/A — scaffolding only, no runtime surface.

## Documentation Changes

Rustdoc module/item docs are included. No docs-site changes (internal crate with
no user-facing API).