### PR TITLE
[FIX](cli): Fix chroma browse --local record loading

### DIFF
--- a/rust/chroma/src/client/chroma_http_client.rs
+++ b/rust/chroma/src/client/chroma_http_client.rs
@@ -710,7 +710,7 @@ impl ChromaHttpClient {
         let tenant_id = self.get_tenant_id().await?;
         let database_name = self.get_database_name().await?;
 
-        let collection: chroma_types::Collection = self
+        let mut collection: chroma_types::Collection = self
             .send_read_only::<(), _, chroma_types::Collection>(
                 "get_collection",
                 Method::GET,
@@ -724,6 +724,16 @@ impl ChromaHttpClient {
                 None::<()>,
             )
             .await?;
+
+        // Local servers may return empty tenant/database in the collection
+        // response. Fall back to the client's resolved values so that
+        // subsequent collection operations build correct API URLs.
+        if collection.tenant.is_empty() {
+            collection.tenant = tenant_id;
+        }
+        if collection.database.is_empty() {
+            collection.database = database_name;
+        }
 
         Ok(ChromaCollection::new(self.clone(), collection))
     }
@@ -756,7 +766,7 @@ impl ChromaHttpClient {
         let tenant_id = self.get_tenant_id().await?;
         let database_name = self.get_database_name().await?;
 
-        let collection: chroma_types::Collection = self
+        let mut collection: chroma_types::Collection = self
             .send_read_only::<(), _, chroma_types::Collection>(
                 "get_collection_by_id",
                 Method::GET,
@@ -771,9 +781,18 @@ impl ChromaHttpClient {
             )
             .await?;
 
+        // Local servers may return empty tenant/database in the collection
+        // response. Fall back to the client's resolved values so that
+        // subsequent collection operations build correct API URLs.
+        if collection.tenant.is_empty() {
+            collection.tenant = tenant_id;
+        }
+        if collection.database.is_empty() {
+            collection.database = database_name;
+        }
+
         Ok(ChromaCollection::new(self.clone(), collection))
     }
-
     /// Retrieves an attached function by name for a specific collection.
     pub async fn get_attached_function(
         &self,

--- a/rust/cli/src/tui/collection_browser/events.rs
+++ b/rust/cli/src/tui/collection_browser/events.rs
@@ -2,8 +2,6 @@ use crate::tui::collection_browser::app_state::AppState;
 use crate::tui::collection_browser::query_editor::Mode;
 use crate::tui::collection_browser::{Record, Screen};
 use chroma::ChromaCollection;
-use chroma_types::operator::Key;
-use chroma_types::plan::SearchPayload;
 use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyModifiers};
 use futures::StreamExt;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
@@ -159,33 +157,25 @@ impl EventsHandler {
         let collection = self.collection.clone();
 
         tokio::spawn(async move {
-            let mut search = SearchPayload::default().select([Key::Document, Key::Metadata]);
-
-            if let Some(ids) = ids {
-                search.filter.query_ids = Some(ids);
-            }
             let r#where = [where_document, metadata]
                 .into_iter()
                 .flatten()
                 .reduce(|a, b| a & b);
-            if let Some(w) = r#where {
-                search = search.r#where(w);
-            }
 
-            let records_response = collection.search(vec![search]).await;
+            let records_response = collection.get(ids, r#where, None, None, None).await;
 
             match records_response {
                 Ok(response) => {
-                    let ids = response.ids.into_iter().next().unwrap_or_default();
-                    let documents = response.documents.into_iter().next().flatten();
-                    let metadatas = response.metadatas.into_iter().next().flatten();
+                    let ids = response.ids;
+                    let documents = response.documents;
+                    let metadatas = response.metadatas;
                     let records = Self::search_response_to_records(ids, documents, metadatas);
                     let _ = tx.send(Action::SearchResult(SearchResultAction::RecordsLoaded(
                         records,
                     )));
                 }
-                Err(_) => {
-                    let _ = tx.send(Action::Error(String::from("Failed to submit search")));
+                Err(e) => {
+                    let _ = tx.send(Action::Error(format!("Failed to submit search: {}", e)));
                 }
             }
         });

--- a/rust/cli/src/tui/collection_browser/events.rs
+++ b/rust/cli/src/tui/collection_browser/events.rs
@@ -112,22 +112,19 @@ impl EventsHandler {
                 0
             });
 
-            let search = SearchPayload::default()
-                .limit(Some(limit), offset)
-                .select([Key::Document, Key::Metadata]);
-
-            let records_response = collection.search(vec![search]).await;
+            let records_response = collection
+                .get(None, None, Some(limit), Some(offset), None)
+                .await;
 
             match records_response {
                 Ok(response) => {
-                    let ids = response.ids.into_iter().next().unwrap_or_default();
-                    let documents = response.documents.into_iter().next().flatten();
-                    let metadatas = response.metadatas.into_iter().next().flatten();
-                    let records = Self::search_response_to_records(ids, documents, metadatas);
+                    let documents = response.documents;
+                    let metadatas = response.metadatas;
+                    let records = Self::search_response_to_records(response.ids, documents, metadatas);
                     let _ = tx.send(Action::Main(MainAction::RecordsLoaded(records, count)));
                 }
-                Err(_) => {
-                    let _ = tx.send(Action::Error(String::from("Failed to load records")));
+                Err(e) => {
+                    let _ = tx.send(Action::Error(format!("Failed to load records: {}", e)));
                 }
             }
         });

--- a/rust/types/idl
+++ b/rust/types/idl
@@ -1,1 +1,1 @@
-../../idl
+C:/Users/nanda/chroma/idl


### PR DESCRIPTION
## Description:
Fixes #7269
- This PR fixes the chroma browse --local command failing to load records due to empty routing parameters and an unsupported search executor.

- Fix Malformed URLs (chroma_http_client.rs): Local servers return empty strings for tenant and database upon collection fetch. Added fallbacks to patch these with the resolved client defaults, ensuring subsequent v2 API calls are routed correctly.

- Fix Unsupported Executor (events.rs): Replaced collection.search() with collection.get() in both load_records and submit_search. The search endpoint is not implemented for the local executor, while get safely handles the required offset/limit pagination.

- UX Improvement: Updated TUI error handlers to surface the actual underlying error messages instead of swallowing them into a generic failure state.