### PR TITLE
[ENH](worker): Run sync and queue async

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -40,9 +40,10 @@ MINIO_BUCKET = "chroma-storage"
 
 @functools.lru_cache(maxsize=1)
 def _minio_client() -> Any:
-    boto3 = pytest.importorskip(
-        "boto3", reason="count_to_file_async test requires boto3"
-    )
+    try:
+        import boto3
+    except ImportError as e:
+        pytest.fail(f"count_to_file_async test requires boto3: {e}")
     return boto3.client(
         "s3",
         endpoint_url=MINIO_S3_ENDPOINT,
@@ -53,9 +54,10 @@ def _minio_client() -> Any:
 
 
 def _minio_get_object(bucket: str, key: str) -> Optional[bytes]:
-    botocore_exceptions = pytest.importorskip(
-        "botocore.exceptions", reason="count_to_file_async test requires botocore"
-    )
+    try:
+        import botocore.exceptions as botocore_exceptions
+    except ImportError as e:
+        pytest.fail(f"count_to_file_async test requires botocore: {e}")
 
     try:
         response = _minio_client().get_object(Bucket=bucket, Key=key)
@@ -88,6 +90,29 @@ def _wait_for_minio_count(
 
     pytest.fail(
         f"Timed out waiting for {s3_path} to contain {expected_count}. Last observed body={last_body!r}"
+    )
+
+
+def _wait_for_record_counter_count(
+    client: Any,
+    output_collection_name: str,
+    expected_count: int,
+    timeout_seconds: float = 180.0,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_count = None
+    while time.monotonic() < deadline:
+        result = client.get_collection(output_collection_name).get("function_output")
+        metadatas = result.get("metadatas")
+        if metadatas:
+            last_count = metadatas[0].get("total_count")
+            if last_count == expected_count:
+                return
+        sleep(5)
+
+    pytest.fail(
+        f"Timed out waiting for {output_collection_name} to contain total_count={expected_count}. "
+        f"Last observed total_count={last_count!r}"
     )
 
 
@@ -299,9 +324,7 @@ def test_functions_allow_one_sync_and_one_async_per_collection(
         is True
     )
     assert (
-        collection.detach_function(
-            attached_async_fn.name, delete_output_collection=True
-        )
+        collection.detach_function(attached_async_fn.name, delete_output_collection=True)
         is True
     )
 
@@ -647,6 +670,128 @@ def test_count_to_file_async_attached_function_counts_late_inputs(
     attached_fn_input_3 = attached_fn.add_input(input_collection_3.id)
     assert attached_fn_input_3 is not None
     _wait_for_minio_count(s3_path, 1200)
+
+
+def test_record_counter_attached_late_counts_existing_and_new_inputs(
+    basic_http_client: System,
+) -> None:
+    client = ClientCreator.from_system(basic_http_client)
+    client.reset()
+
+    collection = client.create_collection(name="late_sync_count_input_collection")
+    collection.add(
+        ids=[f"pre_attach_doc_{i}" for i in range(300)],
+        documents=["test document"] * 300,
+    )
+
+    attached_fn, created = collection.attach_function(
+        name="late_sync_counter",
+        function=RECORD_COUNTER_FUNCTION,
+        output_collection="late_sync_counter_output",
+        params=None,
+    )
+    assert attached_fn is not None
+    assert created is True
+
+    _wait_for_record_counter_count(client, "late_sync_counter_output", 300)
+
+    collection.add(
+        ids=[f"post_attach_doc_{i}" for i in range(300)],
+        documents=["test document"] * 300,
+    )
+
+    _wait_for_record_counter_count(client, "late_sync_counter_output", 600)
+
+
+def test_count_to_file_async_attached_late_counts_existing_and_new_inputs(
+    basic_http_client: System,
+) -> None:
+    client = ClientCreator.from_system(basic_http_client)
+    client.reset()
+
+    collection = client.create_collection(name="late_async_count_input_collection")
+    collection.add(
+        ids=[f"pre_attach_doc_{i}" for i in range(300)],
+        documents=["test document"] * 300,
+    )
+
+    file_key = f"task-api/late-async-count-{uuid.uuid4()}.txt"
+    s3_path = f"s3://{MINIO_BUCKET}/{file_key}"
+
+    attached_fn, created = collection.attach_function(
+        name="late_async_counter",
+        function=COUNT_TO_FILE_ASYNC_FUNCTION,
+        output_collection="late_async_counter_output",
+        params={"s3_path": s3_path},
+    )
+    assert attached_fn is not None
+    assert created is True
+
+    _wait_for_minio_count(s3_path, 300)
+
+    collection.add(
+        ids=[f"post_attach_doc_{i}" for i in range(300)],
+        documents=["test document"] * 300,
+    )
+
+    _wait_for_minio_count(s3_path, 600)
+
+
+def test_sync_and_async_count_functions_can_share_one_input_collection(
+    basic_http_client: System,
+) -> None:
+    client = ClientCreator.from_system(basic_http_client)
+    client.reset()
+
+    collection = client.create_collection(name="shared_count_input_collection")
+    collection.add(ids=["seed"], documents=["seed document"])
+
+    file_key = f"task-api/shared-count-{uuid.uuid4()}.txt"
+    s3_path = f"s3://{MINIO_BUCKET}/{file_key}"
+
+    sync_attached_fn, sync_created = collection.attach_function(
+        name="shared_sync_counter",
+        function=RECORD_COUNTER_FUNCTION,
+        output_collection="shared_sync_counter_output",
+        params=None,
+    )
+    assert sync_attached_fn is not None
+    assert sync_created is True
+
+    async_attached_fn, async_created = collection.attach_function(
+        name="shared_async_counter",
+        function=COUNT_TO_FILE_ASYNC_FUNCTION,
+        output_collection="shared_async_counter_output",
+        params={"s3_path": s3_path},
+    )
+    assert async_attached_fn is not None
+    assert async_created is True
+
+    initial_version = get_collection_version(client, collection.name)
+
+    collection.add(
+        ids=[f"doc_{i}" for i in range(300)],
+        documents=["test document"] * 300,
+    )
+
+    wait_for_version_increase(client, collection.name, initial_version)
+    _wait_for_minio_count(s3_path, 301)
+
+    # Give some time to invalidate the frontend query cache for the sync output.
+    sleep(60)
+
+    result = client.get_collection("shared_sync_counter_output").get("function_output")
+    assert result["metadatas"] is not None
+    assert result["metadatas"][0]["total_count"] == 301
+
+    assert (
+        collection.detach_function(sync_attached_fn.name, delete_output_collection=True)
+        is True
+    )
+    assert (
+        collection.detach_function(async_attached_fn.name, delete_output_collection=True)
+        is True
+    )
 
 
 def test_attach_to_existing_output_collection_rejects_cycle(

--- a/rust/worker/src/execution/operators/get_attached_function.rs
+++ b/rust/worker/src/execution/operators/get_attached_function.rs
@@ -8,7 +8,7 @@ use chroma_types::{
 };
 use thiserror::Error;
 
-/// The `GetAttachedFunctionOperator` lists attached functions for a collection and selects the first one.
+/// The `GetAttachedFunctionOperator` lists attached functions for a collection.
 /// If no functions are found, it returns an empty result (not an error) to allow the orchestrator
 /// to handle the case gracefully.
 #[derive(Clone, Debug)]
@@ -34,7 +34,7 @@ pub struct GetAttachedFunctionInput {
 
 #[derive(Debug)]
 pub struct GetAttachedFunctionOutput {
-    pub attached_function: Option<AttachedFunction>,
+    pub attached_functions: Vec<AttachedFunction>,
 }
 
 #[derive(Debug, Error)]
@@ -124,7 +124,7 @@ impl Operator<GetAttachedFunctionInput, GetAttachedFunctionOutput> for GetAttach
                 input.collection_id.0
             );
             return Ok(GetAttachedFunctionOutput {
-                attached_function: None,
+                attached_functions: Vec::new(),
             });
         }
 
@@ -134,26 +134,21 @@ impl Operator<GetAttachedFunctionInput, GetAttachedFunctionOutput> for GetAttach
             .collect::<Result<Vec<_>, _>>()
             .map_err(GetAttachedFunctionOperatorError::ConversionError)?;
 
-        let attached_function = match input.attached_function_id {
-            Some(attached_function_id) => attached_functions
+        let attached_functions = match input.attached_function_id {
+            Some(attached_function_id) => vec![attached_functions
                 .into_iter()
                 .find(|attached_function| attached_function.id == attached_function_id)
-                .ok_or(GetAttachedFunctionOperatorError::NoAttachedFunctionFound)?,
-            None => attached_functions
-                .into_iter()
-                .next()
-                .ok_or(GetAttachedFunctionOperatorError::NoAttachedFunctionFound)?,
+                .ok_or(GetAttachedFunctionOperatorError::NoAttachedFunctionFound)?],
+            None => attached_functions,
         };
 
         tracing::info!(
-            "[{}]: Found attached function '{}' for collection {}",
+            "[{}]: Found {} attached function(s) for collection {}",
             self.get_name(),
-            attached_function.name,
+            attached_functions.len(),
             input.collection_id.0
         );
 
-        Ok(GetAttachedFunctionOutput {
-            attached_function: Some(attached_function),
-        })
+        Ok(GetAttachedFunctionOutput { attached_functions })
     }
 }

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -378,7 +378,7 @@ impl AttachedFunctionOrchestrator {
         }
     }
 
-    async fn dispatch_sync_function(
+    async fn dispatch_function_execution(
         &mut self,
         attached_function: AttachedFunction,
         ctx: &ComponentContext<Self>,
@@ -772,7 +772,7 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
         }
 
         if let Some(sync_attached_function) = self.pending_sync_attached_function.take() {
-            self.dispatch_sync_function(sync_attached_function, ctx)
+            self.dispatch_function_execution(sync_attached_function, ctx)
                 .await;
         } else if let Some(async_attached_function) = async_attached_function.take() {
             if self
@@ -789,7 +789,7 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
                 return;
             }
 
-            self.dispatch_sync_function(async_attached_function, ctx)
+            self.dispatch_function_execution(async_attached_function, ctx)
                 .await;
         }
     }
@@ -1079,7 +1079,7 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
         );
 
         if let Some(sync_attached_function) = self.pending_sync_attached_function.take() {
-            self.dispatch_sync_function(sync_attached_function, ctx)
+            self.dispatch_function_execution(sync_attached_function, ctx)
                 .await;
             return;
         }

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -21,8 +21,8 @@ use chroma_system::{
     OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
-    AttachedFunctionUuid, Chunk, CollectionAndSegments, CollectionUuid, JobId, LogRecord,
-    SegmentShard, SegmentShardError,
+    AttachedFunction, AttachedFunctionUuid, Chunk, CollectionAndSegments, CollectionUuid, JobId,
+    LogRecord, SegmentShard, SegmentShardError,
 };
 use thiserror::Error;
 use tokio::sync::oneshot::{error::RecvError, Sender};
