### PR TITLE
[TST](worker): Fuse scores across multiple sparse indices

### DIFF
--- a/rust/types/src/execution/operator.rs
+++ b/rust/types/src/execution/operator.rs
@@ -3797,4 +3797,67 @@ mod tests {
             _ => panic!("Expected MaxK aggregate"),
         }
     }
+
+    fn sparse_knn_leaf(index: u32, key: &str, return_rank: bool) -> RankExpr {
+        RankExpr::Knn {
+            query: QueryVector::Sparse(SparseVector::new(vec![index], vec![1.0]).unwrap()),
+            key: Key::field(key),
+            limit: 10,
+            default: None,
+            return_rank,
+        }
+    }
+
+    #[test]
+    fn test_knn_queries_collects_all_sparse_leaves_in_dfs_order() {
+        // Two distinct sparse keys plus a repeat of the first key with a
+        // different query vector. All three leaves must be collected, in order,
+        // with no deduplication by key or query type.
+        let expr = RankExpr::Summation(vec![
+            sparse_knn_leaf(0, "sparse_a", false),
+            sparse_knn_leaf(1, "sparse_b", false),
+            sparse_knn_leaf(2, "sparse_a", false),
+        ]);
+
+        let leaves = expr.knn_queries();
+        assert_eq!(leaves.len(), 3);
+        assert_eq!(leaves[0].key, Key::field("sparse_a"));
+        assert_eq!(leaves[1].key, Key::field("sparse_b"));
+        assert_eq!(leaves[2].key, Key::field("sparse_a"));
+
+        // The two same-key leaves keep their distinct query vectors.
+        match (&leaves[0].query, &leaves[2].query) {
+            (QueryVector::Sparse(first), QueryVector::Sparse(third)) => {
+                assert_ne!(first.indices, third.indices);
+            }
+            _ => panic!("expected sparse query vectors"),
+        }
+    }
+
+    #[test]
+    fn test_rrf_preserves_all_sparse_leaves() {
+        // RRF over multiple sparse leaves expands into arithmetic but must still
+        // surface every leaf (so each gets its own per-key orchestrator).
+        let expr = rrf(
+            vec![
+                sparse_knn_leaf(0, "sparse_a", true),
+                sparse_knn_leaf(1, "sparse_b", true),
+                sparse_knn_leaf(2, "sparse_c", true),
+            ],
+            None,
+            None,
+            false,
+        )
+        .expect("rrf should build");
+
+        let keys: Vec<Key> = expr.knn_queries().into_iter().map(|q| q.key).collect();
+        assert_eq!(
+            keys,
+            vec![
+                Key::field("sparse_a"),
+                Key::field("sparse_b"),
+                Key::field("sparse_c"),
+            ]
+        );
+    }
 }

--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -758,7 +758,10 @@ mod tests {
             return_rank: false,
         };
         let rank = Rank {
-            expr: Some(RankExpr::Summation(vec![sparse_rank_leaf(0, "sparse_a"), bad])),
+            expr: Some(RankExpr::Summation(vec![
+                sparse_rank_leaf(0, "sparse_a"),
+                bad,
+            ])),
         };
         assert!(validate_rank(&rank).is_err());
     }

--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -715,4 +715,51 @@ mod tests {
         });
         assert!(validate_schema(&schema).is_err());
     }
+
+    fn sparse_rank_leaf(index: u32, key: &str) -> crate::operator::RankExpr {
+        crate::operator::RankExpr::Knn {
+            query: crate::operator::QueryVector::Sparse(
+                SparseVector::new(vec![index], vec![1.0]).unwrap(),
+            ),
+            key: Key::field(key),
+            limit: 10,
+            default: None,
+            return_rank: false,
+        }
+    }
+
+    #[test]
+    fn test_validate_rank_admits_multiple_sparse_leaves() {
+        use crate::operator::RankExpr;
+        // Distinct sparse keys plus a repeat of the first key — all valid.
+        let rank = Rank {
+            expr: Some(RankExpr::Summation(vec![
+                sparse_rank_leaf(0, "sparse_a"),
+                sparse_rank_leaf(1, "sparse_b"),
+                sparse_rank_leaf(2, "sparse_a"),
+            ])),
+        };
+        assert!(validate_rank(&rank).is_ok());
+    }
+
+    #[test]
+    fn test_validate_rank_rejects_invalid_sparse_leaf() {
+        use crate::operator::RankExpr;
+        // One valid leaf, one with mismatched indices/values lengths.
+        let bad = RankExpr::Knn {
+            query: crate::operator::QueryVector::Sparse(SparseVector {
+                indices: vec![0, 1],
+                values: vec![1.0],
+                tokens: None,
+            }),
+            key: Key::field("sparse_b"),
+            limit: 10,
+            default: None,
+            return_rank: false,
+        };
+        let rank = Rank {
+            expr: Some(RankExpr::Summation(vec![sparse_rank_leaf(0, "sparse_a"), bad])),
+        };
+        assert!(validate_rank(&rank).is_err());
+    }
 }

