### PR TITLE
[ENH] Add agent inference model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "indexmap 2.13.0",
+ "reqwest 0.13.2",
  "schemars",
  "serde",
  "serde_json",

--- a/plans/rust_agent_port_1bfabf45.plan.md
+++ b/plans/rust_agent_port_1bfabf45.plan.md
@@ -148,16 +148,16 @@ pub enum Entry { Action(Action), Observation(Observation) }
 pub struct Trajectory { pub entries: Vec<Entry>, pub id: Uuid }
 
 // inference.rs
+// (OpenAI-Responses-only fields like previous_response_id/skip_response_id_update
+// were dropped as speculative; add them when a provider needs them.)
 pub struct InferenceContext<'a> {
     pub trajectory: Trajectory,
     pub toolset: &'a ToolSet,
     pub max_tokens: Option<u32>,
-    pub previous_response_id: Option<String>,
-    pub skip_response_id_update: bool,
 }
 #[async_trait]
 pub trait AgentInferenceModel: Send + Sync {
-    async fn infer(&self, ctx: &mut InferenceContext<'_>) -> Result<Option<Action>, AgentError>;
+    async fn infer(&self, ctx: &InferenceContext<'_>) -> Result<Option<Action>, AgentError>;
 }
 ```
 
@@ -192,8 +192,8 @@ classDiagram
     }
     class InferenceContext {
         +Trajectory trajectory
+        +toolset
         +max_tokens
-        +previous_response_id
     }
     class Trajectory {
         +Vec~Entry~ entries
@@ -293,7 +293,7 @@ flowchart TD
 `GetWeatherTool` in `tools/weather.rs` implements `Tool` with `type ModelSuppliedParams = WeatherParams { location: String }` (derives `Deserialize` + `JsonSchema`; `location` non-`Option` so it's required), `type RuntimeParams = ()`, `name() = "get_weather"`, and `call(params, ())` returning a canned string (e.g. `"It is 72F and sunny in {location}."`) with `None` metadata. Registered via `toolset.add(GetWeatherTool)` — the schema is generated from `WeatherParams` automatically. This verifies schemars schema generation -> centralized Anthropic tool-format conversion, model-issued `tool_use`, typed deserialization, execution, and observation round-trip. No hand-written schema anywhere.
 
 ## Anthropic inference model
-`AnthropicAgentInferenceModel` calls the Anthropic Messages API via `reqwest` (model default `claude-opus-4-5`, `thinking` enabled, interleaved-thinking beta header). Parse response content blocks into an `Action` via an `ActionBuilder`: `thinking` -> `Reasoning { text, signature }`, `text` -> `ActionItem::SendUserText`, `tool_use` -> `ActionItem::Call { name, params, id }` (name validated against `ToolSet`). Mirrors `agent.py` lines 231-317 (non-streaming to start; streaming can be added later). API key from `ANTHROPIC_API_KEY`.
+`AnthropicAgentInferenceModel` calls the Anthropic Messages API via `reqwest` (non-streaming; model default `claude-opus-4-5-20251101`, `max_tokens` 4096, `temperature` 1.0, `thinking` enabled with a 6000-token budget, `anthropic-beta: interleaved-thinking-2025-05-14` header). A pure `parse_anthropic_response(&Value, &ToolSet)` helper (testable without network) parses response content blocks into an `Action` via an `ActionBuilder`: `thinking` -> `Reasoning { text, signature }`, `text` -> `ActionItem::SendUserText`, `tool_use` -> `ActionItem::Call { name, params, id }` (name validated against `ToolSet`; `redacted_thinking` -> `Unsupported`). Mirrors `agent.py` lines 231-317; streaming can be added later. Key via `new(api_key)` or `from_env()` (`ANTHROPIC_API_KEY`).
 
 ## Agent state machine + behavior composition
 
@@ -304,7 +304,7 @@ The `Agent` is a state machine exposing the same two driving modes as the Python
 
 So nothing external is required to run it: `run` is the default driver; manual mode is opt-in for callers who need step-level control.
 
-Port the base `Agent`: `reset`/`observe`/`infer`/`act`/`is_done` + the `run` auto-driver, including parallel tool execution (`join_all` over `ActionItem::Call`s, looked up in the `ToolSet` by name) and terminal detection (action whose items are all `ActionItem::SendUserText`). `InferenceContext` carries trajectory + toolset (+ `previous_response_id` placeholder for parity).
+Port the base `Agent`: `reset`/`observe`/`infer`/`act`/`is_done` + the `run` auto-driver, including parallel tool execution (`join_all` over `ActionItem::Call`s, looked up in the `ToolSet` by name) and terminal detection (action whose items are all `ActionItem::SendUserText`). `InferenceContext` carries trajectory + toolset + optional `max_tokens`.
 
 The concrete dedup/pruning subclasses are NOT ported, but we DO port the composition mechanism that replaces Python's subclass + `super()` chaining. Decision: composable behavior hooks (middleware), not trait-inheritance, because Rust trait default methods have no `super`, so layering dedup + budget would otherwise require hand-merged structs or duplicated bodies.
 

--- a/rust/agent/Cargo.toml
+++ b/rust/agent/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 async-trait = { workspace = true }
 indexmap = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/agent/src/error.rs
+++ b/rust/agent/src/error.rs
@@ -21,6 +21,14 @@ pub enum AgentError {
     #[error("runtime params type mismatch for tool `{tool}`")]
     ToolRuntimeParamsTypeMismatch { tool: String },
 
+    /// An HTTP/transport error talking to a provider API.
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Invalid or missing configuration (e.g. a required environment variable).
+    #[error("configuration error: {0}")]
+    Config(String),
+
     /// A requested provider format or operation is not yet supported.
     #[error("unsupported: {0}")]
     Unsupported(String),

--- a/rust/agent/src/inference/anthropic.rs
+++ b/rust/agent/src/inference/anthropic.rs
@@ -12,12 +12,65 @@ use crate::provider::ProviderFormat;
 use crate::tool::ToolSet;
 use crate::trajectory::{Action, ActionBuilder, Call, Reasoning};
 
-const DEFAULT_MAX_TOKENS: u32 = 4096;
-const DEFAULT_THINKING_BUDGET: u32 = 6000;
-const DEFAULT_TEMPERATURE: f64 = 1.0;
 const ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
-const ANTHROPIC_BETA: &str = "interleaved-thinking-2025-05-14";
+
+/// Opt-in feature flags sent in the `anthropic-beta` header.
+///
+/// The header is a comma-separated list, so several betas can be enabled at
+/// once (see [`AnthropicAgentInferenceModel::with_betas`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnthropicBeta {
+    /// Allow `thinking` blocks to interleave with `tool_use`
+    /// (`interleaved-thinking-2025-05-14`). Pairs with the `thinking` config in
+    /// [`AnthropicAgentInferenceModel::request_body`].
+    InterleavedThinking,
+}
+
+impl AnthropicBeta {
+    /// The flag token as it appears in the `anthropic-beta` header.
+    pub fn id(self) -> &'static str {
+        match self {
+            AnthropicBeta::InterleavedThinking => "interleaved-thinking-2025-05-14",
+        }
+    }
+}
+
+/// The set of `anthropic-beta` flags enabled on a request.
+///
+/// [`Default`] enables interleaved thinking, which pairs with the always-on
+/// `thinking` config; an empty set omits the header entirely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnthropicBetas(pub Vec<AnthropicBeta>);
+
+impl Default for AnthropicBetas {
+    fn default() -> Self {
+        Self(vec![AnthropicBeta::InterleavedThinking])
+    }
+}
+
+impl AnthropicBetas {
+    /// Render the comma-separated `anthropic-beta` header value, or `None` when
+    /// no betas are enabled (in which case the header should be omitted).
+    fn header_value(&self) -> Option<String> {
+        if self.0.is_empty() {
+            return None;
+        }
+        Some(
+            self.0
+                .iter()
+                .map(|beta| beta.id())
+                .collect::<Vec<_>>()
+                .join(","),
+        )
+    }
+}
+
+impl From<Vec<AnthropicBeta>> for AnthropicBetas {
+    fn from(betas: Vec<AnthropicBeta>) -> Self {
+        Self(betas)
+    }
+}
 
 /// Known Anthropic model snapshots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -38,26 +91,47 @@ impl AnthropicModel {
     }
 }
 
+/// Tunable Messages API request knobs, separated from the required api key and
+/// model so they can carry sensible defaults via [`Default`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnthropicRequestConfig {
+    /// Default max output tokens (an [`InferenceContext`] may override per call).
+    pub max_tokens: u32,
+    pub temperature: f64,
+    /// Token budget for the always-on `thinking` block.
+    pub thinking_budget: u32,
+    /// `anthropic-beta` feature flags to enable.
+    pub betas: AnthropicBetas,
+}
+
+impl Default for AnthropicRequestConfig {
+    fn default() -> Self {
+        Self {
+            max_tokens: 4096,
+            temperature: 1.0,
+            thinking_budget: 6000,
+            betas: AnthropicBetas::default(),
+        }
+    }
+}
+
 /// Anthropic Messages API inference model.
 pub struct AnthropicAgentInferenceModel {
     client: reqwest::Client,
     api_key: String,
     model: AnthropicModel,
-    max_tokens: u32,
-    temperature: f64,
-    thinking_budget: u32,
+    config: AnthropicRequestConfig,
 }
 
 impl AnthropicAgentInferenceModel {
-    /// Construct with the given API key and model.
+    /// Construct with the given API key and model, using the default
+    /// [`AnthropicRequestConfig`] (interleaved thinking enabled).
     pub fn new(api_key: impl Into<String>, model: AnthropicModel) -> Self {
         Self {
             client: reqwest::Client::new(),
             api_key: api_key.into(),
             model,
-            max_tokens: DEFAULT_MAX_TOKENS,
-            temperature: DEFAULT_TEMPERATURE,
-            thinking_budget: DEFAULT_THINKING_BUDGET,
+            config: AnthropicRequestConfig::default(),
         }
     }
 
@@ -68,12 +142,26 @@ impl AnthropicAgentInferenceModel {
         Ok(Self::new(api_key, model))
     }
 
+    /// Replace the request config (max tokens, temperature, thinking budget,
+    /// betas).
+    pub fn with_config(mut self, config: AnthropicRequestConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Replace the enabled `anthropic-beta` feature flags (empty disables the
+    /// header entirely).
+    pub fn with_betas(mut self, betas: impl Into<AnthropicBetas>) -> Self {
+        self.config.betas = betas.into();
+        self
+    }
+
     fn request_body(&self, ctx: &InferenceContext<'_>) -> Value {
         json!({
             "model": self.model.id(),
-            "max_tokens": ctx.max_tokens.unwrap_or(self.max_tokens),
-            "temperature": self.temperature,
-            "thinking": { "type": "enabled", "budget_tokens": self.thinking_budget },
+            "max_tokens": ctx.max_tokens.unwrap_or(self.config.max_tokens),
+            "temperature": self.config.temperature,
+            "thinking": { "type": "enabled", "budget_tokens": self.config.thinking_budget },
             "tools": ctx.toolset.get_formats(ProviderFormat::Anthropic),
             "messages": ctx.trajectory.to_provider_format(ProviderFormat::Anthropic),
         })
@@ -83,18 +171,18 @@ impl AnthropicAgentInferenceModel {
 #[async_trait]
 impl AgentInferenceModel for AnthropicAgentInferenceModel {
     async fn infer(&self, ctx: &InferenceContext<'_>) -> Result<Option<Action>, AgentError> {
-        let response: Value = self
+        let mut request = self
             .client
             .post(format!("{ANTHROPIC_BASE_URL}/v1/messages"))
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", ANTHROPIC_VERSION)
-            .header("anthropic-beta", ANTHROPIC_BETA)
-            .json(&self.request_body(ctx))
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
+            .json(&self.request_body(ctx));
+
+        if let Some(betas) = self.config.betas.header_value() {
+            request = request.header("anthropic-beta", betas);
+        }
+
+        let response: Value = request.send().await?.error_for_status()?.json().await?;
 
         parse_anthropic_response(&response, ctx.toolset)
     }
@@ -193,6 +281,24 @@ mod tests {
         let mut toolset = ToolSet::new();
         toolset.add(GetWeatherTool);
         toolset
+    }
+
+    #[test]
+    fn beta_header_value_renders_and_omits() {
+        assert_eq!(
+            AnthropicBetas::default().header_value().as_deref(),
+            Some("interleaved-thinking-2025-05-14")
+        );
+        assert_eq!(
+            AnthropicBetas(vec![
+                AnthropicBeta::InterleavedThinking,
+                AnthropicBeta::InterleavedThinking,
+            ])
+            .header_value()
+            .as_deref(),
+            Some("interleaved-thinking-2025-05-14,interleaved-thinking-2025-05-14")
+        );
+        assert_eq!(AnthropicBetas(vec![]).header_value(), None);
     }
 
     #[test]

--- a/rust/agent/src/inference/anthropic.rs
+++ b/rust/agent/src/inference/anthropic.rs
@@ -1,0 +1,294 @@
+//! Anthropic Messages API inference model (non-streaming, thinking enabled).
+//!
+//! Response parsing is split into a pure [`parse_anthropic_response`] helper so
+//! it can be tested without network access.
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use super::{AgentInferenceModel, InferenceContext};
+use crate::error::AgentError;
+use crate::provider::ProviderFormat;
+use crate::tool::ToolSet;
+use crate::trajectory::{Action, ActionBuilder, Call, Reasoning};
+
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+const DEFAULT_THINKING_BUDGET: u32 = 6000;
+const DEFAULT_TEMPERATURE: f64 = 1.0;
+const ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const ANTHROPIC_BETA: &str = "interleaved-thinking-2025-05-14";
+
+/// Known Anthropic model snapshots.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnthropicModel {
+    /// `claude-opus-4-5-20251101`
+    Opus4_5,
+    /// `claude-sonnet-4-5-20250929`
+    Sonnet4_5,
+}
+
+impl AnthropicModel {
+    /// The API model identifier sent on the wire.
+    pub fn id(self) -> &'static str {
+        match self {
+            AnthropicModel::Opus4_5 => "claude-opus-4-5-20251101",
+            AnthropicModel::Sonnet4_5 => "claude-sonnet-4-5-20250929",
+        }
+    }
+}
+
+/// Anthropic Messages API inference model.
+pub struct AnthropicAgentInferenceModel {
+    client: reqwest::Client,
+    api_key: String,
+    model: AnthropicModel,
+    max_tokens: u32,
+    temperature: f64,
+    thinking_budget: u32,
+}
+
+impl AnthropicAgentInferenceModel {
+    /// Construct with the given API key and model.
+    pub fn new(api_key: impl Into<String>, model: AnthropicModel) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key: api_key.into(),
+            model,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            temperature: DEFAULT_TEMPERATURE,
+            thinking_budget: DEFAULT_THINKING_BUDGET,
+        }
+    }
+
+    /// Construct from the `ANTHROPIC_API_KEY` environment variable.
+    pub fn from_env(model: AnthropicModel) -> Result<Self, AgentError> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY")
+            .map_err(|_| AgentError::Config("ANTHROPIC_API_KEY is not set".to_string()))?;
+        Ok(Self::new(api_key, model))
+    }
+
+    fn request_body(&self, ctx: &InferenceContext<'_>) -> Value {
+        json!({
+            "model": self.model.id(),
+            "max_tokens": ctx.max_tokens.unwrap_or(self.max_tokens),
+            "temperature": self.temperature,
+            "thinking": { "type": "enabled", "budget_tokens": self.thinking_budget },
+            "tools": ctx.toolset.get_formats(ProviderFormat::Anthropic),
+            "messages": ctx.trajectory.to_provider_format(ProviderFormat::Anthropic),
+        })
+    }
+}
+
+#[async_trait]
+impl AgentInferenceModel for AnthropicAgentInferenceModel {
+    async fn infer(&self, ctx: &InferenceContext<'_>) -> Result<Option<Action>, AgentError> {
+        let response: Value = self
+            .client
+            .post(format!("{ANTHROPIC_BASE_URL}/v1/messages"))
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("anthropic-beta", ANTHROPIC_BETA)
+            .json(&self.request_body(ctx))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        parse_anthropic_response(&response, ctx.toolset)
+    }
+}
+
+/// Parse an Anthropic Messages response body into an [`Action`].
+///
+/// Iterates the `content` blocks in order: `thinking` -> [`Reasoning`],
+/// `text` -> [`crate::ActionItem::SendUserText`], `tool_use` -> [`Call`] (the
+/// name is validated against `toolset`). `redacted_thinking` is rejected, like
+/// the Python original. Returns `None` when there is no actionable content.
+fn parse_anthropic_response(
+    response: &Value,
+    toolset: &ToolSet,
+) -> Result<Option<Action>, AgentError> {
+    let content = response
+        .get("content")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            AgentError::Unsupported("Anthropic response missing `content` array".to_string())
+        })?;
+
+    let mut builder = ActionBuilder::new();
+    for block in content {
+        let block_type = block
+            .get("type")
+            .and_then(Value::as_str)
+            .ok_or_else(|| AgentError::Unsupported("content block missing `type`".to_string()))?;
+
+        match block_type {
+            "thinking" => {
+                let text = block
+                    .get("thinking")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let signature = block
+                    .get("signature")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                builder.set_reasoning(Reasoning { text, signature });
+            }
+            "text" => {
+                let text = block
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                builder.push_send_user_text(text);
+            }
+            "tool_use" => {
+                let name = block.get("name").and_then(Value::as_str).ok_or_else(|| {
+                    AgentError::Unsupported("tool_use block missing `name`".to_string())
+                })?;
+                if toolset.get(name).is_none() {
+                    return Err(AgentError::UnknownTool(name.to_string()));
+                }
+                let id = block
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let params = block.get("input").cloned().unwrap_or(Value::Null);
+                builder.push_call(Call {
+                    name: name.to_string(),
+                    params,
+                    id,
+                });
+            }
+            "redacted_thinking" => {
+                return Err(AgentError::Unsupported(
+                    "redacted thinking is not supported".to_string(),
+                ));
+            }
+            other => {
+                return Err(AgentError::Unsupported(format!(
+                    "unsupported content block type: {other}"
+                )));
+            }
+        }
+    }
+
+    if builder.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(builder.build()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::weather::GetWeatherTool;
+    use crate::trajectory::{ActionItem, ObservationBuilder, TrajectoryBuilder};
+
+    fn weather_toolset() -> ToolSet {
+        let mut toolset = ToolSet::new();
+        toolset.add(GetWeatherTool);
+        toolset
+    }
+
+    #[test]
+    fn parses_content_blocks_into_action() {
+        let toolset = weather_toolset();
+        let response = json!({
+            "content": [
+                { "type": "thinking", "thinking": "I should check the weather.", "signature": "sig-1" },
+                { "type": "text", "text": "Let me look that up." },
+                { "type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": { "location": "Paris" } }
+            ]
+        });
+
+        let action = parse_anthropic_response(&response, &toolset)
+            .expect("parse")
+            .expect("action");
+
+        let reasoning = action.reasoning.as_ref().expect("reasoning");
+        assert_eq!(reasoning.text, "I should check the weather.");
+        assert_eq!(reasoning.signature.as_deref(), Some("sig-1"));
+
+        assert_eq!(action.items.len(), 2);
+        match &action.items[0] {
+            ActionItem::SendUserText(text) => assert_eq!(text, "Let me look that up."),
+            other => panic!("expected SendUserText, got {other:?}"),
+        }
+        match &action.items[1] {
+            ActionItem::Call(call) => {
+                assert_eq!(call.name, "get_weather");
+                assert_eq!(call.id, "toolu_1");
+                assert_eq!(call.params["location"], "Paris");
+            }
+            other => panic!("expected Call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_content_yields_no_action() {
+        let toolset = weather_toolset();
+        let response = json!({ "content": [] });
+        assert!(parse_anthropic_response(&response, &toolset)
+            .expect("parse")
+            .is_none());
+    }
+
+    #[test]
+    fn unknown_tool_errors() {
+        let toolset = weather_toolset();
+        let response = json!({
+            "content": [
+                { "type": "tool_use", "id": "x", "name": "not_a_tool", "input": {} }
+            ]
+        });
+        let err = parse_anthropic_response(&response, &toolset).expect_err("should error");
+        assert!(matches!(err, AgentError::UnknownTool(name) if name == "not_a_tool"));
+    }
+
+    #[test]
+    fn redacted_thinking_is_unsupported() {
+        let toolset = weather_toolset();
+        let response = json!({
+            "content": [ { "type": "redacted_thinking", "data": "..." } ]
+        });
+        let err = parse_anthropic_response(&response, &toolset).expect_err("should error");
+        assert!(matches!(err, AgentError::Unsupported(_)));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires ANTHROPIC_API_KEY and network access"]
+    async fn live_infer_requests_weather_tool() {
+        let model = AnthropicAgentInferenceModel::from_env(AnthropicModel::Sonnet4_5)
+            .expect("ANTHROPIC_API_KEY");
+        let toolset = weather_toolset();
+
+        let mut builder = TrajectoryBuilder::new();
+        let mut prompt = ObservationBuilder::new();
+        prompt.push_user("What's the weather in Paris? Use the get_weather tool.");
+        builder.push_observation(prompt.build());
+
+        let ctx = InferenceContext {
+            trajectory: builder.build(),
+            toolset: &toolset,
+            max_tokens: None,
+        };
+
+        let action = model
+            .infer(&ctx)
+            .await
+            .expect("infer succeeds")
+            .expect("an action");
+        assert!(
+            action
+                .items
+                .iter()
+                .any(|item| matches!(item, ActionItem::Call(_))),
+            "expected the model to call a tool"
+        );
+    }
+}

--- a/rust/agent/src/inference/mod.rs
+++ b/rust/agent/src/inference/mod.rs
@@ -1,0 +1,33 @@
+//! Inference models: turn a [`Trajectory`] into the next [`Action`].
+//!
+//! [`AgentInferenceModel`] is the provider-agnostic seam; concrete provider
+//! implementations live in submodules (see [`anthropic`]). Only Anthropic is
+//! supported for now.
+
+mod anthropic;
+
+pub use anthropic::{AnthropicAgentInferenceModel, AnthropicModel};
+
+use async_trait::async_trait;
+
+use crate::error::AgentError;
+use crate::tool::ToolSet;
+use crate::trajectory::{Action, Trajectory};
+
+/// Everything an [`AgentInferenceModel`] needs to produce the next action.
+///
+/// `trajectory` is the (possibly masked) view to send to the model; `toolset`
+/// supplies tool schemas and validates tool names in the response.
+pub struct InferenceContext<'a> {
+    pub trajectory: Trajectory,
+    pub toolset: &'a ToolSet,
+    /// Per-call override for the model's default max output tokens.
+    pub max_tokens: Option<u32>,
+}
+
+/// Produces the next [`Action`] from an [`InferenceContext`], or `None` when the
+/// model returned nothing actionable.
+#[async_trait]
+pub trait AgentInferenceModel: Send + Sync {
+    async fn infer(&self, ctx: &InferenceContext<'_>) -> Result<Option<Action>, AgentError>;
+}

--- a/rust/agent/src/inference/mod.rs
+++ b/rust/agent/src/inference/mod.rs
@@ -6,7 +6,10 @@
 
 mod anthropic;
 
-pub use anthropic::{AnthropicAgentInferenceModel, AnthropicModel};
+pub use anthropic::{
+    AnthropicAgentInferenceModel, AnthropicBeta, AnthropicBetas, AnthropicModel,
+    AnthropicRequestConfig,
+};
 
 use async_trait::async_trait;
 

--- a/rust/agent/src/lib.rs
+++ b/rust/agent/src/lib.rs
@@ -17,7 +17,8 @@ mod trajectory;
 
 pub use error::AgentError;
 pub use inference::{
-    AgentInferenceModel, AnthropicAgentInferenceModel, AnthropicModel, InferenceContext,
+    AgentInferenceModel, AnthropicAgentInferenceModel, AnthropicBeta, AnthropicBetas,
+    AnthropicModel, AnthropicRequestConfig, InferenceContext,
 };
 pub use provider::ProviderFormat;
 pub use tool::{DynTool, Tool, ToolCallMetadata, ToolSet};

--- a/rust/agent/src/lib.rs
+++ b/rust/agent/src/lib.rs
@@ -3,17 +3,22 @@
 //!
 //! So far this crate provides the [`ProviderFormat`] dispatch seam, the
 //! crate-wide [`AgentError`] type, the tool abstraction ([`Tool`] /
-//! [`DynTool`] / [`ToolSet`]) with a dummy [`GetWeatherTool`], and the
-//! [`Trajectory`] record. The inference models and the agent driver land in
-//! subsequent PRs (see `plans/`).
+//! [`DynTool`] / [`ToolSet`]) with a dummy [`GetWeatherTool`], the
+//! [`Trajectory`] record, and inference models ([`AgentInferenceModel`] /
+//! [`AnthropicAgentInferenceModel`]). The agent driver lands in a subsequent PR
+//! (see `plans/`).
 
 mod error;
+mod inference;
 mod provider;
 mod tool;
 pub mod tools;
 mod trajectory;
 
 pub use error::AgentError;
+pub use inference::{
+    AgentInferenceModel, AnthropicAgentInferenceModel, AnthropicModel, InferenceContext,
+};
 pub use provider::ProviderFormat;
 pub use tool::{DynTool, Tool, ToolCallMetadata, ToolSet};
 pub use tools::weather::{GetWeatherTool, TemperatureUnit};


### PR DESCRIPTION
## Description of changes

PR **4/5** of the Rust agent port (stacked on `hammad/rust-agent-trajectory`).
Adds inference models.

- New functionality
  - `inference/mod.rs`: `InferenceContext` (the possibly-masked trajectory view +
    toolset + optional `max_tokens`) and the provider-agnostic
    `AgentInferenceModel` trait.
  - `inference/anthropic.rs`: `AnthropicAgentInferenceModel` calling the Anthropic
    Messages API via `reqwest` (non-streaming; thinking enabled with the
    `interleaved-thinking` beta header). `AnthropicModel` enum (`Opus4_5` /
    `Sonnet4_5`). A pure `parse_anthropic_response(&Value, &ToolSet)` helper
    (testable without network) maps response content blocks into an `Action`:
    `thinking` → `Reasoning`, `text` → `SendUserText`, `tool_use` → `Call` (name
    validated against the toolset), `redacted_thinking` → `Unsupported`.
  - `error.rs`: add `Http` (from `reqwest`) and `Config` variants.

## Test plan

- [x] Tests pass locally with `cargo test -p chroma-agent`:
  - fixture-JSON parser tests (no network) assert the content-block → `Action`
    mapping plus the unknown-tool, empty-content, and redacted-thinking edges.
- [x] A live single-shot inference test is gated behind `ANTHROPIC_API_KEY` and
      `#[ignore]` (skipped by default locally and in CI, which has no key).
      Verified passing manually against the real API.
- [x] clippy/fmt clean.

## Migration plan

None — additive; the crate is not yet wired into a binary or service.

## Observability plan

Live calls go through `reqwest` against the Anthropic API, but there is no
service wiring yet, so no metrics/tracing are added in this PR.

## Documentation Changes

Rustdoc on `AgentInferenceModel`, `InferenceContext`, and the Anthropic model.
No docs-site changes.