@@ -71,6 +71,7 @@ pub struct AttachedFunctionOrchestrator {
 
     // Function context
     function_context: OnceCell<FunctionContext>,
+    pending_sync_attached_function: Option<AttachedFunction>,
 
     // Execution state
     state: ExecutionState,
@@ -259,6 +260,7 @@ impl AttachedFunctionOrchestrator {
             output_context,
             result_channel: None,
             function_context: OnceCell::new(),
+            pending_sync_attached_function: None,
             state: ExecutionState::MaterializeApplyCommitFlush,
             orchestrator_context,
             dispatcher,
@@ -324,6 +326,112 @@ impl AttachedFunctionOrchestrator {
         self.function_context
             .set(function_context)
             .map_err(Box::new)
+    }
+
+    fn make_function_context(&self, attached_function: &AttachedFunction) -> FunctionContext {
+        FunctionContext {
+            attached_function_id: attached_function.id,
+            function_id: attached_function.function_id,
+            input_progress: self
+                .get_input_collection_data()
+                .iter()
+                .map(|input_collection_data| FunctionExecutionProgress {
+                    input_collection_id: input_collection_data.collection_info.collection_id,
+                    updated_completion_offset: attached_function.completion_offset,
+                })
+                .collect(),
+            is_async: attached_function.is_async,
+            attached_function: attached_function.clone(),
+        }
+    }
+
+    async fn dispatch_async_function_queue(
+        &mut self,
+        attached_function: &AttachedFunction,
+        ctx: &ComponentContext<Self>,
+    ) -> bool {
+        if let Some(work_queue_client) = &self.output_context.work_queue_client {
+            let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
+            let input = QueueFunctionInput::new(
+                attached_function.id,
+                self.get_input_collection_info().collection_id,
+                attached_function.completion_offset as i64,
+            );
+            let task = wrap(
+                operator,
+                input,
+                ctx.receiver(),
+                self.context().task_cancellation_token.clone(),
+            );
+            let res = self.dispatcher().send(task, None).await;
+            self.ok_or_terminate(res, ctx).await.is_some()
+        } else {
+            tracing::error!("Async attached function found but no WorkQueue client configured");
+            self.terminate_with_result(
+                Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                    "Async function requires WorkQueue configuration".to_string(),
+                )),
+                ctx,
+            )
+            .await;
+            false
+        }
+    }
+
+    async fn dispatch_sync_function(
+        &mut self,
+        attached_function: AttachedFunction,
+        ctx: &ComponentContext<Self>,
+    ) {
+        let output_collection_id = match attached_function.output_collection_id {
+            Some(id) => id,
+            None => {
+                tracing::error!(
+                    "[AttachedFunctionOrchestrator]: Output collection ID not set for attached function '{}'",
+                    attached_function.name
+                );
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::OutputCollectionIdNotSet),
+                    ctx,
+                )
+                .await;
+                return;
+            }
+        };
+
+        let database_name = match chroma_types::DatabaseName::new(
+            self.get_input_collection_info().collection.database.clone(),
+        ) {
+            Some(name) => name,
+            None => {
+                tracing::error!(
+                    "Invalid database name in input collection: {}",
+                    self.get_input_collection_info().collection.database
+                );
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Invalid database name".to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
+                return;
+            }
+        };
+
+        let operator = Box::new(GetCollectionAndSegmentsOperator::new(
+            self.output_context.sysdb.clone(),
+            output_collection_id,
+            database_name,
+        ));
+        let task = wrap(
+            operator,
+            (),
+            ctx.receiver(),
+            self.context().task_cancellation_token.clone(),
+        );
+        let res = self.dispatcher().send(task, None).await;
+        self.ok_or_terminate(res, ctx).await;
     }
 
     async fn finish_no_attached_function(&mut self, ctx: &ComponentContext<Self>) {
@@ -579,133 +687,110 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
             None => return,
         };
 
