### PR TITLE
[BUG](api): fix order-dependent bool/int type check in validate_where

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1270,7 +1270,11 @@ def validate_where(where: Where) -> None:
                     )
                 if isinstance(operand, list) and (
                     len(operand) == 0
-                    or not all(isinstance(x, type(operand[0])) for x in operand)
+                    or not all(
+                        (bool if isinstance(x, bool) else type(x))
+                        is (bool if isinstance(operand[0], bool) else type(operand[0]))
+                        for x in operand
+                    )
                 ):
                     raise ValueError(
                         f"Expected where operand value to be a non-empty list, and all values to be of the same type "


### PR DESCRIPTION
## Problem

`validate_where` rejects mixed `bool`/`int` lists inconsistently depending on element order:

```python
validate_where({"field": {"$in": [True, 1]}})  # raises ValueError
validate_where({"field": {"$in": [1, True]}})  # silently accepted -- BUG
```

Because `bool` is a subclass of `int`, `isinstance(True, int)` returns `True` but `isinstance(1, bool)` returns `False`. The existing type check `isinstance(x, type(operand[0]))` flips its result depending on which element appears first.

## Fix

Normalize the type check to distinguish `bool` from `int` before the `isinstance` comparison, matching the existing pattern already used in `_validate_metadata_list_value` (lines 1050-1054 of the same file).

The fix ensures both `[True, 1]` and `[1, True]` are consistently rejected, while homogeneous lists of `bool`, `int`, `float`, or `str` continue to be accepted.

## Verification

```python
from chromadb.api.types import validate_where

# Both now correctly rejected:
validate_where({"f": {"$in": [True, 1]}})   # ValueError
validate_where({"f": {"$in": [1, True]}})   # ValueError

# Homogeneous lists still accepted:
validate_where({"f": {"$in": [1, 2, 3]}})   # OK
validate_where({"f": {"$in": [True, False]}})  # OK

# Works for $nin too:
validate_where({"f": {"$nin": [1, True]}})  # ValueError
```

Fixes #7181