### PR TITLE
[ENH] Add trajectory core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,6 +1581,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/plans/rust_agent_port_1bfabf45.plan.md
+++ b/plans/rust_agent_port_1bfabf45.plan.md
@@ -12,7 +12,7 @@ todos:
     content: Define typed Tool trait (assoc ModelSuppliedParams + RuntimeParams), blanket impl<T:Tool> DynTool (schemars schema gen + Any downcast of runtime params), ToolCallMetadata, ToolSet (add<T:Tool> caching schema/get/get_formats) (tool.rs)
     status: pending
   - id: trajectory
-    content: Define Action(Vec<ActionItem Text|Call>)/Observation(Vec<ObservationItem User|ToolResult>)/Trajectory enums + builders with plain derive serde and to_anthropic_messages converter (trajectory.rs)
+    content: Define Action(Vec<ActionItem SendUserText|Call>)/Observation(Vec<ObservationItem User|ToolResult>)/Trajectory enums + builders with plain derive serde and to_provider_format (Anthropic) converter (trajectory.rs)
     status: pending
   - id: weather-tool
     content: Implement dummy GetWeatherTool impl Tool with ModelSuppliedParams = WeatherParams { location }; schema auto-generated on add (tools/weather.rs)
@@ -50,7 +50,7 @@ rust/agent/
     tool.rs           # Tool trait (typed, what you write) + blanket DynTool impl (internal), ToolCallMetadata, ToolSet
     tools/
       weather.rs      # dummy GetWeatherTool: impl Tool with ModelSuppliedParams = WeatherParams { location }
-    trajectory.rs     # Action/Observation/Trajectory (name+text enums) + builders + to_anthropic_messages
+    trajectory.rs     # Action/Observation/Trajectory (name+text enums) + builders + to_provider_format
     inference.rs      # AgentInferenceModel trait + AnthropicAgentInferenceModel
     agent.rs          # base Agent driver + AgentBehavior hook trait
     error.rs          # AgentError (thiserror): InvalidJson, UnknownTool, ToolRuntimeParamsTypeMismatch, Http, Unsupported, ...