-        match message.attached_function {
-            Some(attached_function) => {
-                tracing::info!(
-                    "[AttachedFunctionOrchestrator]: Found attached function '{}' for collection",
-                    attached_function.name
+        if message.attached_functions.is_empty() {
+            tracing::info!("[AttachedFunctionOrchestrator]: No attached function found");
+            self.finish_no_attached_function(ctx).await;
+            return;
+        }
+
+        let mut sync_attached_functions = Vec::new();
+        let mut async_attached_functions = Vec::new();
+        for attached_function in message.attached_functions {
+            if attached_function.is_async {
+                async_attached_functions.push(attached_function);
+            } else {
+                sync_attached_functions.push(attached_function);
+            }
+        }
+
+        if self.output_context.is_fn_consumer
+            && (sync_attached_functions.len() + async_attached_functions.len() != 1)
+        {
+            self.terminate_with_result(
+                Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                    "Function consumer execution expects exactly one attached function".to_string(),
+                )),
+                ctx,
+            )
+            .await;
+            return;
+        }
+
+        if sync_attached_functions.len() > 1 || async_attached_functions.len() > 1 {
+            self.terminate_with_result(
+                Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                    "At most one sync and one async attached function are supported per collection"
+                        .to_string(),
+                )),
+                ctx,
+            )
+            .await;
+            return;
+        }
+
+        let sync_attached_function = sync_attached_functions.pop();
+        let mut async_attached_function = async_attached_functions.pop();
+
+        if let Some(sync_attached_function) = sync_attached_function {
+            tracing::info!(
+                "[AttachedFunctionOrchestrator]: Prepared sync attached function '{}' for collection",
+                sync_attached_function.name
+            );
+
+            if self
+                .set_function_context(self.make_function_context(&sync_attached_function))
+                .is_err()
+            {
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Failed to set function context for attached function".to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
+                return;
+            }
+
+            self.pending_sync_attached_function = Some(sync_attached_function);
+        }
+
+        if let Some(async_attached_function) = async_attached_function.as_ref() {
+            tracing::info!(
+                    "[AttachedFunctionOrchestrator]: Queueing async attached function '{}' for collection",
+                    async_attached_function.name
                 );
 
-                if self
-                    .set_function_context(FunctionContext {
-                        attached_function_id: attached_function.id,
-                        function_id: attached_function.function_id,
-                        input_progress: self
-                            .get_input_collection_data()
-                            .iter()
-                            .map(|input_collection_data| FunctionExecutionProgress {
-                                input_collection_id: input_collection_data
-                                    .collection_info
-                                    .collection_id,
-                                updated_completion_offset: attached_function.completion_offset,
-                            })
-                            .collect(),
-                        is_async: attached_function.is_async,
-                        attached_function: attached_function.clone(),
-                    })
-                    .is_err()
+            if !self.output_context.is_fn_consumer {
+                if !self
+                    .dispatch_async_function_queue(async_attached_function, ctx)
+                    .await
                 {
-                    self.terminate_with_result(
-                        Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                            "Failed to set function context for attached function".to_string(),
-                        )),
-                        ctx,
-                    )
-                    .await;
                     return;
                 }
