### PR TITLE
[ENH](schema): Allow multiple sparse vector indices

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -843,7 +843,8 @@ class EmbeddingFunction(Protocol[D]):
     """
 
     @abstractmethod
-    def __call__(self, input: D) -> Embeddings: ...
+    def __call__(self, input: D) -> Embeddings:
+        ...
 
     def embed_query(self, input: D) -> Embeddings:
         """Embed a query input.
@@ -1001,7 +1002,8 @@ def validate_embedding_function(
 
 
 class DataLoader(Protocol[L]):
-    def __call__(self, uris: URIs) -> L: ...
+    def __call__(self, uris: URIs) -> L:
+        ...
 
 
 def validate_ids(ids: IDs) -> IDs:
@@ -1499,7 +1501,8 @@ class SparseEmbeddingFunction(Protocol[D]):
     """
 
     @abstractmethod
-    def __call__(self, input: D) -> SparseVectors: ...
+    def __call__(self, input: D) -> SparseVectors:
+        ...
 
     def embed_query(self, input: D) -> SparseVectors:
         """Embed a query input.
@@ -1681,9 +1684,9 @@ class VectorIndexConfig(BaseModel):
 
     space: Optional[Space] = None
     embedding_function: Optional[Any] = DefaultEmbeddingFunction()
-    source_key: Optional[str] = (
-        None  # key to source the vector from (accepts str or Key)
-    )
+    source_key: Optional[
+        str
+    ] = None  # key to source the vector from (accepts str or Key)
     hnsw: Optional[HnswIndexConfig] = None
     spann: Optional[SpannIndexConfig] = None
 
@@ -1741,9 +1744,9 @@ class SparseVectorIndexConfig(BaseModel):
 
     # TODO(Sanket): Change this to the appropriate sparse ef and use a default here.
     embedding_function: Optional[Any] = None
-    source_key: Optional[str] = (
-        None  # key to source the sparse vector from (accepts str or Key)
-    )
+    source_key: Optional[
+        str
+    ] = None  # key to source the sparse vector from (accepts str or Key)
     bm25: Optional[bool] = None
 
     @field_validator("source_key", mode="before")
@@ -2374,24 +2377,6 @@ class Schema:
                 enabled=enabled, config=cast(BoolInvertedIndexConfig, config)
             )
 
