### PR TITLE
[BUG](api): Fix bool/int where list validation

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1268,14 +1268,23 @@ def validate_where(where: Where) -> None:
                     raise ValueError(
                         f"Expected where operand value to be a str, int, float, bool, or list of those type, got {operand}"
                     )
-                if isinstance(operand, list) and (
-                    len(operand) == 0
-                    or not all(isinstance(x, type(operand[0])) for x in operand)
-                ):
-                    raise ValueError(
-                        f"Expected where operand value to be a non-empty list, and all values to be of the same type "
-                        f"got {operand}"
+                if isinstance(operand, list):
+                    if len(operand) == 0:
+                        raise ValueError(
+                            f"Expected where operand value to be a non-empty list, and all values to be of the same type "
+                            f"got {operand}"
+                        )
+                    first_type = (
+                        bool if isinstance(operand[0], bool) else type(operand[0])
                     )
+                    if not all(
+                        (bool if isinstance(x, bool) else type(x)) is first_type
+                        for x in operand
+                    ):
+                        raise ValueError(
+                            f"Expected where operand value to be a non-empty list, and all values to be of the same type "
+                            f"got {operand}"
+                        )
 
 
 def validate_where_document(where_document: WhereDocument) -> None:

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -2276,6 +2276,17 @@ def test_where_contains_validation():
     )
 
 
+def test_where_in_nin_rejects_mixed_bool_int_lists():
+    from chromadb.api.types import validate_where
+
+    for operator in ["$in", "$nin"]:
+        with pytest.raises(ValueError, match="same type"):
+            validate_where({"field": {operator: [1, True]}})
+
+        with pytest.raises(ValueError, match="same type"):
+            validate_where({"field": {operator: [0, False]}})
+
+
 def _is_python_local_segment(client):
     """Return True when the client is backed by the Python local segment API
     (which does not yet support array metadata)."""


### PR DESCRIPTION
## Summary

Fixes #7181.

This PR fixes order-dependent validation for `$in` and `$nin` where filters when the operand list mixes bool and int values.

## Changes

- Added regression coverage for int-first mixed bool/int `$in` and `$nin` lists
- Updated `validate_where()` to compare normalized exact item types, keeping `bool` distinct from `int`
- No new dependencies
- No public API changes

## Testing

Ran:

```bash
.\.venv\Scripts\python -m pytest chromadb\test\test_api.py::test_where_in_nin_rejects_mixed_bool_int_lists -q
.\.venv\Scripts\python -m pytest chromadb\test\test_api.py::test_list_metadata_validation chromadb\test\test_api.py::test_where_contains_validation chromadb\test\test_api.py::test_where_in_nin_rejects_mixed_bool_int_lists -q
git diff --check
```

## Scope Notes

Kept the fix limited to where-filter validation. Did not run distributed/Tilt-backed tests.