### PR TITLE
[CHORE](js): Move testcontainers out of Ollama runtime deps

### DIFF
--- a/clients/new-js/packages/ai-embeddings/ollama/package.json
+++ b/clients/new-js/packages/ai-embeddings/ollama/package.json
@@ -35,6 +35,7 @@
     "dotenv": "^16.3.1",
     "jest": "^29.7.0",
     "rimraf": "^5.0.0",
+    "testcontainers": "^10.9.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "tsup": "^8.3.5"
@@ -44,8 +45,7 @@
   },
   "dependencies": {
     "@chroma-core/ai-embeddings-common": "workspace:^",
-    "ollama": "^0.5.15",
-    "testcontainers": "^10.9.0"
+    "ollama": "^0.5.15"
   },
   "engines": {
     "node": ">=20"

--- a/clients/new-js/pnpm-lock.yaml
+++ b/clients/new-js/pnpm-lock.yaml
@@ -468,9 +468,6 @@ importers:
       ollama:
         specifier: ^0.5.15
         version: 0.5.15
-      testcontainers:
-        specifier: ^10.9.0
-        version: 10.25.0
     devDependencies:
       '@jest/globals':
         specifier: ^29.7.0
@@ -484,6 +481,9 @@ importers:
       rimraf:
         specifier: ^5.0.0
         version: 5.0.10
+      testcontainers:
+        specifier: ^10.9.0
+        version: 10.25.0
       ts-jest:
         specifier: ^29.1.2
         version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3)


### PR DESCRIPTION
## Summary

Moves `testcontainers` from runtime `dependencies` to `devDependencies` for `@chroma-core/ollama`.

The exported Ollama embedding implementation imports `@chroma-core/ai-embeddings-common`, `chromadb`, and `ollama`, but does not import `testcontainers`. The only package-local `testcontainers` usage appears to be the development helper `start-ollama.ts`, which is not exported by the package.

This avoids exposing downstream `@chroma-core/ollama` consumers to the `testcontainers` dependency tree when they only use the embedding function at runtime.

## Verification

- `corepack pnpm install --lockfile-only --ignore-scripts`
- `./node_modules/.bin/tsup` in `clients/new-js/packages/ai-embeddings/common`
- `./node_modules/.bin/tsup` in `clients/new-js/packages/ai-embeddings/default-embed`
- `./node_modules/.bin/tsup` in `clients/new-js/packages/chromadb`
- `./node_modules/.bin/jest` in `clients/new-js/packages/ai-embeddings/ollama`
- `./node_modules/.bin/tsup` in `clients/new-js/packages/ai-embeddings/ollama`
