### PR TITLE
[BUG](types): Fix KeyError on configuration set

### DIFF
--- a/chromadb/test/configurations/test_collection_configuration.py
+++ b/chromadb/test/configurations/test_collection_configuration.py
@@ -26,6 +26,7 @@ from chromadb.test.conftest import ClientFactories
 from chromadb.test.conftest import is_spann_disabled_mode, skip_reason_spann_disabled
 from chromadb.types import Collection as CollectionModel
 from typing import Optional, TypedDict
+from uuid import uuid4
 
 
 class LegacyEmbeddingFunction(EmbeddingFunction[Embeddable]):
@@ -1741,3 +1742,46 @@ def test_deserializing_custom_embedding_function_with_query_config_no_query_conf
         ef.embed_query(input="How many people in Berlin?"),
         np.array([[1.0, 1.0, 1.0]], dtype=np.float32),
     )
+
+
+def _make_collection_model() -> CollectionModel:
+    return CollectionModel(
+        id=uuid4(),
+        name="test_setitem_collection",
+        configuration_json={},
+        serialized_schema=None,
+        metadata=None,
+        dimension=None,
+        tenant="default_tenant",
+        database="default_database",
+    )
+
+
+def test_collection_setitem_configuration_round_trip() -> None:
+    # "configuration" isn't a model field (configuration_json is), so without
+    # the elif, __setitem__ would call set_configuration and then still hit the
+    # KeyError branch. Reading it back should give us the config again.
+    model = _make_collection_model()
+
+    config = model["configuration"]
+    assert config is not None
+
+    model["configuration"] = config
+
+    assert model["configuration"] is not None
+    assert "embedding_function" in model.configuration_json
+
+
+def test_collection_setitem_model_field() -> None:
+    model = _make_collection_model()
+
+    model["name"] = "renamed_collection"
+    assert model.name == "renamed_collection"
+    assert model["name"] == "renamed_collection"
+
+
+def test_collection_setitem_unknown_key_raises() -> None:
+    model = _make_collection_model()
+
+    with pytest.raises(KeyError):
+        model["does_not_exist"] = "value"

--- a/chromadb/test/configurations/test_collection_configuration.py
+++ b/chromadb/test/configurations/test_collection_configuration.py
@@ -1772,6 +1772,16 @@ def test_collection_setitem_configuration_round_trip() -> None:
     assert "embedding_function" in model.configuration_json
 
 
+def test_collection_setitem_configuration_accepts_dict() -> None:
+    # set_configuration goes through collection_configuration_to_json, which
+    # accepts a CollectionConfiguration-shaped dict as well as the object form.
+    model = _make_collection_model()
+
+    model["configuration"] = {"hnsw": None, "spann": None, "embedding_function": None}
+
+    assert model.configuration_json["embedding_function"] == {"type": "legacy"}
+
+
 def test_collection_setitem_model_field() -> None:
     model = _make_collection_model()
 
@@ -1780,8 +1790,19 @@ def test_collection_setitem_model_field() -> None:
     assert model["name"] == "renamed_collection"
 
 
+def test_collection_getitem_unknown_key_returns_none() -> None:
+    # __getitem__ is intentionally lenient: unknown keys return None rather
+    # than raising (unlike __setitem__).
+    model = _make_collection_model()
+
+    assert model["does_not_exist"] is None
+
+
 def test_collection_setitem_unknown_key_raises() -> None:
     model = _make_collection_model()
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError) as exc_info:
         model["does_not_exist"] = "value"
+
+    # The error should advertise "configuration" as a valid key too.
+    assert "configuration" in str(exc_info.value)

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -133,9 +133,10 @@ class Collection(
         elif key in self.get_model_fields():
             setattr(self, key, value)
         else:
-            raise KeyError(
-                f"No such key: {key}, valid keys are: {self.get_model_fields()}"
-            )
+            # "configuration" is a valid key too, but it's backed by
+            # configuration_json rather than being a model field of its own.
+            valid_keys = ["configuration", *self.get_model_fields().keys()]
+            raise KeyError(f"No such key: {key}, valid keys are: {valid_keys}")
 
     def __eq__(self, __value: object) -> bool:
         # Check that all the model fields are equal

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -127,10 +127,10 @@ class Collection(
     # TODO: This doesn't check types.
     def __setitem__(self, key: str, value: Any) -> None:
         """Allows the collection to be treated as a dictionary"""
-        # For the model attributes we allow the user to access them directly
         if key == "configuration":
             self.set_configuration(value)
-        if key in self.get_model_fields():
+        # For the other model attributes we allow the user to set them directly
+        elif key in self.get_model_fields():
             setattr(self, key, value)
         else:
             raise KeyError(


### PR DESCRIPTION
## Description of changes

While poking around the `Collection` transport model I noticed that setting
the configuration through the dict-style interface always blows up, even
when it actually worked.

`Collection.__setitem__` special-cases the `"configuration"` key, but that
branch was missing an `elif`:

```python
if key == "configuration":
    self.set_configuration(value)
if key in self.get_model_fields():   # <- always evaluated next
    setattr(self, key, value)
else:
    raise KeyError(...)
```

`"configuration"` isn't a real model field (`configuration_json` is), so
after `set_configuration()` succeeds, control falls straight into the
model-field check and raises `KeyError` on what was actually a valid set.
`__getitem__` already handles `"configuration"` correctly, so the two sides
were just out of sync.

- Improvements & Bug fixes
  - Turn the second `if` into an `elif` so `collection["configuration"] = ...`
    no longer raises after a successful `set_configuration()`
  - Add regression tests for the configuration round-trip, a normal
    field set, and the unknown-key `KeyError`

## Test plan

- [x] Tests pass locally with `pytest`

```
pytest chromadb/test/configurations/test_collection_configuration.py -k setitem
```

I also confirmed the new round-trip test fails on `main` (reproduces the
`KeyError`) and passes with the fix.

## Migration plan

None. This only fixes an erroneous exception on an already-supported code
path; no behavior changes for callers that weren't already hitting the bug.

## Observability plan

N/A.

## Documentation Changes

None needed.