### PR TITLE
[ENH] Add system prompt to agent-core

### DIFF
--- a/plans/foundation_agent_and_tools_d6d72ead.plan.md
+++ b/plans/foundation_agent_and_tools_d6d72ead.plan.md
@@ -3,13 +3,13 @@ name: Foundation agent and tools
 overview: Add two retrieval tools to foundation-api — `/api/search` (hybrid dense+sparse RRF over the wiki collection) and `/api/subagent_search` (proxy to the external context-1 deep-research API) — each as a standalone route, then expose both as `chroma-agent` tools behind a new SSE-streaming `/api/agent` route that runs the agent loop with a selectable Anthropic model.
 todos:
   - id: config
-    content: Add query_endpoint_url + deep_research_api_url to FoundationConfig (config.rs)
+    content: Add deep_research_api_url to FoundationConfig (reuse frontend_ingress_url for query plane)
     status: pending
   - id: deps
-    content: Add chroma, chroma-agent, reqwest, futures, async-stream deps to foundation-api (+ workspace async-stream)
+    content: Add chroma-agent, futures, async-stream deps to foundation-api (chroma/reqwest already present; + workspace async-stream)
     status: pending
-  - id: client-helper
-    content: "Add chroma_client.rs: build HTTP client, resolve wiki collection, build Qwen+SPLADE embedders"
+  - id: embed-dense
+    content: "Add WikiEmbedder::embed_dense wrapper over existing ChromaCloudQwenEmbeddingFunction.embed_query_strs; reuse WikiClient for collection access"
     status: pending
   - id: search
     content: Implement run_hybrid_search core + /api/search route (RRF dense+sparse)
@@ -18,7 +18,7 @@ todos:
     content: Implement deep-research stream + collect cores + /api/subagent_search SSE proxy route
     status: pending
   - id: system-prompt
-    content: Add optional system prompt to AnthropicAgentInferenceModel in chroma-agent
+    content: "Add system to InferenceContext + Agent::with_system_prompt (behavior-overridable); render in Anthropic request_body; add with_client for pool reuse"
     status: pending
   - id: tools
     content: Implement SearchTool + SubagentSearchTool (chroma-agent Tool impls) over shared cores
@@ -27,7 +27,7 @@ todos:
     content: Implement /api/agent SSE route driving the agent loop with selectable Anthropic model
     status: pending
   - id: register
-    content: Register routes in routes/mod.rs (+ AuthzAction::RunAgent if needed)
+    content: Register routes in routes/mod.rs (reuse AuthzAction::ViewFoundation)
     status: pending
   - id: tests
     content: Add offline unit tests (RRF payload, SSE parse, system prompt, stubbed agent loop) + fmt/clippy
@@ -45,7 +45,13 @@ Three new routes on `foundation-api`, sharing core logic between a plain route a
 - `POST /api/subagent_search` — proxy to the external "context-1" deep-research API (SSE passthrough).
 - `POST /api/agent` — SSE-streaming agent loop using `chroma-agent`, with a selectable Anthropic model and both tools registered.
 
