### PR TITLE
[BUG](embedding-functions): add missing stacklevel=2 to warnings.warn() (Fixes #7282)

### DIFF
--- a/chromadb/utils/embedding_functions/baseten_embedding_function.py
+++ b/chromadb/utils/embedding_functions/baseten_embedding_function.py
@@ -34,6 +34,7 @@ class BasetenEmbeddingFunction(OpenAIEmbeddingFunction):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         if os.getenv("BASETEN_API_KEY") is not None:

--- a/chromadb/utils/embedding_functions/cloudflare_workers_ai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/cloudflare_workers_ai_embedding_function.py
@@ -50,6 +50,7 @@ class CloudflareWorkersAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         self.model_name = model_name
         self.account_id = account_id

--- a/chromadb/utils/embedding_functions/cohere_embedding_function.py
+++ b/chromadb/utils/embedding_functions/cohere_embedding_function.py
@@ -42,6 +42,7 @@ class CohereEmbeddingFunction(EmbeddingFunction[Embeddable]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         if os.getenv("COHERE_API_KEY") is not None:
             self.api_key_env_var = "COHERE_API_KEY"

--- a/chromadb/utils/embedding_functions/google_embedding_function.py
+++ b/chromadb/utils/embedding_functions/google_embedding_function.py
@@ -247,6 +247,7 @@ class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         if os.getenv("GOOGLE_API_KEY") is not None:
             self.api_key_env_var = "GOOGLE_API_KEY"
@@ -397,6 +398,7 @@ class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         if os.getenv("GOOGLE_API_KEY") is not None:
             self.api_key_env_var = "GOOGLE_API_KEY"
@@ -525,6 +527,7 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         if os.getenv("GOOGLE_API_KEY") is not None:
             self.api_key_env_var = "GOOGLE_API_KEY"

--- a/chromadb/utils/embedding_functions/huggingface_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_embedding_function.py
@@ -39,6 +39,7 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         if os.getenv("HUGGINGFACE_API_KEY") is not None:
             self.api_key_env_var = "HUGGINGFACE_API_KEY"
@@ -161,6 +162,7 @@ class HuggingFaceEmbeddingServer(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         self.url = url

--- a/chromadb/utils/embedding_functions/jina_embedding_function.py
+++ b/chromadb/utils/embedding_functions/jina_embedding_function.py
@@ -79,6 +79,7 @@ class JinaEmbeddingFunction(EmbeddingFunction[Embeddable]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         if os.getenv("JINA_API_KEY") is not None:

--- a/chromadb/utils/embedding_functions/morph_embedding_function.py
+++ b/chromadb/utils/embedding_functions/morph_embedding_function.py
@@ -43,6 +43,7 @@ class MorphEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         self.api_key_env_var = api_key_env_var

--- a/chromadb/utils/embedding_functions/openai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/openai_embedding_function.py
@@ -55,6 +55,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         if os.getenv("OPENAI_API_KEY") is not None:

--- a/chromadb/utils/embedding_functions/perplexity_embedding_function.py
+++ b/chromadb/utils/embedding_functions/perplexity_embedding_function.py
@@ -47,6 +47,7 @@ class PerplexityEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         if os.getenv("PERPLEXITY_API_KEY") is not None:

--- a/chromadb/utils/embedding_functions/roboflow_embedding_function.py
+++ b/chromadb/utils/embedding_functions/roboflow_embedding_function.py
@@ -44,6 +44,7 @@ class RoboflowEmbeddingFunction(EmbeddingFunction[Embeddable]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         if os.getenv("ROBOFLOW_API_KEY") is not None:
             self.api_key_env_var = "ROBOFLOW_API_KEY"

--- a/chromadb/utils/embedding_functions/together_ai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/together_ai_embedding_function.py
@@ -45,6 +45,7 @@ class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         self.model_name = model_name

--- a/chromadb/utils/embedding_functions/voyageai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/voyageai_embedding_function.py
@@ -45,6 +45,7 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Direct api_key configuration will not be persisted. "
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         if os.getenv("VOYAGE_API_KEY") is not None:


### PR DESCRIPTION
Fixes #7282

## Problem

15 `warnings.warn()` calls across 12 embedding function files are missing `stacklevel=2`. Without it, warnings point to library internals (e.g., `chromadb/utils/embedding_functions/huggingface_embedding_function.py:38`) instead of the user code that triggered them.

This makes debugging harder — users see a warning pointing at Chroma internals instead of the actual call site in their own code.

## Solution

Added `stacklevel=2` to all 15 affected `warnings.warn()` calls. All are inside `__init__` methods of embedding function classes where the warning should point to the caller (user code).

### Files Changed (12 files, 15 insertions)

| File | Lines Fixed |
|------|------------|
| `baseten_embedding_function.py` | 1 |
| `cloudflare_workers_ai_embedding_function.py` | 1 |
| `cohere_embedding_function.py` | 1 |
| `google_embedding_function.py` | 3 |
| `huggingface_embedding_function.py` | 2 |
| `jina_embedding_function.py` | 1 |
| `morph_embedding_function.py` | 1 |
| `openai_embedding_function.py` | 1 |
| `perplexity_embedding_function.py` | 1 |
| `roboflow_embedding_function.py` | 1 |
| `together_ai_embedding_function.py` | 1 |
| `voyageai_embedding_function.py` | 1 |

## Verification

- All 15 instances confirmed fixed (zero remaining)
- All 12 modified files pass `ast.parse()` syntax validation
- Diff shows only single-line `stacklevel=2,` additions — no logic changes

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-19 | Add stacklevel=2 to 15 warnings.warn() calls in embedding functions | rtmalikian |

### Files Changed
- chromadb/utils/embedding_functions/baseten_embedding_function.py — add stacklevel=2
- chromadb/utils/embedding_functions/cloudflare_workers_ai_embedding_function.py — add stacklevel=2
- chromadb/utils/embedding_functions/cohere_embedding_function.py — add stacklevel=2
- chromadb/utils/embedding_functions/google_embedding_function.py — add stacklevel=2 (3 call sites)
- chromadb/utils/embedding_functions/huggingface_embedding_function.py — add stacklevel=2 (2 call sites)
- chromadb/utils/embedding_functions/jina_embedding_function.py — add stacklevel=2
- chromadb/utils/embedding_functions/morph_embedding_function.py — add stacklevel=2
- chromadb/utils/embedding_functions/openai_embedding_function.py — add stacklevel=2
- chromadb/utils/embedding_functions/perplexity_embedding_function.py — add stacklevel=2
- chromadb/utils/embedding_functions/roboflow_embedding_function.py — add stacklevel=2
- chromadb/utils/embedding_functions/together_ai_embedding_function.py — add stacklevel=2
- chromadb/utils/embedding_functions/voyageai_embedding_function.py — add stacklevel=2

### Verification
- grep confirms zero remaining warnings.warn() without stacklevel in embedding_functions/
- All modified files pass Python syntax validation (ast.parse)
- Diff is single-line additions only — no behavioral changes

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