@@ -130,7 +130,7 @@ impl ToolSet {
 // The trajectory records tool *names* + text only (tools live in the ToolSet).
 // No Arc<dyn ...> here, no UserTextTool, no custom serde -> plain derive(Serialize, Deserialize).
 pub struct Call { pub name: String, pub params: Value, pub id: String }
-pub enum ActionItem { Text(String), Call(Call) }     // Text = agent message to user
+pub enum ActionItem { SendUserText(String), Call(Call) } // SendUserText = talk to the user (no tool result)
 pub struct Reasoning {
     pub text: String,
     pub signature: Option<String>, // provider round-trip data (e.g. Anthropic thinking signature); None elsewhere
@@ -198,7 +198,7 @@ classDiagram
     class Trajectory {
         +Vec~Entry~ entries
         +Uuid id
-        +to_anthropic_messages() Value
+        +to_provider_format(p) Value
     }
     class Entry { <<enum>> }
     class Action {
@@ -209,7 +209,7 @@ classDiagram
         +String text
         +Option~String~ signature
     }
-    class ActionItem { <<enum>> Text|Call }
+    class ActionItem { <<enum>> SendUserText|Call }
     class Call {
         +String name
         +Value params
@@ -285,15 +285,15 @@ flowchart TD
 - `ToolCallMetadata` pydantic subclassing -> a simple `ToolCallMetadata` type/enum (empty for now; the weather tool returns `None`). Kept as an extension point for future tool metadata.
 - Python's always-present `reasoning` + `reasoning_signature` fields on `Action` -> a single `reasoning: Option<Reasoning>` where `Reasoning { text, signature: Option<String> }`. The Anthropic-specific signature is nested inside the (optional) reasoning block where it semantically belongs, instead of being a stray sibling field on every action.
 - Python's `overrides` dict (runtime side-channel: `ignore_ids`/`query`/`max_tokens`) -> a second, per-tool typed associated type `Tool::RuntimeParams` (model-supplied `ModelSuppliedParams` vs harness-supplied `RuntimeParams`). `call(params, runtime)`. Across the object-safe `DynTool` boundary, the runtime params travel as `Option<Box<dyn Any + Send>>` and are downcast to `T::RuntimeParams` in the blanket impl (the agent resolved the tool by name, so the injector knows the concrete type); `None` falls back to `RuntimeParams::default()`. A type mismatch is a typed `AgentError::ToolRuntimeParamsTypeMismatch`, not a panic. This milestone: the weather tool sets `type RuntimeParams = ()` and the driver passes `None` (no behaviors yet); the wiring for behaviors to *produce* a `RuntimeParams` box is finalized with dedup/budget.
-- Trajectory decoupled from tools: instead of Python's parallel arrays of `Tool` objects, the trajectory records names/text only via enums — `Action { items: Vec<ActionItem> }` where `ActionItem` is `Text(String)` (agent message; replaces `UserTextTool`) or `Call { name, params, id }`, and `Observation { items: Vec<ObservationItem> }` where `ObservationItem` is `User(String)` or `ToolResult { call_id, text, metadata }`. Tool schemas are sent once in the request's `tools` array (from the `ToolSet`), so a per-call tool object is unnecessary. This removes `Arc<dyn ...>` from the trajectory, the `SerializedTool`/hydration machinery, and `UserTextTool`.
+- Trajectory decoupled from tools: instead of Python's parallel arrays of `Tool` objects, the trajectory records names/text only via enums — `Action { items: Vec<ActionItem> }` where `ActionItem` is `SendUserText(String)` (talk to the user; replaces `UserTextTool`, but as an explicit variant rather than a faked tool) or `Call { name, params, id }`, and `Observation { items: Vec<ObservationItem> }` where `ObservationItem` is `User(String)` or `ToolResult { call_id, text, metadata }`. The `SendUserText` vs `Call` split mirrors Anthropic's own `text` vs `tool_use` content-block taxonomy, so the Python `name == "user_text"` checks scattered across every formatter collapse into one match arm. Tool schemas are sent once in the request's `tools` array (from the `ToolSet`), so a per-call tool object is unnecessary. This removes `Arc<dyn ...>` from the trajectory, the `SerializedTool`/hydration machinery, and `UserTextTool`.
 - Serialization: the trajectory is plain `#[derive(Serialize, Deserialize)]` (no tool objects to erase), so no custom serde is needed.
-- `to_provider_format(ANTHROPIC)` -> `to_anthropic_messages()` producing `serde_json::Value` matching the structure in `[trajectory.py](.../trajectory.py)` (`thinking`/`text`/`tool_use` assistant blocks, `text`/`tool_result` user blocks). Other format methods stubbed with an `Unsupported` error for now.
+- `to_provider_format(ANTHROPIC)` -> `Trajectory::to_provider_format(ProviderFormat)` dispatching to a private `to_anthropic_messages()` that produces `serde_json::Value` matching the structure in `[trajectory.py](.../trajectory.py)` (`thinking`/`text`/`tool_use` assistant blocks, `text`/`tool_result` user blocks). Additional providers slot into the match later.
 
 ## Dummy weather tool
 `GetWeatherTool` in `tools/weather.rs` implements `Tool` with `type ModelSuppliedParams = WeatherParams { location: String }` (derives `Deserialize` + `JsonSchema`; `location` non-`Option` so it's required), `type RuntimeParams = ()`, `name() = "get_weather"`, and `call(params, ())` returning a canned string (e.g. `"It is 72F and sunny in {location}."`) with `None` metadata. Registered via `toolset.add(GetWeatherTool)` — the schema is generated from `WeatherParams` automatically. This verifies schemars schema generation -> centralized Anthropic tool-format conversion, model-issued `tool_use`, typed deserialization, execution, and observation round-trip. No hand-written schema anywhere.
 
 ## Anthropic inference model
-`AnthropicAgentInferenceModel` calls the Anthropic Messages API via `reqwest` (model default `claude-opus-4-5`, `thinking` enabled, interleaved-thinking beta header). Parse response content blocks into an `Action` via an `ActionBuilder`: `thinking` -> `Reasoning { text, signature }`, `text` -> `ActionItem::Text`, `tool_use` -> `ActionItem::Call { name, params, id }` (name validated against `ToolSet`). Mirrors `agent.py` lines 231-317 (non-streaming to start; streaming can be added later). API key from `ANTHROPIC_API_KEY`.
+`AnthropicAgentInferenceModel` calls the Anthropic Messages API via `reqwest` (model default `claude-opus-4-5`, `thinking` enabled, interleaved-thinking beta header). Parse response content blocks into an `Action` via an `ActionBuilder`: `thinking` -> `Reasoning { text, signature }`, `text` -> `ActionItem::SendUserText`, `tool_use` -> `ActionItem::Call { name, params, id }` (name validated against `ToolSet`). Mirrors `agent.py` lines 231-317 (non-streaming to start; streaming can be added later). API key from `ANTHROPIC_API_KEY`.
 
 ## Agent state machine + behavior composition
 
@@ -304,7 +304,7 @@ The `Agent` is a state machine exposing the same two driving modes as the Python
 
 So nothing external is required to run it: `run` is the default driver; manual mode is opt-in for callers who need step-level control.
 
-Port the base `Agent`: `reset`/`observe`/`infer`/`act`/`is_done` + the `run` auto-driver, including parallel tool execution (`join_all` over `ActionItem::Call`s, looked up in the `ToolSet` by name) and terminal detection (action whose items are all `ActionItem::Text`). `InferenceContext` carries trajectory + toolset (+ `previous_response_id` placeholder for parity).
+Port the base `Agent`: `reset`/`observe`/`infer`/`act`/`is_done` + the `run` auto-driver, including parallel tool execution (`join_all` over `ActionItem::Call`s, looked up in the `ToolSet` by name) and terminal detection (action whose items are all `ActionItem::SendUserText`). `InferenceContext` carries trajectory + toolset (+ `previous_response_id` placeholder for parity).
 
 The concrete dedup/pruning subclasses are NOT ported, but we DO port the composition mechanism that replaces Python's subclass + `super()` chaining. Decision: composable behavior hooks (middleware), not trait-inheritance, because Rust trait default methods have no `super`, so layering dedup + budget would otherwise require hand-merged structs or duplicated bodies.
 
@@ -349,12 +349,12 @@ flowchart LR
 - Testable milestone (no network): unit tests assert (a) `ToolSet::add(GetWeatherTool)` then `get_formats(Anthropic)` yields the expected `{name, description, input_schema}` JSON with `location` required; (b) `call_json(json!({"location":"Paris"}), None)` returns the canned string and injecting a `TemperatureUnit::Celsius` runtime param switches the unit; (c) a wrong-typed runtime-params box surfaces `ToolRuntimeParamsTypeMismatch` rather than panicking.
 
 ### PR 3 - `hammad/rust-agent-trajectory`
-- Scope (todo: `trajectory`): `trajectory.rs` types (`Action`/`Observation`/`Trajectory`/`Entry`/`Call`/`Reasoning`), builders, and `to_anthropic_messages()`.
-- Testable milestone (no network): serde round-trip test (`Trajectory` -> JSON -> `Trajectory` equality); `to_anthropic_messages()` shape test asserting `thinking`/`text`/`tool_use` assistant blocks and `text`/`tool_result` user blocks match the Python reference structure.
+- Scope (todo: `trajectory`): `trajectory.rs` types (`Action`/`Observation`/`Trajectory`/`Entry`/`Call`/`Reasoning`), builders, and `to_provider_format(ProviderFormat)`.
+- Testable milestone (no network): serde round-trip test (`Trajectory` -> JSON -> `Trajectory` equality); `to_provider_format(Anthropic)` shape test asserting `thinking`/`text`/`tool_use` assistant blocks and `text`/`tool_result` user blocks match the Python reference structure.
 
 ### PR 4 - `hammad/rust-agent-inference`
 - Scope (todo: `inference`): `inference.rs` (`InferenceContext`, `AgentInferenceModel` trait, `AnthropicAgentInferenceModel` via `reqwest`).
-- Testable milestone: unit test feeds a canned Anthropic Messages response body (fixture JSON) through the content-block -> `Action` parser and asserts `thinking`->`Reasoning`, `text`->`ActionItem::Text`, `tool_use`->`ActionItem::Call`. A live single-shot inference test is gated behind `ANTHROPIC_API_KEY` / `#[ignore]`.
+- Testable milestone: unit test feeds a canned Anthropic Messages response body (fixture JSON) through the content-block -> `Action` parser and asserts `thinking`->`Reasoning`, `text`->`ActionItem::SendUserText`, `tool_use`->`ActionItem::Call`. A live single-shot inference test is gated behind `ANTHROPIC_API_KEY` / `#[ignore]`.
 
 ### PR 5 - `hammad/rust-agent-driver`
 - Scope (todos: `agent`, `validate`): `agent.rs` (base `Agent` driver `reset`/`observe`/`infer`/`act`/`is_done`/`run`, `AgentBehavior` hook trait, empty behaviors vec) plus `lib.rs` re-exports.
@@ -366,7 +366,7 @@ Notes:
 
 ## Validation
 - `cargo build -p chroma-agent` and `cargo clippy`.
-- Unit tests (no network): trajectory builders, `to_anthropic_messages` JSON shape, `ToolSet` registration, and `GetWeatherTool` output.
+- Unit tests (no network): trajectory builders, `to_provider_format` JSON shape, `ToolSet` registration, and `GetWeatherTool` output.
 - End-to-end Anthropic loop test ("What's the weather in Paris?") gated behind `ANTHROPIC_API_KEY` / `#[ignore]`, consistent with `rust/chroma` test conventions.
 
 ## Open follow-ups to flag (not done here)

--- a/rust/agent/Cargo.toml
+++ b/rust/agent/Cargo.toml
@@ -10,6 +10,7 @@ schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/rust/agent/src/lib.rs
+++ b/rust/agent/src/lib.rs
@@ -2,20 +2,25 @@
 //! search-agent research framework.
 //!
 //! So far this crate provides the [`ProviderFormat`] dispatch seam, the
-//! crate-wide [`AgentError`] type, and the tool abstraction ([`Tool`] /
-//! [`DynTool`] / [`ToolSet`]) with a dummy [`GetWeatherTool`]. The trajectory,
-//! inference models, and the agent driver land in subsequent PRs (see
-//! `plans/`).
+//! crate-wide [`AgentError`] type, the tool abstraction ([`Tool`] /
+//! [`DynTool`] / [`ToolSet`]) with a dummy [`GetWeatherTool`], and the
+//! [`Trajectory`] record. The inference models and the agent driver land in
+//! subsequent PRs (see `plans/`).
 
 mod error;
 mod provider;
 mod tool;
 pub mod tools;
+mod trajectory;
 
 pub use error::AgentError;
 pub use provider::ProviderFormat;
 pub use tool::{DynTool, Tool, ToolCallMetadata, ToolSet};
 pub use tools::weather::{GetWeatherTool, TemperatureUnit};
+pub use trajectory::{
+    Action, ActionBuilder, ActionItem, Call, Entry, Observation, ObservationBuilder,
+    ObservationItem, Reasoning, Trajectory, TrajectoryBuilder,
+};
 
 #[cfg(test)]
 mod tests {

--- a/rust/agent/src/trajectory/anthropic.rs
+++ b/rust/agent/src/trajectory/anthropic.rs
@@ -1,0 +1,61 @@
+//! Anthropic Messages API rendering for a [`Trajectory`].
+//!
+//! Mirrors the Python `Trajectory.to_anthropic_format`: each [`Action`] becomes
+//! an `assistant` message (optional `thinking` block, then `text` and
+//! `tool_use` blocks) and each [`Observation`] becomes a `user` message
+//! (`text` and `tool_result` blocks).
+
+use serde_json::{json, Value};
+
+use super::{Action, ActionItem, Entry, Observation, ObservationItem, Trajectory};
+
+/// Render `trajectory` into the Anthropic Messages API `messages` array.
+pub(super) fn to_messages(trajectory: &Trajectory) -> Value {
+    let messages: Vec<Value> = trajectory
+        .entries
+        .iter()
+        .map(|entry| match entry {
+            Entry::Action(action) => action_to_message(action),
+            Entry::Observation(observation) => observation_to_message(observation),
+        })
+        .collect();
+    Value::Array(messages)
+}
+
+fn action_to_message(action: &Action) -> Value {
+    let mut content: Vec<Value> = Vec::new();
+    if let Some(reasoning) = &action.reasoning {
+        content.push(json!({
+            "type": "thinking",
+            "thinking": reasoning.text,
+            "signature": reasoning.signature,
+        }));
+    }
+    for item in &action.items {
+        match item {
+            ActionItem::SendUserText(text) => content.push(json!({ "type": "text", "text": text })),
+            ActionItem::Call(call) => content.push(json!({
+                "type": "tool_use",
+                "id": call.id,
+                "name": call.name,
+                "input": call.params,
+            })),
+        }
+    }
+    json!({ "role": "assistant", "content": content })
+}
+
+fn observation_to_message(observation: &Observation) -> Value {
+    let mut content: Vec<Value> = Vec::new();
+    for item in &observation.items {
+        match item {
+            ObservationItem::User(text) => content.push(json!({ "type": "text", "text": text })),
+            ObservationItem::ToolResult { call_id, text, .. } => content.push(json!({
+                "type": "tool_result",
+                "tool_use_id": call_id,
+                "content": [{ "type": "text", "text": text }],
+            })),
+        }
+    }
+    json!({ "role": "user", "content": content })
+}

--- a/rust/agent/src/trajectory/mod.rs
+++ b/rust/agent/src/trajectory/mod.rs
@@ -1,0 +1,334 @@
+//! The agent trajectory: the recorded history of [`Action`]s and
+//! [`Observation`]s.
+//!
+//! Unlike the Python original, the trajectory records tool *names* and text
+//! only (the live tools live in the `ToolSet`), so it is plain
+//! `#[derive(Serialize, Deserialize)]` with no custom serde or tool hydration.
+//! Provider rendering goes through [`Trajectory::to_provider_format`], which
+//! dispatches to a per-provider module (see [`anthropic`]); only Anthropic is
+//! supported for now.
+
+mod anthropic;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::provider::ProviderFormat;
+use crate::tool::ToolCallMetadata;
+
+/// A single tool invocation requested by the model.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Call {
+    pub name: String,
+    /// Model-supplied params (validated/decoded when the tool runs).
+    pub params: Value,
+    /// Provider-assigned id used to correlate the matching tool result.
+    pub id: String,
+}
+
+/// One element of an [`Action`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ActionItem {
+    /// Send a text message to the user. This is the "talk to the user" action
+    /// (Python modeled it as a `UserTextTool`); unlike a [`Call`] it expects no
+    /// tool result back.
+    SendUserText(String),
+    /// A tool call.
+    Call(Call),
+}
+
+/// Reasoning ("thinking") emitted alongside an action.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Reasoning {
+    pub text: String,
+    /// Provider round-trip data (e.g. Anthropic's thinking signature); `None`
+    /// for providers that don't use it.
+    pub signature: Option<String>,
+}
+
+/// What the agent does in a single step: zero or more items, plus optional
+/// reasoning.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Action {
+    pub items: Vec<ActionItem>,
+    pub reasoning: Option<Reasoning>,
+}
+
+/// One element of an [`Observation`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ObservationItem {
+    /// Text from the user (e.g. the initial prompt).
+    User(String),
+    /// The result of a tool call, correlated by `call_id`.
+    ToolResult {
+        call_id: String,
+        text: String,
+        metadata: Option<ToolCallMetadata>,
+    },
+}
+
+/// What the agent observes in a single step.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Observation {
+    pub items: Vec<ObservationItem>,
+}
+
+/// A single entry in the trajectory: either an action or an observation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Entry {
+    Action(Action),
+    Observation(Observation),
+}
+
+/// The full, ordered history of a run.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Trajectory {
+    pub entries: Vec<Entry>,
+    pub id: Uuid,
+}
+
+impl Trajectory {
+    /// Number of [`Action`] entries (i.e. agent/inference steps).
+    ///
+    /// Counts entries, not content blocks: an `Action` with interleaved
+    /// reasoning still contributes exactly one, since one `infer()` produces
+    /// one `Action` regardless of how many thinking/tool_use blocks it holds.
+    pub fn num_actions(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|e| matches!(e, Entry::Action(_)))
+            .count()
+    }
+
+    /// Render the trajectory into `provider`'s message format.
+    ///
+    /// The dispatch seam mirrors `Tool`/`DynTool::to_provider_format`; only
+    /// Anthropic is supported for now.
+    pub fn to_provider_format(&self, provider: ProviderFormat) -> Value {
+        match provider {
+            ProviderFormat::Anthropic => anthropic::to_messages(self),
+        }
+    }
+}
+
+/// Incrementally assembles an [`Action`] (e.g. while parsing model output).
+#[derive(Debug, Default)]
+pub struct ActionBuilder {
+    items: Vec<ActionItem>,
+    reasoning: Option<Reasoning>,
+}
+
+impl ActionBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push_send_user_text(&mut self, text: impl Into<String>) -> &mut Self {
+        self.items.push(ActionItem::SendUserText(text.into()));
+        self
+    }
+
+    pub fn push_call(&mut self, call: Call) -> &mut Self {
+        self.items.push(ActionItem::Call(call));
+        self
+    }
+
+    pub fn set_reasoning(&mut self, reasoning: Reasoning) -> &mut Self {
+        self.reasoning = Some(reasoning);
+        self
+    }
+
+    /// True when the action carries neither items nor reasoning.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty() && self.reasoning.is_none()
+    }
+
+    pub fn build(self) -> Action {
+        Action {
+            items: self.items,
+            reasoning: self.reasoning,
+        }
+    }
+}
+
+/// Incrementally assembles an [`Observation`].
+#[derive(Debug, Default)]
+pub struct ObservationBuilder {
+    items: Vec<ObservationItem>,
+}
+
+impl ObservationBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push_user(&mut self, text: impl Into<String>) -> &mut Self {
+        self.items.push(ObservationItem::User(text.into()));
+        self
+    }
+
+    pub fn push_tool_result(
+        &mut self,
+        call_id: impl Into<String>,
+        text: impl Into<String>,
+        metadata: Option<ToolCallMetadata>,
+    ) -> &mut Self {
+        self.items.push(ObservationItem::ToolResult {
+            call_id: call_id.into(),
+            text: text.into(),
+            metadata,
+        });
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn build(self) -> Observation {
+        Observation { items: self.items }
+    }
+}
+
+/// Builds a [`Trajectory`], assigning it a fresh id.
+#[derive(Debug)]
+pub struct TrajectoryBuilder {
+    trajectory: Trajectory,
+}
+
+impl TrajectoryBuilder {
+    pub fn new() -> Self {
+        Self {
+            trajectory: Trajectory {
+                entries: Vec::new(),
+                id: Uuid::new_v4(),
+            },
+        }
+    }
+
+    pub fn push_action(&mut self, action: Action) -> &mut Self {
+        self.trajectory.entries.push(Entry::Action(action));
+        self
+    }
+
+    pub fn push_observation(&mut self, observation: Observation) -> &mut Self {
+        self.trajectory
+            .entries
+            .push(Entry::Observation(observation));
+        self
+    }
+
+    pub fn len(&self) -> usize {
+        self.trajectory.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.trajectory.entries.is_empty()
+    }
+
+    pub fn build(self) -> Trajectory {
+        self.trajectory
+    }
+}
+
+impl Default for TrajectoryBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_trajectory() -> Trajectory {
+        let mut builder = TrajectoryBuilder::new();
+
+        let mut user = ObservationBuilder::new();
+        user.push_user("What's the weather in Paris?");
+        builder.push_observation(user.build());
+
+        let mut action = ActionBuilder::new();
+        action.set_reasoning(Reasoning {
+            text: "I should look up the weather.".to_string(),
+            signature: Some("sig-abc".to_string()),
+        });
+        action.push_call(Call {
+            name: "get_weather".to_string(),
+            params: json!({ "location": "Paris" }),
+            id: "call_1".to_string(),
+        });
+        builder.push_action(action.build());
+
+        let mut result = ObservationBuilder::new();
+        result.push_tool_result("call_1", "It is 72F and sunny in Paris.", None);
+        builder.push_observation(result.build());
+
+        builder.build()
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let trajectory = sample_trajectory();
+        let json = serde_json::to_string(&trajectory).expect("serialize");
+        let back: Trajectory = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(trajectory, back);
+    }
+
+    #[test]
+    fn num_actions_counts_action_entries() {
+        assert_eq!(sample_trajectory().num_actions(), 1);
+    }
+
+    #[test]
+    fn send_user_text_renders_as_text_block() {
+        let mut builder = TrajectoryBuilder::new();
+        let mut action = ActionBuilder::new();
+        action.push_send_user_text("Here is the forecast.");
+        builder.push_action(action.build());
+
+        let messages = builder
+            .build()
+            .to_provider_format(ProviderFormat::Anthropic);
+        let block = &messages.as_array().expect("array")[0]["content"][0];
+        assert_eq!(block["type"], "text");
+        assert_eq!(block["text"], "Here is the forecast.");
+    }
+
+    #[test]
+    fn to_anthropic_messages_shape() {
+        let messages = sample_trajectory().to_provider_format(ProviderFormat::Anthropic);
+        let messages = messages.as_array().expect("messages array");
+        assert_eq!(messages.len(), 3);
+
+        // User prompt -> user/text.
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[0]["content"][0]["type"], "text");
+        assert_eq!(
+            messages[0]["content"][0]["text"],
+            "What's the weather in Paris?"
+        );
+
+        // Action -> assistant with thinking + tool_use.
+        assert_eq!(messages[1]["role"], "assistant");
+        let content = messages[1]["content"].as_array().expect("content array");
+        assert_eq!(content[0]["type"], "thinking");
+        assert_eq!(content[0]["thinking"], "I should look up the weather.");
+        assert_eq!(content[0]["signature"], "sig-abc");
+        assert_eq!(content[1]["type"], "tool_use");
+        assert_eq!(content[1]["id"], "call_1");
+        assert_eq!(content[1]["name"], "get_weather");
+        assert_eq!(content[1]["input"]["location"], "Paris");
+
+        // Tool result -> user/tool_result.
+        assert_eq!(messages[2]["role"], "user");
+        assert_eq!(messages[2]["content"][0]["type"], "tool_result");
+        assert_eq!(messages[2]["content"][0]["tool_use_id"], "call_1");
+        assert_eq!(
+            messages[2]["content"][0]["content"][0]["text"],
+            "It is 72F and sunny in Paris."
+        );
+    }
+}


