### PR TITLE
[CLN] Use running loop in async FastAPI client

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -119,7 +119,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         # otherwise gracefully fall back to using a singleton client.
         loop_hash = None
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             loop_hash = loop.__hash__()
         except RuntimeError:
             loop_hash = 0


### PR DESCRIPTION
Problem: AsyncFastAPI._get_client() uses asyncio.get_event_loop() to identify the active loop for its per-loop httpx.AsyncClient cache. In async code, get_running_loop() is the modern, explicit API and avoids relying on event loop policy behavior.

Before / after: before, the async client cache asked the policy for an event loop. After, it uses asyncio.get_running_loop() and keeps the existing RuntimeError fallback to the singleton client path when no asyncio loop is running.

Verification:
- python -m py_compile chromadb\api\async_fastapi.py