### PR TITLE
build: ban relative imports via flake8-tidy-imports (#2334)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+extend-ignore = E203,E501,E503,I250
+max-line-length = 88
+ban-relative-imports = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,7 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
-        args:
-          - "--extend-ignore=E203,E501,E503"
-          - "--max-line-length=88"
+        additional_dependencies: ["flake8-tidy-imports"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -8,7 +8,7 @@ It can be used to get information about available schemas and their versions.
 from typing import Dict, List, Set
 import os
 import json
-from .schema_utils import SCHEMAS_DIR
+from chromadb.utils.embedding_functions.schemas.schema_utils import SCHEMAS_DIR
 
 
 def get_available_schemas() -> List[str]:


### PR DESCRIPTION
## Description of changes

Closes #2334. The project prefers absolute imports; this enforces it in lint.

- Improvements & Bug fixes
  - Add `flake8-tidy-imports` with `ban-relative-imports = true` (new `.flake8`) and register the plugin in `.pre-commit-config.yaml`. Existing flake8 settings (`extend-ignore`, `max-line-length`) are moved into `.flake8` so there is a single source of truth.
  - Convert the one remaining relative import to absolute in `chromadb/utils/embedding_functions/schemas/registry.py`.
- New functionality
  - None.

Scope note: the plugin's unnecessary-alias check (`I250`) is intentionally disabled so this PR stays focused on relative imports. Happy to enable it and clean up aliases in a follow-up if preferred.

## Test plan

- [x] `flake8 --select=I252 chromadb` reports 0 — no relative imports remain
- [x] `import chromadb` works after the change
- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

None — lint/config-only change plus one equivalent import rewrite. No runtime behavior changes.

## Observability plan

N/A — no runtime change.

## Documentation Changes

None required.