### PR TITLE
[ENH](sysdb): Allow one sync and one async

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -236,10 +236,10 @@ def test_function_multiple_collections(basic_http_client: System) -> None:
     )
 
 
-def test_functions_one_attached_function_per_collection(
+def test_functions_allow_one_sync_and_one_async_per_collection(
     basic_http_client: System,
 ) -> None:
-    """Test that only one attached function is allowed per collection"""
+    """Test that a collection can have at most one sync and one async attached function"""
     client = ClientCreator.from_system(basic_http_client)
     client.reset()
 
@@ -258,11 +258,10 @@ def test_functions_one_attached_function_per_collection(
     assert attached_fn1 is not None
     assert created is True
 
-    # Attempt to create a second task with a different name should fail
-    # (only one attached function allowed per collection)
+    # A second sync function should fail because the sync slot is already occupied.
     with pytest.raises(
         ChromaError,
-        match="collection already has an attached function: name=task_1, function=record_counter, output_collection=output_1",
+        match="collection already has an attached function with the same execution mode: name=task_1, function=record_counter, output_collection=output_1",
     ):
         collection.attach_function(
             function=RECORD_COUNTER_FUNCTION,
@@ -271,25 +270,42 @@ def test_functions_one_attached_function_per_collection(
             params=None,
         )
 
-    # Attempt to create a task with the same name but different function_id should also fail
+    # An async function should still be allowed on the same input collection.
+    attached_async_fn, async_created = collection.attach_function(
+        function=DUMMY_ASYNC_FUNCTION,
+        name="task_async",
+        output_collection="output_async",
+        params=None,
+    )
+
+    assert attached_async_fn is not None
+    assert async_created is True
+
+    # A second async function should fail because the async slot is now occupied.
     with pytest.raises(
         ChromaError,
-        match=r"collection already has an attached function: name=task_1, function=record_counter, output_collection=output_1",
+        match="collection already has an attached function with the same execution mode: name=task_async, function=dummy_async, output_collection=output_async",
     ):
         collection.attach_function(
-            function=STATISTICS_FUNCTION,
-            name="task_1",
+            function=DUMMY_ASYNC_FUNCTION,
+            name="task_async_2",
             output_collection="output_different",  # Different output collection
             params=None,
         )
 
-    # Detach the first function
+    # Detach both functions.
     assert (
         collection.detach_function(attached_fn1.name, delete_output_collection=True)
         is True
     )
+    assert (
+        collection.detach_function(
+            attached_async_fn.name, delete_output_collection=True
+        )
+        is True
+    )
 
-    # Now we should be able to attach a new function
+    # Now we should be able to attach a new sync function.
     attached_fn2, created2 = collection.attach_function(
         function=RECORD_COUNTER_FUNCTION,
         name="task_2",

--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -77,13 +77,13 @@ func (suite *AttachFunctionTestSuite) setupAttachFunctionMocks(ctx context.Conte
 	// Check if any attached function exists for this collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
-		Return([]*dbmodel.AttachedFunction{}, nil).Once()
+		Return([]*dbmodel.AttachedFunction{}, nil).Twice()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
 	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
 		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Once()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(2)
 	suite.mockFunctionDb.On("GetByName", functionName).
 		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
 	suite.mockFunctionDb.On("GetByID", functionID).
@@ -174,7 +174,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_SuccessfulCreation() {
 	// Check if any attached function exists for this collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
-		Return([]*dbmodel.AttachedFunction{}, nil).Once()
+		Return([]*dbmodel.AttachedFunction{}, nil).Twice()
 
 	// Look up database
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
@@ -182,8 +182,10 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_SuccessfulCreation() {
 		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Once()
 
 	// Look up function
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Once()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(2)
 	suite.mockFunctionDb.On("GetByName", functionName).
+		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
+	suite.mockFunctionDb.On("GetByID", functionID).
 		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
 
 	// Check input collection exists
@@ -307,9 +309,11 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Alrea
 			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollID), (*string)(nil), []uuid.UUID(nil), false).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
-			suite.mockMetaDomain.On("FunctionDb", txCtx).Return(suite.mockFunctionDb).Once()
+			suite.mockMetaDomain.On("FunctionDb", txCtx).Return(suite.mockFunctionDb).Times(2)
 			suite.mockFunctionDb.On("GetByName", functionName).
 				Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
+			suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{functionID}).
+				Return([]*dbmodel.Function{{ID: functionID, Name: functionName, IsAsync: false}}, nil).Once()
 
 			// Validate database matches
 			suite.mockMetaDomain.On("DatabaseDb", txCtx).Return(suite.mockDatabaseDb).Once()
@@ -364,13 +368,13 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_AllowsOutputCollectionI
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
-		Return([]*dbmodel.AttachedFunction{}, nil).Once()
+		Return([]*dbmodel.AttachedFunction{}, nil).Twice()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
 	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
 		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Once()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(2)
 	suite.mockFunctionDb.On("GetByName", functionName).
 		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
 	suite.mockFunctionDb.On("GetByID", functionID).
@@ -480,13 +484,13 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_AllowsAsyncAndSyncFunct
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
-		Return([]*dbmodel.AttachedFunction{existingAsyncAttachedFunction}, nil).Once()
+		Return([]*dbmodel.AttachedFunction{existingAsyncAttachedFunction}, nil).Twice()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Thrice()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(4)
 	suite.mockFunctionDb.On("GetByName", "record_counter").
 		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
 	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{existingAsyncFunctionID}).
-		Return([]*dbmodel.Function{{ID: existingAsyncFunctionID, Name: "dummy_async", IsAsync: true}}, nil).Once()
+		Return([]*dbmodel.Function{{ID: existingAsyncFunctionID, Name: "dummy_async", IsAsync: true}}, nil).Twice()
 	suite.mockFunctionDb.On("GetByID", newSyncFunctionID).
 		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
 
@@ -568,16 +572,14 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RejectsOutputCollection
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, (*string)(nil), []uuid.UUID(nil), false).
-		Return([]*dbmodel.AttachedFunction{}, nil).Once()
+		Return([]*dbmodel.AttachedFunction{}, nil).Twice()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
 	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
 		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Once()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Once()
 	suite.mockFunctionDb.On("GetByName", functionName).
-		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
-	suite.mockFunctionDb.On("GetByID", functionID).
 		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
 
 	suite.mockMetaDomain.On("CollectionDb", mock.Anything).Return(suite.mockCollectionDb).Once()
@@ -670,14 +672,16 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 	// Phase 1: Create attached function in transaction
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
-		Return([]*dbmodel.AttachedFunction{}, nil).Once()
+		Return([]*dbmodel.AttachedFunction{}, nil).Twice()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
 	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
 		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Once()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Once()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(2)
 	suite.mockFunctionDb.On("GetByName", functionName).
+		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
+	suite.mockFunctionDb.On("GetByID", functionID).
 		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
 
 	suite.mockCollectionDb.On("GetCollections",
@@ -741,11 +745,11 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollID), (*string)(nil), []uuid.UUID(nil), false).
 				Return([]*dbmodel.AttachedFunction{incompleteAttachedFunction}, nil).Once()
 
-			suite.mockMetaDomain.On("FunctionDb", txCtx).Return(suite.mockFunctionDb).Once()
+			suite.mockMetaDomain.On("FunctionDb", txCtx).Return(suite.mockFunctionDb).Times(2)
 			suite.mockFunctionDb.On("GetByName", functionName).
 				Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
-			suite.mockFunctionDb.On("GetByID", functionID).
-				Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
+			suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{functionID}).
+				Return([]*dbmodel.Function{{ID: functionID, Name: functionName, IsAsync: false}}, nil).Once()
 
 			// Validate database matches
 			suite.mockMetaDomain.On("DatabaseDb", txCtx).Return(suite.mockDatabaseDb).Once()
