### PR TITLE
[ENH] foundation-api: return not found for unprovisioned search

### DIFF
--- a/rust/foundation-api/src/routes/search.rs
+++ b/rust/foundation-api/src/routes/search.rs
@@ -108,6 +108,10 @@ impl ChromaError for SearchError {
         match self {
             SearchError::RouteDisabled => ErrorCodes::Internal,
             SearchError::MissingToken => ErrorCodes::InvalidArgument,
+            // A 404 resolving the wiki collection means Foundation isn't
+            // provisioned for this tenant. Match the agent route so callers
+            // can distinguish "not set up" from transient FE failures.
+            SearchError::Resolve(err) if err.is_not_found() => ErrorCodes::NotFound,
             SearchError::Resolve(err) => err.code(),
             SearchError::Embed(err) => err.code(),
             SearchError::DenseEmbed(_) => ErrorCodes::Internal,
@@ -428,6 +432,26 @@ mod tests {
                 .any(|k| *k == &Value::String(SPARSE_KEY.to_string())),
             "expected a $knn over the sparse key, got keys: {keys:?}"
         );
+    }
+
+    #[test]
+    fn not_provisioned_resolve_error_maps_to_not_found() {
+        use crate::wiki::WikiClientError;
+        use chroma::client::ChromaHttpClientError;
+        use chroma_error::ChromaError;
+        use reqwest::StatusCode;
+
+        let not_found =
+            SearchError::Resolve(WikiClientError::Client(ChromaHttpClientError::ApiError(
+                "collection not found".to_string(),
+                StatusCode::NOT_FOUND,
+            )));
+        assert!(matches!(not_found.code(), ErrorCodes::NotFound));
+
+        let server_err = SearchError::Resolve(WikiClientError::Client(
+            ChromaHttpClientError::ApiError("boom".to_string(), StatusCode::INTERNAL_SERVER_ERROR),
+        ));
+        assert!(matches!(server_err.code(), ErrorCodes::Internal));
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
- Follow-up to https://github.com/chroma-core/chroma/pull/7275, applying the same unprovisioned Foundation 404 behavior to the sibling `/api/search` route.
  - Return `NotFound` for `/api/search` when resolving the wiki collection returns a downstream 404, matching the `/api/agent` behavior for an unprovisioned Foundation tenant.
  - Preserve `Internal` for other downstream wiki resolution failures.
- New functionality
  - None.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Targeted Rust tests:

```bash
cargo test -p foundation-api routes::search::tests::not_provisioned_resolve_error_maps_to_not_found
cargo test -p foundation-api routes::search
```

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

No migrations or compatibility changes.

## Observability plan

_What is the plan to instrument and monitor this change?_

No new instrumentation. This uses the existing Chroma error-code surface so callers can distinguish an unprovisioned Foundation search route from transient internal failures.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

No documentation changes needed; this aligns `/api/search` error handling with the existing `/api/agent` behavior.
