### PR TITLE
[ENH](foundation-api): Trace init operations

### DIFF
--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -45,6 +45,7 @@ pub struct FoundationInitResponse {
 /// wiki_revisions collections (names overridable via
 /// `CHROMA_FOUNDATION__*` env vars) exist in the tenant resolved from the
 /// auth context. Safe to call repeatedly.
+#[tracing::instrument(name = "foundation_init", skip_all, err(Display))]
 pub async fn foundation_init(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
@@ -53,6 +54,12 @@ pub async fn foundation_init(
         whoami_and_authorize(&*server.auth, &headers, AuthzAction::InitFoundation).await?;
     let tenant = identity.tenant;
     let user_id = identity.user_id;
+    tracing::info!(
+        tenant = %tenant,
+        user_id = %user_id,
+        database = %server.config.foundation.database_name,
+        "foundation init starting"
+    );
 
     let _guard =
         server.scorecard_request(&["op:foundation_init", &format!("tenant:{}", tenant)])?;
@@ -207,6 +214,12 @@ pub async fn foundation_init(
         )
         .await?;
     }
+
+    tracing::info!(
+        tenant = %tenant,
+        num_source_collections = source_collection_ids.len(),
+        "foundation init complete"
+    );
 
     Ok(Json(FoundationInitResponse {
         tenant,
@@ -405,19 +418,31 @@ async fn ensure_currents_collection(
     .await
 }
 
+#[tracing::instrument(
+    name = "ensure_database",
+    skip_all,
+    fields(database = %database_name.as_ref(), tenant = %tenant),
+    err(Display)
+)]
 async fn ensure_database(
     sysdb: &mut SysDb,
     database_name: DatabaseName,
     tenant: String,
 ) -> Result<Uuid, ServerError> {
-    match sysdb
+    // Idempotent: an `AlreadyExists` from a previous/concurrent init is the
+    // success path.
+    let created = match sysdb
         .create_database(Uuid::new_v4(), database_name.clone(), tenant.clone())
         .await
     {
-        Ok(_) | Err(CreateDatabaseError::AlreadyExists(_)) => {}
+        Ok(_) => true,
+        Err(CreateDatabaseError::AlreadyExists(_)) => false,
         Err(e) => return Err(e.into()),
-    }
-    let db = sysdb.get_database(database_name, tenant).await?;
+    };
+
+    let db = sysdb.get_database(database_name.clone(), tenant).await?;
+
+    tracing::info!(database = %database_name.as_ref(), database_id = %db.id, created, "ensured foundation database");
     Ok(db.id)
 }
 
@@ -432,6 +457,12 @@ const GET_OR_CREATE: bool = true;
 /// planner reconciles the Foundation schema (sparse vector index for
 /// SPLADE) with the default config, picks the right segment types for
 /// distributed mode, and emits everything sysdb needs.
+#[tracing::instrument(
+    name = "ensure_collection",
+    skip_all,
+    fields(collection = %collection_name, database = %database_name.as_ref()),
+    err(Display)
+)]
 async fn ensure_collection(
     sysdb: &mut SysDb,
     tenant: String,
@@ -465,6 +496,12 @@ async fn ensure_collection(
             GET_OR_CREATE,
         )
         .await?;
+
+    tracing::info!(
+        collection = %collection_name,
+        collection_id = %collection.collection_id,
+        "ensured foundation collection"
+    );
     Ok(collection)
 }
 

--- a/rust/frontend-core/src/attached_function_ops.rs
+++ b/rust/frontend-core/src/attached_function_ops.rs
@@ -54,6 +54,16 @@ pub struct AddAttachedFunctionInputResult {
 /// Idempotent: if the function already exists (`created = false`), the
 /// finish step is skipped and the existing ID is returned.
 #[allow(clippy::too_many_arguments)]
+#[tracing::instrument(
+    skip_all,
+    fields(
+        attached_function = %name,
+        operator = %operator_name,
+        input_collection_id = %input_collection_id,
+        tenant = %tenant,
+        database_name = %database_name,
+    )
+)]
 pub async fn create_attached_function(
     sysdb: &mut SysDb,
     name: String,
@@ -68,7 +78,7 @@ pub async fn create_attached_function(
 ) -> Result<(AttachedFunctionUuid, bool), CreateAttachedFunctionError> {
     let (id, created) = sysdb
         .create_attached_function(
-            name,
+            name.clone(),
             operator_name,
             input_collection_id,
             output_collection_name,
@@ -80,6 +90,7 @@ pub async fn create_attached_function(
         .await?;
 
     if !created {
+        tracing::info!(attached_function = %name, "attached function already exists");
         return Ok((id, false));
     }
 
@@ -88,11 +99,20 @@ pub async fn create_attached_function(
         .finish_create_attached_function(id, schema_str)
         .await?;
 
+    tracing::info!(attached_function = %name, "created attached function");
     Ok((id, true))
 }
 
 /// Add an input collection to an existing async attached function and mark
 /// the new input ready when it is newly created.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        attached_function = %name,
+        new_input_collection_id = %new_input_collection_id,
+        database_name = %database_name.as_ref(),
+    )
+)]
 pub async fn add_attached_function_input(
     sysdb: &mut SysDb,
     name: String,


### PR DESCRIPTION
## What

Adds tracing to the `/api/init` Foundation bootstrap so a failure shows exactly which step broke — across **database creation, collection creation, and function attachment**.

Stacked on #7313 (schema extraction); **retry/resilience is layered on top in #7312**.

## Changes

- `#[tracing::instrument]` spans on `foundation_init`, `ensure_database`, and `ensure_collection`, with start/complete logs and per-resource "ensured" logs (database create-vs-existed included).
- Spans + `created` / `already exists` logs on the shared `attached_function_ops` (`create_attached_function`, `add_attached_function_input`), so attachment is observable too.

Instrumentation only — no behavior change.

## Testing

- `cargo clippy` clean for `foundation-api` + `frontend-core`
- foundation-api lib tests: 98 passed (Tilt/k8s integration ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)