### PR TITLE
[BUG](api): reject bool values in HNSW parameter validators (Fixes #7288)

### DIFF
--- a/chromadb/segment/impl/vector/hnsw_params.py
+++ b/chromadb/segment/impl/vector/hnsw_params.py
@@ -9,17 +9,22 @@ Validator = Callable[[Union[str, int, float]], bool]
 
 param_validators: Dict[str, Validator] = {
     "hnsw:space": lambda p: bool(re.match(r"^(l2|cosine|ip)$", str(p))),
-    "hnsw:construction_ef": lambda p: isinstance(p, int),
-    "hnsw:search_ef": lambda p: isinstance(p, int),
-    "hnsw:M": lambda p: isinstance(p, int),
-    "hnsw:num_threads": lambda p: isinstance(p, int),
-    "hnsw:resize_factor": lambda p: isinstance(p, (int, float)),
+    "hnsw:construction_ef": lambda p: isinstance(p, int) and not isinstance(p, bool),
+    "hnsw:search_ef": lambda p: isinstance(p, int) and not isinstance(p, bool),
+    "hnsw:M": lambda p: isinstance(p, int) and not isinstance(p, bool),
+    "hnsw:num_threads": lambda p: isinstance(p, int) and not isinstance(p, bool),
+    "hnsw:resize_factor": lambda p: isinstance(p, (int, float))
+    and not isinstance(p, bool),
 }
 
 # Extra params used for persistent hnsw
 persistent_param_validators: Dict[str, Validator] = {
-    "hnsw:batch_size": lambda p: isinstance(p, int) and p > 2,
-    "hnsw:sync_threshold": lambda p: isinstance(p, int) and p > 2,
+    "hnsw:batch_size": lambda p: isinstance(p, int)
+    and not isinstance(p, bool)
+    and p > 2,
+    "hnsw:sync_threshold": lambda p: isinstance(p, int)
+    and not isinstance(p, bool)
+    and p > 2,
 }
 
 


### PR DESCRIPTION
Fixes #7288

## Problem

In `chromadb/segment/impl/vector/hnsw_params.py`, the HNSW parameter validators use `isinstance(p, int)` to check that parameters are integers:

```python
"hnsw:construction_ef": lambda p: isinstance(p, int),
"hnsw:search_ef": lambda p: isinstance(p, int),
"hnsw:M": lambda p: isinstance(p, int),
```

Since `bool` is a subclass of `int` in Python, `isinstance(True, int)` returns `True`. This means boolean values pass validation for all numeric HNSW parameters:
- `True` (equivalent to `1`) passes for `construction_ef`, `search_ef`, `M`, `num_threads`
- `False` (equivalent to `0`) also passes
- For `resize_factor`, `isinstance(True, (int, float))` is `True`

These are semantically invalid values. Setting `construction_ef=True` (1) or `M=True` (1) would produce a nearly unusable HNSW index.

## Solution

Add `and not isinstance(p, bool)` to all numeric validators to explicitly reject boolean values. This is the standard Python pattern for handling the `bool`-is-subclass-of-`int` inheritance.

## Verification

```python
from chromadb.segment.impl.vector.hnsw_params import param_validators, persistent_param_validators

# Bool values are now rejected
assert not param_validators["hnsw:construction_ef"](True)   # rejected ✓
assert not param_validators["hnsw:construction_ef"](False)   # rejected ✓
assert not param_validators["hnsw:search_ef"](True)          # rejected ✓
assert not param_validators["hnsw:M"](True)                  # rejected ✓

# Int values still accepted
assert param_validators["hnsw:construction_ef"](100)          # accepted ✓
assert param_validators["hnsw:search_ef"](100)                # accepted ✓

# Float still accepted for resize_factor
assert param_validators["hnsw:resize_factor"](1.5)            # accepted ✓
assert not param_validators["hnsw:resize_factor"](True)       # rejected ✓

# Persistent validators also fixed
assert not persistent_param_validators["hnsw:batch_size"](True)     # rejected ✓
assert persistent_param_validators["hnsw:batch_size"](100)          # accepted ✓

print("All tests passed!")
```

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-19 | Fix HNSW parameter validators to reject bool values | rtmalikian |

### Files Changed
- `chromadb/segment/impl/vector/hnsw_params.py` — Add `and not isinstance(p, bool)` to all numeric validators

### Verification
- All validators correctly reject `True` and `False`
- All validators correctly accept valid int/float values
- Python syntax check passes

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
