### PR TITLE
[ENH](wal3): add AppendOptions for conditional appends

### DIFF
--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -1,16 +1,16 @@
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use setsum::Setsum;
-use tracing::Span;
-
 use chroma_storage::{
     admissioncontrolleds3::StorageRequestPriority, ETag, PutMode, PutOptions, Storage, StorageError,
 };
 use chroma_types::Cmek;
+use setsum::Setsum;
 
 use crate::backoff::ExponentialBackoff;
-use crate::interfaces::{FragmentPointer, FragmentPublisher, ManifestPublisher, UploadResult};
+use crate::interfaces::{
+    AppendWork, FragmentPointer, FragmentPublisher, ManifestPublisher, UploadResult,
+};
 use crate::{Error, FragmentIdentifier, Garbage, LogPosition, LogWriterOptions, ThrottleOptions};
 
 use super::FragmentUploader;
@@ -24,11 +24,7 @@ struct ManagerState {
     backoff: bool,
     next_write: Instant,
     writers_active: usize,
-    enqueued: Vec<(
-        Vec<Vec<u8>>,
-        tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
-        Span,
-    )>,
+    enqueued: Vec<AppendWork>,
     tearing_down: bool,
 }
 
@@ -74,8 +70,8 @@ impl ManagerState {
 
 impl Drop for ManagerState {
     fn drop(&mut self) {
-        for (_, notify, _) in std::mem::take(&mut self.enqueued).into_iter() {
-            let _ = notify.send(Err(Error::LogContentionRetry));
+        for work in std::mem::take(&mut self.enqueued).into_iter() {
+            let _ = work.tx.send(Err(Error::LogContentionRetry));
         }
     }
 }
@@ -137,22 +133,17 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
     type FragmentPointer = FP;
 
     /// Enqueue work to be published.
-    async fn push_work(
-        &self,
-        messages: Vec<Vec<u8>>,
-        tx: tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
-        span: Span,
-    ) {
+    async fn push_work(&self, work: AppendWork) {
         // SAFETY(rescrv): Mutex poisoning.
         let mut state = self.state.lock().unwrap();
         if state.tearing_down {
-            let _ = tx.send(Err(Error::LogContentionRetry));
+            let _ = work.tx.send(Err(Error::LogContentionRetry));
             self.write_finished.notify_one();
         } else if state.backoff {
-            let _ = tx.send(Err(Error::Backoff));
+            let _ = work.tx.send(Err(Error::Backoff));
             self.write_finished.notify_one();
         } else {
-            state.enqueued.push((messages, tx, span));
+            state.enqueued.push(work);
         }
     }
 
@@ -160,17 +151,7 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
     async fn take_work(
         &self,
         manifest_manager: &(dyn ManifestPublisher<Self::FragmentPointer> + Sync),
-    ) -> Result<
-        Option<(
-            Self::FragmentPointer,
-            Vec<(
-                Vec<Vec<u8>>,
-                tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
-                Span,
-            )>,
-        )>,
-        Error,
-    > {
+    ) -> Result<Option<(Self::FragmentPointer, Vec<AppendWork>)>, Error> {
         // SAFETY(rescrv): Mutex poisoning.
         let mut state = self.state.lock().unwrap();
 
@@ -192,9 +173,9 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
         let mut did_split = false;
         // This loop has two sets of exit conditions that are identical, but switched on
         // `short_read`.
-        for (batch, _, _) in state.enqueued.iter() {
-            let cur_count = batch.len();
-            let cur_bytes = batch.iter().map(|r| r.len()).sum::<usize>();
+        for work in state.enqueued.iter() {
+            let cur_count = work.record_count();
+            let cur_bytes = work.byte_count();
             if split_off > 0
                 && acc_bytes + cur_bytes >= self.options.throttle_fragment.batch_size_bytes
             {
@@ -229,7 +210,7 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
             state.backoff = state
                 .enqueued
                 .iter()
-                .map(|(recs, _, _)| recs.iter().map(|r| r.len()).sum::<usize>())
+                .map(AppendWork::byte_count)
                 .sum::<usize>()
                 >= self.options.throttle_fragment.batch_size_bytes;
             self.write_finished.notify_one();
@@ -307,8 +288,8 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
             state.tearing_down = true;
             std::mem::take(&mut state.enqueued)
         };
-        for (_, tx, _) in enqueued {
-            let _ = tx.send(Err(Error::LogContentionRetry));
+        for work in enqueued {
+            let _ = work.tx.send(Err(Error::LogContentionRetry));
         }
     }
 
@@ -477,8 +458,8 @@ mod tests {
     use crate::interfaces::s3::manifest_manager::ManifestManager;
     use crate::interfaces::s3::S3FragmentUploader;
     use crate::{
-        FragmentSeqNo, FragmentUuid, LogWriterOptions, SnapshotOptions, StorageWrapper,
-        ThrottleOptions,
+        AppendOptions, FragmentSeqNo, FragmentUuid, LogWriterOptions, SnapshotOptions,
+        StorageWrapper, ThrottleOptions,
     };
 
     #[tokio::test]
@@ -558,16 +539,32 @@ mod tests {
         .await
         .unwrap();
         let (tx, _rx1) = tokio::sync::oneshot::channel();
+        let options1 = AppendOptions::new(Vec::from("metadata-1"));
         batch_manager
-            .push_work(vec![vec![1]], tx, tracing::Span::current())
+            .push_work(AppendWork::new(
+                vec![vec![1]],
+                Some(options1.clone()),
+                tx,
+                tracing::Span::current(),
+            ))
             .await;
         let (tx, _rx2) = tokio::sync::oneshot::channel();
         batch_manager
-            .push_work(vec![vec![2, 3]], tx, tracing::Span::current())
+            .push_work(AppendWork::new(
+                vec![vec![2, 3]],
+                None,
+                tx,
+                tracing::Span::current(),
+            ))
             .await;
         let (tx, _rx3) = tokio::sync::oneshot::channel();
         batch_manager
-            .push_work(vec![vec![4, 5, 6]], tx, tracing::Span::current())
+            .push_work(AppendWork::new(
+                vec![vec![4, 5, 6]],
+                None,
+                tx,
+                tracing::Span::current(),
+            ))
             .await;
         let ((seq_no, log_position), work) = batch_manager
             .take_work(&manifest_manager)
@@ -578,9 +575,17 @@ mod tests {
         assert_eq!(log_position.offset(), 1);
         assert_eq!(2, work.len());
         // Check batch 1
-        assert_eq!(vec![vec![1]], work[0].0);
+        assert_eq!(vec![vec![1]], work[0].messages);
+        assert_eq!(
+            Some(options1.admission_metadata.as_ref()),
+            work[0]
+                .options
+                .as_ref()
+                .map(|options| options.admission_metadata.as_ref())
+        );
         // Check batch 2
-        assert_eq!(vec![vec![2, 3]], work[1].0);
+        assert_eq!(vec![vec![2, 3]], work[1].messages);
+        assert!(work[1].options.is_none());
     }
 
     struct DualStorageUploader {

--- a/rust/wal3/src/interfaces/mod.rs
+++ b/rust/wal3/src/interfaces/mod.rs
@@ -10,10 +10,10 @@ use chroma_storage::{ETag, Storage};
 use chroma_types::Cmek;
 
 use crate::{
-    reader::Limits, CursorWitness, Error, Fragment, FragmentIdentifier, FragmentSeqNo,
-    FragmentUuid, Garbage, GarbageCollectionOptions, LogPosition, LogWriterOptions, Manifest,
-    ManifestAndWitness, ManifestBounds, ManifestBoundsAndWitness, Snapshot, SnapshotPointer,
-    StorageWrapper, ThrottleOptions,
+    reader::Limits, AppendOptions, CursorWitness, Error, Fragment, FragmentIdentifier,
+    FragmentSeqNo, FragmentUuid, Garbage, GarbageCollectionOptions, LogPosition, LogWriterOptions,
+    Manifest, ManifestAndWitness, ManifestBounds, ManifestBoundsAndWitness, Snapshot,
+    SnapshotPointer, StorageWrapper, ThrottleOptions,
 };
 
 pub mod batch_manager;
@@ -261,32 +261,17 @@ where
 {
     type FragmentPointer = FP;
 
-    async fn push_work(
-        &self,
-        messages: Vec<Vec<u8>>,
-        tx: tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
-        span: Span,
-    ) {
+    async fn push_work(&self, work: AppendWork) {
         match self {
-            Self::Plain(publisher) => publisher.push_work(messages, tx, span).await,
-            Self::FaultInjecting(publisher) => publisher.push_work(messages, tx, span).await,
+            Self::Plain(publisher) => publisher.push_work(work).await,
+            Self::FaultInjecting(publisher) => publisher.push_work(work).await,
         }
     }
 
     async fn take_work(
         &self,
         manifest_manager: &(dyn ManifestPublisher<Self::FragmentPointer> + Sync),
-    ) -> Result<
-        Option<(
-            Self::FragmentPointer,
-            Vec<(
-                Vec<Vec<u8>>,
-                tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
-                Span,
-            )>,
-        )>,
-        Error,
-    > {
+    ) -> Result<Option<(Self::FragmentPointer, Vec<AppendWork>)>, Error> {
         match self {
             Self::Plain(publisher) => publisher.take_work(manifest_manager).await,
             Self::FaultInjecting(publisher) => publisher.take_work(manifest_manager).await,
@@ -507,32 +492,59 @@ pub trait FragmentUploader<FP: FragmentPointer>: Send + Sync + 'static {
 
 ///////////////////////////////////////// FragmentPublisher ////////////////////////////////////////
 
+/// One enqueued append request awaiting publication.
+pub struct AppendWork {
+    pub messages: Vec<Vec<u8>>,
+    pub options: Option<AppendOptions>,
+    pub tx: tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
+    pub span: Span,
+}
+
+impl AppendWork {
+    pub fn new(
+        messages: Vec<Vec<u8>>,
+        options: Option<AppendOptions>,
+        tx: tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
+        span: Span,
+    ) -> Self {
+        Self {
+            messages,
+            options,
+            tx,
+            span,
+        }
+    }
+
+    pub fn record_count(&self) -> usize {
+        self.messages.len()
+    }
+
+    pub fn byte_count(&self) -> usize {
+        self.messages.iter().map(|r| r.len()).sum()
+    }
+}
+
+impl std::fmt::Debug for AppendWork {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("AppendWork")
+            .field("record_count", &self.record_count())
+            .field("byte_count", &self.byte_count())
+            .field("options", &self.options)
+            .finish_non_exhaustive()
+    }
+}
+
 #[async_trait::async_trait]
 pub trait FragmentPublisher: Send + Sync + 'static {
     type FragmentPointer: FragmentPointer;
 
     /// Enqueue work to be published.
-    async fn push_work(
-        &self,
-        messages: Vec<Vec<u8>>,
-        tx: tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
-        span: Span,
-    );
+    async fn push_work(&self, work: AppendWork);
     /// Take enqueued work to be published.
     async fn take_work(
         &self,
         manifest_manager: &(dyn ManifestPublisher<Self::FragmentPointer> + Sync),
-    ) -> Result<
-        Option<(
-            Self::FragmentPointer,
-            Vec<(
-                Vec<Vec<u8>>,
-                tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
-                Span,
-            )>,
-        )>,
-        Error,
-    >;
+    ) -> Result<Option<(Self::FragmentPointer, Vec<AppendWork>)>, Error>;
     /// Finish the previous call to take_work.
     async fn finish_write(&self);
 

--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -35,11 +35,11 @@ pub use interfaces::s3::{
     S3FragmentPuller, S3FragmentUploader, S3ManifestManagerFactory,
 };
 pub use interfaces::{
-    fragment_upload_replica_fault_label, BatchManager, FaultInjectingFragmentManagerFactory,
-    FragmentConsumer, FragmentManagerFactory, FragmentPointer, FragmentPublisher,
-    FragmentUploadFault, FragmentUploadFaultInjector, FragmentUploader, ManifestConsumer,
-    ManifestManagerFactory, ManifestPublisher, ManifestWitness, PositionWitness,
-    FRAGMENT_UPLOAD_FAULT_LABEL, FRAGMENT_UPLOAD_REPLICA_FAULT_LABELS,
+    fragment_upload_replica_fault_label, AppendWork, BatchManager,
+    FaultInjectingFragmentManagerFactory, FragmentConsumer, FragmentManagerFactory,
+    FragmentPointer, FragmentPublisher, FragmentUploadFault, FragmentUploadFaultInjector,
+    FragmentUploader, ManifestConsumer, ManifestManagerFactory, ManifestPublisher, ManifestWitness,
+    PositionWitness, FRAGMENT_UPLOAD_FAULT_LABEL, FRAGMENT_UPLOAD_REPLICA_FAULT_LABELS,
 };
 pub use manifest::{
     unprefixed_snapshot_path, Manifest, ManifestAndWitness, ManifestBounds,
@@ -541,6 +541,66 @@ impl Default for SnapshotOptions {
     }
 }
 
+////////////////////////////////////////// AppendOptions ///////////////////////////////////////////
+
+/// A synchronous predicate that can inspect earlier enqueued append metadata before admitting an
+/// append.
+pub type AdmissionPredicate = Arc<dyn Fn(&[Arc<[u8]>]) -> bool + Send + Sync + 'static>;
+
+/// Optional controls that travel with one append request.
+#[derive(Clone)]
+pub struct AppendOptions {
+    /// Opaque metadata exposed to later admission predicates.
+    pub admission_metadata: Arc<[u8]>,
+    /// Optional admission predicate evaluated before the append is admitted to the batch.
+    pub admission_predicate: Option<AdmissionPredicate>,
+    /// Optional requirement for the fragment start position selected for this append.
+    pub required_fragment_start: Option<LogPosition>,
+}
+
+impl AppendOptions {
+    /// Create append options with admission metadata and no predicate or fragment-start
+    /// requirement.
+    pub fn new(admission_metadata: impl Into<Arc<[u8]>>) -> Self {
+        Self {
+            admission_metadata: admission_metadata.into(),
+            admission_predicate: None,
+            required_fragment_start: None,
+        }
+    }
+
+    /// Attach an admission predicate.
+    pub fn with_admission_predicate(mut self, admission_predicate: AdmissionPredicate) -> Self {
+        self.admission_predicate = Some(admission_predicate);
+        self
+    }
+
+    /// Attach a required fragment start.
+    pub fn with_required_fragment_start(mut self, required_fragment_start: LogPosition) -> Self {
+        self.required_fragment_start = Some(required_fragment_start);
+        self
+    }
+}
+
+impl Default for AppendOptions {
+    fn default() -> Self {
+        Self::new(Arc::<[u8]>::from([]))
+    }
+}
+
+impl std::fmt::Debug for AppendOptions {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("AppendOptions")
+            .field("admission_metadata_len", &self.admission_metadata.len())
+            .field(
+                "has_admission_predicate",
+                &self.admission_predicate.is_some(),
+            )
+            .field("required_fragment_start", &self.required_fragment_start)
+            .finish()
+    }
+}
+
 ///////////////////////////////////////// LogWriterOptions /////////////////////////////////////////
 
 /// LogWriterOptions control the behavior of the log writer.
@@ -947,10 +1007,28 @@ pub fn fragment_path(prefix: &str, path: &str) -> String {
 #[async_trait::async_trait]
 pub trait LogWriterTrait: std::fmt::Debug + Send + Sync + 'static {
     /// Append a single message to the log.
-    async fn append(&self, message: Vec<u8>) -> Result<LogPosition, Error>;
+    async fn append(&self, message: Vec<u8>) -> Result<LogPosition, Error> {
+        self.append_with_options(message, None).await
+    }
+
+    /// Append a single message to the log with options.
+    async fn append_with_options(
+        &self,
+        message: Vec<u8>,
+        options: Option<AppendOptions>,
+    ) -> Result<LogPosition, Error>;
 
     /// Append multiple messages to the log atomically.
-    async fn append_many(&self, messages: Vec<Vec<u8>>) -> Result<LogPosition, Error>;
+    async fn append_many(&self, messages: Vec<Vec<u8>>) -> Result<LogPosition, Error> {
+        self.append_many_with_options(messages, None).await
+    }
+
+    /// Append multiple messages to the log atomically with options.
+    async fn append_many_with_options(
+        &self,
+        messages: Vec<Vec<u8>>,
+        options: Option<AppendOptions>,
+    ) -> Result<LogPosition, Error>;
 
     /// Returns a possibly-stale copy of the manifest with a witness for verification.
     async fn manifest_and_witness(&self) -> Result<ManifestAndWitness, Error>;
@@ -1004,12 +1082,20 @@ where
     FP::Consumer: 'static,
     MP::Consumer: 'static,
 {
-    async fn append(&self, message: Vec<u8>) -> Result<LogPosition, Error> {
-        LogWriter::append(self, message).await
+    async fn append_with_options(
+        &self,
+        message: Vec<u8>,
+        options: Option<AppendOptions>,
+    ) -> Result<LogPosition, Error> {
+        LogWriter::append_with_options(self, message, options).await
     }
 
-    async fn append_many(&self, messages: Vec<Vec<u8>>) -> Result<LogPosition, Error> {
-        LogWriter::append_many(self, messages).await
+    async fn append_many_with_options(
+        &self,
+        messages: Vec<Vec<u8>>,
+        options: Option<AppendOptions>,
+    ) -> Result<LogPosition, Error> {
+        LogWriter::append_many_with_options(self, messages, options).await
     }
 
     async fn manifest_and_witness(&self) -> Result<ManifestAndWitness, Error> {

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -12,7 +12,7 @@ use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use setsum::Setsum;
-use tracing::{Instrument, Level, Span};
+use tracing::{Instrument, Level};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::interfaces::s3::fragment_uploader::S3FragmentUploader;
@@ -21,10 +21,10 @@ use crate::interfaces::{
     ManifestPublisher,
 };
 use crate::{
-    parse_fragment_path, BatchManager, CursorStore, CursorStoreOptions, Error, ExponentialBackoff,
-    Fragment, FragmentSeqNo, FragmentUuid, Garbage, GarbageCollectionOptions,
-    GarbageCollectionState, LogPosition, LogReader, LogReaderOptions, LogWriterOptions, Manifest,
-    ManifestAndWitness, ManifestManager,
+    parse_fragment_path, AppendOptions, AppendWork, BatchManager, CursorStore, CursorStoreOptions,
+    Error, ExponentialBackoff, Fragment, FragmentSeqNo, FragmentUuid, Garbage,
+    GarbageCollectionOptions, GarbageCollectionState, LogPosition, LogReader, LogReaderOptions,
+    LogWriterOptions, Manifest, ManifestAndWitness, ManifestManager,
 };
 
 /// The epoch writer is a counting writer.  Every epoch exists.  An epoch goes
@@ -255,16 +255,35 @@ impl<
 
     /// Append a message to a log.
     pub async fn append(&self, message: Vec<u8>) -> Result<LogPosition, Error> {
-        self.append_many(vec![message]).await
+        self.append_with_options(message, None).await
+    }
+
+    /// Append a message to a log with options.
+    pub async fn append_with_options(
+        &self,
+        message: Vec<u8>,
+        options: Option<AppendOptions>,
+    ) -> Result<LogPosition, Error> {
+        self.append_many_with_options(vec![message], options).await
     }
 
     #[tracing::instrument(skip(self, messages))]
     pub async fn append_many(&self, messages: Vec<Vec<u8>>) -> Result<LogPosition, Error> {
+        self.append_many_with_options(messages, None).await
+    }
+
+    #[tracing::instrument(skip(self, messages, options))]
+    pub async fn append_many_with_options(
+        &self,
+        messages: Vec<Vec<u8>>,
+        options: Option<AppendOptions>,
+    ) -> Result<LogPosition, Error> {
         let once_log_append_many =
             move |log: &Arc<OnceLogWriter<P, FP::Publisher, MP::Publisher>>| {
                 let messages = messages.clone();
+                let options = options.clone();
                 let log = Arc::clone(log);
-                async move { log.append(messages).await }
+                async move { log.append(messages, options).await }
             };
         self.handle_errors_and_contention(once_log_append_many)
             .await
@@ -616,7 +635,11 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
         Ok(())
     }
 
-    async fn append(self: &Arc<Self>, messages: Vec<Vec<u8>>) -> Result<LogPosition, Error> {
+    async fn append(
+        self: &Arc<Self>,
+        messages: Vec<Vec<u8>>,
+        options: Option<AppendOptions>,
+    ) -> Result<LogPosition, Error> {
         if messages.is_empty() {
             return Err(Error::EmptyBatch);
         }
@@ -625,7 +648,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
         async move {
             let (tx, rx) = tokio::sync::oneshot::channel();
             self.batch_manager
-                .push_work(messages, tx, append_span)
+                .push_work(AppendWork::new(messages, options, tx, append_span))
                 .await;
             match self.batch_manager.take_work(&self.manifest_manager).await {
                 Ok(Some(work)) => {
@@ -648,27 +671,23 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
         .await
     }
 
-    #[allow(clippy::type_complexity)]
-    async fn append_batch(
-        self: Arc<Self>,
-        pointer: P,
-        work: Vec<(
-            Vec<Vec<u8>>,
-            tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
-            Span,
-        )>,
-    ) {
+    async fn append_batch(self: Arc<Self>, pointer: P, work: Vec<AppendWork>) {
         let append_batch_span = tracing::info_span!("append_batch");
         let mut messages = Vec::with_capacity(work.len());
         let mut notifies = Vec::with_capacity(work.len());
         for work in work.into_iter() {
-            notifies.push((work.0.len(), work.1));
-            messages.extend(work.0);
+            let AppendWork {
+                messages: work_messages,
+                options: _,
+                tx,
+                span,
+            } = work;
+            notifies.push((work_messages.len(), tx));
+            messages.extend(work_messages);
             // NOTE(rescrv):  This returns a context that returns a reference to the span, from
             // which we get a span context that we clone.  My initial read of this was to interpret
             // it as creating a span and that is not the case.
-            work.2
-                .add_link(append_batch_span.context().span().span_context().clone());
+            span.add_link(append_batch_span.context().span().span_context().clone());
         }
         async move {
             if notifies.is_empty() {
@@ -1648,29 +1667,14 @@ mod tests {
     impl crate::FragmentPublisher for TestFragmentPublisher {
         type FragmentPointer = (FragmentSeqNo, LogPosition);
 
-        async fn push_work(
-            &self,
-            _messages: Vec<Vec<u8>>,
-            _tx: tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
-            _span: Span,
-        ) {
+        async fn push_work(&self, _work: crate::AppendWork) {
             unreachable!("push_work is not used in this test")
         }
 
         async fn take_work(
             &self,
             _manifest_manager: &(dyn crate::ManifestPublisher<Self::FragmentPointer> + Sync),
-        ) -> Result<
-            Option<(
-                Self::FragmentPointer,
-                Vec<(
-                    Vec<Vec<u8>>,
-                    tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
-                    Span,
-                )>,
-            )>,
-            Error,
-        > {
+        ) -> Result<Option<(Self::FragmentPointer, Vec<crate::AppendWork>)>, Error> {
             unreachable!("take_work is not used in this test")
         }
 


### PR DESCRIPTION
## Description of changes

Introduce AppendOptions carrying admission metadata, an optional
admission predicate, and an optional required fragment start, plumbed
through new append_with_options and append_many_with_options methods on
LogWriter and LogWriterTrait. The original append and append_many become
default wrappers that pass no options.

Replace the ad-hoc (messages, tx, span) work tuple with an AppendWork
struct so the enqueued metadata and options travel together through
push_work and take_work, simplifying the FragmentPublisher signatures.

## Test plan

CI

## Migration plan

Backwards-compatible

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