@@ -990,7 +994,8 @@ func (suite *AttachFunctionTestSuite) TestAddAttachedFunctionInput_SuccessfulCre
 	suite.mockDatabaseDb.On("GetByID", databaseID).
 		Return(&dbmodel.Database{ID: databaseID, Name: databaseName}, nil).Once()
 
-	suite.mockMetaDomain.On("CollectionDb", mock.Anything).Return(suite.mockCollectionDb).Once()
+	suite.mockMetaDomain.On("CollectionDb", mock.Anything).Return(suite.mockCollectionDb).Twice()
+	suite.mockCollectionDb.On("LockCollection", newInputCollectionID).Return((*bool)(nil), nil).Once()
 	suite.mockCollectionDb.On("GetCollections",
 		[]string{newInputCollectionID}, (*string)(nil), tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
 		Return([]*dbmodel.CollectionAndMetadata{{Collection: &dbmodel.Collection{ID: newInputCollectionID}}}, nil).Once()

--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -83,8 +83,10 @@ func (suite *AttachFunctionTestSuite) setupAttachFunctionMocks(ctx context.Conte
 	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
 		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Once()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Once()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
 	suite.mockFunctionDb.On("GetByName", functionName).
+		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
+	suite.mockFunctionDb.On("GetByID", functionID).
 		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
 
 	suite.mockCollectionDb.On("GetCollections",
@@ -305,8 +307,9 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Alrea
 			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollID), (*string)(nil), []uuid.UUID(nil), false).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
-			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup),
-			// not FunctionDb.GetByID, so no mock needed for FunctionDb here
+			suite.mockMetaDomain.On("FunctionDb", txCtx).Return(suite.mockFunctionDb).Once()
+			suite.mockFunctionDb.On("GetByName", functionName).
+				Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
 
 			// Validate database matches
 			suite.mockMetaDomain.On("DatabaseDb", txCtx).Return(suite.mockDatabaseDb).Once()
@@ -367,8 +370,10 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_AllowsOutputCollectionI
 	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
 		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Once()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Once()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
 	suite.mockFunctionDb.On("GetByName", functionName).
+		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
+	suite.mockFunctionDb.On("GetByID", functionID).
 		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
 
 	suite.mockCollectionDb.On("GetCollections",
@@ -477,11 +482,13 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_AllowsAsyncAndSyncFunct
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
 		Return([]*dbmodel.AttachedFunction{existingAsyncAttachedFunction}, nil).Once()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Thrice()
 	suite.mockFunctionDb.On("GetByName", "record_counter").
 		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
 	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{existingAsyncFunctionID}).
 		Return([]*dbmodel.Function{{ID: existingAsyncFunctionID, Name: "dummy_async", IsAsync: true}}, nil).Once()
+	suite.mockFunctionDb.On("GetByID", newSyncFunctionID).
+		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
 	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
@@ -567,8 +574,10 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RejectsOutputCollection
 	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
 		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Once()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Once()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
 	suite.mockFunctionDb.On("GetByName", functionName).
+		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
+	suite.mockFunctionDb.On("GetByID", functionID).
 		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
 
 	suite.mockMetaDomain.On("CollectionDb", mock.Anything).Return(suite.mockCollectionDb).Once()
@@ -732,8 +741,11 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollID), (*string)(nil), []uuid.UUID(nil), false).
 				Return([]*dbmodel.AttachedFunction{incompleteAttachedFunction}, nil).Once()
 
-			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup),
-			// not FunctionDb.GetByID, so no mock needed for FunctionDb here
+			suite.mockMetaDomain.On("FunctionDb", txCtx).Return(suite.mockFunctionDb).Once()
+			suite.mockFunctionDb.On("GetByName", functionName).
+				Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
+			suite.mockFunctionDb.On("GetByID", functionID).
+				Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
 
 			// Validate database matches
 			suite.mockMetaDomain.On("DatabaseDb", txCtx).Return(suite.mockDatabaseDb).Once()
@@ -970,9 +982,9 @@ func (suite *AttachFunctionTestSuite) TestAddAttachedFunctionInput_SuccessfulCre
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &newInputCollectionID, (*string)(nil), []uuid.UUID(nil), false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Once()
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
 	suite.mockFunctionDb.On("GetByID", functionID).