-
-                // Check if this is an async function and handle it early
-                if attached_function.is_async && !self.output_context.is_fn_consumer {
-                    // For async functions, we don't need output collection info
-                    if let Some(work_queue_client) = &self.output_context.work_queue_client {
-                        let operator =
-                            Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
-                        let input = QueueFunctionInput::new(
-                            attached_function.id,
-                            self.get_input_collection_info().collection_id,
-                            attached_function.completion_offset as i64,
-                        );
-                        let task = wrap(
-                            operator,
-                            input,
-                            ctx.receiver(),
-                            self.context().task_cancellation_token.clone(),
-                        );
-                        let res = self.dispatcher().send(task, None).await;
-                        self.ok_or_terminate(res, ctx).await;
-                    } else {
-                        tracing::error!(
-                            "Async attached function found but no WorkQueue client configured"
-                        );
-                        self.terminate_with_result(
-                            Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                                "Async function requires WorkQueue configuration".to_string(),
-                            )),
-                            ctx,
-                        )
-                        .await;
-                    }
-                    return;
-                }
-
-                // For sync functions, we need to get the output collection info
-                let output_collection_id = match attached_function.output_collection_id {
-                    Some(id) => id,
-                    None => {
-                        tracing::error!(
-                            "[AttachedFunctionOrchestrator]: Output collection ID not set for attached function '{}'",
-                            attached_function.name
-                        );
-                        self.terminate_with_result(
-                            Err(AttachedFunctionOrchestratorError::OutputCollectionIdNotSet),
-                            ctx,
-                        )
-                        .await;
-                        return;
-                    }
-                };
-
-                // Next step: get the output collection segments using the existing GetCollectionAndSegmentsOperator
-                let database_name = match chroma_types::DatabaseName::new(
-                    self.get_input_collection_info().collection.database.clone(),
-                ) {
-                    Some(name) => name,
-                    None => {
-                        tracing::error!(
-                            "Invalid database name in input collection: {}",
-                            self.get_input_collection_info().collection.database
-                        );
-                        self.terminate_with_result(
-                            Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                                "Invalid database name".to_string(),
-                            )),
-                            ctx,
-                        )
-                        .await;
-                        return;
-                    }
-                };
-
-                let operator = Box::new(GetCollectionAndSegmentsOperator::new(
-                    self.output_context.sysdb.clone(),
-                    output_collection_id,
-                    database_name,
-                ));
-                let input = ();
-                let task = wrap(
-                    operator,
-                    input,
-                    ctx.receiver(),
-                    self.context().task_cancellation_token.clone(),
-                );
-                let res = self.dispatcher().send(task, None).await;
-                self.ok_or_terminate(res, ctx).await;
+                return;
             }
