### PR TITLE
[BUG](compactor): Fail on work queue init

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -76,6 +76,28 @@ struct CompactionTaskCompletion {
     result: CompactionOutput,
 }
 
+async fn work_queue_client_from_config(
+    config: &Option<crate::fn_consumer::config::GrpcWorkQueueConfig>,
+) -> Result<Option<WorkQueueClient>, Box<dyn ChromaError>> {
+    match config {
+        Some(work_queue_config) => {
+            let client = WorkQueueClient::try_from_config(work_queue_config).await?;
+            tracing::info!(
+                "WorkQueue client initialized for {}:{}",
+                work_queue_config.host,
+                work_queue_config.port
+            );
+            Ok(Some(client))
+        }
+        None => {
+            tracing::info!(
+                "WorkQueue not configured, async attached functions will not be supported"
+            );
+            Ok(None)
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct CompactionManagerContext {
     system: System,
@@ -702,31 +724,7 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
         )
         .await?;
 
-        // Initialize WorkQueueClient if config is provided
-        let work_queue_client = match &config.work_queue {
-            Some(work_queue_config) => {
-                match WorkQueueClient::try_from_config(work_queue_config).await {
-                    Ok(client) => {
-                        tracing::info!(
-                            "WorkQueue client initialized for {}:{}",
-                            work_queue_config.host,
-                            work_queue_config.port
-                        );
-                        Some(client)
-                    }
-                    Err(err) => {
-                        tracing::warn!("Failed to initialize WorkQueue client: {:?}", err);
-                        None
-                    }
-                }
-            }
-            None => {
-                tracing::info!(
-                    "WorkQueue not configured, async attached functions will not be supported"
-                );
-                None
-            }
-        };
+        let work_queue_client = work_queue_client_from_config(&config.work_queue).await?;
 
         CompactionManager::new(
             system.clone(),
@@ -1071,6 +1069,7 @@ impl Handler<GetCollectionAssignmentMessage> for CompactionManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fn_consumer::config::GrpcWorkQueueConfig;
     use chroma_blockstore::arrow::config::{BlockManagerConfig, TEST_MAX_BLOCK_SIZE_BYTES};
     use chroma_cache::{new_cache_for_test, new_non_persistent_cache_for_test};
     use chroma_config::assignment::assignment_policy::RendezvousHashingAssignmentPolicy;
@@ -1084,6 +1083,31 @@ mod tests {
     use chroma_types::SegmentUuid;
     use chroma_types::{Collection, LogRecord, Operation, OperationRecord, Segment};
     use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn test_work_queue_client_from_config_is_optional() {
+        let client = work_queue_client_from_config(&None)
+            .await
+            .expect("missing work queue config should be allowed");
+
+        assert!(client.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_work_queue_client_from_config_errors_when_configured() {
+        let config = Some(GrpcWorkQueueConfig {
+            host: "bad host".to_string(),
+            port: 50051,
+            connect_timeout_ms: 10,
+            request_timeout_ms: 10,
+        });
+
+        let err = work_queue_client_from_config(&config)
+            .await
+            .expect_err("configured work queue should fail fast on invalid endpoint");
+
+        assert_eq!(err.code(), ErrorCodes::Unavailable);
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_compaction_manager() {

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -78,7 +78,7 @@ struct CompactionTaskCompletion {
 
 async fn work_queue_client_from_config(
     config: &Option<crate::fn_consumer::config::GrpcWorkQueueConfig>,
-) -> Result<Option<WorkQueueClient>, Box<dyn ChromaError>> {
+) -> Result<WorkQueueClient, Box<dyn ChromaError>> {
     match config {
         Some(work_queue_config) => {
             let client = WorkQueueClient::try_from_config(work_queue_config).await?;
@@ -87,14 +87,9 @@ async fn work_queue_client_from_config(
                 work_queue_config.host,
                 work_queue_config.port
             );
-            Ok(Some(client))
+            Ok(client)
         }
-        None => {
-            tracing::info!(
-                "WorkQueue not configured, async attached functions will not be supported"
-            );
-            Ok(None)
-        }
+        None => Err(Box::new(CompactionError::MissingWorkQueueConfig)),
     }
 }
 
@@ -149,6 +144,8 @@ pub(crate) enum CompactionError {
     FailedToCompact,
     #[error("Invalid collection UUID in config: {0}")]
     InvalidCollectionUuid(String),
+    #[error("Missing required compaction_service.work_queue config")]
+    MissingWorkQueueConfig,
 }
 
 impl ChromaError for CompactionError {
@@ -156,6 +153,7 @@ impl ChromaError for CompactionError {
         match self {
             CompactionError::FailedToCompact => ErrorCodes::Internal,
             CompactionError::InvalidCollectionUuid(_) => ErrorCodes::InvalidArgument,
+            CompactionError::MissingWorkQueueConfig => ErrorCodes::InvalidArgument,
         }
     }
 }
@@ -752,7 +750,7 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
             Some(bloom_filter_manager),
             config.compactor.shard_size,
             config.compactor.sharding_enabled_tenant_patterns.clone(),
-            work_queue_client,
+            Some(work_queue_client),
         )
     }
 }
@@ -1085,12 +1083,12 @@ mod tests {
     use std::collections::HashMap;
 
     #[tokio::test]
-    async fn test_work_queue_client_from_config_is_optional() {
-        let client = work_queue_client_from_config(&None)
+    async fn test_work_queue_client_from_config_requires_config() {
+        let err = work_queue_client_from_config(&None)
             .await
-            .expect("missing work queue config should be allowed");
+            .expect_err("missing work queue config should fail fast");
 
-        assert!(client.is_none());
+        assert_eq!(err.code(), ErrorCodes::InvalidArgument);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- make compactor startup require compaction_service.work_queue and fail fast when that config is missing
- fail fast when the configured WorkQueueClient cannot be initialized instead of silently degrading to None
- add regression tests for missing vs configured-invalid work queue config

## Testing
- cargo test -p worker test_work_queue_client_from_config -- --nocapture
- cargo test -p worker test_compaction_manager -- --nocapture