--- a/rust/worker/src/execution/operators/rank.rs
+++ b/rust/worker/src/execution/operators/rank.rs
@@ -473,10 +473,8 @@ mod tests {
     /// independently — each consumes its own result slot rather than collapsing.
     #[tokio::test]
     async fn test_same_key_sparse_leaves_run_independently() {
-        let expr = RankExpr::Summation(vec![
-            sparse_leaf(0, "sparse_x"),
-            sparse_leaf(1, "sparse_x"),
-        ]);
+        let expr =
+            RankExpr::Summation(vec![sparse_leaf(0, "sparse_x"), sparse_leaf(1, "sparse_x")]);
 
         // Distinct result sets prove the leaves did not collapse into one.
         let knn_results = vec![

--- a/rust/worker/src/execution/operators/rank.rs
+++ b/rust/worker/src/execution/operators/rank.rs
@@ -400,4 +400,106 @@ mod tests {
         assert_eq!(output.ranks[1].offset_id, 1);
         assert_eq!(output.ranks[1].measure, 0.5); // min(0.8, 0.5) = 0.5
     }
+
+    fn sparse_leaf(index: u32, key: &str) -> RankExpr {
+        RankExpr::Knn {
+            query: chroma_types::operator::QueryVector::Sparse(chroma_types::SparseVector {
+                indices: vec![index],
+                values: vec![1.0],
+                tokens: None,
+            }),
+            key: Key::field(key),
+            limit: 10,
+            // Zero default so records missing from one index still participate.
+            default: Some(0.0),
+            return_rank: false,
+        }
+    }
+
+    /// Weighted arithmetic fusion across two distinct sparse indices:
+    /// `sparse_a * 0.7 + sparse_b * 0.3`. The two leaves consume independent
+    /// per-key result slots in DFS order.
+    #[tokio::test]
+    async fn test_fuse_multiple_sparse_indices_weighted_sum() {
+        let expr = RankExpr::Summation(vec![
+            RankExpr::Multiplication(vec![sparse_leaf(0, "sparse_a"), RankExpr::Value(0.7)]),
+            RankExpr::Multiplication(vec![sparse_leaf(1, "sparse_b"), RankExpr::Value(0.3)]),
+        ]);
+
+        // DFS leaf order: [sparse_a, sparse_b].
+        let knn_results = vec![
+            vec![
+                RecordMeasure {
+                    offset_id: 1,
+                    measure: 1.0,
+                },
+                RecordMeasure {
+                    offset_id: 2,
+                    measure: 0.5,
+                },
+            ],
+            vec![
+                RecordMeasure {
+                    offset_id: 1,
+                    measure: 0.2,
+                },
+                RecordMeasure {
+                    offset_id: 3,
+                    measure: 0.8,
+                },
+            ],
+        ];
+        let input = RankInput { knn_results };
+        let output = expr.run(&input).await.expect("Rank should succeed");
+
+        let scores: HashMap<u32, f32> = output
+            .ranks
+            .iter()
+            .map(|r| (r.offset_id, r.measure))
+            .collect();
+        // id1: 1.0*0.7 + 0.2*0.3 = 0.76
+        // id2: 0.5*0.7 + 0.0*0.3 = 0.35
+        // id3: 0.0*0.7 + 0.8*0.3 = 0.24
+        assert_eq!(scores.len(), 3);
+        assert!((scores[&1] - 0.76).abs() < 1e-6);
+        assert!((scores[&2] - 0.35).abs() < 1e-6);
+        assert!((scores[&3] - 0.24).abs() < 1e-6);
+        // Ascending sort by measure.
+        assert_eq!(output.ranks[0].offset_id, 3);
+        assert_eq!(output.ranks[2].offset_id, 1);
+    }
+
+    /// Two `$knn` leaves on the SAME key with different query vectors must run
+    /// independently — each consumes its own result slot rather than collapsing.
+    #[tokio::test]
+    async fn test_same_key_sparse_leaves_run_independently() {
+        let expr = RankExpr::Summation(vec![
+            sparse_leaf(0, "sparse_x"),
+            sparse_leaf(1, "sparse_x"),
+        ]);
+
+        // Distinct result sets prove the leaves did not collapse into one.
+        let knn_results = vec![
+            vec![RecordMeasure {
+                offset_id: 1,
+                measure: 1.0,
+            }],
+            vec![RecordMeasure {
+                offset_id: 2,
+                measure: 1.0,
+            }],
+        ];
+        let input = RankInput { knn_results };
+        let output = expr.run(&input).await.expect("Rank should succeed");
+
+        let scores: HashMap<u32, f32> = output
+            .ranks
+            .iter()
+            .map(|r| (r.offset_id, r.measure))
+            .collect();
+        // Both records present: id1 from the first leaf, id2 from the second.
+        assert_eq!(scores.len(), 2);
+        assert!((scores[&1] - 1.0).abs() < 1e-6);
+        assert!((scores[&2] - 1.0).abs() < 1e-6);
+    }
 }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

Verifies and locks in arithmetic and RRF score fusion across multiple sparse vector indices. With the segment layer key-aware (#7305) and the schema cap lifted (#7306), the existing `RankExpr` evaluation already fuses multiple sparse `$knn` leaves correctly — leaves are collected in DFS order and results are mapped back positionally — so no new operators were required. This PR adds tests to pin that behavior.

- New functionality
  - Confirmed `RankExpr::knn_queries()` DFS-collects every leaf with no dedup (including repeated keys with different query vectors), and that RRF expansion preserves all leaves.
  - Confirmed `validate_rank` admits multiple sparse leaves while still rejecting invalid sparse queries.
  - Confirmed the worker fuses scores across distinct sparse keys (weighted sum) and runs same-key leaves independently.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
- `cargo test -p chroma-types` — `knn_queries`/`rrf` collect all sparse leaves in DFS order; `validate_rank` multi-leaf admit + invalid-leaf reject.
- `cargo test -p worker` — weighted-sum fusion across two sparse keys; same-key independence.

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

None — test-only change, no behavior change.

## Observability plan

_What is the plan to instrument and monitor this change?_

N/A.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

None.
