### PR TITLE
[ENH] Add /search /subagent_search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3652,6 +3652,7 @@ dependencies = [
 name = "foundation-api"
 version = "1.0.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum 0.8.8",
  "chroma",
@@ -3664,6 +3665,7 @@ dependencies = [
  "chroma-types",
  "figment",
  "frontend-core",
+ "futures",
  "httpmock",
  "mdac",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = ["rust/benchmark", "rust/blockstore", "rust/cache", "rust/chroma", "ru
 [workspace.dependencies]
 anyhow = "1.0"
 arrow = "55.1"
+async-stream = "0.3"
 async-trait = "0.1"
 aws-config = { version = "1.5", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1.63"

--- a/rust/agent/src/tool.rs
+++ b/rust/agent/src/tool.rs
@@ -113,6 +113,9 @@ fn params_input_schema<P: JsonSchema>() -> Value {
         s.meta_schema = None;
     });
     let root = settings.into_generator().into_root_schema_for::<P>();
+    // SAFETY(hammadb): a schemars-generated `RootSchema` is a plain data struct
+    // with no non-string map keys or non-finite floats, so `to_value` is
+    // infallible here.
     let mut value = serde_json::to_value(root).expect("schema serializes to JSON");
     if let Some(obj) = value.as_object_mut() {
         obj.remove("title");

--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -1228,18 +1228,66 @@ impl ChromaCollection {
             .map(Some)
     }
 
-    async fn embed_documents(
+    /// Embeds documents with the collection's schema-derived dense embedding
+    /// function, applying the *document-side* instruction.
+    ///
+    /// This is the same path [`add`](Self::add)/[`upsert`](Self::upsert) take
+    /// when embeddings are omitted; it is also exposed publicly as the
+    /// write-side counterpart of [`embed_query`](Self::embed_query) for callers
+    /// that need to embed documents explicitly.
+    ///
+    /// Returns [`ChromaHttpClientError::MissingEmbeddingFunction`] when the
+    /// collection has no dense embedding function configured.
+    pub async fn embed_documents(
         &self,
         input: &[&str],
+    ) -> Result<Vec<Vec<f32>>, ChromaHttpClientError> {
+        self.embed_with(input, false).await
+    }
+
+    /// Embeds query text with the collection's schema-derived dense embedding
+    /// function, applying the *query-side* instruction.
+    ///
+    /// This is the read-side mirror of the write path's document auto-embed
+    /// ([`add`](Self::add) with omitted embeddings): both pull the same EF off
+    /// the collection schema, but documents use the document instruction while
+    /// queries use the query instruction. It is public because — unlike writes,
+    /// which the server auto-embeds — Chroma's Search API takes pre-computed
+    /// query vectors, so search callers must embed the query themselves and
+    /// want the exact EF the collection was built with (no config drift).
+    ///
+    /// Returns [`ChromaHttpClientError::MissingEmbeddingFunction`] when the
+    /// collection has no dense embedding function configured.
+    ///
+    // TODO: when the Search API can auto-embed query text server-side
+    // (mirroring write-side auto-embed), callers could pass raw query text on
+    // the `$knn` rank and let the EF run on the FE. This explicit client-side
+    // path would stay as an option (e.g. local/precomputed embedding), not
+    // necessarily be removed.
+    pub async fn embed_query(
+        &self,
+        input: &[&str],
+    ) -> Result<Vec<Vec<f32>>, ChromaHttpClientError> {
+        self.embed_with(input, true).await
+    }
+
+    /// Shared dense-embedding helper. `query` selects the query-side instruction
+    /// (`embed_query_strs`) over the document-side one (`embed_strs`).
+    async fn embed_with(
+        &self,
+        input: &[&str],
+        query: bool,
     ) -> Result<Vec<Vec<f32>>, ChromaHttpClientError> {
         let embedding_function = self
             .embedding_function
             .as_ref()
             .ok_or(ChromaHttpClientError::MissingEmbeddingFunction)?;
-        let embeddings = embedding_function
-            .embed_strs(input)
-            .await
-            .map_err(|err| ChromaHttpClientError::EmbeddingFunctionError(err.to_string()))?;
+        let embeddings = if query {
+            embedding_function.embed_query_strs(input).await
+        } else {
+            embedding_function.embed_strs(input).await
+        }
+        .map_err(|err| ChromaHttpClientError::EmbeddingFunctionError(err.to_string()))?;
         if embeddings.len() != input.len() {
             return Err(ChromaHttpClientError::EmbeddingFunctionError(format!(
                 "Embedding function returned {} embeddings for {} inputs",

--- a/rust/foundation-api/Cargo.toml
+++ b/rust/foundation-api/Cargo.toml
@@ -8,12 +8,14 @@ name = "foundation_service"
 path = "src/bin/foundation_service.rs"
 
 [dependencies]
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 figment = { workspace = true }
+futures = { workspace = true }
 opentelemetry = { workspace = true }
 regex = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["json", "stream"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -68,6 +68,10 @@ pub struct FoundationConfig {
     /// attached function is invoked. Matches the chroma frontend default.
     #[serde(default = "FoundationConfig::default_min_records_for_invocation")]
     pub min_records_for_invocation: u64,
+    /// Base URL of the external "context-1" deep-research API Required —
+    /// the subagent route is disabled when unset
+    #[serde(default)]
+    pub deep_research_api_url: Option<String>,
 }
 
 impl FoundationConfig {
@@ -110,6 +114,7 @@ impl Default for FoundationConfig {
             function_name: Self::default_function_name(),
             function_endpoint_url: None,
             min_records_for_invocation: Self::default_min_records_for_invocation(),
+            deep_research_api_url: None,
         }
     }
 }

--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -68,8 +68,8 @@ pub struct FoundationConfig {
     /// attached function is invoked. Matches the chroma frontend default.
     #[serde(default = "FoundationConfig::default_min_records_for_invocation")]
     pub min_records_for_invocation: u64,
-    /// Base URL of the external "context-1" deep-research API Required —
-    /// the subagent route is disabled when unset
+    /// Base URL of the external "context-1" deep-research API. Optional: the
+    /// `subagent_search` route is disabled when unset.
     #[serde(default)]
     pub deep_research_api_url: Option<String>,
 }

--- a/rust/foundation-api/src/routes/mod.rs
+++ b/rust/foundation-api/src/routes/mod.rs
@@ -1,7 +1,27 @@
 use crate::server::FoundationApiServer;
-use axum::{routing::post, Router};
+use axum::{http::HeaderMap, routing::post, Router};
+
+/// HTTP header carrying the caller's Chroma Cloud token, forwarded to the FE
+/// and the embedding service so authz/quota/billing key off the user.
+pub(crate) const CHROMA_TOKEN_HEADER: &str = "x-chroma-token";
+
+/// Returns the caller's Chroma token from the `x-chroma-token` header, or
+/// `None` when it is absent, non-ASCII, or empty. Routes map `None` to their
+/// own missing-token error.
+///
+/// The header-name lookup is case-insensitive: `HeaderMap` normalizes names to
+/// lowercase, so `X-Chroma-Token`, `x-chroma-token`, etc. all match. The token
+/// value is returned verbatim (it is case-sensitive).
+pub(crate) fn caller_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(CHROMA_TOKEN_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|token| !token.is_empty())
+}
 
 pub(crate) mod init;
+pub(crate) mod search;
+pub(crate) mod subagent_search;
 pub(crate) mod upsert_page;
 pub(super) mod whoami;
 
@@ -11,5 +31,10 @@ pub(crate) fn router() -> Router<FoundationApiServer> {
         .route(
             "/api/upsert-page",
             post(upsert_page::foundation_upsert_page),
+        )
+        .route("/api/search", post(search::foundation_search))
+        .route(
+            "/api/subagent_search",
+            post(subagent_search::foundation_subagent_search),
         )
 }

--- a/rust/foundation-api/src/routes/search.rs
+++ b/rust/foundation-api/src/routes/search.rs
@@ -32,6 +32,11 @@ fn default_limit() -> u32 {
 /// modalities.
 const KNN_CANDIDATES: u32 = 100;
 
+/// Upper bound on the requested `limit`. Fusion can never surface more than the
+/// per-arm candidate pool, so clamp here to make that ceiling explicit rather
+/// than letting callers ask for an arbitrarily large page.
+const MAX_LIMIT: u32 = KNN_CANDIDATES;
+
 /// The RRF `k` smoothing constant (the conventional default).
 const RRF_K: u32 = 60;
 
@@ -49,7 +54,9 @@ pub struct SearchRequest {
     /// The search query text. Embedded client-side into dense + sparse vectors.
     #[validate(length(min = 1, message = "query must not be empty"))]
     pub query: String,
-    /// Maximum number of hits to return. Defaults to [`default_limit`].
+    /// Maximum number of hits to return. Defaults to [`default_limit`]; must be
+    /// at least 1 and is clamped down to [`MAX_LIMIT`].
+    #[validate(range(min = 1, message = "limit must be at least 1"))]
     #[serde(default = "default_limit")]
     pub limit: u32,
 }
@@ -157,21 +164,26 @@ async fn run_hybrid_search(
     query: &str,
     limit: u32,
 ) -> Result<Vec<SearchRecord>, SearchError> {
-    let dense = collection
-        .embed_query(&[query])
-        .await
-        .map_err(SearchError::DenseEmbed)?
-        .into_iter()
-        .next()
-        .ok_or(SearchError::EmptyEmbedding)?;
-    let sparse = embedder
-        .embed_sparse(token, &[query])
-        .await?
-        .into_iter()
-        .next()
-        .ok_or(SearchError::EmptyEmbedding)?;
+    let dense_fut = async {
+        collection
+            .embed_query(&[query])
+            .await
+            .map_err(SearchError::DenseEmbed)?
+            .into_iter()
+            .next()
+            .ok_or(SearchError::EmptyEmbedding)
+    };
+    let sparse_fut = async {
+        embedder
+            .embed_sparse(token, &[query])
+            .await?
+            .into_iter()
+            .next()
+            .ok_or(SearchError::EmptyEmbedding)
+    };
+    let (dense, sparse) = tokio::try_join!(dense_fut, sparse_fut)?;
 
-    let payload = build_hybrid_search_payload(dense, sparse, limit)?;
+    let payload = build_hybrid_search_payload(dense, sparse, limit.min(MAX_LIMIT))?;
     let response = collection
         .search(vec![payload])
         .await
@@ -317,6 +329,27 @@ mod tests {
         assert_eq!(hits[1].id, "b-0");
         assert_eq!(hits[1].document, None);
         assert_eq!(hits[1].score, Some(0.4));
+    }
+
+    #[test]
+    fn request_validation_rejects_empty_query_and_zero_limit() {
+        use validator::Validate;
+
+        // Omitted limit falls back to the default and validates.
+        let defaulted: SearchRequest =
+            serde_json::from_value(serde_json::json!({ "query": "hi" })).expect("deserialize");
+        assert_eq!(defaulted.limit, default_limit());
+        assert!(defaulted.validate().is_ok());
+
+        let empty_query: SearchRequest =
+            serde_json::from_value(serde_json::json!({ "query": "", "limit": 5 }))
+                .expect("deserialize");
+        assert!(empty_query.validate().is_err());
+
+        let zero_limit: SearchRequest =
+            serde_json::from_value(serde_json::json!({ "query": "hi", "limit": 0 }))
+                .expect("deserialize");
+        assert!(zero_limit.validate().is_err());
     }
 
     #[test]

--- a/rust/foundation-api/src/routes/search.rs
+++ b/rust/foundation-api/src/routes/search.rs
@@ -1,0 +1,334 @@
+//! `POST /api/search` — hybrid dense+sparse search over the wiki collection.
+//!
+//! Embeds the query with the caller's token (dense Qwen + sparse SPLADE),
+//! fuses the two `$knn` rankings with Reciprocal Rank Fusion, and returns the
+//! top hits. Like the other wiki routes it proxies the actual query to the FE
+//! through [`WikiClient`]; the FE enforces auth, quota, metering, and billing.
+//!
+//! The Chroma `/search` endpoint does not embed query text — the caller
+//! supplies the dense and sparse query vectors, which is why both embedders run
+//! client-side here before the query is issued.
+
+use crate::routes::{caller_token, whoami::whoami_and_authorize};
+use crate::wiki::embed::{WikiEmbedder, SPARSE_KEY};
+use crate::wiki::WikiClientError;
+use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
+use axum::{extract::State, http::HeaderMap, Json};
+use chroma::client::ChromaHttpClientError;
+use chroma::types::{rrf, Key, QueryVector, RankExpr, SearchPayload, SearchResponse, SparseVector};
+use chroma::ChromaCollection;
+use chroma_error::{ChromaError, ChromaValidationError, ErrorCodes};
+use chroma_types::operator::SearchRecord;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+/// Default number of hits returned when the caller omits `limit`.
+fn default_limit() -> u32 {
+    10
+}
+
+/// Candidate pool size requested from each `$knn` arm before fusion. Larger
+/// than the result `limit` so RRF has overlap to work with across the two
+/// modalities.
+const KNN_CANDIDATES: u32 = 100;
+
+/// The RRF `k` smoothing constant (the conventional default).
+const RRF_K: u32 = 60;
+
+/// Fallback rank assigned to a document that an arm did not retrieve (i.e. it
+/// fell outside that arm's top-[`KNN_CANDIDATES`]). Using the candidate-pool
+/// size treats a missing doc as if it ranked just past the cutoff, so it still
+/// contributes to the fused score (union) instead of being dropped
+/// (intersection). Ranks from the engine are 0-based, so this is strictly worse
+/// than any retrieved rank.
+const MISSING_ARM_RANK: f32 = KNN_CANDIDATES as f32;
+
+/// Request body for `POST /api/search`.
+#[derive(Debug, Deserialize, Validate)]
+pub struct SearchRequest {
+    /// The search query text. Embedded client-side into dense + sparse vectors.
+    #[validate(length(min = 1, message = "query must not be empty"))]
+    pub query: String,
+    /// Maximum number of hits to return. Defaults to [`default_limit`].
+    #[serde(default = "default_limit")]
+    pub limit: u32,
+}
+
+/// Response body for `POST /api/search`.
+#[derive(Debug, Serialize)]
+pub struct SearchResponseBody {
+    /// Hits in descending score order.
+    pub hits: Vec<SearchRecord>,
+}
+
+/// Errors raised while running the hybrid search flow (after validation).
+#[derive(Debug, thiserror::Error)]
+pub enum SearchError {
+    /// `frontend_ingress_url` is unset, so the wiki client was never built.
+    #[error("wiki search is not configured")]
+    RouteDisabled,
+    /// The caller's request carried no usable `x-chroma-token`.
+    #[error("missing or invalid x-chroma-token header")]
+    MissingToken,
+    /// Resolving the wiki collection through the proxy failed.
+    #[error(transparent)]
+    Resolve(#[from] WikiClientError),
+    /// Computing the sparse (SPLADE) query embedding failed.
+    #[error(transparent)]
+    Embed(#[from] crate::wiki::embed::WikiEmbedError),
+    /// Computing the dense query embedding via the collection's schema-derived
+    /// embedding function failed.
+    #[error("dense query embedding failed: {0}")]
+    DenseEmbed(ChromaHttpClientError),
+    /// The query produced no embedding vector (empty embedder response).
+    #[error("query produced no embedding vector")]
+    EmptyEmbedding,
+    /// Building the RRF rank expression failed (e.g. weight/rank mismatch).
+    #[error("failed to build search ranking: {0}")]
+    Rank(String),
+    /// The proxied `/search` call to the FE failed.
+    #[error("chroma search failed: {0}")]
+    Query(ChromaHttpClientError),
+}
+
+impl ChromaError for SearchError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            SearchError::RouteDisabled => ErrorCodes::Internal,
+            SearchError::MissingToken => ErrorCodes::InvalidArgument,
+            SearchError::Resolve(err) => err.code(),
+            SearchError::Embed(err) => err.code(),
+            SearchError::DenseEmbed(_) => ErrorCodes::Internal,
+            SearchError::EmptyEmbedding => ErrorCodes::Internal,
+            SearchError::Rank(_) => ErrorCodes::Internal,
+            SearchError::Query(_) => ErrorCodes::Internal,
+        }
+    }
+}
+
+/// `POST /api/search` handler.
+pub async fn foundation_search(
+    headers: HeaderMap,
+    State(server): State<FoundationApiServer>,
+    Json(request): Json<SearchRequest>,
+) -> Result<Json<SearchResponseBody>, ServerError> {
+    let identity =
+        whoami_and_authorize(&*server.auth, &headers, AuthzAction::ViewFoundation).await?;
+    let tenant = identity.tenant;
+
+    let _guard =
+        server.scorecard_request(&["op:foundation_search", &format!("tenant:{tenant}")])?;
+
+    request.validate().map_err(ChromaValidationError::from)?;
+
+    let hits = run_search(&server, &headers, &tenant, &request).await?;
+    Ok(Json(SearchResponseBody { hits }))
+}
+
+/// Resolves the wiki collection then runs the hybrid search core.
+async fn run_search(
+    server: &FoundationApiServer,
+    headers: &HeaderMap,
+    tenant: &str,
+    request: &SearchRequest,
+) -> Result<Vec<SearchRecord>, SearchError> {
+    let wiki_client = server
+        .wiki_client
+        .as_ref()
+        .ok_or(SearchError::RouteDisabled)?;
+    let token = caller_token(headers).ok_or(SearchError::MissingToken)?;
+    let collection = wiki_client.wiki_collection(tenant, token).await?;
+    let embedder = WikiEmbedder::new(None);
+
+    run_hybrid_search(&collection, &embedder, token, &request.query, request.limit).await
+}
+
+/// Embeds the query, issues a single RRF-ranked hybrid search, and maps the
+/// response into [`SearchRecord`]s.
+///
+/// The dense vector comes from the collection's own schema-derived embedding
+/// function (`embed_query`), so it always matches the EF the documents were
+/// embedded with — no config to keep in sync here. The sparse vector is SPLADE,
+/// which is not part of the dense EF, so it is computed separately.
+async fn run_hybrid_search(
+    collection: &ChromaCollection,
+    embedder: &WikiEmbedder,
+    token: &str,
+    query: &str,
+    limit: u32,
+) -> Result<Vec<SearchRecord>, SearchError> {
+    let dense = collection
+        .embed_query(&[query])
+        .await
+        .map_err(SearchError::DenseEmbed)?
+        .into_iter()
+        .next()
+        .ok_or(SearchError::EmptyEmbedding)?;
+    let sparse = embedder
+        .embed_sparse(token, &[query])
+        .await?
+        .into_iter()
+        .next()
+        .ok_or(SearchError::EmptyEmbedding)?;
+
+    let payload = build_hybrid_search_payload(dense, sparse, limit)?;
+    let response = collection
+        .search(vec![payload])
+        .await
+        .map_err(SearchError::Query)?;
+    Ok(search_response_to_hits(response))
+}
+
+/// Builds the single-query RRF hybrid [`SearchPayload`]: a dense `$knn` over
+/// `#embedding` fused with a sparse `$knn` over [`SPARSE_KEY`], both with
+/// `return_rank: true` (required for RRF). Pure (no I/O) so it is unit-testable.
+///
+/// Each arm sets `default` to [`MISSING_ARM_RANK`] rather than `None`: with
+/// `None` on both arms the rank engine fuses by *intersection* (a doc must be in
+/// both arms' top-`KNN_CANDIDATES` to survive), which would drop strong
+/// single-modality hits. A finite default makes fusion a *union*, treating a doc
+/// absent from an arm as ranked just past that arm's candidate cutoff.
+fn build_hybrid_search_payload(
+    dense: Vec<f32>,
+    sparse: SparseVector,
+    limit: u32,
+) -> Result<SearchPayload, SearchError> {
+    let dense_knn = RankExpr::Knn {
+        query: QueryVector::Dense(dense),
+        key: Key::Embedding,
+        limit: KNN_CANDIDATES,
+        default: Some(MISSING_ARM_RANK),
+        return_rank: true,
+    };
+    let sparse_knn = RankExpr::Knn {
+        query: QueryVector::Sparse(sparse),
+        key: Key::field(SPARSE_KEY),
+        limit: KNN_CANDIDATES,
+        default: Some(MISSING_ARM_RANK),
+        return_rank: true,
+    };
+    // Equal weights across the two modalities; no normalization.
+    let rank = rrf(vec![dense_knn, sparse_knn], Some(RRF_K), None, false)
+        .map_err(|err| SearchError::Rank(err.to_string()))?;
+
+    Ok(SearchPayload::default()
+        .rank(rank)
+        .limit(Some(limit), 0)
+        .select([Key::Document, Key::Score, Key::Metadata]))
+}
+
+/// Flattens a single-payload [`SearchResponse`] into [`SearchRecord`]s. The
+/// per-field outer `Vec` is indexed by payload; we send exactly one payload, so
+/// we read row 0. `embedding` is left `None` since we don't select embeddings.
+fn search_response_to_hits(response: SearchResponse) -> Vec<SearchRecord> {
+    let Some(ids) = response.ids.into_iter().next() else {
+        return Vec::new();
+    };
+    let documents = response.documents.into_iter().next().flatten();
+    let scores = response.scores.into_iter().next().flatten();
+    let metadatas = response.metadatas.into_iter().next().flatten();
+
+    ids.into_iter()
+        .enumerate()
+        .map(|(i, id)| SearchRecord {
+            id,
+            document: documents.as_ref().and_then(|d| d.get(i).cloned().flatten()),
+            embedding: None,
+            score: scores.as_ref().and_then(|s| s.get(i).copied().flatten()),
+            metadata: metadatas.as_ref().and_then(|m| m.get(i).cloned().flatten()),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma::types::SearchResponse;
+    use serde_json::Value;
+
+    fn collect_knn_objects(value: &Value, out: &mut Vec<Value>) {
+        match value {
+            Value::Object(map) => {
+                if let Some(knn) = map.get("$knn") {
+                    out.push(knn.clone());
+                }
+                for v in map.values() {
+                    collect_knn_objects(v, out);
+                }
+            }
+            Value::Array(items) => {
+                for v in items {
+                    collect_knn_objects(v, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn hybrid_payload_has_two_knn_arms_with_return_rank() {
+        let sparse = SparseVector::new(vec![1, 5], vec![0.4, 0.7]).expect("sparse");
+        let payload = build_hybrid_search_payload(vec![0.1, 0.2, 0.3], sparse, 7).expect("payload");
+
+        let json = serde_json::to_value(&payload).expect("serialize payload");
+        let mut knns = Vec::new();
+        collect_knn_objects(&json, &mut knns);
+
+        // Exactly the dense + sparse arms.
+        assert_eq!(knns.len(), 2, "expected two $knn nodes, got: {json}");
+
+        // Both arms must return rank for RRF to fuse them.
+        assert!(knns
+            .iter()
+            .all(|knn| knn["return_rank"] == Value::Bool(true)));
+
+        // Both arms must carry a finite default so fusion is a union (missing
+        // docs filled), not an intersection (missing docs dropped).
+        assert!(
+            knns.iter().all(|knn| knn["default"].is_number()),
+            "each $knn arm needs a numeric default for union fusion, got: {json}"
+        );
+
+        // One arm targets the dense embedding, the other the sparse key.
+        let keys: Vec<&Value> = knns.iter().map(|knn| &knn["key"]).collect();
+        assert!(
+            keys.iter()
+                .any(|k| *k == &Value::String(SPARSE_KEY.to_string())),
+            "expected a $knn over the sparse key, got keys: {keys:?}"
+        );
+    }
+
+    #[test]
+    fn maps_search_response_rows_into_hits() {
+        let response = SearchResponse {
+            ids: vec![vec!["a-0".to_string(), "b-0".to_string()]],
+            documents: vec![Some(vec![Some("doc a".to_string()), None])],
+            embeddings: vec![None],
+            metadatas: vec![None],
+            scores: vec![Some(vec![Some(0.9), Some(0.4)])],
+            select: vec![vec![]],
+        };
+
+        let hits = search_response_to_hits(response);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].id, "a-0");
+        assert_eq!(hits[0].document.as_deref(), Some("doc a"));
+        assert_eq!(hits[0].score, Some(0.9));
+        assert_eq!(hits[1].id, "b-0");
+        assert_eq!(hits[1].document, None);
+        assert_eq!(hits[1].score, Some(0.4));
+    }
+
+    #[test]
+    fn maps_empty_response_to_no_hits() {
+        let response = SearchResponse {
+            ids: vec![],
+            documents: vec![],
+            embeddings: vec![],
+            metadatas: vec![],
+            scores: vec![],
+            select: vec![],
+        };
+        assert!(search_response_to_hits(response).is_empty());
+    }
+}

--- a/rust/foundation-api/src/routes/subagent_search/events.rs
+++ b/rust/foundation-api/src/routes/subagent_search/events.rs
@@ -132,15 +132,14 @@ pub(crate) struct RankedDocument {
     pub justification: String,
 }
 
-/// Failure to turn a completed subagent stream into structured results.
+/// Failure to turn a completed subagent stream into structured results. An
+/// answer that parses to zero documents is *not* an error — it is a valid
+/// empty result — so the only failure is the absence of any terminal answer.
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub(crate) enum SubagentResultError {
     /// The stream finished without a terminal `user_text` action.
     #[error("subagent stream produced no terminal answer")]
     NoFinalAnswer,
-    /// The terminal answer didn't contain any parseable `<Document>` blocks.
-    #[error("subagent answer contained no parseable <Document> blocks")]
-    NoDocuments,
 }
 
 /// Matches one `<Document id=…><Justification>…</Justification></Document>`
@@ -151,6 +150,8 @@ static DOCUMENT_BLOCK: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r#"(?is)<Document\s+id=["']?([^"'>\s]+)["']?\s*>\s*<Justification>\s*(.*?)\s*</Justification>\s*</Document>"#,
     )
+    // SAFETY(hammadb): the pattern is a compile-time constant validated by the
+    // unit tests, so compilation cannot fail at runtime.
     .expect("DOCUMENT_BLOCK regex is valid")
 });
 

--- a/rust/foundation-api/src/routes/subagent_search/events.rs
+++ b/rust/foundation-api/src/routes/subagent_search/events.rs
@@ -1,0 +1,168 @@
+//! Typed model of the deep-research agent's event schema.
+//!
+//! [`AgentEvent`] is what we parse *from* the deep-research dependency;
+//! [`SubagentSearchEvent`] is what we emit *to* our callers. Both share the
+//! `action`/`observation` payload structs so re-emitting a step event is a
+//! faithful, typed round-trip rather than an opaque passthrough.
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::LazyLock;
+
+// ---------------------------------------------------------------------------
+// Inbound: events parsed from the deep-research dependency
+// ---------------------------------------------------------------------------
+
+/// One step event from the deep-research agent (`{"type": …, "data": {…}}`).
+/// Unrecognized event types and unparseable lines become
+/// [`AgentEvent::Unknown`] and are dropped rather than forwarded blindly.
+#[derive(Debug)]
+pub(crate) enum AgentEvent {
+    Action(ActionData),
+    Observation(ObservationData),
+    Done,
+    Error(ErrorData),
+    Unknown,
+}
+
+impl AgentEvent {
+    /// Classifies a raw event JSON line by its `type`, deserializing the
+    /// payload. Any malformed payload (or unknown type) degrades to
+    /// [`AgentEvent::Unknown`].
+    pub(crate) fn parse(raw: &str) -> Self {
+        let Ok(value) = serde_json::from_str::<Value>(raw) else {
+            return AgentEvent::Unknown;
+        };
+        let data = || value.get("data").cloned().unwrap_or(Value::Null);
+        match value.get("type").and_then(Value::as_str) {
+            Some("action") => from_data(data()).map_or(AgentEvent::Unknown, AgentEvent::Action),
+            Some("observation") => {
+                from_data(data()).map_or(AgentEvent::Unknown, AgentEvent::Observation)
+            }
+            Some("done") => AgentEvent::Done,
+            Some("error") => from_data(data()).map_or(AgentEvent::Unknown, AgentEvent::Error),
+            _ => AgentEvent::Unknown,
+        }
+    }
+}
+
+/// Deserializes an event's `data` object into a typed payload, returning `None`
+/// if it doesn't match the expected shape.
+fn from_data<T: for<'de> Deserialize<'de>>(data: Value) -> Option<T> {
+    serde_json::from_value(data).ok()
+}
+
+/// The `data` of an `action` event. `tools` and `params` are position-aligned
+/// arrays (the `i`th param belongs to the `i`th tool).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct ActionData {
+    #[serde(default)]
+    pub tools: Vec<ToolRef>,
+    #[serde(default)]
+    pub params: Vec<Value>,
+    #[serde(default)]
+    pub sources: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<String>,
+}
+
+/// A tool referenced in an `action` event.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct ToolRef {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// The `data` of an `observation` event.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct ObservationData {
+    #[serde(default)]
+    pub sources: Vec<String>,
+}
+
+/// The `data` of an `error` event the agent emits when its loop fails.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct ErrorData {
+    pub message: String,
+}
+
+impl ActionData {
+    /// The `text` of this action's last `user_text` tool, if any — the agent
+    /// "speaking" to the user.
+    pub(crate) fn user_text(&self) -> Option<&str> {
+        self.tools
+            .iter()
+            .zip(&self.params)
+            .rev()
+            .find(|(tool, _)| tool.name == "user_text")
+            .and_then(|(_, param)| param.get("text").and_then(Value::as_str))
+    }
+
+    /// True if every tool in this action is `user_text` (a pure "answer" step).
+    /// We surface the answer only via the structured `result`, so these are not
+    /// re-emitted as progress.
+    pub(crate) fn is_answer_only(&self) -> bool {
+        !self.tools.is_empty() && self.tools.iter().all(|tool| tool.name == "user_text")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Outbound: events we emit to our callers
+// ---------------------------------------------------------------------------
+
+/// The events `/api/subagent_search` emits. Step events mirror the agent's
+/// `action`/`observation`; `result` carries the final answer parsed into
+/// structured documents; `done` terminates the stream.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", content = "data", rename_all = "lowercase")]
+pub(crate) enum SubagentSearchEvent {
+    Action(ActionData),
+    Observation(ObservationData),
+    Result { documents: Vec<RankedDocument> },
+    Done,
+}
+
+/// A single document the subagent ranked, parsed out of the terminal answer's
+/// `<Document id=…><Justification>…</Justification></Document>` block.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct RankedDocument {
+    pub id: String,
+    pub justification: String,
+}
+
+/// Failure to turn a completed subagent stream into structured results.
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub(crate) enum SubagentResultError {
+    /// The stream finished without a terminal `user_text` action.
+    #[error("subagent stream produced no terminal answer")]
+    NoFinalAnswer,
+    /// The terminal answer didn't contain any parseable `<Document>` blocks.
+    #[error("subagent answer contained no parseable <Document> blocks")]
+    NoDocuments,
+}
+
+/// Matches one `<Document id=…><Justification>…</Justification></Document>`
+/// block. `id` may be unquoted or single/double-quoted; the justification is
+/// captured non-greedily and may span lines (`(?is)` = case-insensitive +
+/// dot-matches-newline).
+static DOCUMENT_BLOCK: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?is)<Document\s+id=["']?([^"'>\s]+)["']?\s*>\s*<Justification>\s*(.*?)\s*</Justification>\s*</Document>"#,
+    )
+    .expect("DOCUMENT_BLOCK regex is valid")
+});
+
+/// Parses the agent's free-text final answer into ranked documents, preserving
+/// the order they appear (most relevant first, per the prompt). Justification
+/// whitespace is collapsed to a single space.
+pub(crate) fn parse_ranked_documents(answer: &str) -> Vec<RankedDocument> {
+    DOCUMENT_BLOCK
+        .captures_iter(answer)
+        .map(|caps| RankedDocument {
+            id: caps[1].to_string(),
+            justification: caps[2].split_whitespace().collect::<Vec<_>>().join(" "),
+        })
+        .collect()
+}

--- a/rust/foundation-api/src/routes/subagent_search/mod.rs
+++ b/rust/foundation-api/src/routes/subagent_search/mod.rs
@@ -8,7 +8,8 @@
 //! - `action` / `observation` — forwarded as typed progress events.
 //! - `result` — the agent's final answer parsed into structured
 //!   [`RankedDocument`]s (so callers don't re-parse the `<Document>` block),
-//!   emitted just before the terminal `done`.
+//!   emitted just before the terminal `done`. An answer with no documents is a
+//!   valid empty `result`, not an error.
 //! - `done` — terminates the stream.
 //!
 //! An upstream `error` event ends the stream with a [`SubagentStreamError`];
@@ -140,8 +141,8 @@ fn sse_event(event: &SubagentSearchEvent) -> Result<Event, SubagentStreamError> 
 /// the terminal `done`.
 ///
 /// Ends the stream with a [`SubagentStreamError`] on a transport/upstream
-/// failure, on an upstream `error` event, or if the final answer contained no
-/// parseable documents.
+/// failure, on an upstream `error` event, or if the upstream closes without a
+/// terminal `done`. An answer with zero documents is a valid empty `result`.
 fn stream_subagent_search(
     http: reqwest::Client,
     url: String,
@@ -155,6 +156,10 @@ fn stream_subagent_search(
         // The terminal answer is the last `action`'s `user_text`; track it as
         // events stream by so we can emit it as a structured `result`.
         let mut final_answer: Option<String> = None;
+        // Whether we saw a terminal `done`. If the upstream byte stream ends
+        // without one (and without an `error`), we synthesize an error below so
+        // the caller never sees a silent, terminator-less close.
+        let mut saw_done = false;
         while let Some(item) = data.next().await {
             let raw = match item {
                 Ok(raw) => raw,
@@ -189,16 +194,14 @@ fn stream_subagent_search(
                 }
                 // Emit the structured `result` then `done` as the terminator.
                 AgentEvent::Done => {
+                    saw_done = true;
+                    // An answer that parses to zero documents is a legitimate
+                    // "no hits" result, not a failure — emit an empty `result`
+                    // so it stays distinguishable from a broken stream.
                     let documents = final_answer
                         .as_deref()
                         .map(parse_ranked_documents)
                         .unwrap_or_default();
-                    if documents.is_empty() {
-                        yield Err(SubagentStreamError(
-                            "subagent answer contained no parseable documents".to_string(),
-                        ));
-                        return;
-                    }
                     vec![
                         SubagentSearchEvent::Result { documents },
                         SubagentSearchEvent::Done,
@@ -217,6 +220,14 @@ fn stream_subagent_search(
                     }
                 }
             }
+        }
+
+        // The byte stream ended without a `done` (or `error`, which would have
+        // returned above): surface a terminal error so the close is never silent.
+        if !saw_done {
+            yield Err(SubagentStreamError(
+                "deep research stream ended without a terminal event".to_string(),
+            ));
         }
     }
 }
@@ -319,9 +330,9 @@ fn parse_sse_data_line(line: &[u8]) -> Option<String> {
 /// `user_text` from the last `action` event) and parses its
 /// `<Document>/<Justification>` blocks into structured [`RankedDocument`]s.
 ///
-/// Errors if the stream produced no terminal answer, or if the answer did not
-/// follow the documented `<Document>` format. Used by the `subagent_search`
-/// agent tool in the next PR in the stack.
+/// Errors only if the stream produced no terminal answer; an answer that parses
+/// to zero documents yields `Ok(vec![])`. Used by the `subagent_search` agent
+/// tool in the next PR in the stack.
 #[allow(dead_code)]
 pub(crate) async fn collect_subagent_search_final(
     http: reqwest::Client,
@@ -344,12 +355,10 @@ pub(crate) async fn collect_subagent_search_final(
         }
     }
 
+    // A terminal answer that parses to zero documents is a valid "no hits"
+    // result; only the genuine absence of any terminal answer is an error.
     let answer = final_answer.ok_or(SubagentResultError::NoFinalAnswer)?;
-    let documents = parse_ranked_documents(&answer);
-    if documents.is_empty() {
-        return Err(SubagentResultError::NoDocuments);
-    }
-    Ok(documents)
+    Ok(parse_ranked_documents(&answer))
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/foundation-api/src/routes/subagent_search/mod.rs
+++ b/rust/foundation-api/src/routes/subagent_search/mod.rs
@@ -1,0 +1,363 @@
+//! `POST /api/subagent_search` — runs a query against the external "context-1"
+//! deep-research API and streams the result back to the caller.
+//!
+//! This endpoint owns its wire contract; it is not a transparent proxy. We
+//! parse every event from the dependency into a typed [`AgentEvent`] and
+//! re-emit our own [`SubagentSearchEvent`]s:
+//!
+//! - `action` / `observation` — forwarded as typed progress events.
+//! - `result` — the agent's final answer parsed into structured
+//!   [`RankedDocument`]s (so callers don't re-parse the `<Document>` block),
+//!   emitted just before the terminal `done`.
+//! - `done` — terminates the stream.
+//!
+//! An upstream `error` event ends the stream with a [`SubagentStreamError`];
+//! unknown event types are dropped.
+//!
+//! The deep-research dependency is reached at `POST {url}/search` with a JSON
+//! body of `{query, model, collection_name, chroma_api_key, chroma_tenant,
+//! chroma_database}` and an `Accept: text/event-stream` response of
+//! `data: {"type": action|observation|done|error, "data": {...}}` lines.
+//!
+//! Credentials are taken from the request: the caller's `x-chroma-token` is the
+//! Chroma API key, the tenant comes from the resolved identity, and the
+//! database/collection come from foundation config.
+
+mod events;
+use crate::routes::{caller_token, whoami::whoami_and_authorize};
+use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::{extract::State, http::HeaderMap, Json};
+use chroma_error::{ChromaError, ErrorCodes};
+use events::{parse_ranked_documents, AgentEvent, SubagentResultError, SubagentSearchEvent};
+use futures::{Stream, StreamExt};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+/// Deep-research model. Fixed to `scout`; deliberately not user-configurable.
+const MODEL: &str = "scout";
+/// The SSE field prefix the upstream emits each event under.
+const SSE_DATA_PREFIX: &str = "data: ";
+
+/// Request body for `POST /api/subagent_search`.
+#[derive(Debug, Deserialize)]
+pub struct SubagentSearchRequest {
+    /// The research query.
+    pub query: String,
+}
+
+/// Chroma credentials + target collection forwarded to the deep-research API.
+#[derive(Debug, Clone)]
+pub struct SubagentSearchCreds {
+    pub chroma_api_key: String,
+    pub chroma_tenant: String,
+    pub chroma_database: String,
+    pub collection_name: String,
+}
+
+/// Errors raised before the SSE stream starts. Once streaming begins,
+/// mid-stream failures are surfaced as a [`SubagentStreamError`] instead.
+#[derive(Debug, thiserror::Error)]
+pub enum SubagentSearchError {
+    /// `deep_research_api_url` is unset, so the route is disabled.
+    #[error("deep research is not configured")]
+    RouteDisabled,
+    /// The caller's request carried no usable `x-chroma-token`.
+    #[error("missing or invalid x-chroma-token header")]
+    MissingToken,
+}
+
+impl ChromaError for SubagentSearchError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            SubagentSearchError::RouteDisabled => ErrorCodes::Internal,
+            SubagentSearchError::MissingToken => ErrorCodes::InvalidArgument,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+/// `POST /api/subagent_search` handler.
+pub async fn foundation_subagent_search(
+    headers: HeaderMap,
+    State(server): State<FoundationApiServer>,
+    Json(request): Json<SubagentSearchRequest>,
+) -> Result<Sse<impl Stream<Item = Result<Event, SubagentStreamError>>>, ServerError> {
+    let identity =
+        whoami_and_authorize(&*server.auth, &headers, AuthzAction::ViewFoundation).await?;
+    let tenant = identity.tenant;
+
+    let _guard = server
+        .scorecard_request(&["op:foundation_subagent_search", &format!("tenant:{tenant}")])?;
+
+    let url = server
+        .config
+        .foundation
+        .deep_research_api_url
+        .clone()
+        .ok_or(SubagentSearchError::RouteDisabled)?;
+    let token = caller_token(&headers)
+        .ok_or(SubagentSearchError::MissingToken)?
+        .to_string();
+
+    let creds = SubagentSearchCreds {
+        chroma_api_key: token,
+        chroma_tenant: tenant,
+        chroma_database: server.config.foundation.database_name.clone(),
+        collection_name: server.config.foundation.wiki_collection.clone(),
+    };
+
+    let stream =
+        stream_subagent_search(server.shared_http_client.clone(), url, creds, request.query);
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+// ---------------------------------------------------------------------------
+// SSE stream: typed progress events, then a parsed `result`, then `done`
+// ---------------------------------------------------------------------------
+
+/// A transport/upstream failure encountered mid-stream. Because the SSE
+/// response has already returned `200 OK`, axum can only end the body when one
+/// of these is yielded — the client sees the stream terminate.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct SubagentStreamError(String);
+
+/// Serializes one of our owned events into an SSE frame, surfacing a
+/// serialization failure as a stream error rather than panicking.
+fn sse_event(event: &SubagentSearchEvent) -> Result<Event, SubagentStreamError> {
+    serde_json::to_string(event)
+        .map(|json| Event::default().data(json))
+        .map_err(|err| SubagentStreamError(format!("failed to serialize event: {err}")))
+}
+
+/// Runs the deep-research agent and streams typed [`SubagentSearchEvent`]s to
+/// the caller: the agent's `action`/`observation` steps, then a `result` event
+/// carrying the final answer parsed into structured [`RankedDocument`]s, then
+/// the terminal `done`.
+///
+/// Ends the stream with a [`SubagentStreamError`] on a transport/upstream
+/// failure, on an upstream `error` event, or if the final answer contained no
+/// parseable documents.
+fn stream_subagent_search(
+    http: reqwest::Client,
+    url: String,
+    creds: SubagentSearchCreds,
+    query: String,
+) -> impl Stream<Item = Result<Event, SubagentStreamError>> {
+    async_stream::stream! {
+        let data = subagent_search_data_stream(http, url, creds, query);
+        futures::pin_mut!(data);
+
+        // The terminal answer is the last `action`'s `user_text`; track it as
+        // events stream by so we can emit it as a structured `result`.
+        let mut final_answer: Option<String> = None;
+        while let Some(item) = data.next().await {
+            let raw = match item {
+                Ok(raw) => raw,
+                Err(message) => {
+                    yield Err(SubagentStreamError(message));
+                    return;
+                }
+            };
+
+            // Map the upstream event to the events we emit (often one, none
+            // for suppressed/unknown events, two for the terminal pair).
+            let outgoing: Vec<SubagentSearchEvent> = match AgentEvent::parse(&raw) {
+                AgentEvent::Action(action) => {
+                    if let Some(text) = action.user_text() {
+                        final_answer = Some(text.to_string());
+                    }
+                    // The raw `<Document>` answer is surfaced only as the
+                    // structured `result`, so don't also emit it as progress.
+                    if action.is_answer_only() {
+                        Vec::new()
+                    } else {
+                        vec![SubagentSearchEvent::Action(action)]
+                    }
+                }
+                AgentEvent::Observation(observation) => {
+                    vec![SubagentSearchEvent::Observation(observation)]
+                }
+                // An upstream agent error terminates our stream.
+                AgentEvent::Error(error) => {
+                    yield Err(SubagentStreamError(error.message));
+                    return;
+                }
+                // Emit the structured `result` then `done` as the terminator.
+                AgentEvent::Done => {
+                    let documents = final_answer
+                        .as_deref()
+                        .map(parse_ranked_documents)
+                        .unwrap_or_default();
+                    if documents.is_empty() {
+                        yield Err(SubagentStreamError(
+                            "subagent answer contained no parseable documents".to_string(),
+                        ));
+                        return;
+                    }
+                    vec![
+                        SubagentSearchEvent::Result { documents },
+                        SubagentSearchEvent::Done,
+                    ]
+                }
+                // Unknown / unparseable events carry nothing we can model.
+                AgentEvent::Unknown => Vec::new(),
+            };
+
+            for event in &outgoing {
+                match sse_event(event) {
+                    Ok(frame) => yield Ok(frame),
+                    Err(err) => {
+                        yield Err(err);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// POSTs to the deep-research API and yields the raw JSON payload of each SSE
+/// `data:` line. Transport or non-2xx failures yield a single `Err` and end
+/// the stream.
+fn subagent_search_data_stream(
+    http: reqwest::Client,
+    url: String,
+    creds: SubagentSearchCreds,
+    query: String,
+) -> impl Stream<Item = Result<String, String>> {
+    async_stream::stream! {
+        let response = match send_search_request(&http, &url, &creds, &query).await {
+            Ok(response) => response,
+            Err(err) => {
+                yield Err(err);
+                return;
+            }
+        };
+
+        // Reassemble `data:` lines from the byte stream. We buffer *bytes* (not
+        // a `String`) and decode only complete lines: a UTF-8 codepoint can
+        // straddle a chunk boundary, but never a `\n` (0x0A), so per-line
+        // decoding is lossless. The upstream emits exactly one `data: {json}`
+        // line per event, so each decoded data line is a complete JSON value.
+        let mut bytes = response.bytes_stream();
+        let mut buffer: Vec<u8> = Vec::new();
+        while let Some(chunk) = bytes.next().await {
+            let chunk = match chunk {
+                Ok(chunk) => chunk,
+                Err(err) => {
+                    yield Err(format!("deep research stream failed: {err}"));
+                    return;
+                }
+            };
+            buffer.extend_from_slice(&chunk);
+            while let Some(newline) = buffer.iter().position(|&b| b == b'\n') {
+                let line: Vec<u8> = buffer.drain(..=newline).collect();
+                if let Some(data) = parse_sse_data_line(&line) {
+                    yield Ok(data);
+                }
+            }
+        }
+        // Emit any trailing event the upstream left unterminated by a newline.
+        if let Some(data) = parse_sse_data_line(&buffer) {
+            yield Ok(data);
+        }
+    }
+}
+
+/// Sends the `POST {url}/search` request, returning the streaming response or a
+/// human-readable error for transport failures and non-2xx statuses.
+async fn send_search_request(
+    http: &reqwest::Client,
+    url: &str,
+    creds: &SubagentSearchCreds,
+    query: &str,
+) -> Result<reqwest::Response, String> {
+    let endpoint = format!("{}/search", url.trim_end_matches('/'));
+    http.post(&endpoint)
+        .header("accept", "text/event-stream")
+        .json(&subagent_search_payload(creds, query))
+        .send()
+        .await
+        .and_then(|resp| resp.error_for_status())
+        .map_err(|err| format!("deep research request failed: {err}"))
+}
+
+/// Builds the deep-research `/search` request body. The model is fixed to
+/// [`MODEL`].
+fn subagent_search_payload(creds: &SubagentSearchCreds, query: &str) -> Value {
+    json!({
+        "query": query,
+        "model": MODEL,
+        "collection_name": creds.collection_name,
+        "chroma_api_key": creds.chroma_api_key,
+        "chroma_tenant": creds.chroma_tenant,
+        "chroma_database": creds.chroma_database,
+    })
+}
+
+/// Returns the JSON payload of an SSE `data:` line. The line is split on `\n`,
+/// so its bytes form complete UTF-8 codepoints; the trailing CR/LF is trimmed.
+/// Blank lines, comments (`:`), and other SSE fields (`event:`, `id:`, …) yield
+/// `None`.
+fn parse_sse_data_line(line: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(line)
+        .trim_end_matches(['\r', '\n'])
+        .strip_prefix(SSE_DATA_PREFIX)
+        .map(str::to_string)
+}
+
+// ---------------------------------------------------------------------------
+// Result collection: distill a finished stream into structured documents
+// ---------------------------------------------------------------------------
+
+/// Consumes the deep-research stream, extracts the agent's final answer (the
+/// `user_text` from the last `action` event) and parses its
+/// `<Document>/<Justification>` blocks into structured [`RankedDocument`]s.
+///
+/// Errors if the stream produced no terminal answer, or if the answer did not
+/// follow the documented `<Document>` format. Used by the `subagent_search`
+/// agent tool in the next PR in the stack.
+#[allow(dead_code)]
+pub(crate) async fn collect_subagent_search_final(
+    http: reqwest::Client,
+    url: String,
+    creds: SubagentSearchCreds,
+    query: String,
+) -> Result<Vec<events::RankedDocument>, SubagentResultError> {
+    let stream = subagent_search_data_stream(http, url, creds, query);
+    futures::pin_mut!(stream);
+
+    // Keep the last action's `user_text` — the agent's final answer.
+    let mut final_answer: Option<String> = None;
+    while let Some(item) = stream.next().await {
+        if let Ok(raw) = item {
+            if let AgentEvent::Action(action) = AgentEvent::parse(&raw) {
+                if let Some(text) = action.user_text() {
+                    final_answer = Some(text.to_string());
+                }
+            }
+        }
+    }
+
+    let answer = final_answer.ok_or(SubagentResultError::NoFinalAnswer)?;
+    let documents = parse_ranked_documents(&answer);
+    if documents.is_empty() {
+        return Err(SubagentResultError::NoDocuments);
+    }
+    Ok(documents)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Tests live in `tests/`, split by type and numbered for readability. The
+// `tests` module reaches this module's private items via `super::super::` (and
+// the event types via `super::super::events::`).
+#[cfg(test)]
+mod tests;

--- a/rust/foundation-api/src/routes/subagent_search/tests/00_unit.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/00_unit.rs
@@ -1,0 +1,172 @@
+//! Synchronous unit tests: event parsing/serialization, SSE line decoding, and
+//! request-body building. No network or async runtime.
+
+use super::super::events::{
+    parse_ranked_documents, ActionData, AgentEvent, ErrorData, RankedDocument, SubagentSearchEvent,
+};
+use super::super::{parse_sse_data_line, subagent_search_payload, SubagentSearchCreds};
+use serde_json::{json, Value};
+
+fn test_creds() -> SubagentSearchCreds {
+    SubagentSearchCreds {
+        chroma_api_key: "tok".to_string(),
+        chroma_tenant: "team".to_string(),
+        chroma_database: "FOUNDATION".to_string(),
+        collection_name: "wiki".to_string(),
+    }
+}
+
+fn parse_action(value: Value) -> ActionData {
+    match AgentEvent::parse(&value.to_string()) {
+        AgentEvent::Action(action) => action,
+        other => panic!("expected an action, got {other:?}"),
+    }
+}
+
+#[test]
+fn agent_event_parses_each_kind() {
+    assert!(matches!(
+        AgentEvent::parse(&json!({"type":"action","data":{"tools":[],"params":[]}}).to_string()),
+        AgentEvent::Action(_)
+    ));
+    assert!(matches!(
+        AgentEvent::parse(
+            &json!({"type":"observation","data":{"step":1,"sources":["a"]}}).to_string()
+        ),
+        AgentEvent::Observation(_)
+    ));
+    assert!(matches!(
+        AgentEvent::parse(&json!({"type":"done","data":{}}).to_string()),
+        AgentEvent::Done
+    ));
+    assert!(matches!(
+        AgentEvent::parse(&json!({"type":"error","data":{"message":"boom"}}).to_string()),
+        AgentEvent::Error(ErrorData { message }) if message == "boom"
+    ));
+    // Unknown event types and unparseable lines degrade to `Unknown`.
+    assert!(matches!(
+        AgentEvent::parse(&json!({"type":"surprise","data":{}}).to_string()),
+        AgentEvent::Unknown
+    ));
+    assert!(matches!(AgentEvent::parse("not json"), AgentEvent::Unknown));
+}
+
+#[test]
+fn action_user_text_takes_last_and_detects_answer_only() {
+    // A tool-call action with no user_text.
+    let search = parse_action(json!({
+        "type": "action",
+        "data": { "tools": [{ "name": "search" }], "params": [{ "query": "rag" }] }
+    }));
+    assert_eq!(search.user_text(), None);
+    assert!(!search.is_answer_only());
+
+    // A mixed action: keeps the last user_text but is not answer-only.
+    let mixed = parse_action(json!({
+        "type": "action",
+        "data": {
+            "tools": [{ "name": "search" }, { "name": "user_text" }],
+            "params": [{ "query": "rag" }, { "text": "mid-chain" }],
+        }
+    }));
+    assert_eq!(mixed.user_text(), Some("mid-chain"));
+    assert!(!mixed.is_answer_only());
+
+    // A pure answer action.
+    let answer = parse_action(json!({
+        "type": "action",
+        "data": { "tools": [{ "name": "user_text" }], "params": [{ "text": "final answer" }] }
+    }));
+    assert_eq!(answer.user_text(), Some("final answer"));
+    assert!(answer.is_answer_only());
+}
+
+#[test]
+fn result_event_serializes_with_documents() {
+    let event = SubagentSearchEvent::Result {
+        documents: vec![RankedDocument {
+            id: "doc-1".to_string(),
+            justification: "Relevant.".to_string(),
+        }],
+    };
+    let value: Value = serde_json::to_value(&event).unwrap();
+    assert_eq!(value["type"], "result");
+    assert_eq!(value["data"]["documents"][0]["id"], "doc-1");
+    assert_eq!(value["data"]["documents"][0]["justification"], "Relevant.");
+}
+
+#[test]
+fn done_event_serializes_without_data() {
+    let value: Value = serde_json::to_value(SubagentSearchEvent::Done).unwrap();
+    assert_eq!(value, json!({ "type": "done" }));
+}
+
+#[test]
+fn parses_ranked_documents_in_order() {
+    // Mixes unquoted, double-, and single-quoted ids and multi-line
+    // justifications, with surrounding prose the parser should ignore.
+    let answer = "\
+Here are the results:
+
+<Document id=compactor-1>
+<Justification>
+The compactor merges log segments
+into the index.
+</Justification>
+</Document>
+
+<Document id=\"query-2\">
+<Justification>Query nodes serve reads.</Justification>
+</Document>
+
+<Document id='gc-3'>
+<Justification>GC reclaims storage.</Justification>
+</Document>";
+
+    let docs = parse_ranked_documents(answer);
+    assert_eq!(
+        docs,
+        vec![
+            RankedDocument {
+                id: "compactor-1".to_string(),
+                justification: "The compactor merges log segments into the index.".to_string(),
+            },
+            RankedDocument {
+                id: "query-2".to_string(),
+                justification: "Query nodes serve reads.".to_string(),
+            },
+            RankedDocument {
+                id: "gc-3".to_string(),
+                justification: "GC reclaims storage.".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn parses_no_documents_from_unstructured_text() {
+    assert!(parse_ranked_documents("I could not find anything relevant.").is_empty());
+}
+
+#[test]
+fn parses_only_sse_data_lines() {
+    assert_eq!(
+        parse_sse_data_line(b"data: {\"type\":\"done\"}\n").as_deref(),
+        Some("{\"type\":\"done\"}")
+    );
+    assert_eq!(parse_sse_data_line(b""), None);
+    assert_eq!(parse_sse_data_line(b": keep-alive comment"), None);
+    assert_eq!(parse_sse_data_line(b"event: action"), None);
+}
+
+#[test]
+fn builds_subagent_search_payload() {
+    let creds = test_creds();
+    let payload = subagent_search_payload(&creds, "what is rag");
+    assert_eq!(payload["query"], "what is rag");
+    assert_eq!(payload["model"], "scout");
+    assert_eq!(payload["collection_name"], "wiki");
+    assert_eq!(payload["chroma_api_key"], "tok");
+    assert_eq!(payload["chroma_tenant"], "team");
+    assert_eq!(payload["chroma_database"], "FOUNDATION");
+}

--- a/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
@@ -1,0 +1,128 @@
+//! Integration tests: drive the SSE stream against a mocked deep-research
+//! dependency (`httpmock`) and assert the events we emit end-to-end.
+
+use super::super::events::RankedDocument;
+use super::super::{collect_subagent_search_final, stream_subagent_search, SubagentSearchCreds};
+use futures::StreamExt;
+use httpmock::MockServer;
+
+fn test_creds() -> SubagentSearchCreds {
+    SubagentSearchCreds {
+        chroma_api_key: "tok".to_string(),
+        chroma_tenant: "team".to_string(),
+        chroma_database: "FOUNDATION".to_string(),
+        collection_name: "wiki".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn streams_and_collects_final_from_mocked_sse() {
+    let server = MockServer::start_async().await;
+    // Two action events (the second carries the terminal answer) then done,
+    // framed as SSE `data:` lines like the upstream emits.
+    let body = concat!(
+        "data: {\"type\":\"action\",\"data\":{\"tools\":[{\"name\":\"search\"}],\"params\":[{\"query\":\"rag\"}]}}\n\n",
+        "data: {\"type\":\"observation\",\"data\":{\"sources\":[\"a\"]}}\n\n",
+        "data: {\"type\":\"action\",\"data\":{\"tools\":[{\"name\":\"user_text\"}],\"params\":[{\"text\":\"<Document id=doc-1><Justification>Relevant to rag.</Justification></Document>\"}]}}\n\n",
+        "data: {\"type\":\"done\",\"data\":{}}\n\n",
+    );
+    let mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path("/search");
+            then.status(200)
+                .header("content-type", "text/event-stream")
+                .body(body);
+        })
+        .await;
+
+    // The stream forwards the search action + observation (2 events), drops
+    // the raw `user_text` answer action, and injects `result` + `done` —
+    // so: action, observation, result, done = 4.
+    let stream = stream_subagent_search(
+        reqwest::Client::new(),
+        server.base_url(),
+        test_creds(),
+        "rag".to_string(),
+    );
+    let count = stream
+        .fold(0usize, |acc, ev| async move {
+            assert!(ev.is_ok());
+            acc + 1
+        })
+        .await;
+    assert_eq!(count, 4, "action + observation + result + done");
+
+    // The collect core resolves the terminal answer into ranked documents.
+    let documents = collect_subagent_search_final(
+        reqwest::Client::new(),
+        server.base_url(),
+        test_creds(),
+        "rag".to_string(),
+    )
+    .await
+    .expect("documents parse");
+    assert_eq!(
+        documents,
+        vec![RankedDocument {
+            id: "doc-1".to_string(),
+            justification: "Relevant to rag.".to_string(),
+        }]
+    );
+    assert_eq!(mock.calls(), 2);
+}
+
+#[tokio::test]
+async fn upstream_error_event_ends_stream_with_error() {
+    let server = MockServer::start_async().await;
+    // A well-formed stream that ends in an `error` event instead of `done`.
+    let body = concat!(
+        "data: {\"type\":\"action\",\"data\":{\"tools\":[{\"name\":\"search\"}],\"params\":[{\"query\":\"rag\"}]}}\n\n",
+        "data: {\"type\":\"error\",\"data\":{\"message\":\"agent exploded\"}}\n\n",
+    );
+    let mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path("/search");
+            then.status(200)
+                .header("content-type", "text/event-stream")
+                .body(body);
+        })
+        .await;
+
+    let stream = stream_subagent_search(
+        reqwest::Client::new(),
+        server.base_url(),
+        test_creds(),
+        "rag".to_string(),
+    );
+    let events: Vec<_> = stream.collect().await;
+    // The action streams through, then the error terminates the stream.
+    assert_eq!(events.len(), 2);
+    assert!(events[0].is_ok());
+    assert!(events[1].is_err(), "the error event ends the stream");
+    assert_eq!(mock.calls(), 1);
+}
+
+#[tokio::test]
+async fn upstream_error_status_ends_stream_with_error() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path("/search");
+            then.status(500).body("boom");
+        })
+        .await;
+
+    let stream = stream_subagent_search(
+        reqwest::Client::new(),
+        server.base_url(),
+        test_creds(),
+        "rag".to_string(),
+    );
+    let events: Vec<_> = stream.collect().await;
+    assert_eq!(events.len(), 1, "a failed request should yield one item");
+    assert!(
+        events[0].is_err(),
+        "the failure should surface as a stream error, not an event"
+    );
+    assert_eq!(mock.calls(), 1);
+}

--- a/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
@@ -103,6 +103,84 @@ async fn upstream_error_event_ends_stream_with_error() {
 }
 
 #[tokio::test]
+async fn answer_with_no_documents_emits_empty_result_then_done() {
+    let server = MockServer::start_async().await;
+    // A terminal answer that yields no `<Document>` blocks (a legitimate
+    // "found nothing" result) followed by done.
+    let body = concat!(
+        "data: {\"type\":\"action\",\"data\":{\"tools\":[{\"name\":\"user_text\"}],\"params\":[{\"text\":\"I could not find anything relevant.\"}]}}\n\n",
+        "data: {\"type\":\"done\",\"data\":{}}\n\n",
+    );
+    let mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path("/search");
+            then.status(200)
+                .header("content-type", "text/event-stream")
+                .body(body);
+        })
+        .await;
+
+    // The answer-only action is dropped; result + done are injected. No error.
+    let stream = stream_subagent_search(
+        reqwest::Client::new(),
+        server.base_url(),
+        test_creds(),
+        "rag".to_string(),
+    );
+    let events: Vec<_> = stream.collect().await;
+    assert_eq!(events.len(), 2, "empty result + done");
+    assert!(events.iter().all(|e| e.is_ok()), "no hits is not an error");
+
+    // The collect core resolves the same stream to an empty document list.
+    let documents = collect_subagent_search_final(
+        reqwest::Client::new(),
+        server.base_url(),
+        test_creds(),
+        "rag".to_string(),
+    )
+    .await
+    .expect("empty results are Ok");
+    assert!(documents.is_empty());
+    assert_eq!(mock.calls(), 2);
+}
+
+#[tokio::test]
+async fn stream_without_terminator_ends_with_synthesized_error() {
+    let server = MockServer::start_async().await;
+    // A stream that ends after an action, never sending `done` or `error`.
+    let body = concat!(
+        "data: {\"type\":\"action\",\"data\":{\"tools\":[{\"name\":\"search\"}],\"params\":[{\"query\":\"rag\"}]}}\n\n",
+        "data: {\"type\":\"observation\",\"data\":{\"sources\":[\"a\"]}}\n\n",
+    );
+    let mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path("/search");
+            then.status(200)
+                .header("content-type", "text/event-stream")
+                .body(body);
+        })
+        .await;
+
+    let stream = stream_subagent_search(
+        reqwest::Client::new(),
+        server.base_url(),
+        test_creds(),
+        "rag".to_string(),
+    );
+    let events: Vec<_> = stream.collect().await;
+    // action + observation stream through, then a synthesized terminal error
+    // so the caller never sees a silent close.
+    assert_eq!(events.len(), 3);
+    assert!(events[0].is_ok());
+    assert!(events[1].is_ok());
+    assert!(
+        events[2].is_err(),
+        "a terminator-less close should surface as a stream error"
+    );
+    assert_eq!(mock.calls(), 1);
+}
+
+#[tokio::test]
 async fn upstream_error_status_ends_stream_with_error() {
     let server = MockServer::start_async().await;
     let mock = server

--- a/rust/foundation-api/src/routes/subagent_search/tests/02_live.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/02_live.rs
@@ -1,0 +1,81 @@
+//! Live end-to-end test against the real deep-research API. Ignored by default
+//! (no network in CI); run explicitly with credentials.
+
+use super::super::events::{parse_ranked_documents, AgentEvent};
+use super::super::{subagent_search_data_stream, SubagentSearchCreds};
+use futures::StreamExt;
+
+/// Live end-to-end test against the real deep-research API. Ignored by
+/// default (no network in CI). Run with the credentials/endpoint set:
+///
+/// ```bash
+/// DEEP_RESEARCH_API_URL=https://chroma-core--search-agent-api-serve.modal.run \
+/// CHROMA_API_KEY=ck-... CHROMA_TENANT=... CHROMA_DATABASE=foundation-research \
+/// DEEP_RESEARCH_COLLECTION=wiki_master \
+/// cargo test -p foundation-api -- --ignored --nocapture live_subagent_search
+/// ```
+#[tokio::test]
+#[ignore = "hits the live deep-research API; requires credentials"]
+async fn live_subagent_search_streams_events() {
+    let url = std::env::var("DEEP_RESEARCH_API_URL").expect("DEEP_RESEARCH_API_URL");
+    let creds = SubagentSearchCreds {
+        chroma_api_key: std::env::var("CHROMA_API_KEY").expect("CHROMA_API_KEY"),
+        chroma_tenant: std::env::var("CHROMA_TENANT").expect("CHROMA_TENANT"),
+        chroma_database: std::env::var("CHROMA_DATABASE").expect("CHROMA_DATABASE"),
+        collection_name: std::env::var("DEEP_RESEARCH_COLLECTION")
+            .expect("DEEP_RESEARCH_COLLECTION"),
+    };
+    let query = std::env::var("DEEP_RESEARCH_QUERY")
+        .unwrap_or_else(|_| "What does the Chroma compactor do?".to_string());
+
+    let http = reqwest::Client::new();
+    let raw = subagent_search_data_stream(http, url, creds, query);
+    futures::pin_mut!(raw);
+
+    let mut final_answer: Option<String> = None;
+    let mut count = 0usize;
+    let mut saw_done = false;
+    let mut saw_error = false;
+    while let Some(item) = raw.next().await {
+        let data = match item {
+            Ok(data) => data,
+            Err(message) => panic!("stream transport error: {message}"),
+        };
+        count += 1;
+        match AgentEvent::parse(&data) {
+            AgentEvent::Action(action) => {
+                eprintln!("event: action");
+                if let Some(text) = action.user_text() {
+                    final_answer = Some(text.to_string());
+                }
+            }
+            AgentEvent::Observation(_) => eprintln!("event: observation"),
+            AgentEvent::Done => {
+                eprintln!("event: done");
+                saw_done = true;
+            }
+            AgentEvent::Error(error) => {
+                saw_error = true;
+                eprintln!("event: error -> {}", error.message);
+            }
+            AgentEvent::Unknown => eprintln!("event: unknown"),
+        }
+    }
+
+    assert!(count > 0, "expected at least one SSE event");
+    assert!(!saw_error, "upstream returned an error event");
+    assert!(saw_done, "expected a terminal `done` event");
+
+    let answer = final_answer.expect("terminal user_text answer");
+    eprintln!("\n=== raw final answer ===\n{answer}");
+
+    let documents = parse_ranked_documents(&answer);
+    eprintln!("\n=== parsed {} document(s) ===", documents.len());
+    for (rank, doc) in documents.iter().enumerate() {
+        eprintln!("{:>3}. {}\n     {}", rank + 1, doc.id, doc.justification);
+    }
+    assert!(
+        !documents.is_empty(),
+        "expected the answer to parse into ranked documents"
+    );
+}

--- a/rust/foundation-api/src/routes/subagent_search/tests/mod.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/mod.rs
@@ -1,0 +1,10 @@
+//! Tests for the `subagent_search` route, split by type and numbered for
+//! readability. The numeric filename prefixes require `#[path]` (a module name
+//! can't begin with a digit); the files are plain siblings of this `mod.rs`.
+
+#[path = "01_integration.rs"]
+mod integration;
+#[path = "02_live.rs"]
+mod live;
+#[path = "00_unit.rs"]
+mod unit;

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -14,7 +14,7 @@
 //! delete-then-add below will be replaced with it to close the partial-write
 //! window and the read-then-write race on a slug.
 
-use super::whoami::whoami_and_authorize;
+use crate::routes::{caller_token, whoami::whoami_and_authorize};
 use crate::wiki::chunking::{chunk_content, chunk_id_for, title_from_content, ChunkingConfig};
 use crate::wiki::client::is_not_found;
 use crate::wiki::embed::WikiEmbedder;
@@ -35,10 +35,6 @@ use std::future::Future;
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use validator::{Validate, ValidationError};
-
-/// HTTP header carrying the caller's Chroma Cloud token, forwarded to the FE on
-/// every proxied call so authz/quota/billing key off the user.
-const CHROMA_TOKEN_HEADER: &str = "x-chroma-token";
 
 /// Max records per `add` request. Chroma Cloud's embedding service rejects
 /// calls with more than this many docs, and large pages can exceed it, so adds
@@ -120,7 +116,7 @@ pub enum UpsertPageError {
     #[error("wiki record I/O is not configured")]
     RouteDisabled,
     /// The caller's request carried no usable `x-chroma-token`.
-    #[error("missing or invalid {CHROMA_TOKEN_HEADER} header")]
+    #[error("missing or invalid x-chroma-token header")]
     MissingToken,
     /// Resolving the wiki collection through the proxy failed.
     #[error(transparent)]
@@ -178,7 +174,7 @@ async fn upsert_page(
         .wiki_client
         .as_ref()
         .ok_or(UpsertPageError::RouteDisabled)?;
-    let token = chroma_token(headers)?;
+    let token = caller_token(headers).ok_or(UpsertPageError::MissingToken)?;
 
     // Resolve (cache-first) the wiki collection identity, then derive the
     // chunker from its metadata so writes match how the collection was created.
@@ -370,15 +366,6 @@ where
         }
         UpsertPageError::RecordIo(err)
     })
-}
-
-/// Extracts the caller's Chroma token from the request headers.
-fn chroma_token(headers: &HeaderMap) -> Result<&str, UpsertPageError> {
-    headers
-        .get(CHROMA_TOKEN_HEADER)
-        .and_then(|value| value.to_str().ok())
-        .filter(|token| !token.is_empty())
-        .ok_or(UpsertPageError::MissingToken)
 }
 
 /// Validates the slug against [`SLUG_RE`].

--- a/rust/foundation-api/src/server.rs
+++ b/rust/foundation-api/src/server.rs
@@ -60,6 +60,11 @@ pub struct FoundationApiServer {
     // Read by the wiki record-I/O routes added later in the stack.
     #[allow(dead_code)]
     pub(crate) wiki_client: Option<WikiClient>,
+    /// Process-wide HTTP client (one shared connection pool) for outbound calls
+    /// that don't go through the Chroma client: the deep-research SSE proxy and,
+    /// in a later PR, the agent's Anthropic inference model. Cloned per request;
+    /// clones share the pool (reqwest pools per host internally).
+    pub(crate) shared_http_client: reqwest::Client,
 }
 
 impl FoundationApiServer {
@@ -102,6 +107,7 @@ impl FoundationApiServer {
             system,
             metrics,
             wiki_client,
+            shared_http_client: reqwest::Client::new(),
         }
     }
 

--- a/rust/foundation-api/src/server.rs
+++ b/rust/foundation-api/src/server.rs
@@ -61,9 +61,7 @@ pub struct FoundationApiServer {
     #[allow(dead_code)]
     pub(crate) wiki_client: Option<WikiClient>,
     /// Process-wide HTTP client (one shared connection pool) for outbound calls
-    /// that don't go through the Chroma client: the deep-research SSE proxy and,
-    /// in a later PR, the agent's Anthropic inference model. Cloned per request;
-    /// clones share the pool (reqwest pools per host internally).
+    /// that don't go through the Chroma client
     pub(crate) shared_http_client: reqwest::Client,
 }
 


### PR DESCRIPTION
## Description of changes

Second PR in the foundation-agent stack. Adds the two retrieval endpoints that
will back the agent's tools, plus the wiring they share.

- New functionality
  - `POST /api/search`: hybrid dense + sparse search over the wiki collection,
    returning ranked hits.
  - `POST /api/subagent_search`: SSE endpoint that proxies the deep-research
    service, re-emitting a narrow typed event stream (`SearchCall`, etc.) and
    parsing the terminal `<Document>`/`<Justification>` payload into structured
    JSON so downstream consumers never see the raw format.
- Improvements & Bug fixes
  - `FoundationApiServer` gains a shared outbound `reqwest` client (one pooled
    client reused for non-Chroma calls).
  - `deep_research_api_url` added to foundation config; `subagent_search` is
    only mounted when it is set.
  - `rust/chroma` collection helper exposes the query path used by `/api/search`.

## Test plan

- [x] `cargo test -p foundation-api`
- Unit tests cover request/payload shaping and `<Document>` parsing;
  integration tests drive the SSE stream against a mocked upstream
  (`httpmock`); an `#[ignore]` live test hits the real service.

## Migration plan

None — new routes; `subagent_search` degrades to unavailable when
`deep_research_api_url` is unset.

## Observability plan

Requests go through the existing scorecard/authz path and are tagged per
tenant.

## Documentation Changes

Module-level and handler docstrings document the request/response and event
schemas.