### PR TITLE
[ENH](foundation): Propagate traces to HTTP functions

### DIFF
--- a/rust/worker/src/execution/functions/http_currents.rs
+++ b/rust/worker/src/execution/functions/http_currents.rs
@@ -6,6 +6,7 @@ use chroma_types::{AttachedFunction, Chunk, LogRecord};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::execution::functions::trace_headers::current_trace_headers;
 use crate::execution::operators::execute_task::{AttachedFunctionExecutor, HydratedInputBatch};
 
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
@@ -143,6 +144,7 @@ impl HttpCurrentsExecutor {
         let response = self
             .client
             .post(&currents_url)
+            .headers(current_trace_headers())
             .header("Modal-Key", &self.modal_key)
             .header("Modal-Secret", &self.modal_secret)
             .json(request_body)

--- a/rust/worker/src/execution/functions/http_generate.rs
+++ b/rust/worker/src/execution/functions/http_generate.rs
@@ -8,6 +8,7 @@ use frontend_core::foundation::source_kind_for_collection_name;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::execution::functions::trace_headers::current_trace_headers;
 use crate::execution::operators::execute_task::{AttachedFunctionExecutor, HydratedInputBatch};
 
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
@@ -143,6 +144,7 @@ impl HttpGenerateExecutor {
         let response = self
             .client
             .post(&generate_url)
+            .headers(current_trace_headers())
             .header("Modal-Key", &self.modal_key)
             .header("Modal-Secret", &self.modal_secret)
             .json(request_body)

--- a/rust/worker/src/execution/functions/mod.rs
+++ b/rust/worker/src/execution/functions/mod.rs
@@ -3,6 +3,7 @@ pub mod http_currents;
 pub mod http_generate;
 pub mod revision_history;
 mod statistics;
+mod trace_headers;
 
 pub use count_to_file_async::CountToFileAsyncExecutor;
 pub use http_currents::HttpCurrentsExecutor;

--- a/rust/worker/src/execution/functions/trace_headers.rs
+++ b/rust/worker/src/execution/functions/trace_headers.rs
@@ -1,0 +1,28 @@
+use opentelemetry::global;
+use opentelemetry::propagation::Injector;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+struct ReqwestHeaderInjector<'a>(&'a mut reqwest::header::HeaderMap);
+
+impl Injector for ReqwestHeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        let Ok(name) = reqwest::header::HeaderName::from_bytes(key.as_bytes()) else {
+            return;
+        };
+        let Ok(value) = reqwest::header::HeaderValue::from_str(&value) else {
+            return;
+        };
+        self.0.insert(name, value);
+    }
+}
+
+pub fn current_trace_headers() -> reqwest::header::HeaderMap {
+    let mut headers = reqwest::header::HeaderMap::new();
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(
+            &tracing::Span::current().context(),
+            &mut ReqwestHeaderInjector(&mut headers),
+        );
+    });
+    headers
+}


### PR DESCRIPTION
## Summary

- inject W3C trace context headers into foundation HTTP function POSTs
- share a small reqwest header injector between generate and currents executors
- lets foundation-research Modal spans attach to the caller trace 

## Verification

- cargo fmt --package worker
- cargo check -p worker