### PR TITLE
[ENH] Replace ValueError with InvalidArgumentError in client.py

### DIFF
--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -2,6 +2,7 @@ from typing import Optional, Sequence
 from types import TracebackType
 from uuid import UUID
 
+
 from overrides import override
 import httpx
 from chromadb.api import AdminAPI, ClientAPI, ServerAPI
@@ -12,6 +13,7 @@ from chromadb.api.collection_configuration import (
     validate_embedding_function_conflict_on_get,
 )
 from chromadb.api.shared_system_client import SharedSystemClient
+from chromadb.errors import InvalidArgumentError
 from chromadb.api.types import (
     CollectionMetadata,
     DataLoader,
@@ -133,14 +135,14 @@ class Client(SharedSystemClient, ClientAPI):
         try:
             return self._server.get_user_identity()
         except httpx.ConnectError:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
         # Propagate ChromaErrors
         except ChromaError as e:
             raise e
         except Exception as e:
-            raise ValueError(str(e))
+            raise InvalidArgumentError(str(e))
 
     # region BaseAPI Methods
     # Note - we could do this in less verbose ways, but they break type checking
@@ -640,21 +642,21 @@ class Client(SharedSystemClient, ClientAPI):
         try:
             self._admin_client.get_tenant(name=tenant)
         except httpx.ConnectError:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
         # Propagate ChromaErrors
         except ChromaError as e:
             raise e
         except Exception:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Could not connect to tenant {tenant}. Are you sure it exists?"
             )
 
         try:
             self._admin_client.get_database(name=database, tenant=tenant)
         except httpx.ConnectError:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
 


### PR DESCRIPTION
Fixes part of #3026

## Changes made in `chromadb/api/client.py`:

- Added import for `InvalidArgumentError` from `chromadb.errors`
- Replaced all 5 instances of `raise ValueError` with `raise InvalidArgumentError`
  - `get_user_identity()` - connection error and general exception handler
  - `_validate_tenant_database()` - connection errors and tenant/database not found errors

No logic changes — only error type replacements as requested in the issue.