### PR DESCRIPTION
## Description of changes

PR **3/5** of the Rust agent port (stacked on `hammad/rust-agent-tool-core`).
Adds the trajectory record.

- New functionality
  - `trajectory/mod.rs`: the recorded run history — `Trajectory` / `Entry` /
    `Action` / `Observation`, plus `Call`, `Reasoning`, `ActionItem`
    (`SendUserText` | `Call`) and `ObservationItem` (`User` | `ToolResult`).
    Unlike the Python original, entries store tool *names* and text only (live
    tools live in the `ToolSet`), so the types are plain `Serialize`/
    `Deserialize` with no custom serde or tool hydration.
  - Builders (`ActionBuilder` / `ObservationBuilder` / `TrajectoryBuilder`) and
    `Trajectory::num_actions()`.
  - `Trajectory::to_provider_format(ProviderFormat)` dispatching to a
    per-provider module; `trajectory/anthropic.rs` renders the Anthropic Messages
    shape (`thinking`/`text`/`tool_use` assistant blocks, `text`/`tool_result`
    user blocks).

Modeling note: "talk to the user" is just another `ActionItem`
(`SendUserText`) rather than a magic tool, staying faithful to Anthropic's wire
protocol while avoiding Python's magic-string checks.

## Test plan

- [x] Tests pass locally with `cargo test -p chroma-agent` (no network):
  - serde round-trip (`Trajectory` → JSON → `Trajectory` equality);
  - `to_provider_format(Anthropic)` shape test asserting the assistant/user
    block structure matches the Python reference.
- [x] clippy/fmt clean.

## Migration plan

None — additive; not yet wired into a binary or service.

## Observability plan

N/A — no runtime surface yet.

## Documentation Changes

Rustdoc on the trajectory types, builders, and the provider-format seam. No
docs-site changes.