### PR TITLE
[ENH] Add coding agent traces

### DIFF
--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -141,13 +141,17 @@ pub async fn foundation_init(
     )
     .await?;
 
+    // The agent_sessions collection is wired into the sources->wiki function
+    // below, so it carries the chunk-sibling grouping flag like the other
+    // source collections (keeps a job's chunk records in one partition and
+    // surfaces the trailing end-of-job marker after every sibling chunk).
     let agent_sessions_name = format!("{}_{}", foundation_cfg.agent_sessions_collection, user_id);
     let agent_sessions = ensure_collection(
         &mut sysdb,
         tenant.clone(),
         db_name.clone(),
         &agent_sessions_name,
-        None,
+        Some(group_chunk_siblings_metadata()),
         Some(1024),
         CollectionEmbeddingFunctions {
             dense: Some(qwen_embedding_function()),
@@ -199,6 +203,18 @@ pub async fn foundation_init(
             )
             .await?;
         }
+
+        // Wire the per-user coding-agent traces collection into the same
+        // sources->wiki function so synced agent sessions flow into the
+        // shared wiki output alongside slack/notion.
+        attached_function_ops::add_attached_function_input(
+            &mut sysdb,
+            foundation_attached_function_name(),
+            *base_source_id,
+            agent_sessions.collection_id,
+            db_name.clone(),
+        )
+        .await?;
     }
 
     Ok(Json(FoundationInitResponse {

--- a/rust/frontend-core/src/foundation.rs
+++ b/rust/frontend-core/src/foundation.rs
@@ -22,8 +22,8 @@ pub fn source_kind_for_collection_name(
     if collection_name.contains("notion") {
         return Ok("notion");
     }
-    if collection_name.contains("coding") {
-        return Ok("coding_agent_sessions");
+    if collection_name.contains("coding") || collection_name.contains("agent_sessions") {
+        return Ok("coding_agent_session");
     }
     Err(FoundationSourceKindError::UnknownSourceCollection(
         collection_name.to_string(),
@@ -61,11 +61,19 @@ mod tests {
     fn detects_coding_source_kind() {
         assert_eq!(
             source_kind_for_collection_name("coding").unwrap(),
-            "coding_agent_sessions"
+            "coding_agent_session"
         );
         assert_eq!(
             source_kind_for_collection_name("my_coding_collection").unwrap(),
-            "coding_agent_sessions"
+            "coding_agent_session"
+        );
+    }
+
+    #[test]
+    fn detects_agent_sessions_source_kind() {
+        assert_eq!(
+            source_kind_for_collection_name("agent_sessions_hammad").unwrap(),
+            "coding_agent_session"
         );
     }
 }


### PR DESCRIPTION
## Description of changes

Wires per-user coding-agent trace collections into the Foundation sources→wiki pipeline so synced agent sessions are summarized into the shared wiki.

- Improvements & Bug fixes
  - `source_kind_for_collection_name` now recognizes `agent_sessions*` collections and returns the canonical singular kind `coding_agent_session` (was `coding_agent_sessions`), matching what foundation-research's parser expects on the HTTP generate path.
- New functionality
  - `/init` attaches each user's `agent_sessions_{user_id}` collection as an input to the `foundation_sources_to_wiki` function (same idempotent fan-in used for slack/notion), so coding-agent traces flow into the shared `wiki` output.
  - `agent_sessions` collections are now created with the chunk-sibling grouping flag so chunked add-file uploads partition correctly and surface end-of-job markers like other sources.

> Note: the matching consumer-side change (accepting the `coding_agent_session` kind on the attached-function HTTP path) lives in the `foundation-research` repo, not this PR.

## Test plan

- [x] `cargo test -p frontend-core foundation` (source_kind detection, incl. new `agent_sessions` case)
- [x] `cargo test -p foundation-api` (init compiles; schema tests pass — pre-existing network-dependent tests excluded)
- End-to-end: run `/init`, confirm `foundation_sources_to_wiki` lists `agent_sessions_{user_id}` as an input, sync a session via the CLI, and confirm a wiki page is produced.

## Migration plan

`create_collection` uses `get_or_create`, so the new chunk-sibling grouping metadata only applies to newly created `agent_sessions` collections. Pre-existing collections must be recreated to pick up the flag. `/init` wiring is idempotent and safe to re-run.

## Observability plan

Existing attached-function execution logging/tracing in the worker (`HttpGenerateExecutor`) covers the new input; no new instrumentation added.

## Documentation Changes

None required.
