### PR TITLE
[BUG] Seed foundation currents with a constant placeholder vector

### DIFF
--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -89,13 +89,18 @@ pub async fn foundation_init(
         CollectionEmbeddingFunctions::default(),
     )
     .await?;
+    // Currents records carry their payload in metadata and are only ever
+    // fetched by metadata (never vector-searched), so the collection has no
+    // embedding function. Pin the dense index to a single dimension to match
+    // the constant placeholder vector the seed writes (see
+    // `ensure_currents_collection`).
     let currents = ensure_collection(
         &mut sysdb,
         tenant.clone(),
         db_name.clone(),
         &foundation_cfg.currents_collection,
         None,
-        None,
+        Some(1),
         CollectionEmbeddingFunctions::default(),
     )
     .await?;
@@ -363,6 +368,11 @@ async fn ensure_currents_collection(
     let records = mock_currents_records();
 
     let ids: Vec<String> = records.iter().map(|record| record.id.clone()).collect();
+    // The currents collection has no embedding function, so passing `None`
+    // embeddings would make the client try (and fail) to embed the document
+    // text with `MissingEmbeddingFunction`. These records are never
+    // vector-searched, so write a constant 1-dim placeholder vector instead.
+    let embeddings: Vec<Vec<f32>> = vec![vec![1.0]; ids.len()];
     let documents: Vec<Option<String>> = records
         .iter()
         .map(|record| Some(record.document.clone()))
@@ -380,13 +390,7 @@ async fn ensure_currents_collection(
         })
         .collect();
     collection
-        .upsert(
-            ids,
-            None::<Vec<Vec<f32>>>,
-            Some(documents),
-            None,
-            Some(metadatas),
-        )
+        .upsert(ids, embeddings, Some(documents), None, Some(metadatas))
         .await
         .map_err(FoundationInitError::RecordIo)?;
     Ok(())


### PR DESCRIPTION
The currents collection is created without an embedding function, so the seed's `upsert` with `None` embeddings made the client try to embed the document text and fail with `MissingEmbeddingFunction` before sending any request. `/api/init` returned 500, which the CLI swallows as a warning, so the collection was created but left empty.

Currents records are fetched by metadata only and never vector-searched, so write a constant 1-dim `[1.0]` placeholder vector instead and pin the dense index to `dimension: Some(1)` to match.

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