-		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: true}, nil).Once()
+		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: true}, nil).Twice()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
 	suite.mockDatabaseDb.On("GetByID", databaseID).

--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -435,6 +435,106 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_AllowsOutputCollectionI
 	suite.mockTxImpl.AssertExpectations(suite.T())
 }
 
+func (suite *AttachFunctionTestSuite) TestAttachFunction_AllowsAsyncAndSyncFunctionsOnSameInputCollection() {
+	ctx := context.Background()
+
+	existingAttachedFunctionID := uuid.New()
+	existingAsyncFunctionID := uuid.New()
+	newSyncFunctionID := dbmodel.FunctionRecordCounter
+	attachedFunctionName := "sync-attached-function"
+	inputCollectionID := "shared-input-collection"
+	outputCollectionName := "sync-output-collection"
+	tenantID := "test-tenant"
+	databaseName := "test-database"
+	databaseID := "database-uuid"
+	minRecordsForInvocation := uint64(100)
+
+	request := &coordinatorpb.AttachFunctionRequest{
+		Name:                    attachedFunctionName,
+		InputCollectionId:       inputCollectionID,
+		OutputCollectionName:    outputCollectionName,
+		FunctionName:            "record_counter",
+		TenantId:                tenantID,
+		Database:                databaseName,
+		MinRecordsForInvocation: minRecordsForInvocation,
+	}
+
+	existingAsyncAttachedFunction := &dbmodel.AttachedFunction{
+		ID:                      existingAttachedFunctionID,
+		Name:                    "existing-async-function",
+		TenantID:                tenantID,
+		DatabaseID:              databaseID,
+		InputCollectionID:       inputCollectionID,
+		OutputCollectionName:    "async-output-collection",
+		FunctionID:              existingAsyncFunctionID,
+		MinRecordsForInvocation: int64(minRecordsForInvocation),
+		IsReady:                 true,
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+	}
+
+	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
+		Return([]*dbmodel.AttachedFunction{existingAsyncAttachedFunction}, nil).Once()
+
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
+	suite.mockFunctionDb.On("GetByName", "record_counter").
+		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
+	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{existingAsyncFunctionID}).
+		Return([]*dbmodel.Function{{ID: existingAsyncFunctionID, Name: "dummy_async", IsAsync: true}}, nil).Once()
+
+	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
+	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
+		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Once()
+
+	suite.mockCollectionDb.On("GetCollections",
+		[]string{inputCollectionID}, (*string)(nil), tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
+		Return([]*dbmodel.CollectionAndMetadata{{Collection: &dbmodel.Collection{ID: inputCollectionID}}}, nil).Times(2)
+
+	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Times(2)
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), (*string)(nil), matchStringPtr(inputCollectionID), []uuid.UUID(nil), false).
+		Return([]*dbmodel.AttachedFunction{}, nil).Twice()
+
+	suite.mockMetaDomain.On("CollectionDb", mock.Anything).Return(suite.mockCollectionDb).Once()
+	suite.mockCollectionDb.On("GetCollections",
+		[]string(nil), matchStringPtr(outputCollectionName), tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
+		Return([]*dbmodel.CollectionAndMetadata{}, nil).Once()
+
+	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
+	suite.mockAttachedFunctionDb.On("Insert", mock.MatchedBy(func(attachedFunction *dbmodel.AttachedFunction) bool {
+		return attachedFunction.Name == attachedFunctionName &&
+			attachedFunction.InputCollectionID == inputCollectionID &&
+			attachedFunction.OutputCollectionName == outputCollectionName &&
+			attachedFunction.FunctionID == newSyncFunctionID &&
+			attachedFunction.TenantID == tenantID &&
+			attachedFunction.DatabaseID == databaseID &&
+			attachedFunction.MinRecordsForInvocation == int64(minRecordsForInvocation)
+	})).Return(nil).Once()
+	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Maybe()
+	suite.mockMetaDomain.On("CollectionDb", mock.Anything).Return(suite.mockCollectionDb).Maybe()
+	suite.mockCollectionDb.On("LockCollection", mock.AnythingOfType("string")).Return((*bool)(nil), nil).Maybe()
+
+	suite.mockTxImpl.On("Transaction", ctx, mock.AnythingOfType("func(context.Context) error")).
+		Run(func(args mock.Arguments) {
+			txFunc := args.Get(1).(func(context.Context) error)
+			err := txFunc(context.Background())
+			suite.NoError(err)
+		}).Return(nil).Once()
+
+	response, err := suite.coordinator.AttachFunction(ctx, request)
+
+	suite.NoError(err)
+	suite.NotNil(response)
+	suite.NotEmpty(response.AttachedFunction.Id)
+
+	suite.mockMetaDomain.AssertExpectations(suite.T())
+	suite.mockAttachedFunctionDb.AssertExpectations(suite.T())
+	suite.mockFunctionDb.AssertExpectations(suite.T())
+	suite.mockDatabaseDb.AssertExpectations(suite.T())
+	suite.mockCollectionDb.AssertExpectations(suite.T())
+	suite.mockTxImpl.AssertExpectations(suite.T())
+}
+
 func (suite *AttachFunctionTestSuite) TestAttachFunction_RejectsOutputCollectionInputWhenAnyUpstreamFunctionIsSync() {
 	ctx := context.Background()
 
@@ -657,7 +757,9 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 	suite.mockMetaDomain.AssertExpectations(suite.T())
 }
 
-// TestAttachFunction_IdempotentRequest_ParameterMismatch tests when attached function exists but with different parameters:
+// TestAttachFunction_IdempotentRequest_ParameterMismatch tests when a ready attached
+// function already exists on the same collection with the same execution mode but
+// different parameters:
 // - Attached function already exists with different function_name
 // - Should return AlreadyExists error with descriptive message
 // - Should not proceed with any initialization
@@ -711,7 +813,13 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 	}
 
 	// ===== Phase 1: Transaction checks if task exists - finds task with different params =====
