### PR TITLE
[ENH] foundation-api: return 404 when Foundation isn't provisioned

### DIFF
--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -106,6 +106,11 @@ impl ChromaError for AgentRouteError {
             AgentRouteError::RouteDisabled => ErrorCodes::Internal,
             AgentRouteError::MissingToken => ErrorCodes::InvalidArgument,
             AgentRouteError::UnknownModel(_) => ErrorCodes::InvalidArgument,
+            // A 404 resolving the wiki collection means Foundation isn't
+            // provisioned for this tenant — surface it as NotFound (404) so
+            // callers can tell "not set up" apart from a transient failure,
+            // rather than collapsing it into a generic 500.
+            AgentRouteError::Resolve(err) if err.is_not_found() => ErrorCodes::NotFound,
             AgentRouteError::Resolve(err) => err.code(),
             AgentRouteError::Inference(_) => ErrorCodes::Internal,
         }

--- a/rust/foundation-api/src/routes/agent/tests/00_unit.rs
+++ b/rust/foundation-api/src/routes/agent/tests/00_unit.rs
@@ -48,6 +48,29 @@ fn request_validation_requires_non_empty_query() {
 }
 
 #[test]
+fn not_provisioned_resolve_error_maps_to_not_found() {
+    use super::super::AgentRouteError;
+    use crate::wiki::WikiClientError;
+    use chroma::client::ChromaHttpClientError;
+    use chroma_error::{ChromaError, ErrorCodes};
+    use reqwest::StatusCode;
+
+    // A 404 resolving the wiki collection means Foundation isn't provisioned
+    // for the tenant; the route must surface NotFound (404), not a 500, so
+    // dashboard-api can render its "set up Foundation" reply.
+    let not_found = AgentRouteError::Resolve(WikiClientError::Client(
+        ChromaHttpClientError::ApiError("collection not found".to_string(), StatusCode::NOT_FOUND),
+    ));
+    assert!(matches!(not_found.code(), ErrorCodes::NotFound));
+
+    // Other downstream failures still collapse to Internal (500).
+    let server_err = AgentRouteError::Resolve(WikiClientError::Client(
+        ChromaHttpClientError::ApiError("boom".to_string(), StatusCode::INTERNAL_SERVER_ERROR),
+    ));
+    assert!(matches!(server_err.code(), ErrorCodes::Internal));
+}
+
+#[test]
 fn action_event_splits_reasoning_text_and_calls() {
     let mut builder = ActionBuilder::new();
     builder.set_reasoning(Reasoning {

--- a/rust/foundation-api/src/wiki/client.rs
+++ b/rust/foundation-api/src/wiki/client.rs
@@ -64,6 +64,15 @@ impl ChromaError for WikiClientError {
     }
 }
 
+impl WikiClientError {
+    /// Whether this is a 404 from the FE — i.e. the `FOUNDATION` database or
+    /// the `wiki` collection does not exist, so Foundation isn't provisioned
+    /// for this tenant (as opposed to a transient or internal failure).
+    pub(crate) fn is_not_found(&self) -> bool {
+        matches!(self, WikiClientError::Client(err) if is_not_found(err))
+    }
+}
+
 /// A cheaply-cloneable factory for per-request Chroma collection handles that
 /// proxy to the FE. Holds one long-lived client (shared connection pool) plus
 /// a tenant-scoped cache of the wiki collection identity.
@@ -324,6 +333,25 @@ mod tests {
             StatusCode::INTERNAL_SERVER_ERROR,
         )));
         assert!(!is_not_found(&ChromaHttpClientError::NoBackendAvailable));
+    }
+
+    #[test]
+    fn wiki_client_error_is_not_found_only_on_client_404() {
+        use reqwest::StatusCode;
+        // A 404 from the FE (missing FOUNDATION db / wiki collection).
+        assert!(WikiClientError::Client(ChromaHttpClientError::ApiError(
+            "missing".to_string(),
+            StatusCode::NOT_FOUND,
+        ))
+        .is_not_found());
+        // Other downstream failures are not "not provisioned".
+        assert!(!WikiClientError::Client(ChromaHttpClientError::ApiError(
+            "boom".to_string(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ))
+        .is_not_found());
+        assert!(!WikiClientError::MissingIngressUrl.is_not_found());
+        assert!(!WikiClientError::InvalidToken("nope".to_string()).is_not_found());
     }
 
     #[test]


### PR DESCRIPTION
POST /api/agent resolves the FOUNDATION 'wiki' collection before it starts the LLM loop. When a tenant has no FOUNDATION database / wiki collection (Foundation isn't provisioned for them), the FE returns 404, but WikiClientError::Client collapsed every downstream error to Internal, so the route answered 500 — indistinguishable from a real failure.

Map a 404 from the wiki-collection lookup to ErrorCodes::NotFound, scoped to the agent route via AgentRouteError::code (guarded by a new WikiClientError::is_not_found). The route now answers 404 for a not-provisioned tenant; every other error and route is unchanged. This lets dashboard-api's Foundation Slack bot tell 'not set up' apart from a transient failure and reply with setup guidance instead of a generic apology.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
