### PR TITLE
[BUG](api): Fix order-dependent $in/$nin type check

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1176,6 +1176,12 @@ def validate_metadatas(metadatas: Metadatas) -> Metadatas:
     return metadatas
 
 
+def _normalized_scalar_type(value: object) -> type:
+    # bool must be normalized before int since isinstance(True, int) is True, which would
+    # otherwise make homogeneity checks order-dependent for mixed bool/int lists.
+    return bool if isinstance(value, bool) else type(value)
+
+
 def validate_where(where: Where) -> None:
     """
     Validates where to ensure it is a dictionary of strings to strings, ints, floats or operator expressions,
@@ -1270,7 +1276,10 @@ def validate_where(where: Where) -> None:
                     )
                 if isinstance(operand, list) and (
                     len(operand) == 0
-                    or not all(isinstance(x, type(operand[0])) for x in operand)
+                    or not all(
+                        _normalized_scalar_type(x) is _normalized_scalar_type(operand[0])
+                        for x in operand
+                    )
                 ):
                     raise ValueError(
                         f"Expected where operand value to be a non-empty list, and all values to be of the same type "

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -2276,6 +2276,28 @@ def test_where_contains_validation():
     )
 
 
+def test_where_in_mixed_bool_int_rejected_order_independent():
+    """Regression test for #7181.
+
+    A mixed bool/int list must be rejected regardless of element order. Because bool is a
+    subclass of int, the previous isinstance-based homogeneity check flipped depending on which
+    element appeared first.
+    """
+    from chromadb.api.types import validate_where
+
+    with pytest.raises(ValueError):
+        validate_where({"field": {"$in": [True, 1]}})
+    with pytest.raises(ValueError):
+        validate_where({"field": {"$in": [1, True]}})
+    with pytest.raises(ValueError):
+        validate_where({"field": {"$nin": [1, True]}})
+
+    # Homogeneous lists are still accepted.
+    validate_where({"field": {"$in": [1, 2, 3]}})
+    validate_where({"field": {"$in": [True, False]}})
+    validate_where({"field": {"$nin": ["a", "b"]}})
+
+
 def _is_python_local_segment(client):
     """Return True when the client is backed by the Python local segment API
     (which does not yet support array metadata)."""


### PR DESCRIPTION
## Description of changes

Fixes #7181

`validate_where` enforced list homogeneity for `$in` / `$nin` operands with `isinstance(x, type(operand[0]))`. Because `bool` is a subclass of `int`, `isinstance(True, int)` is `True` but `isinstance(1, bool)` is `False`, so the same mixed bool/int list was accepted or rejected depending on element order:

```python
validate_where({"field": {"$in": [True, 1]}})  # raised ValueError
validate_where({"field": {"$in": [1, True]}})  # silently accepted (bug)
```

This normalizes each element's type (treating `bool` before `int`) before comparing, via a small `_normalized_scalar_type` helper, mirroring the existing correct handling in `_validate_metadata_list_value`. Mixed bool/int lists are now rejected consistently regardless of order, and homogeneous lists are unaffected.

## Test plan

Added a regression test in `chromadb/test/test_api.py` asserting both `[True, 1]` and `[1, True]` are rejected for `$in` and `$nin`, while homogeneous int, bool, and string lists are still accepted. Existing `validate_where` tests pass.

*This contribution was prepared with the assistance of an AI agent; all changes were reviewed and verified locally.*

## Documentation Changes

None