-            None => {
-                tracing::info!("[AttachedFunctionOrchestrator]: No attached function found");
-                self.finish_no_attached_function(ctx).await;
+        }
+
+        if let Some(sync_attached_function) = self.pending_sync_attached_function.take() {
+            self.dispatch_sync_function(sync_attached_function, ctx)
+                .await;
+        } else if let Some(async_attached_function) = async_attached_function.take() {
+            if self
+                .set_function_context(self.make_function_context(&async_attached_function))
+                .is_err()
+            {
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Failed to set function context for attached function".to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
+                return;
             }
+
+            self.dispatch_sync_function(async_attached_function, ctx)
+                .await;
         }
     }
 }
@@ -993,14 +1078,14 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
             "[AttachedFunctionOrchestrator]: Async function successfully queued for external processing"
         );
 
-        // For async functions, we don't have any output records to apply
-        // The function will be processed asynchronously by an external consumer
-        let collection_info = self.get_input_collection_info();
-        let job_id = collection_info.collection_id.into();
-        self.terminate_with_result(
-            Ok(AttachedFunctionOrchestratorResponse::NoAttachedFunction { job_id }),
-            ctx,
-        )
-        .await;
+        if let Some(sync_attached_function) = self.pending_sync_attached_function.take() {
+            self.dispatch_sync_function(sync_attached_function, ctx)
+                .await;
+            return;
+        }
+
+        // For async-only functions, we don't have any output records to apply.
+        // The function will be processed asynchronously by an external consumer.
+        self.finish_no_attached_function(ctx).await;
     }
 }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -21,7 +21,9 @@ use chroma_system::{
     wrap, ComponentHandle, Dispatcher, Orchestrator, OrchestratorContext, PanicError, System,
     TaskError,
 };