-	// Mock transaction call - it will fail with validation error
+	// Mock transaction call - it will fail with validation error.
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
+	suite.mockFunctionDb.On("GetByName", requestedOperatorName).
+		Return(&dbmodel.Function{ID: uuid.New(), Name: requestedOperatorName, IsAsync: false}, nil).Once()
+	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{existingOperatorID}).
+		Return([]*dbmodel.Function{{ID: existingOperatorID, Name: existingOperatorName, IsAsync: false}}, nil).Once()
+
 	suite.mockTxImpl.On("Transaction", ctx, mock.AnythingOfType("func(context.Context) error")).
 		Run(func(args mock.Arguments) {
 			txFunc := args.Get(1).(func(context.Context) error)
@@ -723,12 +831,8 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), []uuid.UUID(nil), false).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
-			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup)
-			// which returns "record_counter" for FunctionRecordCounter - different from requestedOperatorName
-			// Validation returns (false, nil) early, so DatabaseDb.GetDatabases is NOT called
-
 			_ = txFunc(txCtx)
-		}).Return(status.Errorf(codes.AlreadyExists, "collection already has an attached function: name=%s, function=%s, output_collection=%s", attachedFunctionName, existingOperatorName, outputCollectionName)).Once()
+		}).Return(status.Errorf(codes.AlreadyExists, "collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s", attachedFunctionName, existingOperatorName, outputCollectionName)).Once()
 
 	// Execute AttachFunction
 	response, err := suite.coordinator.AttachFunction(ctx, request)
@@ -736,7 +840,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 	// Assertions - should fail with AlreadyExists error
 	suite.Error(err)
 	suite.Nil(response)
-	suite.Contains(err.Error(), "collection already has an attached function")
+	suite.Contains(err.Error(), "collection already has an attached function with the same execution mode")
 	suite.Contains(err.Error(), existingOperatorName)
 	suite.Contains(err.Error(), outputCollectionName)
 
@@ -747,6 +851,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 	// Verify read mocks were called
 	suite.mockMetaDomain.AssertExpectations(suite.T())
 	suite.mockAttachedFunctionDb.AssertExpectations(suite.T())
+	suite.mockFunctionDb.AssertExpectations(suite.T())
 }
 
 func TestAttachFunctionTestSuite(t *testing.T) {

--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -854,6 +854,81 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 	suite.mockFunctionDb.AssertExpectations(suite.T())
 }
 
+func (suite *AttachFunctionTestSuite) TestAttachFunction_NotReadySameModeBlocksDifferentRequest() {
+	ctx := context.Background()
+
+	existingAttachedFunctionID := uuid.New()
+	attachedFunctionName := "existing-attached-function"
+	inputCollectionID := "input-collection-id"
+	outputCollectionName := "output-collection"
+	existingFunctionName := "record_counter"
+	requestedFunctionName := "different_function"
+	tenantID := "test-tenant"
+	databaseName := "test-database"
+	databaseID := "database-uuid"
+	existingFunctionID := dbmodel.FunctionRecordCounter
+	minRecordsForInvocation := uint64(100)
+	now := time.Now()
+
+	request := &coordinatorpb.AttachFunctionRequest{
+		Name:                    attachedFunctionName,
+		InputCollectionId:       inputCollectionID,
+		OutputCollectionName:    outputCollectionName,
+		FunctionName:            requestedFunctionName,
+		TenantId:                tenantID,
+		Database:                databaseName,
+		MinRecordsForInvocation: minRecordsForInvocation,
+	}
+
+	existingAttachedFunction := &dbmodel.AttachedFunction{
+		ID:                      existingAttachedFunctionID,
+		Name:                    attachedFunctionName,
+		TenantID:                tenantID,
+		DatabaseID:              databaseID,
+		InputCollectionID:       inputCollectionID,
+		OutputCollectionName:    outputCollectionName,
+		FunctionID:              existingFunctionID,
+		MinRecordsForInvocation: int64(minRecordsForInvocation),
+		IsReady:                 false,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Twice()
+	suite.mockFunctionDb.On("GetByName", requestedFunctionName).
+		Return(&dbmodel.Function{ID: uuid.New(), Name: requestedFunctionName, IsAsync: false}, nil).Once()
+	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{existingFunctionID}).
+		Return([]*dbmodel.Function{{ID: existingFunctionID, Name: existingFunctionName, IsAsync: false}}, nil).Once()
+
+	suite.mockTxImpl.On("Transaction", ctx, mock.AnythingOfType("func(context.Context) error")).
+		Run(func(args mock.Arguments) {
+			txFunc := args.Get(1).(func(context.Context) error)
+			txCtx := context.Background()
+
+			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
+			inputCollID := inputCollectionID
+			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, (*string)(nil), []uuid.UUID(nil), false).
+				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
+
+			_ = txFunc(txCtx)
+		}).Return(status.Errorf(codes.AlreadyExists, "collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s", attachedFunctionName, existingFunctionName, outputCollectionName)).Once()
+
+	response, err := suite.coordinator.AttachFunction(ctx, request)
+
+	suite.Error(err)
+	suite.Nil(response)
+	suite.Contains(err.Error(), "collection already has an attached function with the same execution mode")
+	suite.Contains(err.Error(), existingFunctionName)
+	suite.Contains(err.Error(), outputCollectionName)
+
+	suite.mockTxImpl.AssertNumberOfCalls(suite.T(), "Transaction", 1)
+	suite.mockAttachedFunctionDb.AssertNotCalled(suite.T(), "Insert")
+
+	suite.mockMetaDomain.AssertExpectations(suite.T())
+	suite.mockAttachedFunctionDb.AssertExpectations(suite.T())
+	suite.mockFunctionDb.AssertExpectations(suite.T())
+}
+
 func TestAttachFunctionTestSuite(t *testing.T) {
 	suite.Run(t, new(AttachFunctionTestSuite))
 }

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -497,12 +497,46 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 
 	// ===== Step 1: Create attached function with is_ready = false =====
 	err := s.catalog.txImpl.Transaction(ctx, func(txCtx context.Context) error {
-		// Check if there's any active (ready, non-deleted) attached function for this collection
-		// We only allow one active attached function per collection
+		// Check if there are any active (ready, non-deleted) attached functions for this collection.
+		// We allow at most one active sync function and one active async function per collection.
 		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &req.InputCollectionId, nil, nil, false)
 		if err != nil {
 			log.Error("AttachFunction: failed to check for existing attached function", zap.Error(err))
 			return err
+		}
+
+		// Look up function by name up front so we can validate coexistence with any existing
+		// attached functions on the same input collection.
+		function, err := s.catalog.metaDomain.FunctionDb(txCtx).GetByName(req.FunctionName)
+		if err != nil {
+			log.Error("AttachFunction: failed to get function", zap.Error(err))
+			return err
+		}
+		if function == nil {
+			log.Error("AttachFunction: function not found", zap.String("function_name", req.FunctionName))
+			return common.ErrFunctionNotFound
+		}
+
+		existingFunctionIDs := make([]uuid.UUID, 0, len(existingAttachedFunctions))
+		seenExistingFunctionIDs := make(map[uuid.UUID]struct{}, len(existingAttachedFunctions))
+		for _, attachedFunction := range existingAttachedFunctions {
+			if _, ok := seenExistingFunctionIDs[attachedFunction.FunctionID]; ok {
+				continue
+			}
+			seenExistingFunctionIDs[attachedFunction.FunctionID] = struct{}{}
+			existingFunctionIDs = append(existingFunctionIDs, attachedFunction.FunctionID)
+		}
+
+		existingFunctionsByID := make(map[uuid.UUID]*dbmodel.Function, len(existingFunctionIDs))
+		if len(existingFunctionIDs) > 0 {
+			existingFunctions, err := s.catalog.metaDomain.FunctionDb(txCtx).GetByIDs(existingFunctionIDs)
+			if err != nil {
+				log.Error("AttachFunction: failed to load existing functions for input collection validation", zap.Error(err))
+				return err
+			}
+			for _, existingFunction := range existingFunctions {
+				existingFunctionsByID[existingFunction.ID] = existingFunction
+			}
 		}
 
 		for _, attachedFunction := range existingAttachedFunctions {
@@ -518,17 +552,25 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 			}
 
 			if attachedFunction.IsReady {
-				log.Error("AttachFunction: collection already has an attached function", zap.String("name", attachedFunction.Name))
-				functionName, err := dbmodel.GetFunctionNameByID(attachedFunction.FunctionID)
-				if err != nil {
-					log.Error("AttachFunction: unknown function ID", zap.Error(err))
-					return err
+				existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
+				if !ok {
+					log.Error("AttachFunction: unknown function ID on existing attached function",
+						zap.Error(err),
+						zap.Stringer("function_id", attachedFunction.FunctionID))
+					return common.ErrFunctionNotFound
 				}
-				return status.Errorf(codes.AlreadyExists,
-					"collection already has an attached function: name=%s, function=%s, output_collection=%s",
-					attachedFunction.Name,
-					functionName,
-					attachedFunction.OutputCollectionName)
+				if existingFunction.IsAsync == function.IsAsync {
+					log.Error("AttachFunction: collection already has an attached function with the same execution mode",
+						zap.String("name", attachedFunction.Name),
+						zap.String("existing_function", existingFunction.Name),
+						zap.String("requested_function", function.Name),
+						zap.Bool("is_async", function.IsAsync))
+					return status.Errorf(codes.AlreadyExists,
+						"collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s",
+						attachedFunction.Name,
+						existingFunction.Name,
+						attachedFunction.OutputCollectionName)
+				}
 			}
 		}
 
@@ -543,16 +585,6 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 			return common.ErrDatabaseNotFound
 		}
 