-    def _validate_single_sparse_vector_index(self, key: str) -> None:
-        """
-        Validate that only one sparse vector index is enabled per collection.
-
-        Raises ValueError if another key already has a sparse vector index enabled.
-        """
-        for existing_key, value_types in self.keys.items():
-            if existing_key == key:
-                continue  # Skip the current key being updated
-            if value_types.sparse_vector is not None:
-                if value_types.sparse_vector.sparse_vector_index is not None:
-                    if value_types.sparse_vector.sparse_vector_index.enabled:
-                        raise ValueError(
-                            f"Cannot enable sparse vector index on key '{key}'. "
-                            f"A sparse vector index is already enabled on key '{existing_key}'. "
-                            f"Only one sparse vector index is allowed per collection."
-                        )
-
     def _validate_sparse_vector_config(self, config: SparseVectorIndexConfig) -> None:
         """
         Validate that if source_key is provided then embedding_function is also provided
@@ -2407,10 +2392,8 @@ class Schema:
         """Set an index configuration for a specific key."""
         config_name = self._get_config_class_name(config)
 
-        # Validate sparse vector index - only one is allowed per collection
-        # Do this BEFORE creating the key entry
+        # Validate sparse vector config before creating the key entry.
         if config_name == "SparseVectorIndexConfig" and enabled:
-            self._validate_single_sparse_vector_index(key)
             self._validate_sparse_vector_config(cast(SparseVectorIndexConfig, config))
 
         if key not in self.keys:
@@ -2469,8 +2452,6 @@ class Schema:
         """Enable all possible index types for a specific key."""
         if key not in self.keys:
             self.keys[key] = ValueTypes()
-
-        self._validate_single_sparse_vector_index(key)
 
         # Enable all index types with default configs
         self.keys[key].string = StringValueType(

--- a/chromadb/test/api/test_schema.py
+++ b/chromadb/test/api/test_schema.py
@@ -194,6 +194,20 @@ class TestNewSchema:
             schema.defaults.sparse_vector.sparse_vector_index.enabled is False
         )  # Still disabled by default
 
+    def test_create_multiple_sparse_vector_indices(self) -> None:
+        """Multiple sparse vector indices on different keys are allowed."""
+        schema = Schema()
+
+        schema.create_index(config=SparseVectorIndexConfig(), key="sparse_a")
+        # A second sparse index on a different key must succeed.
+        schema.create_index(config=SparseVectorIndexConfig(), key="sparse_b")
+
+        for key in ("sparse_a", "sparse_b"):
+            assert key in schema.keys
+            sparse_index = schema.keys[key].sparse_vector.sparse_vector_index  # type: ignore[union-attr]
+            assert sparse_index is not None
+            assert sparse_index.enabled is True
+
     def test_create_sparse_vector_index_with_custom_config(self) -> None:
         """Test creating a sparse vector index with custom config including embedding function."""
         schema = Schema()
@@ -1134,7 +1148,9 @@ class TestNewSchema:
                 == "mock_embedding"
             )
             # Verify the EF config is correct
-            ef_config = deserialized.defaults.float_list.vector_index.config.embedding_function.get_config()
+            ef_config = (
+                deserialized.defaults.float_list.vector_index.config.embedding_function.get_config()
+            )
             assert ef_config["model_name"] == "custom_model_v3"
             # HNSW config should be preserved
             assert deserialized.defaults.float_list.vector_index.config.hnsw is not None
@@ -1318,7 +1334,9 @@ class TestNewSchema:
                 == "mock_embedding"
             )
             # Verify the EF config is correct
-            ef_config = deserialized.defaults.float_list.vector_index.config.embedding_function.get_config()
+            ef_config = (
+                deserialized.defaults.float_list.vector_index.config.embedding_function.get_config()
+            )
             assert ef_config["model_name"] == "spann_model"
             # SPANN config should be preserved
             assert (

--- a/clients/new-js/packages/chromadb/src/schema.ts
+++ b/clients/new-js/packages/chromadb/src/schema.ts
@@ -251,72 +251,72 @@ export class SparseVectorIndexConfig {
 }
 
 export class FtsIndexType {
-  constructor(public enabled: boolean, public config: FtsIndexConfig) { }
+  constructor(public enabled: boolean, public config: FtsIndexConfig) {}
 }
 
 export class StringInvertedIndexType {
   constructor(
     public enabled: boolean,
     public config: StringInvertedIndexConfig,
-  ) { }
+  ) {}
 }
 
 export class VectorIndexType {
-  constructor(public enabled: boolean, public config: VectorIndexConfig) { }
+  constructor(public enabled: boolean, public config: VectorIndexConfig) {}
 }
 
 export class SparseVectorIndexType {
   constructor(
     public enabled: boolean,
     public config: SparseVectorIndexConfig,
-  ) { }
+  ) {}
 }
 
 export class IntInvertedIndexType {
-  constructor(public enabled: boolean, public config: IntInvertedIndexConfig) { }
+  constructor(public enabled: boolean, public config: IntInvertedIndexConfig) {}
 }
 
 export class FloatInvertedIndexType {
   constructor(
     public enabled: boolean,
     public config: FloatInvertedIndexConfig,
-  ) { }
+  ) {}
 }
 
 export class BoolInvertedIndexType {
   constructor(
     public enabled: boolean,
     public config: BoolInvertedIndexConfig,
-  ) { }
+  ) {}
 }
 
 export class StringValueType {
   constructor(
     public ftsIndex: FtsIndexType | null = null,
     public stringInvertedIndex: StringInvertedIndexType | null = null,
-  ) { }
+  ) {}
 }
 
 export class FloatListValueType {
-  constructor(public vectorIndex: VectorIndexType | null = null) { }
+  constructor(public vectorIndex: VectorIndexType | null = null) {}
 }
 
 export class SparseVectorValueType {
-  constructor(public sparseVectorIndex: SparseVectorIndexType | null = null) { }
+  constructor(public sparseVectorIndex: SparseVectorIndexType | null = null) {}
 }
 
 export class IntValueType {
-  constructor(public intInvertedIndex: IntInvertedIndexType | null = null) { }
+  constructor(public intInvertedIndex: IntInvertedIndexType | null = null) {}
 }
 
 export class FloatValueType {
   constructor(
     public floatInvertedIndex: FloatInvertedIndexType | null = null,
-  ) { }
+  ) {}
 }
 
 export class BoolValueType {
-  constructor(public boolInvertedIndex: BoolInvertedIndexType | null = null) { }
+  constructor(public boolInvertedIndex: BoolInvertedIndexType | null = null) {}
 }
 
 export class ValueTypes {
@@ -351,11 +351,11 @@ const cloneObject = <T>(value: T): T => {
   return Array.isArray(value)
     ? (value.map((item) => cloneObject(item)) as T)
     : (Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
-        k,
-        cloneObject(v),
-      ]),
-    ) as T);
+        Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+          k,
+          cloneObject(v),
+        ]),
+      ) as T);
 };
 
 const resolveEmbeddingFunctionName = (
@@ -520,7 +520,11 @@ export class Schema {
     }
 
     // Only allow #document with FtsIndexConfig
-    if (keyProvided && key === DOCUMENT_KEY && !(config instanceof FtsIndexConfig)) {
+    if (
+      keyProvided &&
+      key === DOCUMENT_KEY &&
+      !(config instanceof FtsIndexConfig)
+    ) {
       throw new Error(
         `Cannot create index on special key '${key}' with this config. Only FtsIndexConfig is allowed for #document.`,
       );
@@ -545,7 +549,10 @@ export class Schema {
     }
 
     // FTS index is only allowed on #document key
-    if (config instanceof FtsIndexConfig && (!keyProvided || key !== DOCUMENT_KEY)) {
+    if (
+      config instanceof FtsIndexConfig &&
+      (!keyProvided || key !== DOCUMENT_KEY)
+    ) {
       throw new Error(
         "FTS index can only be enabled on #document key. Use createIndex(new FtsIndexConfig(), '#document')",
       );
@@ -586,13 +593,15 @@ export class Schema {
 
     // Disallow using special internal key #embedding
     if (keyProvided && key && key === EMBEDDING_KEY) {
-      throw new Error(
-        "Cannot modify #embedding. Currently not supported",
-      );
+      throw new Error("Cannot modify #embedding. Currently not supported");
     }
 
     // Only allow #document with FtsIndexConfig (to disable FTS)
-    if (keyProvided && key === DOCUMENT_KEY && !(config instanceof FtsIndexConfig)) {
+    if (
+      keyProvided &&
+      key === DOCUMENT_KEY &&
+      !(config instanceof FtsIndexConfig)
+    ) {
       throw new Error(
         `Cannot delete index on special key '${key}' with this config. Only FtsIndexConfig is allowed for #document.`,
       );
@@ -619,7 +628,10 @@ export class Schema {
     }
 
     // FTS deletion is only allowed on #document key
-    if (config instanceof FtsIndexConfig && (!keyProvided || key !== DOCUMENT_KEY)) {
+    if (
+      config instanceof FtsIndexConfig &&
+      (!keyProvided || key !== DOCUMENT_KEY)
+    ) {
       throw new Error("Deleting FTS index is only supported on #document key.");
     }
 
@@ -769,7 +781,6 @@ export class Schema {
     enabled: boolean,
   ): void {
     if (config instanceof SparseVectorIndexConfig && enabled) {
-      this.validateSingleSparseVectorIndex(key);
       this.validateSparseVectorConfig(config);
     }
 
@@ -863,18 +874,6 @@ export class Schema {
     current.boolean = new BoolValueType(
       new BoolInvertedIndexType(false, new BoolInvertedIndexConfig()),
     );
-  }
-
-  private validateSingleSparseVectorIndex(targetKey: string): void {
-    for (const [existingKey, valueTypes] of Object.entries(this.keys)) {
-      if (existingKey === targetKey) continue;
-      const sparseIndex = valueTypes.sparseVector?.sparseVectorIndex;
-      if (sparseIndex?.enabled) {
-        throw new Error(
-          `Cannot enable sparse vector index on key '${targetKey}'. A sparse vector index is already enabled on key '${existingKey}'. Only one sparse vector index is allowed per collection.`,
-        );
-      }
-    }
   }
 
   private validateSparseVectorConfig(config: SparseVectorIndexConfig): void {
@@ -1087,7 +1086,8 @@ export class Schema {
       !embeddingFunction.supportedSpaces().includes(resolvedSpace)
     ) {
       console.warn(
-        `Space '${resolvedSpace}' is not supported by embedding function '${resolveEmbeddingFunctionName(embeddingFunction) ?? "unknown"
+        `Space '${resolvedSpace}' is not supported by embedding function '${
+          resolveEmbeddingFunctionName(embeddingFunction) ?? "unknown"
         }'. Supported spaces: ${embeddingFunction
           .supportedSpaces()
           .join(", ")}`,

--- a/clients/new-js/packages/chromadb/test/schema.test.ts
+++ b/clients/new-js/packages/chromadb/test/schema.test.ts
@@ -26,7 +26,7 @@ import { ChromaClient } from "../src/chroma-client";
 class MockEmbedding implements EmbeddingFunction {
   public readonly name = "mock_embedding";
 
-  constructor(private readonly modelName = "mock_model") { }
+  constructor(private readonly modelName = "mock_model") {}
 
   async generate(texts: string[]): Promise<number[][]> {
     return texts.map(() => [1, 2, 3]);
@@ -52,7 +52,7 @@ class MockEmbedding implements EmbeddingFunction {
 class MockSparseEmbedding implements SparseEmbeddingFunction {
   public readonly name = "mock_sparse";
 
-  constructor(private readonly identifier = "mock_sparse") { }
+  constructor(private readonly identifier = "mock_sparse") {}
 
   async generate(texts: string[]) {
     return texts.map(() => ({ indices: [0, 1], values: [1, 1] }));
@@ -70,7 +70,7 @@ class MockSparseEmbedding implements SparseEmbeddingFunction {
 class DeterministicSparseEmbedding implements SparseEmbeddingFunction {
   public readonly name = "deterministic_sparse";
 
-  constructor(private readonly label = "det") { }
+  constructor(private readonly label = "det") {}
 
   async generate(texts: string[]) {
     return texts.map((text, index) => {
@@ -175,6 +175,20 @@ describe("Schema", () => {
     expect(schema.defaults.sparseVector?.sparseVectorIndex?.enabled).toBe(
       false,
     );
+  });
+
+  it("create multiple sparse vector indices", () => {
+    const schema = new Schema();
+
+    schema.createIndex(new SparseVectorIndexConfig(), "sparse_a");
+    // A second sparse index on a different key must succeed.
+    schema.createIndex(new SparseVectorIndexConfig(), "sparse_b");
+
+    for (const key of ["sparse_a", "sparse_b"]) {
+      expect(schema.keys[key].sparseVector?.sparseVectorIndex?.enabled).toBe(
+        true,
+      );
+    }
   });
 
   it("create sparse vector index with custom config", () => {
@@ -411,9 +425,9 @@ describe("Schema", () => {
       /Deleting FTS index is only supported on #document key/,
     );
     // FTS deletion on custom key is blocked
-    expect(() =>
-      schema.deleteIndex(ftsConfig, "my_text_field"),
-    ).toThrow(/Deleting FTS index is only supported on #document key/);
+    expect(() => schema.deleteIndex(ftsConfig, "my_text_field")).toThrow(
+      /Deleting FTS index is only supported on #document key/,
+    );
 
     // FTS deletion on #document is allowed and disables FTS
     schema.deleteIndex(ftsConfig, DOCUMENT_KEY);
@@ -865,9 +879,7 @@ describe("Schema", () => {
     ).toThrow(/Cannot create index on special key '#document'/);
 
     // Test 3: Cannot disable all indexes globally
-    expect(() => schema.deleteIndex()).toThrow(
-      /Cannot disable all indexes/,
-    );
+    expect(() => schema.deleteIndex()).toThrow(/Cannot disable all indexes/);
 
     // Test 4: Cannot enable all indexes globally
     expect(() => schema.createIndex()).toThrow(

--- a/docs/mintlify/cloud/schema/index-reference.mdx
+++ b/docs/mintlify/cloud/schema/index-reference.mdx
@@ -81,7 +81,7 @@ These index types have no configuration parameters.
 
 **Limitations**:
 - Must specify a metadata key name (per-key configuration required)
-- Only one sparse vector index allowed per collection
+- Sparse vector indices must be declared at collection creation and cannot be added later
 - Cannot be deleted once created
 
 <Callout>

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -83,8 +83,6 @@ pub enum SchemaBuilderError {
     SpecialKeyModificationNotAllowed { key: String },
     #[error("Sparse vector index requires a specific key. Use create_index(Some(\"key_name\"), config) instead of create_index(None, config)")]
     SparseVectorRequiresKey,
-    #[error("Only one sparse vector index allowed per collection. Key '{existing_key}' already has a sparse vector index. Remove it first or use that key.")]
-    MultipleSparseVectorIndexes { existing_key: String },
     #[error("Vector index deletion not supported. The vector index is always enabled on #embedding. To disable vector search, disable the collection instead.")]
     VectorIndexDeletionNotSupported,
     #[error("Sparse vector index deletion not supported yet. Sparse vector indexes cannot be removed once created.")]
@@ -2804,27 +2802,6 @@ impl Schema {
         config: IndexConfig,
         enabled: bool,
     ) -> Result<(), SchemaBuilderError> {
-        // Check for multiple sparse vector indexes BEFORE getting mutable reference
-        if enabled && matches!(config, IndexConfig::SparseVector(_)) {
-            // Find existing sparse vector index
-            let existing_key = self
-                .keys
-                .iter()
-                .find(|(k, v)| {
-                    k.as_str() != key
-                        && v.sparse_vector
-                            .as_ref()
-                            .and_then(|sv| sv.sparse_vector_index.as_ref())
-                            .map(|idx| idx.enabled)
-                            .unwrap_or(false)
-                })
-                .map(|(k, _)| k.clone());
-
-            if let Some(existing_key) = existing_key {
-                return Err(SchemaBuilderError::MultipleSparseVectorIndexes { existing_key });
-            }
-        }
-
         // Get or create ValueTypes for this key
         let value_types = self.keys.entry(key.to_string()).or_default();
 
@@ -6443,8 +6420,8 @@ mod tests {
             SchemaBuilderError::SparseVectorRequiresKey
         ));
 
-        // Error: Multiple sparse vector indexes (only one allowed per collection)
-        let result = Schema::new_default(KnnIndex::Hnsw)
+        // Multiple sparse vector indexes are now allowed per collection.
+        let schema = Schema::new_default(KnnIndex::Hnsw)
             .create_index(
                 Some("sparse1"),
                 IndexConfig::SparseVector(SparseVectorIndexConfig {
@@ -6461,14 +6438,14 @@ mod tests {
                     embedding_function: None,
                     source_key: None,
                     bm25: None,
-                    algorithm: SparseIndexAlgorithm::Wand,
+                    algorithm: SparseIndexAlgorithm::MaxScore,
                 }),
-            );
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SchemaBuilderError::MultipleSparseVectorIndexes { existing_key } if existing_key == "sparse1"
-        ));
+            )
+            .expect("second sparse should succeed");
+        assert_eq!(
+            schema.enabled_sparse_keys(),
+            vec!["sparse1".to_string(), "sparse2".to_string()]
+        );
     }
 
     #[test]

--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -336,12 +336,13 @@ pub fn validate_schema(schema: &Schema) -> Result<(), ValidationError> {
             .as_ref()
             .and_then(|vt| vt.sparse_vector_index.as_ref())
         {
-            if svit.enabled {
-                if svit.config.source_key.is_some() && svit.config.embedding_function.is_none() {
-                    return Err(ValidationError::new("schema").with_message(
-                        "If source_key is provided then embedding_function must also be provided since there is no default embedding function.".into(),
-                    ));
-                }
+            if svit.enabled
+                && svit.config.source_key.is_some()
+                && svit.config.embedding_function.is_none()
+            {
+                return Err(ValidationError::new("schema").with_message(
+                    "If source_key is provided then embedding_function must also be provided since there is no default embedding function.".into(),
+                ));
             }
             // Validate source_key for sparse vector index
             if let Some(source_key) = &svit.config.source_key {
@@ -668,18 +669,21 @@ mod tests {
         algorithm: crate::SparseIndexAlgorithm,
     ) {
         use crate::{SparseVectorIndexConfig, SparseVectorIndexType, SparseVectorValueType};
-        schema.keys.entry(key.to_string()).or_default().sparse_vector =
-            Some(SparseVectorValueType {
-                sparse_vector_index: Some(SparseVectorIndexType {
-                    enabled: true,
-                    config: SparseVectorIndexConfig {
-                        embedding_function: None,
-                        source_key: None,
-                        bm25: None,
-                        algorithm,
-                    },
-                }),
-            });
+        schema
+            .keys
+            .entry(key.to_string())
+            .or_default()
+            .sparse_vector = Some(SparseVectorValueType {
+            sparse_vector_index: Some(SparseVectorIndexType {
+                enabled: true,
+                config: SparseVectorIndexConfig {
+                    embedding_function: None,
+                    source_key: None,
+                    bm25: None,
+                    algorithm,
+                },
+            }),
+        });
     }
 
     #[test]
@@ -693,7 +697,10 @@ mod tests {
 
     #[test]
     fn test_validate_schema_rejects_default_sparse_index() {
-        use crate::{KnnIndex, SparseIndexAlgorithm, SparseVectorIndexConfig, SparseVectorIndexType, SparseVectorValueType};
+        use crate::{
+            KnnIndex, SparseIndexAlgorithm, SparseVectorIndexConfig, SparseVectorIndexType,
+            SparseVectorValueType,
+        };
         let mut schema = Schema::new_default(KnnIndex::Hnsw);
         schema.defaults.sparse_vector = Some(SparseVectorValueType {
             sparse_vector_index: Some(SparseVectorIndexType {

--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -245,7 +245,6 @@ pub fn validate_search_payload(payload: &SearchPayload) -> Result<(), Validation
 
 /// Validate schema
 pub fn validate_schema(schema: &Schema) -> Result<(), ValidationError> {
-    let mut sparse_index_keys = Vec::new();
     if schema
         .defaults
         .float_list
@@ -269,7 +268,7 @@ pub fn validate_schema(schema: &Schema) -> Result<(), ValidationError> {
         .as_ref()
         .is_some_and(|vt| vt.sparse_vector_index.as_ref().is_some_and(|it| it.enabled))
     {
-        return Err(ValidationError::new("schema").with_message("Sparse vector index cannot be enabled by default. Please enable sparse vector index on specific keys. At most one sparse vector index is allowed for the collection.".into()));
+        return Err(ValidationError::new("schema").with_message("Sparse vector index cannot be enabled by default. Please enable sparse vector index on specific keys.".into()));
     }
     if schema
         .defaults
@@ -338,13 +337,6 @@ pub fn validate_schema(schema: &Schema) -> Result<(), ValidationError> {
             .and_then(|vt| vt.sparse_vector_index.as_ref())
         {
             if svit.enabled {
-                sparse_index_keys.push(key);
-                if sparse_index_keys.len() > 1 {
-                    return Err(ValidationError::new("schema").with_message(
-                        format!("At most one sparse vector index is allowed for the collection: {sparse_index_keys:?}")
-                            .into(),
-                    ));
-                }
                 if svit.config.source_key.is_some() && svit.config.embedding_function.is_none() {
                     return Err(ValidationError::new("schema").with_message(
                         "If source_key is provided then embedding_function must also be provided since there is no default embedding function.".into(),
@@ -668,5 +660,52 @@ mod tests {
             ..Default::default()
         };
         assert!(validate_search_payload(&payload).is_err());
+    }
+
+    fn schema_with_sparse_key(
+        schema: &mut Schema,
+        key: &str,
+        algorithm: crate::SparseIndexAlgorithm,
+    ) {
+        use crate::{SparseVectorIndexConfig, SparseVectorIndexType, SparseVectorValueType};
+        schema.keys.entry(key.to_string()).or_default().sparse_vector =
+            Some(SparseVectorValueType {
+                sparse_vector_index: Some(SparseVectorIndexType {
+                    enabled: true,
+                    config: SparseVectorIndexConfig {
+                        embedding_function: None,
+                        source_key: None,
+                        bm25: None,
+                        algorithm,
+                    },
+                }),
+            });
+    }
+
+    #[test]
+    fn test_validate_schema_allows_multiple_sparse_keys() {
+        use crate::{KnnIndex, SparseIndexAlgorithm};
+        let mut schema = Schema::new_default(KnnIndex::Hnsw);
+        schema_with_sparse_key(&mut schema, "sparse_a", SparseIndexAlgorithm::Wand);
+        schema_with_sparse_key(&mut schema, "sparse_b", SparseIndexAlgorithm::MaxScore);
+        assert!(validate_schema(&schema).is_ok());
+    }
+
+    #[test]
+    fn test_validate_schema_rejects_default_sparse_index() {
+        use crate::{KnnIndex, SparseIndexAlgorithm, SparseVectorIndexConfig, SparseVectorIndexType, SparseVectorValueType};
+        let mut schema = Schema::new_default(KnnIndex::Hnsw);
+        schema.defaults.sparse_vector = Some(SparseVectorValueType {
+            sparse_vector_index: Some(SparseVectorIndexType {
+                enabled: true,
+                config: SparseVectorIndexConfig {
+                    embedding_function: None,
+                    source_key: None,
+                    bm25: None,
+                    algorithm: SparseIndexAlgorithm::Wand,
+                },
+            }),
+        });
+        assert!(validate_schema(&schema).is_err());
     }
 }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

Lifts the "at most one sparse vector index per collection" cap across every schema validator, now that the segment/query layer is key-aware (#7305). Collections may declare multiple sparse vector indices, each on a distinct metadata key.

- Improvements & Bug fixes
  - Remove the single-sparse-index check from the Rust validators (`validators.rs`) and the schema builder (`SchemaBuilderError::MultipleSparseVectorIndexes`), the Python client (`_validate_single_sparse_vector_index`), and the TS client (`validateSingleSparseVectorIndex`).
  - Keep all other guards intact: defaults still cannot enable a sparse index, and each sparse index must be bound to a metadata key.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
- `cargo test -p chroma-types` — builder now accepts multiple sparse indices; `validate_rank` unaffected.
- `pytest chromadb/test/api/test_schema.py` — added `test_create_multiple_sparse_vector_indices`.
- `clients/new-js` schema tests — added "create multiple sparse vector indices" case.

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

Backward compatible. Schemas remain write-once-read-many, so multiple sparse indices are declared at collection-creation time and cannot be added later. Existing single-sparse collections are unaffected.

## Observability plan

_What is the plan to instrument and monitor this change?_

No new metrics needed.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

Updated `docs/mintlify/cloud/schema/index-reference.mdx`: the limitation now reads that sparse vector indices must be declared at collection creation and cannot be added later (replacing "only one sparse vector index allowed per collection").
