### PR TITLE
[ENH](logservice): add conditional push and insert offset to proto

### DIFF
--- a/idl/chromadb/proto/logservice.proto
+++ b/idl/chromadb/proto/logservice.proto
@@ -17,11 +17,18 @@ message PushLogsRequest {
   string database_name = 5;
   repeated OperationRecord records = 2;
   optional Cmek cmek = 3;  // Encryption key for log fragments
+  optional PushLogsCondition condition = 4;
+}
+
+message PushLogsCondition {
+  int64 observed_log_offset = 1;
+  repeated string read_ids = 2;
 }
 
 message PushLogsResponse {
   int32 record_count = 1;
   bool log_is_sealed = 2;
+  optional int64 first_inserted_record_offset = 3;
 }
 
 message ScoutLogsRequest {

--- a/idl/chromadb/proto/logservice.proto
+++ b/idl/chromadb/proto/logservice.proto
@@ -17,17 +17,27 @@ message PushLogsRequest {
   string database_name = 5;
   repeated OperationRecord records = 2;
   optional Cmek cmek = 3;  // Encryption key for log fragments
+  // Optimistic-concurrency guard for the append. When present, the service
+  // appends records only if the condition still holds at commit time.
   optional PushLogsCondition condition = 4;
 }
 
 message PushLogsCondition {
+  // Log upper-bound offset observed by the caller's read snapshot. The service
+  // checks records at offsets >= this value for conflicting writes.
   int64 observed_log_offset = 1;
+  // IDs read by the caller's snapshot. A conditional push aborts if any read ID,
+  // or any ID written by this request, has a conflicting write after the
+  // observed offset.
   repeated string read_ids = 2;
 }
 
 message PushLogsResponse {
   int32 record_count = 1;
   bool log_is_sealed = 2;
+  // Offset assigned to the first record inserted by this push, when the service
+  // can determine it. This is absent if the append succeeds but durable
+  // contention hides the exact start offset.
   optional int64 first_inserted_record_offset = 3;
 }
 

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -152,6 +152,7 @@ impl ChromaGrpcClients {
             records,
             cmek: None,
             database_name: "test_db".to_string(),
+            condition: None,
         };
 
         let response = self.log_service.push_logs(push_req).await?;

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2344,6 +2344,7 @@ impl LogServer {
         Ok(Response::new(PushLogsResponse {
             record_count,
             log_is_sealed: false,
+            first_inserted_record_offset: None,
         }))
     }
 
@@ -5329,6 +5330,7 @@ mod tests {
                     .expect("Logs should be valid"),
                 cmek: None,
                 database_name: db_name.to_string(),
+                condition: None,
             });
             if let Err(err) = server.push_logs(proto_push_log_req).await {
                 if err.code() == Code::Unavailable {
@@ -5366,6 +5368,7 @@ mod tests {
             .expect("operation record should convert to proto")],
             cmek: None,
             database_name: "default_database".to_string(),
+            condition: None,
         };
 
         log_server.faults.inject(

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -488,6 +488,7 @@ impl GrpcLog {
                     RecordConversionError,
                 >>()?,
             cmek: cmek_proto,
+            condition: None,
         };
 
         let resp = self


### PR DESCRIPTION
## Description of changes

Extend PushLogsRequest and PushLogsResponse to support conditional
log appends:
- Add optional PushLogsCondition with observed_log_offset and read_ids
- Add optional first_inserted_record_offset to PushLogsResponse

Update all PushLogsRequest construction sites and the log-service
response to populate the new fields with None defaults.

## Test plan

CI

## Migration plan

Backwards compatible

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI