### PR TITLE
[BUG](api): fix grammar errors in validation error messages in types.py (Fixes #7294)

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1235,7 +1235,7 @@ def validate_where(where: Where) -> None:
                 if operator in ["$in", "$nin"]:
                     if not isinstance(operand, list):
                         raise ValueError(
-                            f"Expected operand value to be an list for operator {operator}, got {operand}"
+                            f"Expected operand value to be a list for operator {operator}, got {operand}"
                         )
                 # $contains/$not_contains: scalar operand (checks if array field contains value)
                 if operator in ["$contains", "$not_contains"]:
@@ -1266,7 +1266,7 @@ def validate_where(where: Where) -> None:
 
                 if not isinstance(operand, (str, int, float, bool, list)):
                     raise ValueError(
-                        f"Expected where operand value to be a str, int, float, bool, or list of those type, got {operand}"
+                        f"Expected where operand value to be a str, int, float, bool, or list of those types, got {operand}"
                     )
                 if isinstance(operand, list) and (
                     len(operand) == 0
@@ -1353,7 +1353,7 @@ def validate_n_results(n_results: int) -> int:
     # Check Number of requested results
     if not isinstance(n_results, int):
         raise ValueError(
-            f"Expected requested number of results to be a int, got {n_results}"
+            f"Expected requested number of results to be an int, got {n_results}"
         )
     if n_results <= 0:
         raise TypeError(


### PR DESCRIPTION
Fixes #7294

## Problem
Three validation error messages in `chromadb/api/types.py` contain grammar errors that are visible to users when they pass invalid parameters:

1. **`validate_where` line 1238:** `"an list"` → `"a list"` — incorrect article before consonant
2. **`validate_where` line 1269:** `"those type"` → `"those types"` — missing plural
3. **`validate_n_results` line 1356:** `"a int"` → `"an int"` — incorrect article before vowel

## Solution
Fix the three grammar errors in the error message strings. No logic changes — only string literals are modified.

## Verification
```bash
python3 -c "import ast; ast.parse(open('chromadb/api/types.py').read()); print('Syntax OK')"
# Syntax OK
```

All three changes are in error message strings only. No behavioral change.

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-19 | Fix 3 grammar errors in validation error messages | rtmalikian |

### Files Changed
- `chromadb/api/types.py` — Fixed "an list" → "a list", "those type" → "those types", "a int" → "an int"

### Verification
- Python syntax check passes
- Changes are string-only (no logic modifications)

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