-		// Look up function by name
-		function, err := s.catalog.metaDomain.FunctionDb(txCtx).GetByName(req.FunctionName)
-		if err != nil {
-			log.Error("AttachFunction: failed to get function", zap.Error(err))
-			return err
-		}
-		if function == nil {
-			log.Error("AttachFunction: function not found", zap.String("function_name", req.FunctionName))
-			return common.ErrFunctionNotFound
-		}
 		// Check if input collection exists
 		collections, err := s.catalog.metaDomain.CollectionDb(txCtx).GetCollections([]string{req.InputCollectionId}, nil, req.TenantId, req.Database, nil, nil, false)
 		if err != nil {

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -418,24 +418,52 @@ func (s *Coordinator) insertAttachedFunctionForInputCollection(
 		}
 	}
 
+	requestedFunction, err := s.catalog.metaDomain.FunctionDb(ctx).GetByID(spec.FunctionID)
+	if err != nil {
+		return false, err
+	}
+	if requestedFunction == nil {
+		return false, common.ErrFunctionNotFound
+	}
+
+	existingFunctionIDs := make([]uuid.UUID, 0, len(existingAttachedFunctions))
+	seenExistingFunctionIDs := make(map[uuid.UUID]struct{}, len(existingAttachedFunctions))
+	for _, attachedFunction := range existingAttachedFunctions {
+		if _, ok := seenExistingFunctionIDs[attachedFunction.FunctionID]; ok {
+			continue
+		}
+		seenExistingFunctionIDs[attachedFunction.FunctionID] = struct{}{}
+		existingFunctionIDs = append(existingFunctionIDs, attachedFunction.FunctionID)
+	}
+
+	existingFunctionsByID := make(map[uuid.UUID]*dbmodel.Function, len(existingFunctionIDs))
+	if len(existingFunctionIDs) > 0 {
+		existingFunctions, err := s.catalog.metaDomain.FunctionDb(ctx).GetByIDs(existingFunctionIDs)
+		if err != nil {
+			return false, err
+		}
+		for _, existingFunction := range existingFunctions {
+			existingFunctionsByID[existingFunction.ID] = existingFunction
+		}
+	}
+
 	for _, attachedFunction := range existingAttachedFunctions {
 		if attachedFunction.ID == spec.AttachedFunctionID {
 			return !attachedFunction.IsReady, nil
 		}
 
-		if attachedFunction.IsReady {
-			functionName, err := dbmodel.GetFunctionNameByID(attachedFunction.FunctionID)
-			if err != nil {
-				return false, err
-			}
-			return false, status.Errorf(codes.AlreadyExists,
-				"collection already has an attached function: name=%s, function=%s, output_collection=%s",
-				attachedFunction.Name,
-				functionName,
-				attachedFunction.OutputCollectionName)
+		existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
+		if !ok {
+			return false, common.ErrFunctionNotFound
 		}
 
-		return false, common.ErrAttachedFunctionAlreadyExists
+		if existingFunction.IsAsync == requestedFunction.IsAsync {
+			return false, status.Errorf(codes.AlreadyExists,
+				"collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s",
+				attachedFunction.Name,
+				existingFunction.Name,
+				attachedFunction.OutputCollectionName)
+		}
 	}
 
 	collections, err := s.catalog.metaDomain.CollectionDb(ctx).GetCollections(
@@ -1242,14 +1270,58 @@ func (s *Coordinator) FinishCreateAttachedFunction(ctx context.Context, req *coo
 			return err
 		}
 
-		// 7. Validate that there is only one ready attached function for this collection
+		// 7. Validate that there is at most one ready sync function and one ready
+		// async function for this collection.
 		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &attachedFunction.InputCollectionID, nil, nil, true)
 		if err != nil {
 			log.Error("FinishCreateAttachedFunction: failed to get attached functions", zap.Error(err))
 			return err
 		}
-		if len(existingAttachedFunctions) > 1 {
-			log.Error("FinishCreateAttachedFunction: multiple attached functions found for collection", zap.String("collection_id", attachedFunction.InputCollectionID))
+
+		functionIDs := make([]uuid.UUID, 0, len(existingAttachedFunctions))
+		seenFunctionIDs := make(map[uuid.UUID]struct{}, len(existingAttachedFunctions))
+		for _, existingAttachedFunction := range existingAttachedFunctions {
+			if _, ok := seenFunctionIDs[existingAttachedFunction.FunctionID]; ok {
+				continue
+			}
+			seenFunctionIDs[existingAttachedFunction.FunctionID] = struct{}{}
+			functionIDs = append(functionIDs, existingAttachedFunction.FunctionID)
+		}
+
+		functionsByID := make(map[uuid.UUID]*dbmodel.Function, len(functionIDs))
+		if len(functionIDs) > 0 {
+			functions, err := s.catalog.metaDomain.FunctionDb(txCtx).GetByIDs(functionIDs)
+			if err != nil {
+				log.Error("FinishCreateAttachedFunction: failed to load functions", zap.Error(err))
+				return err
+			}
+			for _, function := range functions {
+				functionsByID[function.ID] = function
+			}
+		}
+
+		readySyncCount := 0
+		readyAsyncCount := 0
+		for _, existingAttachedFunction := range existingAttachedFunctions {
+			function, ok := functionsByID[existingAttachedFunction.FunctionID]
+			if !ok {
+				log.Error("FinishCreateAttachedFunction: unknown function on attached function",
+					zap.Stringer("function_id", existingAttachedFunction.FunctionID))
+				return common.ErrFunctionNotFound
+			}
+
+			if function.IsAsync {
+				readyAsyncCount++
+			} else {
+				readySyncCount++
+			}
+		}
+
+		if readySyncCount > 1 || readyAsyncCount > 1 {
+			log.Error("FinishCreateAttachedFunction: too many ready attached functions found for collection",
+				zap.String("collection_id", attachedFunction.InputCollectionID),
+				zap.Int("ready_sync_count", readySyncCount),
+				zap.Int("ready_async_count", readyAsyncCount))
 			return common.ErrAttachedFunctionAlreadyExists
 		}
 

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -405,6 +405,42 @@ type attachedFunctionInsertSpec struct {
 	MinRecordsForInvocation int64
 }
 
+// attached functions are stored per input collection, so async functions with
+// multiple inputs can produce several rows that reference the same function ID.
+func uniqueFunctionIDs(attachedFunctions []*dbmodel.AttachedFunction) []uuid.UUID {
+	functionIDs := make([]uuid.UUID, 0, len(attachedFunctions))
+	seenFunctionIDs := make(map[uuid.UUID]struct{}, len(attachedFunctions))
+	for _, attachedFunction := range attachedFunctions {
+		if _, ok := seenFunctionIDs[attachedFunction.FunctionID]; ok {
+			continue
+		}
+		seenFunctionIDs[attachedFunction.FunctionID] = struct{}{}
+		functionIDs = append(functionIDs, attachedFunction.FunctionID)
+	}
+	return functionIDs
+}
+
+func (s *Coordinator) loadFunctionsForAttachedFunctions(ctx context.Context, attachedFunctions []*dbmodel.AttachedFunction) (map[uuid.UUID]*dbmodel.Function, error) {
+	functionsByID := make(map[uuid.UUID]*dbmodel.Function, len(attachedFunctions))
+	functionIDs := uniqueFunctionIDs(attachedFunctions)
+	if len(functionIDs) == 0 {
+		return functionsByID, nil
+	}
+
+	functions, err := s.catalog.metaDomain.FunctionDb(ctx).GetByIDs(functionIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, function := range functions {
+		functionsByID[function.ID] = function
+	}
+	return functionsByID, nil
+}
+
+// insertAttachedFunctionForInputCollection assumes the caller already holds the
+// lock for spec.InputCollectionID. AttachFunction takes that lock as part of the
+// full graph lock, while AddAttachedFunctionInput locks the new input collection
+// directly before calling this helper.
 func (s *Coordinator) insertAttachedFunctionForInputCollection(
 	ctx context.Context,
 	spec attachedFunctionInsertSpec,
@@ -426,25 +462,9 @@ func (s *Coordinator) insertAttachedFunctionForInputCollection(
 		return false, common.ErrFunctionNotFound
 	}
 
-	existingFunctionIDs := make([]uuid.UUID, 0, len(existingAttachedFunctions))
-	seenExistingFunctionIDs := make(map[uuid.UUID]struct{}, len(existingAttachedFunctions))
-	for _, attachedFunction := range existingAttachedFunctions {
-		if _, ok := seenExistingFunctionIDs[attachedFunction.FunctionID]; ok {
-			continue
-		}
-		seenExistingFunctionIDs[attachedFunction.FunctionID] = struct{}{}
-		existingFunctionIDs = append(existingFunctionIDs, attachedFunction.FunctionID)
-	}
-
-	existingFunctionsByID := make(map[uuid.UUID]*dbmodel.Function, len(existingFunctionIDs))
-	if len(existingFunctionIDs) > 0 {
-		existingFunctions, err := s.catalog.metaDomain.FunctionDb(ctx).GetByIDs(existingFunctionIDs)
-		if err != nil {
-			return false, err
-		}
-		for _, existingFunction := range existingFunctions {
-			existingFunctionsByID[existingFunction.ID] = existingFunction
-		}
+	existingFunctionsByID, err := s.loadFunctionsForAttachedFunctions(ctx, existingAttachedFunctions)
+	if err != nil {
+		return false, err
 	}
 
 	for _, attachedFunction := range existingAttachedFunctions {
@@ -525,14 +545,6 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 
 	// ===== Step 1: Create attached function with is_ready = false =====
 	err := s.catalog.txImpl.Transaction(ctx, func(txCtx context.Context) error {
-		// Check if there are any active (ready, non-deleted) attached functions for this collection.
-		// We allow at most one active sync function and one active async function per collection.
-		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &req.InputCollectionId, nil, nil, false)
-		if err != nil {
-			log.Error("AttachFunction: failed to check for existing attached function", zap.Error(err))
-			return err
-		}
-
 		// Look up function by name up front so we can validate coexistence with any existing
 		// attached functions on the same input collection.
 		function, err := s.catalog.metaDomain.FunctionDb(txCtx).GetByName(req.FunctionName)
@@ -545,26 +557,18 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 			return common.ErrFunctionNotFound
 		}
 
-		existingFunctionIDs := make([]uuid.UUID, 0, len(existingAttachedFunctions))
-		seenExistingFunctionIDs := make(map[uuid.UUID]struct{}, len(existingAttachedFunctions))
-		for _, attachedFunction := range existingAttachedFunctions {
-			if _, ok := seenExistingFunctionIDs[attachedFunction.FunctionID]; ok {
-				continue
-			}
-			seenExistingFunctionIDs[attachedFunction.FunctionID] = struct{}{}
-			existingFunctionIDs = append(existingFunctionIDs, attachedFunction.FunctionID)
+		// Fast path for idempotent requests and conservative same-mode
+		// conflicts. This is repeated under graph locks below before insert so
+		// the final decision does not rely on this pre-lock snapshot.
+		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &req.InputCollectionId, nil, nil, false)
+		if err != nil {
+			log.Error("AttachFunction: failed to check for existing attached function", zap.Error(err))
+			return err
 		}
-
-		existingFunctionsByID := make(map[uuid.UUID]*dbmodel.Function, len(existingFunctionIDs))
-		if len(existingFunctionIDs) > 0 {
-			existingFunctions, err := s.catalog.metaDomain.FunctionDb(txCtx).GetByIDs(existingFunctionIDs)
-			if err != nil {
-				log.Error("AttachFunction: failed to load existing functions for input collection validation", zap.Error(err))
-				return err
-			}
-			for _, existingFunction := range existingFunctions {
-				existingFunctionsByID[existingFunction.ID] = existingFunction
-			}
+		existingFunctionsByID, err := s.loadFunctionsForAttachedFunctions(txCtx, existingAttachedFunctions)
+		if err != nil {
+			log.Error("AttachFunction: failed to load existing functions for input collection validation", zap.Error(err))
+			return err
 		}
 
 		for _, attachedFunction := range existingAttachedFunctions {
@@ -582,7 +586,6 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 			existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
 			if !ok {
 				log.Error("AttachFunction: unknown function ID on existing attached function",
-					zap.Error(err),
 					zap.Stringer("function_id", attachedFunction.FunctionID))
 				return common.ErrFunctionNotFound
 			}
@@ -652,30 +655,23 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 			return err
 		}
 
+		// Re-read same-input attached functions after taking graph locks. This
+		// keeps the final same-mode validation from using a stale pre-lock
+		// snapshot if another attach raced with this one.
+		existingAttachedFunctions, err = s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &req.InputCollectionId, nil, nil, false)
+		if err != nil {
+			log.Error("AttachFunction: failed to check for existing attached function under graph lock", zap.Error(err))
+			return err
+		}
+
 		// Validate that the input collection can accept another upstream edge.
 		inputCollectionIDStr := req.InputCollectionId
 		attachedFunctionsUsingAsOutput := graphState.upstreamFunctions[inputCollectionIDStr]
 		if len(attachedFunctionsUsingAsOutput) > 0 {
-			// Load each referenced function once so we can check its execution mode.
-			functionIDs := make([]uuid.UUID, 0, len(attachedFunctionsUsingAsOutput))
-			seenFunctionIDs := make(map[uuid.UUID]struct{}, len(attachedFunctionsUsingAsOutput))
-			for _, attachedFunction := range attachedFunctionsUsingAsOutput {
-				if _, ok := seenFunctionIDs[attachedFunction.FunctionID]; ok {
-					continue
-				}
-				seenFunctionIDs[attachedFunction.FunctionID] = struct{}{}
-				functionIDs = append(functionIDs, attachedFunction.FunctionID)
-			}
-
-			functions, err := s.catalog.metaDomain.FunctionDb(txCtx).GetByIDs(functionIDs)
+			functionsByID, err := s.loadFunctionsForAttachedFunctions(txCtx, attachedFunctionsUsingAsOutput)
 			if err != nil {
 				log.Error("AttachFunction: failed to load functions for output collection validation", zap.Error(err))
 				return err
-			}
-
-			functionsByID := make(map[uuid.UUID]*dbmodel.Function, len(functions))
-			for _, existingFunction := range functions {
-				functionsByID[existingFunction.ID] = existingFunction
 			}
 
 			for _, attachedFunction := range attachedFunctionsUsingAsOutput {
@@ -839,6 +835,12 @@ func (s *Coordinator) AddAttachedFunctionInput(ctx context.Context, req *coordin
 		if database == nil {
 			log.Error("AddAttachedFunctionInput: database not found", zap.String("database_id", baseAttachedFunction.DatabaseID))
 			return common.ErrDatabaseNotFound
+		}
+
+		_, err = s.catalog.metaDomain.CollectionDb(txCtx).LockCollection(req.InputCollectionId)
+		if err != nil {
+			log.Error("AddAttachedFunctionInput: failed to lock input collection", zap.Error(err))
+			return err
 		}
 
 		created, err = s.insertAttachedFunctionForInputCollection(txCtx, attachedFunctionInsertSpec{
@@ -1278,26 +1280,10 @@ func (s *Coordinator) FinishCreateAttachedFunction(ctx context.Context, req *coo
 			return err
 		}
 
-		functionIDs := make([]uuid.UUID, 0, len(existingAttachedFunctions))
-		seenFunctionIDs := make(map[uuid.UUID]struct{}, len(existingAttachedFunctions))
-		for _, existingAttachedFunction := range existingAttachedFunctions {
-			if _, ok := seenFunctionIDs[existingAttachedFunction.FunctionID]; ok {
-				continue
-			}
-			seenFunctionIDs[existingAttachedFunction.FunctionID] = struct{}{}
-			functionIDs = append(functionIDs, existingAttachedFunction.FunctionID)
-		}
-
-		functionsByID := make(map[uuid.UUID]*dbmodel.Function, len(functionIDs))
-		if len(functionIDs) > 0 {
-			functions, err := s.catalog.metaDomain.FunctionDb(txCtx).GetByIDs(functionIDs)
-			if err != nil {
-				log.Error("FinishCreateAttachedFunction: failed to load functions", zap.Error(err))
-				return err
-			}
-			for _, function := range functions {
-				functionsByID[function.ID] = function
-			}
+		functionsByID, err := s.loadFunctionsForAttachedFunctions(txCtx, existingAttachedFunctions)
+		if err != nil {
+			log.Error("FinishCreateAttachedFunction: failed to load functions", zap.Error(err))
+			return err
 		}
 
 		readySyncCount := 0

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -551,26 +551,25 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 				return nil
 			}
 
-			if attachedFunction.IsReady {
-				existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
-				if !ok {
-					log.Error("AttachFunction: unknown function ID on existing attached function",
-						zap.Error(err),
-						zap.Stringer("function_id", attachedFunction.FunctionID))
-					return common.ErrFunctionNotFound
-				}
-				if existingFunction.IsAsync == function.IsAsync {
-					log.Error("AttachFunction: collection already has an attached function with the same execution mode",
-						zap.String("name", attachedFunction.Name),
-						zap.String("existing_function", existingFunction.Name),
-						zap.String("requested_function", function.Name),
-						zap.Bool("is_async", function.IsAsync))
-					return status.Errorf(codes.AlreadyExists,
-						"collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s",
-						attachedFunction.Name,
-						existingFunction.Name,
-						attachedFunction.OutputCollectionName)
-				}
+			existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
+			if !ok {
+				log.Error("AttachFunction: unknown function ID on existing attached function",
+					zap.Error(err),
+					zap.Stringer("function_id", attachedFunction.FunctionID))
+				return common.ErrFunctionNotFound
+			}
+			if existingFunction.IsAsync == function.IsAsync {
+				log.Error("AttachFunction: collection already has an attached function with the same execution mode",
+					zap.String("name", attachedFunction.Name),
+					zap.String("existing_function", existingFunction.Name),
+					zap.String("requested_function", function.Name),
+					zap.Bool("is_async", function.IsAsync),
+					zap.Bool("is_ready", attachedFunction.IsReady))
+				return status.Errorf(codes.AlreadyExists,
+					"collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s",
+					attachedFunction.Name,
+					existingFunction.Name,
+					attachedFunction.OutputCollectionName)
 			}
 		}
 


### PR DESCRIPTION
## Description of changes

This PR relaxes attached-function validation from "one attached function per input collection" to "at most one sync and at most one async attached function per input collection".

- Improvements & Bug fixes
  - Updates `AttachFunction`, `FinishCreateAttachedFunction`, and the insert helper to enforce the new invariant by function execution mode.
  - Treats not-ready same-mode functions as occupying their slot, preserving idempotent retry behavior while preventing duplicate same-mode rows during partial creation/recovery.
  - Keeps the existing output-collection rule: collections produced by sync upstream functions still cannot become inputs to downstream functions.
- New functionality
  - Allows one sync function and one async function to share the same input collection, which is needed for `wiki` to support sync revision history plus async currents refresh.
  - Updates distributed task API coverage for the new attach/detach rule.

## Test plan

- [x] `env PATH=/opt/homebrew/bin:/usr/local/bin:$PATH DOCKER_HOST=unix:///Users/tnayak/.orbstack/run/docker.sock GOCACHE=/private/tmp/chroma-go-cache /usr/local/go/bin/go test -count=1 ./pkg/sysdb/coordinator`
- [x] `./bin/cluster-test.sh pytest chromadb/test/distributed/test_task_api.py::test_functions_allow_one_sync_and_one_async_per_collection`
- [x] `./bin/cluster-test.sh pytest chromadb/test/distributed/test_task_api.py::test_sync_and_async_count_functions_can_share_one_input_collection`

## Migration plan

No database migration in this PR. This changes coordinator validation semantics only. Existing valid states remain valid; newly allowed states are constrained to one sync and one async function per input collection.

## Observability plan

Existing coordinator logs continue to record attach failures. The new same-mode rejection path logs the existing function, requested function, execution mode, and readiness state.

## Documentation Changes

No public docs changes. This is internal attached-function behavior and test coverage has been updated.