-use chroma_types::{Collection, CollectionUuid, JobId, Schema, SegmentFlushInfo, SegmentUuid};
+use chroma_types::{
+    AttachedFunctionUuid, Collection, CollectionUuid, JobId, Schema, SegmentFlushInfo, SegmentUuid,
+};
 use opentelemetry::metrics::Counter;
 use thiserror::Error;
 
@@ -163,10 +165,7 @@ pub struct CollectionCompactInfo {
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum BackfillResult {
-    BackfillCompleted {
-        function_context: FunctionContext,
-        collection_register_info: CollectionRegisterInfo,
-    },
+    BackfillCompleted,
     NoBackfillRequired,
 }
 
@@ -711,7 +710,9 @@ impl CompactionContext {
         })
     }
 
-    async fn needs_backfill(&mut self) -> Result<bool, CompactionError> {
+    async fn stale_attached_function_ids(
+        &mut self,
+    ) -> Result<Vec<AttachedFunctionUuid>, CompactionError> {
         let collection_info = self.get_collection_info()?;
         let collection_id = collection_info.collection_id;
         let log_position = collection_info.collection.log_position;
@@ -757,6 +758,7 @@ impl CompactionContext {
             .map_err(|_| CompactionError::InvariantViolation("GetAttachedFunction task failed"))?;
 
         let log_position_u64 = log_position.max(0) as u64;
+        let mut stale_function_ids = Vec::new();
 
         for function in &output.attached_functions {
             if log_position_u64 < function.completion_offset {
@@ -764,12 +766,13 @@ impl CompactionContext {
                     "Log position is less than completion offset",
                 ));
             }
+
+            if function.completion_offset < log_position_u64 {
+                stale_function_ids.push(function.id);
+            }
         }
 
-        Ok(output
-            .attached_functions
-            .iter()
-            .any(|function| function.completion_offset < log_position_u64))
+        Ok(stale_function_ids)
     }
 
     async fn run_backfill_attached_function_workflow(
@@ -777,13 +780,16 @@ impl CompactionContext {
         database_name: chroma_types::DatabaseName,
         system: System,
     ) -> Result<BackfillResult, CompactionError> {
-        // See if we need backfill
-        if !self.needs_backfill().await? {
+        let stale_function_ids = self.stale_attached_function_ids().await?;
+        if stale_function_ids.is_empty() {
             tracing::debug!("No backfill needed");
             return Ok(BackfillResult::NoBackfillRequired);
         }
 
-        tracing::debug!("Backfill needed");
+        tracing::debug!(
+            count = stale_function_ids.len(),
+            "Attached function backfill needed"
+        );
 
         let log_fetch_records = match self
             .run_get_logs(
@@ -811,22 +817,32 @@ impl CompactionContext {
             materialized_log_data: log_fetch_records,
         };
 
-        let result = Box::pin(self.run_attached_function_workflow(
-            vec![input_collection_data],
-            system,
-            true,
-            None,
-        ))
-        .await?;
+        let mut ran_backfill = false;
+        for attached_function_id in stale_function_ids {
+            let result = Box::pin(self.run_attached_function_workflow(
+                vec![input_collection_data.clone()],
+                system.clone(),
+                true,
+                Some(attached_function_id),
+            ))
+            .await?;
 
-        match result {
-            Some((function_context, collection_register_info)) => {
-                Ok(BackfillResult::BackfillCompleted {
-                    function_context,
-                    collection_register_info,
-                })
+            if let Some((function_context, collection_register_info)) = result {
+                Box::pin(self.run_register(
+                    vec![collection_register_info],
+                    Some(function_context),
+                    system.clone(),
+                ))
+                .await?;
             }
-            None => Ok(BackfillResult::NoBackfillRequired),
+
+            ran_backfill = true;
+        }
+
+        if ran_backfill {
+            Ok(BackfillResult::BackfillCompleted)
+        } else {
+            Ok(BackfillResult::NoBackfillRequired)
         }
     }
 
@@ -947,22 +963,10 @@ impl CompactionContext {
                     .await?;
 
                     match fn_result {
-                        BackfillResult::BackfillCompleted {
-                            function_context,
-                            collection_register_info,
-                        } => {
-                            // Backfill was needed and completed - register and return
-                            let results = vec![collection_register_info];
-                            Box::pin(self.run_register(
-                                results,
-                                Some(function_context),
-                                system.clone(),
-                            ))
-                            .await?;
-
+                        BackfillResult::BackfillCompleted => {
+                            // Backfill was needed and completed.
                             // TODO(tanujnay112): Should we look into just doing the rest of the compaction workflow
                             // instead of exiting here?
-
                             return Ok(CompactionResponse::Success {
                                 job_id: collection_id.into(),
                             });

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -756,21 +756,20 @@ impl CompactionContext {
             .into_inner()
             .map_err(|_| CompactionError::InvariantViolation("GetAttachedFunction task failed"))?;
 
-        // Check if we have an attached function
-        match output.attached_function {
-            Some(function) => {
-                // Check if backfill is needed by comparing offsets
-                // log_position is i64, completion_offset is u64
-                let log_position_u64 = log_position.max(0) as u64;
-                if log_position_u64 < function.completion_offset {
-                    return Err(CompactionError::InvariantViolation(
-                        "Log position is less than completion offset",
-                    ));
-                }
-                Ok(function.completion_offset < log_position_u64)
+        let log_position_u64 = log_position.max(0) as u64;
+
+        for function in &output.attached_functions {
+            if log_position_u64 < function.completion_offset {
+                return Err(CompactionError::InvariantViolation(
+                    "Log position is less than completion offset",
+                ));
             }
-            None => Ok(false), // No attached function means no backfill needed
         }
+
+        Ok(output
+            .attached_functions
+            .iter()
+            .any(|function| function.completion_offset < log_position_u64))
     }
 
     async fn run_backfill_attached_function_workflow(


### PR DESCRIPTION
## Description of changes

his PR extends the attached function orchestration to support **both a sync and an async function simultaneously** on a single collection. Previously, only one attached function was handled at a time. The key behavioral change:

- **Sync function**: runs inline (blocking the compaction pipeline)
- **Async function**: queued to the work queue, then the sync function (if any) runs after the queue completes

The stack's prior PR ([#7265](https://app.graphite.com/github/pr-or-issue/chroma-core/chroma/7265)) added sysdb support for one sync + one async; this PR wires up the worker-side orchestration to consume that.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

Tests added to test_tasks_api.py

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_