### PR TITLE
[BUG](client): Validate sparse vector lengths

### DIFF
--- a/chromadb/test/utils/test_sparse_embedding_utils.py
+++ b/chromadb/test/utils/test_sparse_embedding_utils.py
@@ -1,0 +1,62 @@
+import pytest
+
+from chromadb.base_types import SparseVector
+from chromadb.utils.sparse_embedding_utils import normalize_sparse_vector
+
+
+def test_normalize_sorts_indices() -> None:
+    result = normalize_sparse_vector(indices=[3, 1, 2], values=[30.0, 10.0, 20.0])
+    assert result.indices == [1, 2, 3]
+    assert result.values == [10.0, 20.0, 30.0]
+    assert result.labels is None
+
+
+def test_normalize_sorts_indices_with_labels() -> None:
+    result = normalize_sparse_vector(
+        indices=[2, 0, 1],
+        values=[20.0, 0.0, 10.0],
+        labels=["c", "a", "b"],
+    )
+    assert result.indices == [0, 1, 2]
+    assert result.values == [0.0, 10.0, 20.0]
+    assert result.labels == ["a", "b", "c"]
+
+
+def test_normalize_empty() -> None:
+    result = normalize_sparse_vector(indices=[], values=[])
+    assert result.indices == []
+    assert result.values == []
+    assert result.labels is None
+
+
+def test_normalize_raises_on_indices_values_length_mismatch() -> None:
+    # The docstring promises a ValueError, but zip() silently truncates the
+    # longer list, dropping data. More values than indices.
+    with pytest.raises(ValueError):
+        normalize_sparse_vector(indices=[1, 2], values=[10.0, 20.0, 30.0])
+
+
+def test_normalize_raises_on_more_indices_than_values() -> None:
+    with pytest.raises(ValueError):
+        normalize_sparse_vector(indices=[1, 2, 3], values=[10.0, 20.0])
+
+
+def test_normalize_raises_on_labels_length_mismatch() -> None:
+    with pytest.raises(ValueError):
+        normalize_sparse_vector(
+            indices=[1, 2], values=[10.0, 20.0], labels=["only-one"]
+        )
+
+
+def test_normalize_does_not_silently_drop_data() -> None:
+    # Regression: zip() truncation used to silently drop the extra index,
+    # producing a 2-element SparseVector instead of raising.
+    try:
+        result = normalize_sparse_vector(indices=[1, 2, 3], values=[10.0, 20.0])
+    except ValueError:
+        return
+    assert isinstance(result, SparseVector)
+    pytest.fail(
+        "Expected ValueError on mismatched lengths; got "
+        f"{result!r} (data silently dropped)"
+    )

--- a/chromadb/utils/sparse_embedding_utils.py
+++ b/chromadb/utils/sparse_embedding_utils.py
@@ -27,6 +27,20 @@ def normalize_sparse_vector(
         ValueError: If values are not numeric
         ValueError: If labels is provided and has different length than indices
     """
+    # zip() silently truncates to the shortest input, which would drop data
+    # instead of surfacing a mismatch. Validate lengths up front so the
+    # documented ValueError is raised rather than producing a malformed vector.
+    if len(indices) != len(values):
+        raise ValueError(
+            f"indices and values must have the same length, "
+            f"got {len(indices)} indices and {len(values)} values"
+        )
+    if labels is not None and len(labels) != len(indices):
+        raise ValueError(
+            f"labels must have the same length as indices, "
+            f"got {len(labels)} labels and {len(indices)} indices"
+        )
+
     if not indices:
         return SparseVector(indices=[], values=[], labels=None)
 


### PR DESCRIPTION
## Bug

`chromadb.utils.sparse_embedding_utils.normalize_sparse_vector` documents that it raises `ValueError` when:

- `indices` and `values` have different lengths, and
- `labels` (when provided) has a different length than `indices`.

In practice neither check existed. The function passed its inputs directly to `zip()`, which silently truncates to the shortest sequence. So mismatched inputs produced a malformed `SparseVector` with data dropped, rather than raising.

```python
>>> from chromadb.utils.sparse_embedding_utils import normalize_sparse_vector
>>> normalize_sparse_vector(indices=[1, 2, 3], values=[10.0, 20.0])
SparseVector(indices=[1, 2], values=[10.0, 20.0], labels=None)  # index 3 silently dropped
```

`SparseVector.__post_init__` cannot catch this because `zip()` truncation happens first, so the constructed (truncated) lists are internally consistent.

## Fix

Validate the lengths up front in `normalize_sparse_vector` and raise `ValueError` on a mismatch, matching the documented contract.

## Verification

Added `chromadb/test/utils/test_sparse_embedding_utils.py` covering the happy paths (sorting with/without labels, empty input) and the mismatch cases.

```
python -m pytest chromadb/test/utils/test_sparse_embedding_utils.py -v
# 7 passed
```

Before the fix the three mismatch tests + the regression guard fail with `DID NOT RAISE ValueError`; after the fix all 7 pass. The BM25 embedding function (a real caller of `normalize_sparse_vector`) test suite still passes:

```
python -m pytest chromadb/test/ef/test_chroma_bm25_embedding_function.py -q
# 8 passed
```

> AI-assisted drafting; changes reviewed and verified by a human before submission.