### PR TITLE
[ENH] Bootstrap foundation currents collection

### DIFF
--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -39,6 +39,8 @@ pub struct FoundationConfig {
     pub wiki_collection: String,
     #[serde(default = "FoundationConfig::default_wiki_revisions_collection")]
     pub wiki_revisions_collection: String,
+    #[serde(default = "FoundationConfig::default_currents_collection")]
+    pub currents_collection: String,
     /// Base name for the per-user file-uploads collection. The actual
     /// collection name is `{base}_{user_id}`, making it private to the
     /// authenticated user rather than shared tenant-wide.
@@ -80,6 +82,9 @@ impl FoundationConfig {
     fn default_wiki_revisions_collection() -> String {
         "wiki_revisions".to_string()
     }
+    fn default_currents_collection() -> String {
+        "currents".to_string()
+    }
     fn default_file_uploads_collection() -> String {
         "file_uploads".to_string()
     }
@@ -104,6 +109,7 @@ impl Default for FoundationConfig {
             frontend_ingress_url: None,
             wiki_collection: Self::default_wiki_collection(),
             wiki_revisions_collection: Self::default_wiki_revisions_collection(),
+            currents_collection: Self::default_currents_collection(),
             file_uploads_collection: Self::default_file_uploads_collection(),
             agent_sessions_collection: Self::default_agent_sessions_collection(),
             source_collections: Self::default_source_collections(),

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -1,14 +1,16 @@
 use super::whoami::whoami_and_authorize;
 use crate::{
     auth::AuthzAction, config::FoundationConfig, errors::ServerError, server::FoundationApiServer,
+    wiki::WikiClientError,
 };
 use axum::{extract::State, http::HeaderMap, Json};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_sysdb::SysDb;
 use chroma_types::{
     Collection, CollectionUuid, CreateDatabaseError, DatabaseName, EmbeddingFunctionConfiguration,
-    EmbeddingFunctionNewConfiguration, IndexConfig, KnnIndex, Metadata, MetadataValue, Schema,
-    SparseIndexAlgorithm, SparseVectorIndexConfig, CHROMA_GROUP_CHUNK_SIBLINGS_KEY, DOCUMENT_KEY,
+    EmbeddingFunctionNewConfiguration, Include, IncludeList, IndexConfig, KnnIndex, Metadata,
+    MetadataValue, Schema, SparseIndexAlgorithm, SparseVectorIndexConfig,
+    CHROMA_GROUP_CHUNK_SIBLINGS_KEY, DOCUMENT_KEY,
 };
 use frontend_core::{
     attached_function_ops,
@@ -17,7 +19,7 @@ use frontend_core::{
     },
     foundation::source_kind_for_collection_name,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -29,6 +31,7 @@ pub struct FoundationInitResponse {
     pub database_id: String,
     pub wiki_collection_id: String,
     pub wiki_revisions_collection_id: String,
+    pub currents_collection_id: String,
     pub file_uploads_collection_id: String,
     pub agent_sessions_collection_id: String,
     /// Source collection name -> id for each ensured source collection
@@ -84,6 +87,27 @@ pub async fn foundation_init(
         None,
         Some(1),
         CollectionEmbeddingFunctions::default(),
+    )
+    .await?;
+    let currents = ensure_collection(
+        &mut sysdb,
+        tenant.clone(),
+        db_name.clone(),
+        &foundation_cfg.currents_collection,
+        None,
+        Some(1024),
+        CollectionEmbeddingFunctions {
+            dense: Some(qwen_embedding_function()),
+            sparse: Some(splade_embedding_function()),
+        },
+    )
+    .await?;
+
+    maybe_seed_currents_collection(
+        &server,
+        &headers,
+        &tenant,
+        &foundation_cfg.currents_collection,
     )
     .await?;
 
@@ -181,6 +205,7 @@ pub async fn foundation_init(
         database_id: database_id.to_string(),
         wiki_collection_id: wiki.collection_id.to_string(),
         wiki_revisions_collection_id: wiki_revisions.collection_id.to_string(),
+        currents_collection_id: currents.collection_id.to_string(),
         file_uploads_collection_id: file_uploads.collection_id.to_string(),
         agent_sessions_collection_id: agent_sessions.collection_id.to_string(),
         source_collection_ids,
@@ -291,11 +316,218 @@ async fn ensure_revision_history_function(
 enum FoundationInitError {
     #[error("Configured foundation database name is shorter than the 3-character minimum")]
     DatabaseNameTooShort,
+    #[error("foundation frontend_ingress_url is not configured")]
+    FrontendIngressUrlMissing,
+    #[error("missing or invalid x-chroma-token header")]
+    MissingToken,
+    #[error(transparent)]
+    WikiClient(#[from] WikiClientError),
+    #[error("chroma record I/O failed: {0}")]
+    RecordIo(chroma::client::ChromaHttpClientError),
 }
 
 impl ChromaError for FoundationInitError {
     fn code(&self) -> ErrorCodes {
-        ErrorCodes::InvalidArgument
+        match self {
+            FoundationInitError::DatabaseNameTooShort | FoundationInitError::MissingToken => {
+                ErrorCodes::InvalidArgument
+            }
+            FoundationInitError::FrontendIngressUrlMissing
+            | FoundationInitError::WikiClient(_)
+            | FoundationInitError::RecordIo(_) => ErrorCodes::Internal,
+        }
+    }
+}
+
+const CHROMA_TOKEN_HEADER: &str = "x-chroma-token";
+
+fn chroma_token(headers: &HeaderMap) -> Result<&str, FoundationInitError> {
+    headers
+        .get(CHROMA_TOKEN_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|token| !token.is_empty())
+        .ok_or(FoundationInitError::MissingToken)
+}
+
+async fn ensure_currents_collection(
+    server: &FoundationApiServer,
+    headers: &HeaderMap,
+    tenant: &str,
+    collection_name: &str,
+) -> Result<(), ServerError> {
+    let wiki_client = server
+        .wiki_client
+        .as_ref()
+        .ok_or(FoundationInitError::FrontendIngressUrlMissing)?;
+    let token = chroma_token(headers)?;
+    let records = mock_currents_records();
+    let desired_ids: Vec<String> = records.iter().map(|record| record.id.clone()).collect();
+    let collection = wiki_client
+        .get_collection_by_name(tenant, token, collection_name)
+        .await?;
+    let existing = collection
+        .get(
+            Some(desired_ids.clone()),
+            None,
+            None,
+            None,
+            Some(IncludeList(vec![Include::Metadata])),
+        )
+        .await
+        .map_err(FoundationInitError::RecordIo)?;
+    let existing_ids: std::collections::HashSet<&str> =
+        existing.ids.iter().map(String::as_str).collect();
+    let missing_records: Vec<MockCurrentRecord> = records
+        .into_iter()
+        .filter(|record| !existing_ids.contains(record.id.as_str()))
+        .collect();
+    if missing_records.is_empty() {
+        return Ok(());
+    }
+
+    let ids: Vec<String> = missing_records
+        .iter()
+        .map(|record| record.id.clone())
+        .collect();
+    let documents: Vec<Option<String>> = missing_records
+        .iter()
+        .map(|record| Some(record.document.clone()))
+        .collect();
+    let metadatas: Vec<Option<Metadata>> = missing_records
+        .into_iter()
+        .map(|record| Some(record.metadata))
+        .collect();
+    collection
+        .add(
+            ids,
+            None::<Vec<Vec<f32>>>,
+            Some(documents),
+            None,
+            Some(metadatas),
+        )
+        .await
+        .map_err(FoundationInitError::RecordIo)?;
+    Ok(())
+}
+
+async fn maybe_seed_currents_collection(
+    server: &FoundationApiServer,
+    headers: &HeaderMap,
+    tenant: &str,
+    collection_name: &str,
+) -> Result<(), ServerError> {
+    if server.wiki_client.is_none() {
+        tracing::info!(
+            collection_name = collection_name,
+            "skipping currents mock seed because frontend_ingress_url is not configured"
+        );
+        return Ok(());
+    }
+
+    if chroma_token(headers).is_err() {
+        tracing::info!(
+            collection_name = collection_name,
+            "skipping currents mock seed because request carried no x-chroma-token"
+        );
+        return Ok(());
+    }
+
+    ensure_currents_collection(server, headers, tenant, collection_name).await
+}
+
+struct MockCurrentRecord {
+    id: String,
+    document: String,
+    metadata: Metadata,
+}
+
+#[derive(Debug, Deserialize)]
+struct MockCurrentFixture {
+    tilegroup_id: String,
+    label: String,
+    headline: String,
+    summary: String,
+    tiles: Vec<MockTileFixture>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MockTileFixture {
+    slug: String,
+    title: String,
+    role: String,
+    blurb: String,
+}
+
+fn mock_currents_records() -> Vec<MockCurrentRecord> {
+    let fixture = include_str!("mock_currents.json");
+    let tilegroups: Vec<MockCurrentFixture> =
+        serde_json::from_str(fixture).expect("mock_currents.json must be valid");
+    tilegroups.into_iter().map(mock_current_record).collect()
+}
+
+fn mock_current_record(fixture: MockCurrentFixture) -> MockCurrentRecord {
+    let MockCurrentFixture {
+        tilegroup_id,
+        label,
+        headline,
+        summary,
+        tiles,
+    } = fixture;
+    let page_slugs: Vec<String> = tiles.iter().map(|tile| tile.slug.clone()).collect();
+    let tile_roles: Vec<String> = tiles.iter().map(|tile| tile.role.clone()).collect();
+    let mut metadata = Metadata::new();
+    metadata.insert(
+        "tilegroup_id".to_string(),
+        MetadataValue::Str(tilegroup_id.clone()),
+    );
+    metadata.insert("label".to_string(), MetadataValue::Str(label.clone()));
+    metadata.insert("headline".to_string(), MetadataValue::Str(headline.clone()));
+    metadata.insert("summary".to_string(), MetadataValue::Str(summary.clone()));
+    metadata.insert(
+        "tile_count".to_string(),
+        MetadataValue::Int(tiles.len() as i64),
+    );
+    metadata.insert(
+        "page_slugs".to_string(),
+        MetadataValue::StringArray(page_slugs),
+    );
+    metadata.insert(
+        "tile_roles".to_string(),
+        MetadataValue::StringArray(tile_roles),
+    );
+    for (idx, tile) in tiles.iter().enumerate() {
+        let key = format!("tile_{:02}_json", idx + 1);
+        let value = serde_json::json!({
+            "order": idx + 1,
+            "slug": tile.slug,
+            "title": tile.title,
+            "role": tile.role,
+            "blurb": tile.blurb,
+        });
+        metadata.insert(key, MetadataValue::Str(value.to_string()));
+    }
+
+    let tiles_document = tiles
+        .iter()
+        .enumerate()
+        .map(|(idx, tile)| {
+            format!(
+                "Tile {}\nSlug: {}\nTitle: {}\nRole: {}\nBlurb: {}",
+                idx + 1,
+                tile.slug,
+                tile.title,
+                tile.role,
+                tile.blurb
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let document = format!("{}: {}. {}\n\n{}", label, headline, summary, tiles_document);
+
+    MockCurrentRecord {
+        id: format!("tilegroup:{tilegroup_id}"),
+        document,
+        metadata,
     }
 }
 

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -313,8 +313,8 @@ async fn ensure_revision_history_function(
 enum FoundationInitError {
     #[error("Configured foundation database name is shorter than the 3-character minimum")]
     DatabaseNameTooShort,
-    #[error("foundation frontend_ingress_url is not configured")]
-    FrontendIngressUrlMissing,
+    #[error("foundation wiki record I/O is unavailable")]
+    WikiRouteUnavailable,
     #[error("missing or invalid x-chroma-token header")]
     MissingToken,
     #[error(transparent)]
@@ -329,7 +329,7 @@ impl ChromaError for FoundationInitError {
             FoundationInitError::DatabaseNameTooShort | FoundationInitError::MissingToken => {
                 ErrorCodes::InvalidArgument
             }
-            FoundationInitError::FrontendIngressUrlMissing
+            FoundationInitError::WikiRouteUnavailable
             | FoundationInitError::WikiClient(_)
             | FoundationInitError::RecordIo(_) => ErrorCodes::Internal,
         }
@@ -355,7 +355,7 @@ async fn ensure_currents_collection(
     let wiki_client = server
         .wiki_client
         .as_ref()
-        .ok_or(FoundationInitError::FrontendIngressUrlMissing)?;
+        .ok_or(FoundationInitError::WikiRouteUnavailable)?;
     let token = chroma_token(headers)?;
     let collection = wiki_client
         .get_collection_by_name(tenant, token, collection_name)
@@ -401,7 +401,7 @@ async fn maybe_seed_currents_collection(
     if server.wiki_client.is_none() {
         tracing::info!(
             collection_name = collection_name,
-            "skipping currents mock seed because frontend_ingress_url is not configured"
+            "skipping currents mock seed because foundation wiki record I/O is unavailable"
         );
         return Ok(());
     }

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -9,8 +9,8 @@ use chroma_sysdb::SysDb;
 use chroma_types::{
     Collection, CollectionUuid, CreateDatabaseError, DatabaseName, EmbeddingFunctionConfiguration,
     EmbeddingFunctionNewConfiguration, IndexConfig, KnnIndex, Metadata, MetadataValue, Schema,
-    SparseIndexAlgorithm, SparseVectorIndexConfig, UpdateMetadata,
-    CHROMA_GROUP_CHUNK_SIBLINGS_KEY, DOCUMENT_KEY,
+    SparseIndexAlgorithm, SparseVectorIndexConfig, UpdateMetadata, CHROMA_GROUP_CHUNK_SIBLINGS_KEY,
+    DOCUMENT_KEY,
 };
 use frontend_core::{
     attached_function_ops,

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -8,8 +8,8 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_sysdb::SysDb;
 use chroma_types::{
     Collection, CollectionUuid, CreateDatabaseError, DatabaseName, EmbeddingFunctionConfiguration,
-    EmbeddingFunctionNewConfiguration, Include, IncludeList, IndexConfig, KnnIndex, Metadata,
-    MetadataValue, Schema, SparseIndexAlgorithm, SparseVectorIndexConfig,
+    EmbeddingFunctionNewConfiguration, IndexConfig, KnnIndex, Metadata, MetadataValue, Schema,
+    SparseIndexAlgorithm, SparseVectorIndexConfig, UpdateMetadata,
     CHROMA_GROUP_CHUNK_SIBLINGS_KEY, DOCUMENT_KEY,
 };
 use frontend_core::{
@@ -360,45 +360,30 @@ async fn ensure_currents_collection(
         .as_ref()
         .ok_or(FoundationInitError::FrontendIngressUrlMissing)?;
     let token = chroma_token(headers)?;
-    let records = mock_currents_records();
-    let desired_ids: Vec<String> = records.iter().map(|record| record.id.clone()).collect();
     let collection = wiki_client
         .get_collection_by_name(tenant, token, collection_name)
         .await?;
-    let existing = collection
-        .get(
-            Some(desired_ids.clone()),
-            None,
-            None,
-            None,
-            Some(IncludeList(vec![Include::Metadata])),
-        )
-        .await
-        .map_err(FoundationInitError::RecordIo)?;
-    let existing_ids: std::collections::HashSet<&str> =
-        existing.ids.iter().map(String::as_str).collect();
-    let missing_records: Vec<MockCurrentRecord> = records
-        .into_iter()
-        .filter(|record| !existing_ids.contains(record.id.as_str()))
-        .collect();
-    if missing_records.is_empty() {
-        return Ok(());
-    }
+    let records = mock_currents_records();
 
-    let ids: Vec<String> = missing_records
-        .iter()
-        .map(|record| record.id.clone())
-        .collect();
-    let documents: Vec<Option<String>> = missing_records
+    let ids: Vec<String> = records.iter().map(|record| record.id.clone()).collect();
+    let documents: Vec<Option<String>> = records
         .iter()
         .map(|record| Some(record.document.clone()))
         .collect();
-    let metadatas: Vec<Option<Metadata>> = missing_records
+    let metadatas: Vec<Option<UpdateMetadata>> = records
         .into_iter()
-        .map(|record| Some(record.metadata))
+        .map(|record| {
+            Some(
+                record
+                    .metadata
+                    .into_iter()
+                    .map(|(key, value)| (key, value.into()))
+                    .collect(),
+            )
+        })
         .collect();
     collection
-        .add(
+        .upsert(
             ids,
             None::<Vec<Vec<f32>>>,
             Some(documents),

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -95,11 +95,8 @@ pub async fn foundation_init(
         db_name.clone(),
         &foundation_cfg.currents_collection,
         None,
-        Some(1024),
-        CollectionEmbeddingFunctions {
-            dense: Some(qwen_embedding_function()),
-            sparse: Some(splade_embedding_function()),
-        },
+        None,
+        CollectionEmbeddingFunctions::default(),
     )
     .await?;
 

--- a/rust/foundation-api/src/routes/mock_currents.json
+++ b/rust/foundation-api/src/routes/mock_currents.json
@@ -1,0 +1,130 @@
+[
+  {
+    "tilegroup_id": "tg_deployment_automation",
+    "label": "Strategic Tensions",
+    "headline": "Deployment automation is being bypassed instead of repaired",
+    "summary": "Release and hotfix workflows keep falling back to manual coordination while architectural coupling remains unresolved.",
+    "tiles": [
+      {
+        "slug": "broken-hotfix-workflow",
+        "title": "Broken hotfix workflow",
+        "role": "decision",
+        "blurb": "The intended hotfix path broke often enough that manual intervention became the default escape hatch."
+      },
+      {
+        "slug": "release-process-friction",
+        "title": "Release process friction",
+        "role": "evidence",
+        "blurb": "Release coordination started absorbing architecture work because deployment boundaries stayed blurry."
+      },
+      {
+        "slug": "version-drift-between-services",
+        "title": "Version drift between services",
+        "role": "consequence",
+        "blurb": "Hosted and OSS services drifted independently, so automation could no longer assume compatible artifacts."
+      },
+      {
+        "slug": "manual-deploy-playbook",
+        "title": "Manual deploy playbook",
+        "role": "workaround",
+        "blurb": "The workaround became institutional knowledge, masking the fact that the root fix was still missing."
+      }
+    ]
+  },
+  {
+    "tilegroup_id": "tg_silent_state_transitions",
+    "label": "Quiet Assumptions",
+    "headline": "Silent state transitions hide initialization failures until downstream work breaks",
+    "summary": "Multiple setup flows appear complete before they are actually usable, which turns missing finalization into a delayed failure mode.",
+    "tiles": [
+      {
+        "slug": "attached-functions-lifecycle",
+        "title": "Attached functions lifecycle",
+        "role": "decision",
+        "blurb": "The setup flow looks successful before the finalize step has actually made the function runnable."
+      },
+      {
+        "slug": "asynchronous-validation-design",
+        "title": "Asynchronous validation design",
+        "role": "evidence",
+        "blurb": "Validation moved downstream, making correctness depend on later async work rather than the initial write succeeding cleanly."
+      },
+      {
+        "slug": "segment-model-architecture",
+        "title": "Segment model architecture",
+        "role": "consequence",
+        "blurb": "Downstream systems operate as if state is valid, so failures surface later and farther from the original action."
+      },
+      {
+        "slug": "metadata-database-design",
+        "title": "Metadata database design",
+        "role": "open_thread",
+        "blurb": "The metadata layer still carries unresolved questions about when state should be considered durable versus merely accepted."
+      }
+    ]
+  },
+  {
+    "tilegroup_id": "tg_multi_region_rollout",
+    "label": "Operational Pressure",
+    "headline": "Multi-region rollout is moving faster than infrastructure readiness and decision clarity",
+    "summary": "Expansion work keeps surfacing unresolved ownership, deployment, and reliability questions that were manageable in one region but compound across many.",
+    "tiles": [
+      {
+        "slug": "multi-region-strategy",
+        "title": "Multi-region strategy",
+        "role": "decision",
+        "blurb": "The strategic push is clear, but foundational decisions are still being worked out in parallel with rollout pressure."
+      },
+      {
+        "slug": "region-failover-requirements",
+        "title": "Region failover requirements",
+        "role": "evidence",
+        "blurb": "Reliability requirements reveal gaps that were easy to postpone in the single-region setup."
+      },
+      {
+        "slug": "deployment-topology-tradeoffs",
+        "title": "Deployment topology tradeoffs",
+        "role": "consequence",
+        "blurb": "Topology choices now affect recovery posture, operator burden, and how quickly new regions can come online."
+      },
+      {
+        "slug": "customer-expansion-requests",
+        "title": "Customer expansion requests",
+        "role": "pressure",
+        "blurb": "Customer pull keeps compressing the time available to resolve the underlying infrastructure choices well."
+      }
+    ]
+  },
+  {
+    "tilegroup_id": "tg_search_mapping_failures",
+    "label": "Architecture Under Stress",
+    "headline": "Fragmented task mapping creates silent search failures across systems",
+    "summary": "Several systems rely on mappings that drift quietly, so search can look healthy while recall and routing degrade underneath it.",
+    "tiles": [
+      {
+        "slug": "task-routing-overview",
+        "title": "Task routing overview",
+        "role": "decision",
+        "blurb": "Routing logic depends on mappings that are maintained across boundaries rather than enforced in one place."
+      },
+      {
+        "slug": "search-indexing-pipeline",
+        "title": "Search indexing pipeline",
+        "role": "evidence",
+        "blurb": "Indexing and mapping assumptions live in separate layers, making drift easy to miss during normal operations."
+      },
+      {
+        "slug": "query-debugging-playbook",
+        "title": "Query debugging playbook",
+        "role": "workaround",
+        "blurb": "Operators compensate with manual debugging because failures often look like low relevance instead of outright errors."
+      },
+      {
+        "slug": "cross-system-ownership-gaps",
+        "title": "Cross-system ownership gaps",
+        "role": "open_thread",
+        "blurb": "No single boundary owns the mapping contract end to end, so the same issue can recur in new forms."
+      }
+    ]
+  }
+]

--- a/rust/foundation-api/src/wiki/client.rs
+++ b/rust/foundation-api/src/wiki/client.rs
@@ -146,6 +146,25 @@ impl WikiClient {
         Ok(collection)
     }
 
+    /// Resolves an arbitrary foundation collection by name for this request.
+    ///
+    /// Unlike [`Self::wiki_collection`], this does not cache by name because
+    /// the main hot path only needs the wiki collection. Callers that need a
+    /// different collection during bootstrapping can still reuse the shared FE
+    /// connection pool and auth scoping through this helper.
+    pub async fn get_collection_by_name(
+        &self,
+        tenant: &str,
+        token: &str,
+        collection_name: &str,
+    ) -> Result<ChromaCollection, WikiClientError> {
+        let client = self.scoped_client(tenant, token)?;
+        client
+            .get_collection(collection_name)
+            .await
+            .map_err(Into::into)
+    }
+
     /// Drops the cached wiki collection identity for `tenant`. Call this after
     /// a `NotFound` from the FE, since the collection may have been recreated
     /// with a new id.


### PR DESCRIPTION
## Description of changes

This PR bootstraps a new `currents` collection during the foundation init flow. It adds:

1. A config field for the collection name
2. A `get_collection_by_name` helper on `WikiClient`
3. Seeding logic that idempotently upserts mock "tilegroup" records into the collection on init
4. A JSON fixture file with 4 mock tilegroups

The seeding is intentionally soft — if `frontend_ingress_url` is unconfigured or no auth token is present, it logs and skips rather than failing.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_