-Decisions (confirmed): retrieval via the `rust/chroma` HTTP client against a configured Chroma query endpoint; `/agent` streams SSE (mirroring OpenAI/Anthropic `stream: true` and the Python reference); Anthropic models only (`Opus4_5`/`Sonnet4_5`), key from `ANTHROPIC_API_KEY`; collection fixed to the foundation wiki collection.
+Decisions (confirmed): retrieval reuses the existing `WikiClient` (a scoped `ChromaHttpClient` proxy to `frontend_ingress_url`) rather than a new client; `/agent` streams SSE (mirroring OpenAI/Anthropic `stream: true` and the Python reference); Anthropic models only (`Opus4_5`/`Sonnet4_5`), key from `ANTHROPIC_API_KEY`; collection fixed to the foundation wiki collection.
+
+### Post-rebase reuse (what main already provides)
+The rebase added most of the data-plane plumbing this plan originally specified. Reuse it instead of re-building:
+- [`WikiClient`](rust/foundation-api/src/wiki/client.rs) — a `ChromaHttpClient` built from `frontend_ingress_url`, with `scoped_client(tenant, token)` (uses the caller's `x-chroma-token` + `database_name`) and `wiki_collection(tenant, token) -> ChromaCollection` (cached per tenant). Stored on `FoundationApiServer.wiki_client: Option<WikiClient>`. **This replaces the planned `chroma_client.rs` helper and the `query_endpoint_url` config field** (use `frontend_ingress_url`).
+- [`WikiEmbedder`](rust/foundation-api/src/wiki/embed.rs) — runtime SPLADE via `ChromaCloudSpladeEmbeddingFunction` (`embed_sparse(token, docs)`), auth'd by the caller's token, endpoint from `CHROMA_EMBED_URL`/SDK default. **Only the dense Qwen query path is missing** (see Changes §3).
+- Auth/creds pattern: per-request `x-chroma-token` (helper `chroma_token(headers)` in `upsert_page.rs`), tenant from `whoami_and_authorize`, database from `config.foundation.database_name`. **No `CHROMA_API_KEY` env** — drop that from the original plan.
 
 ## Architecture
 
@@ -65,8 +71,8 @@ flowchart TD
     subRoute --> drCore["stream_deep_research()"]
     subTool --> drCollect["collect_deep_research_final()"]
 
-    searchCore -->|"embed Qwen+SPLADE, rrf() RankExpr"| chromaClient["rust/chroma HTTP client"]
-    chromaClient -->|"POST /search"| chromaQuery[(Chroma query endpoint)]
+    searchCore -->|"WikiEmbedder Qwen+SPLADE, rrf() RankExpr"| wikiClient["WikiClient (ChromaHttpClient -> FE)"]
+    wikiClient -->|"POST /search"| chromaQuery[(Chroma frontend / query plane)]
     drCore --> deepApi[(context-1 deep-research API)]
     loop -->|infer| anthropic[(Anthropic Messages API)]
 ```
@@ -76,45 +82,59 @@ Key insight from research: the Chroma `/search` endpoint does **not** embed quer
 ## Changes
 
 ### 1. Config — [rust/foundation-api/src/config.rs](rust/foundation-api/src/config.rs)
-Add to `FoundationConfig` (same `Option<String>` pattern as `function_endpoint_url`):
-- `query_endpoint_url: Option<String>` — base URL of the Chroma query frontend the `rust/chroma` client targets.
+Add **one** field to `FoundationConfig` (same `Option<String>` pattern as `function_endpoint_url`):
 - `deep_research_api_url: Option<String>` — base URL of the context-1 deep-research API (e.g. `https://chroma-core--search-agent-api-serve.modal.run`).
 
-Handlers read `server.config.foundation.*`; missing values produce a typed `ChromaError` (mirror `MissingFunctionEndpointUrl` in [init.rs](rust/foundation-api/src/routes/init.rs)). `CHROMA_API_KEY` env supplies both the client cloud token and the embedding-function key; tenant/database come from the auth identity (`whoami_and_authorize`).
+Do **not** add a query endpoint URL — reuse the existing `frontend_ingress_url` (already drives `WikiClient`). Handlers read `server.config.foundation.*`; a missing `deep_research_api_url` disables `/api/subagent_search` and the subagent tool (return a typed `RouteDisabled`-style error, mirroring how `wiki_client == None` disables `/api/upsert-page`). Creds are the per-request `x-chroma-token` + tenant from `whoami_and_authorize` + `database_name` from config — no `CHROMA_API_KEY` env.
 
-### 2. Dependencies — [rust/foundation-api/Cargo.toml](rust/foundation-api/Cargo.toml)
-Add: `chroma` (HTTP client, embeddings, search types), `chroma-agent` (agent loop), `reqwest` (json), `futures`, and a new workspace dep `async-stream = "0.3"` (added to root `[workspace.dependencies]`) for building the SSE `Stream`. Axum SSE uses `axum::response::sse::{Sse, Event, KeepAlive}` (already available via the workspace `axum`).
+### 2. Dependencies + shared HTTP client — [rust/foundation-api/Cargo.toml](rust/foundation-api/Cargo.toml), [server.rs](rust/foundation-api/src/server.rs)
+`chroma` and `reqwest` are already present after the rebase. Add only: `chroma-agent` (agent loop), `futures` (stream utils), and a new workspace dep `async-stream = "0.3"` (added to root `[workspace.dependencies]`) for building the SSE `Stream`. Axum SSE uses `axum::response::sse::{Sse, Event, KeepAlive}` (already available via the workspace `axum`).
 
-### 3. Chroma client helper — `rust/foundation-api/src/chroma_client.rs` (new)
-- `build_client(cfg, tenant, database) -> ChromaHttpClient` using `ChromaHttpClientOptions` with `endpoint = query_endpoint_url`, `ChromaAuthMethod::cloud_api_key(CHROMA_API_KEY)`, tenant, database.
-- `wiki_collection(client, cfg) -> ChromaCollection` via `client.get_collection(cfg.wiki_collection)`.
-- Build the Qwen dense + SPLADE sparse embedding functions (`chroma::embed::chroma_cloud::ChromaCloudQwenEmbeddingFunction` / `...SpladeEmbeddingFunction` builders, `api_key_env_var("CHROMA_API_KEY")`, models `Qwen/Qwen3-Embedding-0.6B` and `prithivida/Splade_PP_en_v1` — matching [init.rs](rust/foundation-api/src/routes/init.rs) lines 329-358).
+Add a shared `http_client: reqwest::Client` field to `FoundationApiServer` (built once at startup). It is cloned per request into the Anthropic model (`with_client`), the deep-research stream, and embedding functions where supported, so connection pools are reused rather than recreated.
+
+### 3. Dense query embedding — thin wrapper in [rust/foundation-api/src/wiki/embed.rs](rust/foundation-api/src/wiki/embed.rs)
+The dense embedding function **already exists** in the rust client: [`ChromaCloudQwenEmbeddingFunction`](rust/chroma/src/embed/chroma_cloud.rs) (sibling of the SPLADE one `WikiEmbedder` already uses). It implements `EmbeddingFunction::embed_query_strs`, which applies the **query-side instruction** (vs `embed_strs` for documents) — exactly what query embedding needs. So this is *not* new embedding logic; just a ~10-line `WikiEmbedder::embed_dense(token, queries) -> Vec<Vec<f32>>` that builds the function and calls `embed_query_strs`, mirroring the existing `embed_sparse`.
+- Build via `ChromaCloudQwenEmbeddingFunction::builder().api_key(token)` matching the wiki collection's EF (model `Qwen/Qwen3-Embedding-0.6B`, task + instructions per `qwen_embedding_function()` in [init.rs](rust/foundation-api/src/routes/init.rs)) so query and document vectors share a space.
+- Note: the exact config-driven constructor `ChromaCloudQwenEmbeddingFunction::try_from_config(&EmbeddingFunctionNewConfiguration, client_api_key)` is `pub(crate)`. To reconstruct the EF directly from the collection's stored config (avoiding duplicating init's task/instructions), either promote a public constructor in `rust/chroma`, or mirror init's builder config in foundation-api. Default: mirror init's config for now.
+- Sparse query vector: reuse the existing `embed_sparse` (SPLADE's `embed_query_strs` defaults to `embed_strs`, so query == document — fine).
+
+No new `chroma_client.rs` — the search path resolves its collection through `WikiClient::wiki_collection(tenant, token)`.
 
 ### 4. `/api/search` — `rust/foundation-api/src/routes/search.rs` (new)
 - `SearchParams { query: String, limit: Option<u32> }`, `SearchHit { id, document, score, metadata }`.
-- Core `run_hybrid_search(collection, qwen, splade, params) -> Vec<SearchHit>`:
-  1. `qwen.embed_query_strs(&[query])` and `splade.embed_query_strs(&[query])` (client-side).
+- Core `run_hybrid_search(collection: &ChromaCollection, embedder: &WikiEmbedder, token, params) -> Vec<SearchHit>`:
+  1. `embedder.embed_dense(token, &[query])` and `embedder.embed_sparse(token, &[query])` (caller-token-authed, client-side).
   2. Build `rrf(vec![dense_knn(Key::Embedding), sparse_knn(Key::field("sparse_embedding"))], Some(60), None, false)` with `return_rank: true` on both KNN nodes.
   3. `collection.search(vec![SearchPayload::default().rank(rrf).limit(Some(limit),0).select([Key::Document, Key::Score, Key::Metadata])])`, map to hits.
-- Handler `foundation_search`: `whoami_and_authorize(AuthzAction::Search)`, scorecard guard, build client/collection/embedders, call core, return `Json<Vec<SearchHit>>`.
+- Handler `foundation_search`: `whoami_and_authorize(AuthzAction::ViewFoundation)`, scorecard guard, `token = chroma_token(headers)`, `collection = server.wiki_client.as_ref().ok_or(RouteDisabled)?.wiki_collection(tenant, token).await?`, call core, return `Json<Vec<SearchHit>>`.
 
 ### 5. `/api/subagent_search` — `rust/foundation-api/src/routes/subagent_search.rs` (new)
-Deep-research API contract (from [search_agent_client.py](file:///Users/hammad/Documents/search_agent_research/inference/search_agent_client.py)): `POST {url}/search` with `{query, model, collection_name, chroma_api_key, chroma_tenant, chroma_database, use_nx1_prompt}`, `Accept: text/event-stream`; SSE `data:` lines of `{type: action|observation|done|error, data}`.
-- `stream_deep_research(cfg, creds, params) -> impl Stream<Item=Event>`: reqwest streaming POST, forward upstream SSE lines as axum SSE events.
+Deep-research API contract (from [search_agent_client.py](file:///Users/hammad/Documents/search_agent_research/inference/search_agent_client.py)): `POST {url}/search` with `{query, model, collection_name, chroma_api_key, chroma_tenant, chroma_database}`, `Accept: text/event-stream`; SSE `data:` lines of `{type: action|observation|done|error, data}`. (`use_nx1_prompt` is not exposed — rely on the upstream default.)
+- `stream_deep_research(url, creds, params) -> impl Stream<Item=Event>`: reqwest streaming POST, forward upstream SSE lines as axum SSE events. `creds` = `{ chroma_api_key: x-chroma-token, chroma_tenant: identity.tenant, chroma_database: config.database_name, collection_name: config.wiki_collection }`.
 - `collect_deep_research_final(...) -> String`: consume the stream, return the final `user_text` from the last `action` (the terminal answer) — used by the tool.
-- Handler `foundation_subagent_search`: auth + scorecard, return `Sse` proxying `stream_deep_research`.
+- Handler `foundation_subagent_search`: `whoami_and_authorize(AuthzAction::ViewFoundation)` + scorecard, resolve `deep_research_api_url` (else `RouteDisabled`), return `Sse` proxying `stream_deep_research`.
 
 ### 6. Agent tools — `rust/foundation-api/src/agent_tools/{mod.rs,search_tool.rs,subagent_search_tool.rs}` (new)
-Each implements `chroma_agent::Tool`, carrying per-request state as struct fields (no `RuntimeParams` needed; `type RuntimeParams = ()`):
-- `SearchTool { collection, qwen, splade }`: `ModelSuppliedParams { query, limit }`; `call()` runs `run_hybrid_search` and formats hits into a text block for the model. `name = "search"`.
-- `SubagentSearchTool { http, url, creds, collection_name, model }`: `ModelSuppliedParams { query }`; `call()` runs `collect_deep_research_final` and returns the text. `name = "subagent_search"`.
+Each implements `chroma_agent::Tool`, carrying per-request state as struct fields (no `RuntimeParams` needed; `type RuntimeParams = ()`). State is resolved once in the `/api/agent` handler (collection via `WikiClient`, token from headers):
+- `SearchTool { collection: ChromaCollection, embedder: WikiEmbedder, token: String }`: `ModelSuppliedParams { query, limit }`; `call()` runs `run_hybrid_search` and formats hits into a text block for the model. `name = "search"`.
+- `SubagentSearchTool { http, url, creds, model }`: `ModelSuppliedParams { query }`; `call()` runs `collect_deep_research_final` and returns the text. `name = "subagent_search"`.
 
-### 7. Agent crate — system prompt support — [rust/agent/src/inference/anthropic.rs](rust/agent/src/inference/anthropic.rs)
-Add `system: Option<String>` to `AnthropicAgentInferenceModel` with `with_system_prompt(self, String)`; include `"system"` in `request_body` when present. Small additive change so `/agent` can steer the agent (the crate's `prompts.rs` was deferred).
+### 7. Agent crate — system prompt (generic) + reusable HTTP client — [agent.rs](rust/agent/src/agent.rs), [inference/mod.rs](rust/agent/src/inference/mod.rs), [inference/anthropic.rs](rust/agent/src/inference/anthropic.rs)
+Decision (answering "should it be on the inference-model trait / a provider thing?"): **no to provider-specific.** The system prompt is part of the *agent definition* and should have a generic entrypoint. It is the same shape as `max_tokens`, which already lives on `InferenceContext` and is set generically: the `AgentBehavior::prepare_for_inference(&mut ctx)` hook exists precisely to project run-level config into each per-call view. So:
+- Add `system: Option<String>` to `InferenceContext` (generic field, alongside `max_tokens`). This is the provider-agnostic transport; only the wire-rendering is provider-specific.
+- Add `Agent::with_system_prompt(impl Into<String>)` storing `system_prompt: Option<String>` (the agent-definition entrypoint). In `Agent::infer`, initialize `ctx.system = self.system_prompt.clone()` **before** running `prepare_for_inference`, so a behavior can override it via the existing hook (the "behavior" route — no new hook needed).
+- `AnthropicAgentInferenceModel::request_body` reads `ctx.system` and emits top-level `"system"` when present. The `AgentInferenceModel` trait is unchanged.
+
+This keeps ownership at the agent/behavior layer (run-constant source of truth), uses the generic `InferenceContext` as transport (matching `max_tokens`), and confines provider knowledge to wire rendering — not a per-provider `with_system_prompt`.
+
+Separately (connection-pool reuse, see §8): `AnthropicAgentInferenceModel::new` does `reqwest::Client::new()`, creating a fresh pool per construction. Add `with_client(reqwest::Client)` / `new_with_client(...)` so the `/agent` route injects a shared client and reuses its pool.
 
 ### 8. `/api/agent` — `rust/foundation-api/src/routes/agent.rs` (new)
+- `whoami_and_authorize(AuthzAction::ViewFoundation)` + scorecard.
 - `AgentParams { query: String, model: String }`; map `model` -> `AnthropicModel` (`"opus"|"opus-4.5" => Opus4_5`, `"sonnet"|"sonnet-4.5" => Sonnet4_5`), else 400.
-- Build `AnthropicAgentInferenceModel::from_env(model).with_system_prompt(SEARCH_SYSTEM_PROMPT)`, a `ToolSet` with `SearchTool` + `SubagentSearchTool`, and `Agent::new(toolset, Box::new(model))`.
+- Resolve `token`/`tenant`, build the wiki `ChromaCollection` via `WikiClient`, a `WikiEmbedder`, and the deep-research creds.
+- Build `AnthropicAgentInferenceModel::from_env(model).with_client(shared_http)` (provider/transport config only), a `ToolSet` with `SearchTool` + `SubagentSearchTool`, and `Agent::new(toolset, Box::new(model)).with_system_prompt(SEARCH_SYSTEM_PROMPT)` (the system prompt is set on the agent, not the model).
+- **Connection-pool reuse**: hold a shared `reqwest::Client` on `FoundationApiServer` (clone it into the Anthropic model via `with_client`, into the deep-research stream, and — where possible — into the embedding functions). `reqwest::Client` is `Clone` and clones share one pool, so clone-per-request is cheap; constructing fresh clients per request is not. `WikiClient`'s `ChromaHttpClient` already reuses its own pool.
 - Drive manually inside an `async_stream::stream!` (spawned with an mpsc sender; `Agent` is `Send`), emitting SSE events that mirror the reference schema:
   - `reset()`, `observe(ObservationBuilder::push_user(query))`
   - loop: `infer()` -> emit `{type:"action", data:{step, reasoning, tools:[{name,params}]}}`; `act()` -> emit `{type:"observation", data:{step, results:[{call_id,text}]}}` and `observe`; until `is_done()` or `infer` -> None.
@@ -130,16 +150,51 @@ Router::new()
     .route("/api/subagent_search", post(subagent_search::foundation_subagent_search))
     .route("/api/agent", post(agent::foundation_agent))
 ```
-Add an `AuthzAction::RunAgent` variant in [frontend-core/src/auth.rs](rust/frontend-core/src/auth.rs) if a distinct authz action is wanted (else reuse `Search`).
+Authz: reuse the existing `AuthzAction::ViewFoundation` (the foundation "viewer" level) for all three routes — they are read/retrieval paths. No new `AuthzAction` variant needed.
+
+## PR stack
+
+Three stacked PRs, each branch off the previous. PR 1 is `chroma-agent`-only and independent; PRs 2–3 are foundation-api and build on it.
+
+```mermaid
+flowchart LR
+    pr1["PR 1 hammad/agent-system-prompt<br/>(chroma-agent)"] --> pr2["PR 2 hammad/foundation-search-tools<br/>(/api/search + /api/subagent_search)"] --> pr3["PR 3 hammad/foundation-agent-route<br/>(/api/agent loop)"]
+```
+
+### PR 1 — `hammad/agent-system-prompt`
+- Scope (todo: `system-prompt`): in `chroma-agent`, add `system: Option<String>` to `InferenceContext`; `Agent::with_system_prompt` (seeded into `ctx.system` before `prepare_for_inference`, so behaviors can override); render top-level `"system"` in `AnthropicAgentInferenceModel::request_body`; add `with_client(reqwest::Client)` for pool reuse. Trait unchanged.
+- Test plan:
+  - Unit: `Agent::with_system_prompt` value reaches `ctx.system`; `request_body` includes top-level `system` when set and omits it by default.
+  - Unit: a stub `prepare_for_inference` behavior overrides `ctx.system`.
+  - Unit: `with_client` stores the injected client (e.g. construct two models from one client; assert no panic / pool reuse via type).
+  - `cargo test/clippy/fmt -p chroma-agent` clean; existing live Anthropic `#[ignore]` test still compiles.
+
+### PR 2 — `hammad/foundation-search-tools`
+- Scope (todos: `config`, `deps`, `embed-dense`, `search`, `subagent`): add `deep_research_api_url` to `FoundationConfig` (reuse `frontend_ingress_url` for the query plane); add `chroma-agent`/`futures`/workspace `async-stream` deps + shared `http_client` on `FoundationApiServer`; add `WikiEmbedder::embed_dense`; implement `run_hybrid_search` + `POST /api/search`; implement deep-research stream/collect cores + `POST /api/subagent_search` (SSE). Both routes use `AuthzAction::ViewFoundation`. No agent loop yet.
+- Test plan:
+  - Unit: config parse for `deep_research_api_url` (present + fail-closed when absent, mirroring `function_endpoint_url`).
+  - Unit: `run_hybrid_search` builds the RRF `SearchPayload` — two `$knn` nodes, `return_rank: true`, sparse key `sparse_embedding` — without network.
+  - Unit: deep-research SSE parser turns a canned transcript into forwarded events / final text.
+  - Integration (offline, `httpmock` already a dev-dep): `/api/search` against a mocked FE search response; `/api/subagent_search` against a mocked upstream SSE stream.
+  - Manual/live (`#[ignore]`): `/api/search` and `/api/subagent_search` against a real deployment.
+  - `cargo build/clippy/fmt -p foundation-api` clean.
+
+### PR 3 — `hammad/foundation-agent-route`
+- Scope (todos: `tools`, `agent-route`, `register`, `tests`): implement `SearchTool` + `SubagentSearchTool` (`chroma-agent` `Tool` impls over the PR-2 cores); implement `POST /api/agent` SSE route driving the loop with a selectable Anthropic model, `with_client(shared_http)` + `with_system_prompt`; register all three routes in `routes/mod.rs`.
+- Test plan:
+  - Unit: model-string mapping (`opus`/`sonnet` → `AnthropicModel`, unknown → 400).
+  - Unit: offline agent loop with a stub inference model + stub tools, asserting the SSE event order (`action` → `observation` → `done`), incl. a tool-error path surfaced as an observation (per `ToolErrorPolicy::ReportToModel`).
+  - Manual/live (`#[ignore]`, `ANTHROPIC_API_KEY` + deployment): end-to-end `/api/agent` run that calls `search`/`subagent_search`.
+  - `cargo build/clippy/fmt -p foundation-api` clean.
 
 ## Testing
-- `chroma-agent`: unit test that `with_system_prompt` puts `system` in the request body.
+- `chroma-agent`: unit test that `Agent::with_system_prompt` lands as `InferenceContext.system` and that `AnthropicAgentInferenceModel::request_body` emits top-level `system` (omitted by default); plus a test that a `prepare_for_inference` behavior can override `ctx.system`.
 - `search.rs`: unit test building the RRF `SearchPayload` (assert two `$knn` nodes, `return_rank: true`, sparse key `sparse_embedding`) without network.
 - `subagent_search.rs`: unit test parsing a canned SSE transcript into the final text.
 - `agent.rs`: offline test driving the loop with a stub inference model + stub tools, asserting the SSE event sequence (action -> observation -> done). Live Anthropic/deep-research paths gated behind env (`#[ignore]`), per repo convention.
 - `cargo build/clippy/fmt -p foundation-api` and `-p chroma-agent` clean.
 
 ## Open items / deploy inputs
-- `query_endpoint_url` and `deep_research_api_url` are deploy-provided (no defaults, fail-closed like `function_endpoint_url`). The deep-research URL default in the reference is `https://chroma-core--search-agent-api-serve.modal.run`.
-- Confirm the wiki collection's sparse index key is `sparse_embedding` (matches init schema) and that the query endpoint resolves the wiki collection by name for the request's tenant/database.
+- `deep_research_api_url` is deploy-provided (no default, fail-closed; route/tool disabled when unset). The reference default is `https://chroma-core--search-agent-api-serve.modal.run`. The query plane reuses the already-configured `frontend_ingress_url`.
+- Confirm the wiki collection's sparse index key is `sparse_embedding` (matches init schema) and that the dense Qwen query EF config matches the collection's (`Qwen/Qwen3-Embedding-0.6B`, `generic_retrieval`) so vectors share a space.
 - The Anthropic inference model is non-streaming, so `/agent` SSE is step-level (action/observation), not token-level — consistent with the Python reference.

--- a/rust/agent/src/agent.rs
+++ b/rust/agent/src/agent.rs
@@ -90,6 +90,7 @@ pub struct Agent {
     behaviors: Vec<Box<dyn AgentBehavior>>,
     max_trajectory_length: usize,
     tool_error_policy: ToolErrorPolicy,
+    system_prompt: Option<String>,
     builder: TrajectoryBuilder,
 }
 
@@ -102,6 +103,7 @@ impl Agent {
             behaviors: Vec::new(),
             max_trajectory_length: DEFAULT_MAX_TRAJECTORY_LENGTH,
             tool_error_policy: ToolErrorPolicy::default(),
+            system_prompt: None,
             builder: TrajectoryBuilder::new(),
         }
     }
@@ -109,6 +111,15 @@ impl Agent {
     /// Register a behavior (invoked after any already-registered behaviors).
     pub fn with_behavior(mut self, behavior: Box<dyn AgentBehavior>) -> Self {
         self.behaviors.push(behavior);
+        self
+    }
+
+    /// Set the system prompt sent on every inference call. It is seeded into
+    /// [`InferenceContext::system`] before behaviors run, so a
+    /// [`AgentBehavior::prepare_for_inference`] hook can still override it. How
+    /// the prompt is rendered on the wire is the inference model's concern.
+    pub fn with_system_prompt(mut self, system_prompt: impl Into<String>) -> Self {
+        self.system_prompt = Some(system_prompt.into());
         self
     }
 
@@ -175,6 +186,7 @@ impl Agent {
             trajectory: self.builder.trajectory().clone(),
             toolset: &self.toolset,
             max_tokens: None,
+            system: self.system_prompt.clone(),
         };
         for behavior in &mut self.behaviors {
             behavior.prepare_for_inference(&mut ctx);
@@ -293,7 +305,7 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::json;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     /// Offline inference model: calls `get_weather` once, then ends with text.
     ///
@@ -527,5 +539,62 @@ mod tests {
             agent.trajectory().entries.last(),
             Some(Entry::Action(_))
         ));
+    }
+
+    /// Records the `system` it sees, then ends the run with a text action.
+    struct CaptureSystem {
+        seen: Arc<Mutex<Option<String>>>,
+    }
+
+    #[async_trait]
+    impl AgentInferenceModel for CaptureSystem {
+        async fn infer(&self, ctx: &InferenceContext<'_>) -> Result<Option<Action>, AgentError> {
+            *self.seen.lock().unwrap() = ctx.system.clone();
+            let mut action = ActionBuilder::new();
+            action.push_send_user_text("done");
+            Ok(Some(action.build()))
+        }
+    }
+
+    fn capture_agent(seen: Arc<Mutex<Option<String>>>) -> Agent {
+        Agent::new(ToolSet::new(), Box::new(CaptureSystem { seen }))
+    }
+
+    async fn infer_once(mut agent: Agent) {
+        let mut initial = ObservationBuilder::new();
+        initial.push_user("hi");
+        agent.observe(initial.build());
+        agent.infer().await.expect("infer succeeds");
+    }
+
+    #[tokio::test]
+    async fn system_prompt_reaches_inference_context() {
+        let seen = Arc::new(Mutex::new(None));
+        infer_once(capture_agent(seen.clone()).with_system_prompt("you are helpful")).await;
+        assert_eq!(seen.lock().unwrap().as_deref(), Some("you are helpful"));
+    }
+
+    #[tokio::test]
+    async fn system_prompt_defaults_to_none() {
+        let seen = Arc::new(Mutex::new(Some("sentinel".to_string())));
+        infer_once(capture_agent(seen.clone())).await;
+        assert!(seen.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn behavior_can_override_system_prompt() {
+        struct OverrideSystem;
+        impl AgentBehavior for OverrideSystem {
+            fn prepare_for_inference(&mut self, ctx: &mut InferenceContext<'_>) {
+                ctx.system = Some("overridden".to_string());
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(None));
+        let agent = capture_agent(seen.clone())
+            .with_system_prompt("original")
+            .with_behavior(Box::new(OverrideSystem));
+        infer_once(agent).await;
+        assert_eq!(seen.lock().unwrap().as_deref(), Some("overridden"));
     }
 }

--- a/rust/agent/src/inference/anthropic.rs
+++ b/rust/agent/src/inference/anthropic.rs
@@ -142,6 +142,15 @@ impl AnthropicAgentInferenceModel {
         Ok(Self::new(api_key, model))
     }
 
+    /// Reuse a shared [`reqwest::Client`] instead of the per-instance one built
+    /// by [`new`](Self::new). Cloning a client shares its connection pool, so a
+    /// caller that builds a model per request can avoid spawning a fresh pool
+    /// each time.
+    pub fn with_client(mut self, client: reqwest::Client) -> Self {
+        self.client = client;
+        self
+    }
+
     /// Replace the request config (max tokens, temperature, thinking budget,
     /// betas).
     pub fn with_config(mut self, config: AnthropicRequestConfig) -> Self {
@@ -157,14 +166,22 @@ impl AnthropicAgentInferenceModel {
     }
 
     fn request_body(&self, ctx: &InferenceContext<'_>) -> Value {
-        json!({
+        let mut body = json!({
             "model": self.model.id(),
             "max_tokens": ctx.max_tokens.unwrap_or(self.config.max_tokens),
             "temperature": self.config.temperature,
             "thinking": { "type": "enabled", "budget_tokens": self.config.thinking_budget },
             "tools": ctx.toolset.get_formats(ProviderFormat::Anthropic),
             "messages": ctx.trajectory.to_provider_format(ProviderFormat::Anthropic),
-        })
+        });
+
+        // Anthropic takes the system prompt as a top-level field; omit it when
+        // unset rather than sending `null`.
+        if let Some(system) = &ctx.system {
+            body["system"] = json!(system);
+        }
+
+        body
     }
 }
 
@@ -302,6 +319,53 @@ mod tests {
     }
 
     #[test]
+    fn request_body_includes_system_only_when_set() {
+        let model = AnthropicAgentInferenceModel::new("test-key", AnthropicModel::Sonnet4_5);
+        let toolset = weather_toolset();
+        let trajectory = {
+            let mut builder = TrajectoryBuilder::new();
+            let mut obs = ObservationBuilder::new();
+            obs.push_user("hi");
+            builder.push_observation(obs.build());
+            builder.build()
+        };
+
+        let ctx = InferenceContext {
+            trajectory: trajectory.clone(),
+            toolset: &toolset,
+            max_tokens: None,
+            system: None,
+        };
+        assert!(model.request_body(&ctx).get("system").is_none());
+
+        let ctx = InferenceContext {
+            trajectory,
+            toolset: &toolset,
+            max_tokens: None,
+            system: Some("Be terse.".to_string()),
+        };
+        assert_eq!(model.request_body(&ctx)["system"], json!("Be terse."));
+    }
+
+    #[test]
+    fn with_client_yields_a_usable_model() {
+        let shared = reqwest::Client::new();
+        let model = AnthropicAgentInferenceModel::new("test-key", AnthropicModel::Opus4_5)
+            .with_client(shared.clone());
+        let toolset = weather_toolset();
+        let ctx = InferenceContext {
+            trajectory: TrajectoryBuilder::new().build(),
+            toolset: &toolset,
+            max_tokens: None,
+            system: None,
+        };
+        assert_eq!(
+            model.request_body(&ctx)["model"],
+            json!("claude-opus-4-5-20251101")
+        );
+    }
+
+    #[test]
     fn parses_content_blocks_into_action() {
         let toolset = weather_toolset();
         let response = json!({
@@ -375,13 +439,20 @@ mod tests {
 
         let mut builder = TrajectoryBuilder::new();
         let mut prompt = ObservationBuilder::new();
-        prompt.push_user("What's the weather in Paris? Use the get_weather tool.");
+        prompt.push_user("What's the weather in Paris?");
         builder.push_observation(prompt.build());
 
+        // Exercise the system-prompt wire path end-to-end: steer tool use via
+        // the system prompt rather than the user turn.
         let ctx = InferenceContext {
             trajectory: builder.build(),
             toolset: &toolset,
             max_tokens: None,
+            system: Some(
+                "You are a weather assistant. Always call the get_weather tool to answer \
+                 weather questions."
+                    .to_string(),
+            ),
         };
 
         let action = model

--- a/rust/agent/src/inference/mod.rs
+++ b/rust/agent/src/inference/mod.rs
@@ -26,6 +26,11 @@ pub struct InferenceContext<'a> {
     pub toolset: &'a ToolSet,
     /// Per-call override for the model's default max output tokens.
     pub max_tokens: Option<u32>,
+    /// System prompt to send with this call. Owned by the agent definition
+    /// (see [`crate::Agent::with_system_prompt`]) and seeded before behaviors
+    /// run, so an [`crate::AgentBehavior::prepare_for_inference`] hook may
+    /// override it. The provider decides how to render it on the wire.
+    pub system: Option<String>,
 }
 
 /// Produces the next [`Action`] from an [`InferenceContext`], or `None` when the


### PR DESCRIPTION
## Description of changes

First PR in the foundation-agent stack. Teaches `chroma-agent` to carry a
system prompt and pass it on the Anthropic wire.

- New functionality
  - `Agent::with_system_prompt(..)` stores an optional system prompt and
    threads it into the per-turn `InferenceContext`.
  - `AnthropicAgentInferenceModel` emits the prompt as the Messages API
    top-level `system` field (omitted when unset).
- Improvements & Bug fixes
  - `InferenceContext` carries the system prompt so any inference model can use
    it without changing the trait's call shape.

## Test plan

- [x] `cargo test -p chroma-agent`
- Unit test asserts the prompt is serialized onto the Anthropic request body;
  the live test exercises the wire path end-to-end.

## Migration plan

None — additive API; the system prompt defaults to absent.

## Observability plan

No new surfaces; covered by existing agent/inference logging.

## Documentation Changes

Docstrings added for the new `with_system_prompt` API and the `system` wire
field.