### PR TITLE
[ENH](foundation-api): Trace & retry init operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,7 @@ version = "1.0.0"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
+ "backon",
  "chroma-api-types",
  "chroma-error",
  "chroma-log",

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -19,6 +19,7 @@ use frontend_core::{
         plan_create_collection, supported_segment_types, ExecutorKind, TenantFeatureFlags,
     },
     foundation::source_kind_for_collection_name,
+    retry::retry_transient,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -429,18 +430,34 @@ async fn ensure_database(
     database_name: DatabaseName,
     tenant: String,
 ) -> Result<Uuid, ServerError> {
-    // Idempotent: an `AlreadyExists` from a previous/concurrent init is the
-    // success path.
-    let created = match sysdb
-        .create_database(Uuid::new_v4(), database_name.clone(), tenant.clone())
-        .await
+    // Generate the id once so retries don't churn through fresh UUIDs; the
+    // create is keyed on the (tenant, name) pair and is idempotent — an
+    // `AlreadyExists` from a previous/concurrent init is the success path.
+    let database_id = Uuid::new_v4();
+    let created = match retry_transient(|| {
+        let mut sysdb = sysdb.clone();
+        let database_name = database_name.clone();
+        let tenant = tenant.clone();
+        async move {
+            sysdb
+                .create_database(database_id, database_name, tenant)
+                .await
+        }
+    })
+    .await
     {
         Ok(_) => true,
         Err(CreateDatabaseError::AlreadyExists(_)) => false,
         Err(e) => return Err(e.into()),
     };
 
-    let db = sysdb.get_database(database_name.clone(), tenant).await?;
+    let db = retry_transient(|| {
+        let mut sysdb = sysdb.clone();
+        let database_name = database_name.clone();
+        let tenant = tenant.clone();
+        async move { sysdb.get_database(database_name, tenant).await }
+    })
+    .await?;
 
     tracing::info!(database = %database_name.as_ref(), database_id = %db.id, created, "ensured foundation database");
     Ok(db.id)
@@ -482,20 +499,37 @@ async fn ensure_collection(
         KnnIndex::Spann,
         TenantFeatureFlags::default(),
     )?;
-    let collection = sysdb
-        .create_collection(
-            tenant,
-            database_name,
-            plan.collection_id,
-            collection_name.to_string(),
-            plan.segments,
-            plan.configuration,
-            plan.schema,
-            metadata,
-            dimension,
-            GET_OR_CREATE,
-        )
-        .await?;
+    // `GET_OR_CREATE` makes this idempotent in a single round trip, so a
+    // transient sysdb failure is safe to retry. The plan (collection id +
+    // segments + config) is fixed up front and reused across attempts.
+    let collection_id = plan.collection_id;
+    let collection = retry_transient(|| {
+        let mut sysdb = sysdb.clone();
+        let tenant = tenant.clone();
+        let database_name = database_name.clone();
+        let collection_name = collection_name.to_string();
+        let segments = plan.segments.clone();
+        let configuration = plan.configuration.clone();
+        let schema = plan.schema.clone();
+        let metadata = metadata.clone();
+        async move {
+            sysdb
+                .create_collection(
+                    tenant,
+                    database_name,
+                    collection_id,
+                    collection_name,
+                    segments,
+                    configuration,
+                    schema,
+                    metadata,
+                    dimension,
+                    GET_OR_CREATE,
+                )
+                .await
+        }
+    })
+    .await?;
 
     tracing::info!(
         collection = %collection_name,

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -45,6 +45,7 @@ pub struct FoundationInitResponse {
 /// wiki_revisions collections (names overridable via
 /// `CHROMA_FOUNDATION__*` env vars) exist in the tenant resolved from the
 /// auth context. Safe to call repeatedly.
+#[tracing::instrument(name = "foundation_init", skip_all, err(Display))]
 pub async fn foundation_init(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
@@ -53,6 +54,12 @@ pub async fn foundation_init(
         whoami_and_authorize(&*server.auth, &headers, AuthzAction::InitFoundation).await?;
     let tenant = identity.tenant;
     let user_id = identity.user_id;
+    tracing::info!(
+        tenant = %tenant,
+        user_id = %user_id,
+        database = %server.config.foundation.database_name,
+        "foundation init starting"
+    );
 
     let _guard =
         server.scorecard_request(&["op:foundation_init", &format!("tenant:{}", tenant)])?;
@@ -207,6 +214,12 @@ pub async fn foundation_init(
         )
         .await?;
     }
+
+    tracing::info!(
+        tenant = %tenant,
+        num_source_collections = source_collection_ids.len(),
+        "foundation init complete"
+    );
 
     Ok(Json(FoundationInitResponse {
         tenant,
@@ -405,19 +418,31 @@ async fn ensure_currents_collection(
     .await
 }
 
+#[tracing::instrument(
+    name = "ensure_database",
+    skip_all,
+    fields(database = %database_name.as_ref(), tenant = %tenant),
+    err(Display)
+)]
 async fn ensure_database(
     sysdb: &mut SysDb,
     database_name: DatabaseName,
     tenant: String,
 ) -> Result<Uuid, ServerError> {
-    match sysdb
+    // Idempotent: an `AlreadyExists` from a previous/concurrent init is the
+    // success path.
+    let created = match sysdb
         .create_database(Uuid::new_v4(), database_name.clone(), tenant.clone())
         .await
     {
-        Ok(_) | Err(CreateDatabaseError::AlreadyExists(_)) => {}
+        Ok(_) => true,
+        Err(CreateDatabaseError::AlreadyExists(_)) => false,
         Err(e) => return Err(e.into()),
-    }
-    let db = sysdb.get_database(database_name, tenant).await?;
+    };
+
+    let db = sysdb.get_database(database_name.clone(), tenant).await?;
+
+    tracing::info!(database = %database_name.as_ref(), database_id = %db.id, created, "ensured foundation database");
     Ok(db.id)
 }
 
@@ -432,6 +457,12 @@ const GET_OR_CREATE: bool = true;
 /// planner reconciles the Foundation schema (sparse vector index for
 /// SPLADE) with the default config, picks the right segment types for
 /// distributed mode, and emits everything sysdb needs.
+#[tracing::instrument(
+    name = "ensure_collection",
+    skip_all,
+    fields(collection = %collection_name, database = %database_name.as_ref()),
+    err(Display)
+)]
 async fn ensure_collection(
     sysdb: &mut SysDb,
     tenant: String,
@@ -465,6 +496,12 @@ async fn ensure_collection(
             GET_OR_CREATE,
         )
         .await?;
+
+    tracing::info!(
+        collection = %collection_name,
+        collection_id = %collection.collection_id,
+        "ensured foundation collection"
+    );
     Ok(collection)
 }
 

--- a/rust/frontend-core/Cargo.toml
+++ b/rust/frontend-core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 async-trait = { workspace = true }
 axum = { workspace = true }
+backon = { workspace = true }
 figment = { workspace = true }
 http-body-util = { workspace = true }
 mdac = { workspace = true }

--- a/rust/frontend-core/src/attached_function_ops.rs
+++ b/rust/frontend-core/src/attached_function_ops.rs
@@ -54,6 +54,16 @@ pub struct AddAttachedFunctionInputResult {
 /// Idempotent: if the function already exists (`created = false`), the
 /// finish step is skipped and the existing ID is returned.
 #[allow(clippy::too_many_arguments)]
+#[tracing::instrument(
+    skip_all,
+    fields(
+        attached_function = %name,
+        operator = %operator_name,
+        input_collection_id = %input_collection_id,
+        tenant = %tenant,
+        database_name = %database_name,
+    )
+)]
 pub async fn create_attached_function(
     sysdb: &mut SysDb,
     name: String,
@@ -68,7 +78,7 @@ pub async fn create_attached_function(
 ) -> Result<(AttachedFunctionUuid, bool), CreateAttachedFunctionError> {
     let (id, created) = sysdb
         .create_attached_function(
-            name,
+            name.clone(),
             operator_name,
             input_collection_id,
             output_collection_name,
@@ -80,6 +90,7 @@ pub async fn create_attached_function(
         .await?;
 
     if !created {
+        tracing::info!(attached_function = %name, "attached function already exists");
         return Ok((id, false));
     }
 
@@ -88,11 +99,20 @@ pub async fn create_attached_function(
         .finish_create_attached_function(id, schema_str)
         .await?;
 
+    tracing::info!(attached_function = %name, "created attached function");
     Ok((id, true))
 }
 
 /// Add an input collection to an existing async attached function and mark
 /// the new input ready when it is newly created.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        attached_function = %name,
+        new_input_collection_id = %new_input_collection_id,
+        database_name = %database_name.as_ref(),
+    )
+)]
 pub async fn add_attached_function_input(
     sysdb: &mut SysDb,
     name: String,

--- a/rust/frontend-core/src/attached_function_ops.rs
+++ b/rust/frontend-core/src/attached_function_ops.rs
@@ -13,6 +13,8 @@ use chroma_types::{
     DatabaseName, FinishCreateAttachedFunctionError, Operation, OperationRecord, Schema,
 };
 
+use crate::retry::retry_transient;
+
 /// Errors that can occur when creating (and optionally backfilling) an
 /// attached function.
 #[derive(Debug, thiserror::Error)]
@@ -76,28 +78,50 @@ pub async fn create_attached_function(
     min_records_for_invocation: u64,
     output_schema: Schema,
 ) -> Result<(AttachedFunctionUuid, bool), CreateAttachedFunctionError> {
-    let (id, created) = sysdb
-        .create_attached_function(
-            name.clone(),
-            operator_name,
-            input_collection_id,
-            output_collection_name,
-            params,
-            tenant,
-            database_name,
-            min_records_for_invocation,
-        )
-        .await?;
+    // The create RPC is idempotent (returns `created = false` when the function
+    // already exists), so retrying a transient sysdb failure is safe.
+    let (id, created) = retry_transient(|| {
+        let mut sysdb = sysdb.clone();
+        let name = name.clone();
+        let operator_name = operator_name.clone();
+        let output_collection_name = output_collection_name.clone();
+        let params = params.clone();
+        let tenant = tenant.clone();
+        let database_name = database_name.clone();
+        async move {
+            sysdb
+                .create_attached_function(
+                    name,
+                    operator_name,
+                    input_collection_id,
+                    output_collection_name,
+                    params,
+                    tenant,
+                    database_name,
+                    min_records_for_invocation,
+                )
+                .await
+        }
+    })
+    .await?;
 
     if !created {
         tracing::info!(attached_function = %name, "attached function already exists");
         return Ok((id, false));
     }
 
+    // Retry `finish` on its own. It must NOT be folded into a whole-function
+    // retry: on a retry the create RPC would return `created = false` and
+    // short-circuit, silently skipping `finish` and leaving the function
+    // half-attached. `finish_create_attached_function` is keyed on `id`, so
+    // retrying it directly is idempotent.
     let schema_str = serde_json::to_string(&output_schema)?;
-    sysdb
-        .finish_create_attached_function(id, schema_str)
-        .await?;
+    retry_transient(|| {
+        let mut sysdb = sysdb.clone();
+        let schema_str = schema_str.clone();
+        async move { sysdb.finish_create_attached_function(id, schema_str).await }
+    })
+    .await?;
 
     tracing::info!(attached_function = %name, "created attached function");
     Ok((id, true))
@@ -120,27 +144,43 @@ pub async fn add_attached_function_input(
     new_input_collection_id: CollectionUuid,
     database_name: DatabaseName,
 ) -> Result<(AttachedFunctionUuid, bool), CreateAttachedFunctionError> {
-    let add_input_result = prepare_add_attached_function_input(
-        sysdb,
-        name,
-        existing_input_collection_id,
-        new_input_collection_id,
-        database_name,
-    )
+    // `prepare` only reads sysdb and issues the idempotent add-input RPC (it
+    // performs no `finish`), so retrying the whole unit on a transient failure
+    // is safe — unlike folding `finish` (below) into the same retry.
+    let add_input_result = retry_transient(|| {
+        let mut sysdb = sysdb.clone();
+        let name = name.clone();
+        let database_name = database_name.clone();
+        async move {
+            prepare_add_attached_function_input(
+                &mut sysdb,
+                name,
+                existing_input_collection_id,
+                new_input_collection_id,
+                database_name,
+            )
+            .await
+        }
+    })
     .await?;
 
     if !add_input_result.created {
         return Ok((add_input_result.attached_function_id, false));
     }
 
-    sysdb
-        .finish_create_attached_function(
-            add_input_result.attached_function_id,
-            add_input_result.output_schema_str,
-        )
-        .await?;
+    let attached_function_id = add_input_result.attached_function_id;
+    retry_transient(|| {
+        let mut sysdb = sysdb.clone();
+        let output_schema_str = add_input_result.output_schema_str.clone();
+        async move {
+            sysdb
+                .finish_create_attached_function(attached_function_id, output_schema_str)
+                .await
+        }
+    })
+    .await?;
 
-    Ok((add_input_result.attached_function_id, true))
+    Ok((attached_function_id, true))
 }
 
 pub async fn prepare_add_attached_function_input(

--- a/rust/frontend-core/src/lib.rs
+++ b/rust/frontend-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod config;
 pub mod errors;
 pub mod foundation;
 pub mod middleware;
+pub mod retry;
 pub mod routes;
 pub mod traced_json;
 pub mod tracing;

--- a/rust/frontend-core/src/retry.rs
+++ b/rust/frontend-core/src/retry.rs
@@ -1,0 +1,109 @@
+//! Retry policy for transient sysdb failures.
+//!
+//! Setup operations (creating databases, collections, and attached functions)
+//! talk to sysdb over gRPC. A momentary backend hiccup — the service briefly
+//! `UNAVAILABLE`, an aborted Spanner transaction, a missed deadline — should
+//! not fail the whole operation. [`retry_transient`] rides those out with
+//! bounded exponential backoff while failing fast on deterministic
+//! client/logic errors (invalid argument, not found, already exists, …).
+//!
+//! Span instrumentation stays the caller's concern: callers wrap the operation
+//! in a `#[tracing::instrument]` span and the retry loop runs inside it (so the
+//! span covers every attempt and gives each retry warning its context). The
+//! loop itself only emits a `warn!` per retry via `.notify`, matching the
+//! workspace convention of driving `backon` directly with a small
+//! transient-error predicate plus a notify hook (cf. `is_retryable_error` and
+//! the `.notify` retry logs in `frontend/src/executor/distributed.rs` and
+//! `frontend/src/impls/service_based_frontend.rs`).
+//!
+//! Note the sysdb *client* does not retry; only the sysdb *server* retries its
+//! Spanner transactions. This loop adds the transport-level coverage (a dropped
+//! RPC, sysdb restarting) the server-side retries can't see. Callers must
+//! ensure the wrapped operation is idempotent, since it may run more than once.
+
+use std::future::Future;
+use std::time::Duration;
+
+use backon::{ExponentialBuilder, Retryable};
+use chroma_error::{ChromaError, ErrorCodes};
+
+/// Retries after the initial attempt before giving up.
+const MAX_RETRIES: usize = 3;
+/// Delay before the first retry; doubles each attempt up to [`MAX_DELAY`].
+const MIN_DELAY: Duration = Duration::from_millis(200);
+/// Ceiling on the backoff delay between attempts.
+const MAX_DELAY: Duration = Duration::from_secs(5);
+
+/// Whether a gRPC error code reflects a transient backend condition worth
+/// retrying rather than a deterministic failure. Use as the `backon`
+/// `.when(|e| is_transient(e.code()))` predicate.
+pub fn is_transient(code: ErrorCodes) -> bool {
+    matches!(
+        code,
+        ErrorCodes::Unavailable | ErrorCodes::Aborted | ErrorCodes::DeadlineExceeded
+    )
+}
+
+/// Bounded exponential backoff (with jitter) for transient sysdb retries.
+fn transient_backoff() -> ExponentialBuilder {
+    ExponentialBuilder::default()
+        .with_max_times(MAX_RETRIES)
+        .with_min_delay(MIN_DELAY)
+        .with_max_delay(MAX_DELAY)
+        .with_jitter()
+}
+
+/// Run an idempotent async sysdb `operation`, retrying only
+/// [transient](is_transient) failures with [`transient_backoff`] and emitting a
+/// `warn!` per retry (within the caller's span). Errors are returned unchanged
+/// once retries are exhausted (or immediately for non-transient errors), so
+/// callers keep their typed error and existing handling (e.g. mapping
+/// `AlreadyExists` to success).
+pub async fn retry_transient<T, E, F, Fut>(operation: F) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: ChromaError,
+{
+    operation
+        .retry(transient_backoff())
+        .when(|err: &E| is_transient(err.code()))
+        .notify(|err: &E, delay: Duration| {
+            tracing::warn!(
+                error = %err,
+                retry_after_ms = delay.as_millis() as u64,
+                "retrying transient sysdb failure",
+            );
+        })
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_codes_are_retried() {
+        for code in [
+            ErrorCodes::Unavailable,
+            ErrorCodes::Aborted,
+            ErrorCodes::DeadlineExceeded,
+        ] {
+            assert!(is_transient(code), "{code:?} should be retried");
+        }
+    }
+
+    #[test]
+    fn deterministic_codes_are_not_retried() {
+        for code in [
+            ErrorCodes::InvalidArgument,
+            ErrorCodes::NotFound,
+            ErrorCodes::AlreadyExists,
+            ErrorCodes::PermissionDenied,
+            ErrorCodes::Internal,
+            ErrorCodes::Unauthenticated,
+        ] {
+            assert!(!is_transient(code), "{code:?} should not be retried");
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds tracing **and** transient-failure retry to the `/api/init` Foundation bootstrap — database creation, collection creation, and function attachment.

> Note: this PR carries **both** the tracing and retry changes. The tracing change (originally #7311) was merged into its stacked base branch rather than `main`, so it never landed in `main`; it's re-landed here alongside retry. The schema/EF extraction (#7313) is already in `main`.

## Tracing
- `#[tracing::instrument]` spans on `foundation_init`, `ensure_database`, `ensure_collection`, plus start/complete and per-resource "ensured" logs.
- Spans + `created` / `already exists` logs on `attached_function_ops` (`create_attached_function`, `add_attached_function_input`), with `tenant` / `database_name` in the span fields.

## Retry
- New `frontend_core::retry::retry_transient` — pure `backon` wrapper gated on transient gRPC codes (`Unavailable`/`Aborted`/`DeadlineExceeded`), mirroring `is_retryable_error` in the distributed executor. Emits a `warn!` per retry via `.notify`; tracing spans stay the outer layer.
- Wraps the idempotent sysdb calls: `ensure_database`, `ensure_collection`, and the attach create/finish RPCs (attachment retries at the individual-RPC level so a transient `finish` failure isn't swallowed by the create RPC's `created=false` short-circuit).

## Testing
- `cargo clippy` clean; foundation-api init tests (10) + `retry` unit tests (2) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)