### PR TITLE
[ENH](wal3): enforce required_fragment_start on publish

### DIFF
--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -69,6 +69,62 @@ impl ManagerState {
     }
 }
 
+fn required_fragment_start_for_selected(
+    selected: &[AppendWork],
+) -> Result<Option<LogPosition>, Error> {
+    let mut required_fragment_start = None;
+    for work in selected {
+        let Some(next_required_fragment_start) = work.required_fragment_start() else {
+            continue;
+        };
+        if let Some(required_fragment_start) = required_fragment_start {
+            if required_fragment_start != next_required_fragment_start {
+                tracing::error!(
+                    ?required_fragment_start,
+                    ?next_required_fragment_start,
+                    selected_work_count = selected.len(),
+                    "selected wal3 batch has incompatible required_fragment_start values"
+                );
+                return Err(Error::LogContentionRetry);
+            }
+        } else {
+            required_fragment_start = Some(next_required_fragment_start);
+        }
+    }
+    Ok(required_fragment_start)
+}
+
+fn take_selected_work(state: &mut ManagerState, split_off: usize) -> Vec<AppendWork> {
+    let mut work = std::mem::take(&mut state.enqueued);
+    state.enqueued = work.split_off(split_off);
+    let mut admission_metadata = std::mem::take(&mut state.admission_metadata);
+    state.admission_metadata = admission_metadata.split_off(split_off);
+    debug_assert_eq!(work.len(), admission_metadata.len());
+    debug_assert_eq!(state.enqueued.len(), state.admission_metadata.len());
+    work
+}
+
+fn refresh_backoff_after_split(state: &mut ManagerState, options: &LogWriterOptions) -> bool {
+    if !state.enqueued.is_empty() {
+        state.backoff = state
+            .enqueued
+            .iter()
+            .map(AppendWork::byte_count)
+            .sum::<usize>()
+            >= options.throttle_fragment.batch_size_bytes;
+        true
+    } else {
+        state.backoff = false;
+        false
+    }
+}
+
+fn reject_selected_work(work: Vec<AppendWork>, err: Error) {
+    for work in work {
+        let _ = work.tx.send(Err(err.clone()));
+    }
+}
+
 impl Drop for ManagerState {
     fn drop(&mut self) {
         for work in std::mem::take(&mut self.enqueued).into_iter() {
@@ -166,7 +222,7 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
     async fn take_work(
         &self,
         manifest_manager: &(dyn ManifestPublisher<Self::FragmentPointer> + Sync),
-    ) -> Result<Option<(Self::FragmentPointer, Vec<AppendWork>)>, Error> {
+    ) -> Result<Option<(Self::FragmentPointer, Option<LogPosition>, Vec<AppendWork>)>, Error> {
         // SAFETY(rescrv): Mutex poisoning.
         let mut state = self.state.lock().unwrap();
 
@@ -216,30 +272,48 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
             self.write_finished.notify_one();
             return Ok(None);
         }
+        let required_fragment_start =
+            match required_fragment_start_for_selected(&state.enqueued[..split_off]) {
+                Ok(required_fragment_start) => required_fragment_start,
+                Err(err) => {
+                    let work = take_selected_work(&mut state, split_off);
+                    if refresh_backoff_after_split(&mut state, &self.options) {
+                        self.write_finished.notify_one();
+                    }
+                    reject_selected_work(work, err);
+                    return Ok(None);
+                }
+            };
         let Some(pointer) =
             state.select_for_write(&self.options.throttle_fragment, manifest_manager, acc_count)?
         else {
             // Cannot yet select for write.  Notify will come from the timeout background is on.
             return Ok(None);
         };
-        let mut work = std::mem::take(&mut state.enqueued);
-        state.enqueued = work.split_off(split_off);
-        let mut admission_metadata = std::mem::take(&mut state.admission_metadata);
-        state.admission_metadata = admission_metadata.split_off(split_off);
-        debug_assert_eq!(work.len(), admission_metadata.len());
-        debug_assert_eq!(state.enqueued.len(), state.admission_metadata.len());
-        if !state.enqueued.is_empty() {
-            state.backoff = state
-                .enqueued
-                .iter()
-                .map(AppendWork::byte_count)
-                .sum::<usize>()
-                >= self.options.throttle_fragment.batch_size_bytes;
-            self.write_finished.notify_one();
-        } else {
-            state.backoff = false;
+        if let (Some(required_fragment_start), Some(assigned_fragment_start)) =
+            (required_fragment_start, pointer.fragment_start())
+        {
+            if required_fragment_start != assigned_fragment_start {
+                tracing::info!(
+                    ?required_fragment_start,
+                    ?assigned_fragment_start,
+                    selected_work_count = split_off,
+                    "selected wal3 batch missed required_fragment_start"
+                );
+                let work = take_selected_work(&mut state, split_off);
+                state.finish_write();
+                if refresh_backoff_after_split(&mut state, &self.options) {
+                    self.write_finished.notify_one();
+                }
+                reject_selected_work(work, Error::LogContentionRetry);
+                return Ok(None);
+            }
         }
-        Ok(Some((pointer, work)))
+        let work = take_selected_work(&mut state, split_off);
+        if refresh_backoff_after_split(&mut state, &self.options) {
+            self.write_finished.notify_one();
+        }
+        Ok(Some((pointer, required_fragment_start, work)))
     }
 
     /// Finish the previous call to take_work.
@@ -481,8 +555,9 @@ mod tests {
     use crate::interfaces::s3::manifest_manager::ManifestManager;
     use crate::interfaces::s3::S3FragmentUploader;
     use crate::{
-        AppendOptions, FragmentSeqNo, FragmentUuid, LogWriterOptions, SnapshotOptions,
-        StorageWrapper, ThrottleOptions,
+        AppendOptions, FragmentSeqNo, FragmentUuid, LogWriterOptions, Manifest, ManifestAndWitness,
+        ManifestWitness, Snapshot, SnapshotOptions, SnapshotPointer, StorageWrapper,
+        ThrottleOptions,
     };
 
     struct NoopUploader;
@@ -520,6 +595,41 @@ mod tests {
         BatchManager::new(LogWriterOptions::default(), NoopUploader).unwrap()
     }
 
+    struct NoopS3Uploader;
+
+    #[async_trait::async_trait]
+    impl FragmentUploader<(FragmentSeqNo, LogPosition)> for NoopS3Uploader {
+        async fn upload_parquet(
+            &self,
+            _pointer: &(FragmentSeqNo, LogPosition),
+            _messages: Vec<Vec<u8>>,
+            _cmek: Option<Cmek>,
+            _epoch_micros: u64,
+        ) -> Result<UploadResult, Error> {
+            unreachable!("upload_parquet is not used in required-start selection tests")
+        }
+
+        async fn preferred_storage(&self) -> Storage {
+            unreachable!("preferred_storage is not used in required-start selection tests")
+        }
+
+        async fn preferred_prefix(&self) -> String {
+            unreachable!("preferred_prefix is not used in required-start selection tests")
+        }
+
+        async fn preferred_storage_wrapper(&self) -> &StorageWrapper {
+            unreachable!("preferred_storage_wrapper is not used in required-start selection tests")
+        }
+
+        async fn storages(&self) -> &[StorageWrapper] {
+            unreachable!("storages is not used in required-start selection tests")
+        }
+    }
+
+    fn s3_batch_manager() -> BatchManager<(FragmentSeqNo, LogPosition), NoopS3Uploader> {
+        BatchManager::new(LogWriterOptions::default(), NoopS3Uploader).unwrap()
+    }
+
     async fn enqueue(
         batch_manager: &BatchManager<FragmentUuid, NoopUploader>,
         message: Vec<u8>,
@@ -535,6 +645,175 @@ mod tests {
             ))
             .await;
         rx
+    }
+
+    async fn enqueue_s3(
+        batch_manager: &BatchManager<(FragmentSeqNo, LogPosition), NoopS3Uploader>,
+        message: Vec<u8>,
+        options: Option<AppendOptions>,
+    ) -> tokio::sync::oneshot::Receiver<Result<LogPosition, Error>> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        batch_manager
+            .push_work(AppendWork::new(
+                vec![message],
+                options,
+                tx,
+                tracing::Span::current(),
+            ))
+            .await;
+        rx
+    }
+
+    struct PanickingS3ManifestPublisher;
+
+    #[async_trait::async_trait]
+    impl ManifestPublisher<(FragmentSeqNo, LogPosition)> for PanickingS3ManifestPublisher {
+        async fn recover(&mut self) -> Result<(), Error> {
+            unreachable!("recover is not used in required-start selection tests")
+        }
+
+        async fn manifest_and_witness(&self) -> Result<ManifestAndWitness, Error> {
+            unreachable!("manifest_and_witness is not used in required-start selection tests")
+        }
+
+        fn assign_timestamp(&self, _record_count: usize) -> Option<(FragmentSeqNo, LogPosition)> {
+            unreachable!("incompatible required starts should fail before timestamp assignment")
+        }
+
+        async fn publish_fragment(
+            &self,
+            _pointer: &(FragmentSeqNo, LogPosition),
+            _path: &str,
+            _messages_len: u64,
+            _num_bytes: u64,
+            _setsum: Setsum,
+            _required_fragment_start: Option<LogPosition>,
+            _successful_regions: &[String],
+        ) -> Result<LogPosition, Error> {
+            unreachable!("publish_fragment is not used in required-start selection tests")
+        }
+
+        async fn garbage_applies_cleanly(&self, _garbage: &Garbage) -> Result<bool, Error> {
+            unreachable!("garbage_applies_cleanly is not used in required-start selection tests")
+        }
+
+        async fn apply_garbage(&self, _garbage: Garbage) -> Result<(), Error> {
+            unreachable!("apply_garbage is not used in required-start selection tests")
+        }
+
+        async fn compute_garbage(
+            &self,
+            _options: &crate::GarbageCollectionOptions,
+            _first_to_keep: LogPosition,
+        ) -> Result<Option<Garbage>, Error> {
+            unreachable!("compute_garbage is not used in required-start selection tests")
+        }
+
+        async fn snapshot_load(
+            &self,
+            _pointer: &SnapshotPointer,
+        ) -> Result<Option<Snapshot>, Error> {
+            unreachable!("snapshot_load is not used in required-start selection tests")
+        }
+
+        async fn snapshot_install(&self, _snapshot: &Snapshot) -> Result<SnapshotPointer, Error> {
+            unreachable!("snapshot_install is not used in required-start selection tests")
+        }
+
+        async fn manifest_head(&self, _witness: &ManifestWitness) -> Result<bool, Error> {
+            unreachable!("manifest_head is not used in required-start selection tests")
+        }
+
+        async fn manifest_load(&self) -> Result<Option<(Manifest, ManifestWitness)>, Error> {
+            unreachable!("manifest_load is not used in required-start selection tests")
+        }
+
+        fn shutdown(&self) {}
+
+        async fn destroy(&self) -> Result<(), Error> {
+            unreachable!("destroy is not used in required-start selection tests")
+        }
+
+        async fn load_intrinsic_cursor(&self) -> Result<Option<LogPosition>, Error> {
+            unreachable!("load_intrinsic_cursor is not used in required-start selection tests")
+        }
+    }
+
+    struct FixedS3ManifestPublisher {
+        assigned_fragment_start: LogPosition,
+    }
+
+    #[async_trait::async_trait]
+    impl ManifestPublisher<(FragmentSeqNo, LogPosition)> for FixedS3ManifestPublisher {
+        async fn recover(&mut self) -> Result<(), Error> {
+            unreachable!("recover is not used in required-start selection tests")
+        }
+
+        async fn manifest_and_witness(&self) -> Result<ManifestAndWitness, Error> {
+            unreachable!("manifest_and_witness is not used in required-start selection tests")
+        }
+
+        fn assign_timestamp(&self, _record_count: usize) -> Option<(FragmentSeqNo, LogPosition)> {
+            Some((FragmentSeqNo::BEGIN, self.assigned_fragment_start))
+        }
+
+        async fn publish_fragment(
+            &self,
+            _pointer: &(FragmentSeqNo, LogPosition),
+            _path: &str,
+            _messages_len: u64,
+            _num_bytes: u64,
+            _setsum: Setsum,
+            _required_fragment_start: Option<LogPosition>,
+            _successful_regions: &[String],
+        ) -> Result<LogPosition, Error> {
+            unreachable!("publish_fragment is not used in required-start selection tests")
+        }
+
+        async fn garbage_applies_cleanly(&self, _garbage: &Garbage) -> Result<bool, Error> {
+            unreachable!("garbage_applies_cleanly is not used in required-start selection tests")
+        }
+
+        async fn apply_garbage(&self, _garbage: Garbage) -> Result<(), Error> {
+            unreachable!("apply_garbage is not used in required-start selection tests")
+        }
+
+        async fn compute_garbage(
+            &self,
+            _options: &crate::GarbageCollectionOptions,
+            _first_to_keep: LogPosition,
+        ) -> Result<Option<Garbage>, Error> {
+            unreachable!("compute_garbage is not used in required-start selection tests")
+        }
+
+        async fn snapshot_load(
+            &self,
+            _pointer: &SnapshotPointer,
+        ) -> Result<Option<Snapshot>, Error> {
+            unreachable!("snapshot_load is not used in required-start selection tests")
+        }
+
+        async fn snapshot_install(&self, _snapshot: &Snapshot) -> Result<SnapshotPointer, Error> {
+            unreachable!("snapshot_install is not used in required-start selection tests")
+        }
+
+        async fn manifest_head(&self, _witness: &ManifestWitness) -> Result<bool, Error> {
+            unreachable!("manifest_head is not used in required-start selection tests")
+        }
+
+        async fn manifest_load(&self) -> Result<Option<(Manifest, ManifestWitness)>, Error> {
+            unreachable!("manifest_load is not used in required-start selection tests")
+        }
+
+        fn shutdown(&self) {}
+
+        async fn destroy(&self) -> Result<(), Error> {
+            unreachable!("destroy is not used in required-start selection tests")
+        }
+
+        async fn load_intrinsic_cursor(&self) -> Result<Option<LogPosition>, Error> {
+            unreachable!("load_intrinsic_cursor is not used in required-start selection tests")
+        }
     }
 
     #[tokio::test]
@@ -654,6 +933,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mismatched_required_fragment_starts_reject_selected_batch() {
+        let batch_manager = s3_batch_manager();
+        let first_rx = enqueue_s3(
+            &batch_manager,
+            Vec::from("first"),
+            Some(
+                AppendOptions::new(Vec::from("first"))
+                    .with_required_fragment_start(LogPosition::from_offset(10)),
+            ),
+        )
+        .await;
+        let second_rx = enqueue_s3(
+            &batch_manager,
+            Vec::from("second"),
+            Some(
+                AppendOptions::new(Vec::from("second"))
+                    .with_required_fragment_start(LogPosition::from_offset(11)),
+            ),
+        )
+        .await;
+
+        let selected = batch_manager
+            .take_work(&PanickingS3ManifestPublisher)
+            .await
+            .expect("required-start rejection should not fail take_work");
+
+        assert!(selected.is_none());
+        assert_eq!(0, batch_manager.count_waiters());
+        assert!(matches!(
+            first_rx
+                .await
+                .expect("first append should receive a result"),
+            Err(Error::LogContentionRetry)
+        ));
+        assert!(matches!(
+            second_rx
+                .await
+                .expect("second append should receive a result"),
+            Err(Error::LogContentionRetry)
+        ));
+    }
+
+    #[tokio::test]
+    async fn s3_required_fragment_start_mismatch_rejects_before_upload_selection() {
+        let batch_manager = s3_batch_manager();
+        let rx = enqueue_s3(
+            &batch_manager,
+            Vec::from("record"),
+            Some(
+                AppendOptions::new(Vec::from("record"))
+                    .with_required_fragment_start(LogPosition::from_offset(42)),
+            ),
+        )
+        .await;
+        let manifest = FixedS3ManifestPublisher {
+            assigned_fragment_start: LogPosition::from_offset(41),
+        };
+
+        let selected = batch_manager
+            .take_work(&manifest)
+            .await
+            .expect("required-start mismatch should not fail take_work");
+
+        assert!(selected.is_none());
+        assert_eq!(0, batch_manager.count_waiters());
+        assert!(matches!(
+            rx.await.expect("append should receive a result"),
+            Err(Error::LogContentionRetry)
+        ));
+    }
+
+    #[tokio::test]
     async fn test_k8s_integration_upload_parquet_returns_retry_on_already_exists() {
         let storage = s3_client_for_test_with_new_bucket().await;
         let prefix = "test-upload-parquet-retry";
@@ -757,13 +1108,14 @@ mod tests {
                 tracing::Span::current(),
             ))
             .await;
-        let ((seq_no, log_position), work) = batch_manager
+        let ((seq_no, log_position), required_fragment_start, work) = batch_manager
             .take_work(&manifest_manager)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(seq_no, FragmentSeqNo::from_u64(1));
         assert_eq!(log_position.offset(), 1);
+        assert_eq!(None, required_fragment_start);
         assert_eq!(2, work.len());
         // Check batch 1
         assert_eq!(vec![vec![1]], work[0].messages);

--- a/rust/wal3/src/interfaces/mod.rs
+++ b/rust/wal3/src/interfaces/mod.rs
@@ -27,6 +27,9 @@ pub use batch_manager::BatchManager;
 pub trait FragmentPointer: Clone + Send + Sync + 'static {
     fn try_create(ident: FragmentIdentifier, pos: LogPosition) -> Option<Self>;
     fn identifier(&self) -> FragmentIdentifier;
+    fn fragment_start(&self) -> Option<LogPosition> {
+        None
+    }
     fn bootstrap(position: LogPosition) -> Self
     where
         Self: Sized;
@@ -43,6 +46,10 @@ impl FragmentPointer for (FragmentSeqNo, LogPosition) {
 
     fn identifier(&self) -> FragmentIdentifier {
         FragmentIdentifier::SeqNo(self.0)
+    }
+
+    fn fragment_start(&self) -> Option<LogPosition> {
+        Some(self.1)
     }
 
     fn bootstrap(position: LogPosition) -> Self {
@@ -271,7 +278,7 @@ where
     async fn take_work(
         &self,
         manifest_manager: &(dyn ManifestPublisher<Self::FragmentPointer> + Sync),
-    ) -> Result<Option<(Self::FragmentPointer, Vec<AppendWork>)>, Error> {
+    ) -> Result<Option<(Self::FragmentPointer, Option<LogPosition>, Vec<AppendWork>)>, Error> {
         match self {
             Self::Plain(publisher) => publisher.take_work(manifest_manager).await,
             Self::FaultInjecting(publisher) => publisher.take_work(manifest_manager).await,
@@ -531,6 +538,13 @@ impl AppendWork {
             .map(|options| Arc::clone(&options.admission_metadata))
             .unwrap_or_else(|| Arc::<[u8]>::from([]))
     }
+
+    /// Return the required fragment start, if this append has one.
+    pub fn required_fragment_start(&self) -> Option<LogPosition> {
+        self.options
+            .as_ref()
+            .and_then(|options| options.required_fragment_start)
+    }
 }
 
 impl std::fmt::Debug for AppendWork {
@@ -553,7 +567,7 @@ pub trait FragmentPublisher: Send + Sync + 'static {
     async fn take_work(
         &self,
         manifest_manager: &(dyn ManifestPublisher<Self::FragmentPointer> + Sync),
-    ) -> Result<Option<(Self::FragmentPointer, Vec<AppendWork>)>, Error>;
+    ) -> Result<Option<(Self::FragmentPointer, Option<LogPosition>, Vec<AppendWork>)>, Error>;
     /// Finish the previous call to take_work.
     async fn finish_write(&self);
 
@@ -725,6 +739,7 @@ pub trait ManifestPublisher<FP: FragmentPointer>: Send + Sync + 'static {
         messages_len: u64,
         num_bytes: u64,
         setsum: Setsum,
+        required_fragment_start: Option<LogPosition>,
         successful_regions: &[String],
     ) -> Result<LogPosition, Error>;
     /// Check if the garbge will apply "cleanly", that is without violating invariants.

--- a/rust/wal3/src/interfaces/mod.rs
+++ b/rust/wal3/src/interfaces/mod.rs
@@ -732,6 +732,7 @@ pub trait ManifestPublisher<FP: FragmentPointer>: Send + Sync + 'static {
     /// the fragment during upload. For single-region deployments, this is empty (all regions
     /// are implied). For multi-region deployments, only these regions should be recorded as
     /// having the fragment.
+    #[allow(clippy::too_many_arguments)]
     async fn publish_fragment(
         &self,
         pointer: &FP,

--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -898,7 +898,6 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                     let pointer = pointer.clone();
                     let path = path.clone();
                     let regions = regions.clone();
-                    let required_fragment_start = required_fragment_start;
                     Box::pin(async move {
                         let row = tx
                             .read_row(

--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -872,6 +872,7 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
         messages_len: u64,
         num_bytes: u64,
         setsum: Setsum,
+        required_fragment_start: Option<LogPosition>,
         successful_regions: &[String],
     ) -> Result<LogPosition, Error> {
         if messages_len > i64::MAX as u64 {
@@ -897,6 +898,7 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                     let pointer = pointer.clone();
                     let path = path.clone();
                     let regions = regions.clone();
+                    let required_fragment_start = required_fragment_start;
                     Box::pin(async move {
                         let row = tx
                             .read_row(
@@ -936,6 +938,17 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                             return Ok(Err(Error::CorruptManifest(format!(
                             "negative enumeration_offset {enumeration_offset} for manifest {log_id}"
                         ))));
+                        }
+                        let fragment_start = LogPosition::from_offset(enumeration_offset as u64);
+                        if let Some(required_fragment_start) = required_fragment_start {
+                            if required_fragment_start != fragment_start {
+                                tracing::info!(
+                                    ?required_fragment_start,
+                                    ?fragment_start,
+                                    "repl publish_fragment missed required_fragment_start"
+                                );
+                                return Ok(Err(Error::LogContentionRetry));
+                            }
                         }
                         let enumeration_limit =
                             match enumeration_offset.checked_add(messages_len_i64) {
@@ -1011,7 +1024,7 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
                         }
                         tx.buffer_write(mutations);
                         Ok::<Result<LogPosition, Error>, google_cloud_spanner::client::Error>(Ok(
-                            LogPosition::from_offset(enumeration_offset as u64),
+                            fragment_start,
                         ))
                     })
                 })
@@ -2008,6 +2021,7 @@ mod tests {
                 messages_len,
                 num_bytes,
                 setsum,
+                None,
                 &["dummy".to_string()],
             )
             .await;
@@ -2043,6 +2057,45 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_k8s_mcmr_integration_publish_fragment_required_start_mismatch() {
+        let Some(client) = setup_spanner_client().await else {
+            panic!("Spanner emulator not reachable. Is Tilt running?");
+        };
+
+        let log_id = Uuid::new_v4();
+        let manifest = make_empty_manifest();
+        ManifestManager::init(vec!["dummy".to_string()], &client, log_id, &manifest)
+            .await
+            .expect("init failed");
+
+        let manager = ManifestManager::new(Arc::new(client.clone()), "dummy".to_string(), log_id);
+        let pointer = FragmentUuid::generate();
+        let result = manager
+            .publish_fragment(
+                &pointer,
+                "test/path/fragment.parquet",
+                10,
+                1024,
+                make_setsum(1),
+                Some(LogPosition::from_offset(1)),
+                &["dummy".to_string()],
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(Error::LogContentionRetry)),
+            "expected LogContentionRetry, got {result:?}"
+        );
+        let Some((loaded_manifest, _)) = ManifestManager::load(&client, log_id, "dummy")
+            .await
+            .expect("load failed")
+        else {
+            panic!("manifest should exist after required-start rejection");
+        };
+        assert_eq!(make_empty_manifest(), loaded_manifest);
+    }
+
     // Test publishing multiple fragments in sequence.
     #[tokio::test]
     async fn test_k8s_mcmr_integration_publish_multiple_fragments() {
@@ -2067,6 +2120,7 @@ mod tests {
                 10,
                 100,
                 make_setsum(1),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -2082,6 +2136,7 @@ mod tests {
                 20,
                 200,
                 make_setsum(2),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -2097,6 +2152,7 @@ mod tests {
                 30,
                 300,
                 make_setsum(3),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -2141,6 +2197,7 @@ mod tests {
                 10,
                 100,
                 make_setsum(1),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -2153,6 +2210,7 @@ mod tests {
                 20,
                 200,
                 make_setsum(2),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -2219,6 +2277,7 @@ mod tests {
                 10,
                 100,
                 make_setsum(1),
+                None,
                 &["region-b".to_string()],
             )
             .await
@@ -2282,6 +2341,7 @@ mod tests {
                 20,
                 100,
                 make_setsum(1),
+                None,
                 &["region-b".to_string()],
             )
             .await
@@ -2353,6 +2413,7 @@ mod tests {
                     messages_len,
                     num_bytes,
                     setsum,
+                    None,
                     &["dummy".to_string()],
                 )
                 .await
@@ -2402,6 +2463,7 @@ mod tests {
                 messages_len,
                 100,
                 Setsum::default(),
+                None,
                 &["dummy".to_string()],
             )
             .await;
@@ -2441,6 +2503,7 @@ mod tests {
                 5,
                 500,
                 setsum1,
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -2455,6 +2518,7 @@ mod tests {
                 10,
                 1000,
                 setsum2,
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -2590,6 +2654,7 @@ mod tests {
                         10,
                         100,
                         make_setsum((i + 1) as u8),
+                        None,
                         &["dummy".to_string()],
                     )
                     .await
@@ -2686,6 +2751,7 @@ mod tests {
                 100,
                 100,
                 Setsum::default(),
+                None,
                 &["dummy".to_string()],
             )
             .await;
@@ -2869,14 +2935,30 @@ mod tests {
         let setsum1 = make_setsum(1);
         let pointer1 = FragmentUuid::generate();
         manager
-            .publish_fragment(&pointer1, "path1", 10, 100, setsum1, &["dummy".to_string()])
+            .publish_fragment(
+                &pointer1,
+                "path1",
+                10,
+                100,
+                setsum1,
+                None,
+                &["dummy".to_string()],
+            )
             .await
             .expect("first publish failed");
 
         let setsum2 = make_setsum(2);
         let pointer2 = FragmentUuid::generate();
         manager
-            .publish_fragment(&pointer2, "path2", 10, 100, setsum2, &["dummy".to_string()])
+            .publish_fragment(
+                &pointer2,
+                "path2",
+                10,
+                100,
+                setsum2,
+                None,
+                &["dummy".to_string()],
+            )
             .await
             .expect("second publish failed");
 
@@ -3276,6 +3358,7 @@ mod tests {
                 10,
                 100,
                 make_setsum(1),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -3346,6 +3429,7 @@ mod tests {
                 20,
                 100,
                 make_setsum(1),
+                None,
                 &["region-b".to_string()],
             )
             .await
@@ -3385,6 +3469,7 @@ mod tests {
                 10,
                 100,
                 make_setsum(1),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -3426,6 +3511,7 @@ mod tests {
                 10,
                 100,
                 make_setsum(1),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -3498,6 +3584,7 @@ mod tests {
                 10,
                 100,
                 make_setsum(1),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -3560,6 +3647,7 @@ mod tests {
                 10,
                 100,
                 make_setsum(1),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -3627,6 +3715,7 @@ mod tests {
                 10,
                 100,
                 make_setsum(1),
+                None,
                 &["dummy".to_string()],
             )
             .await
@@ -3678,7 +3767,15 @@ mod tests {
         let setsum1 = make_setsum(1);
         let pointer1 = FragmentUuid::generate();
         manager
-            .publish_fragment(&pointer1, "path1", 5, 100, setsum1, &["dummy".to_string()])
+            .publish_fragment(
+                &pointer1,
+                "path1",
+                5,
+                100,
+                setsum1,
+                None,
+                &["dummy".to_string()],
+            )
             .await
             .expect("first publish failed");
 
@@ -3696,7 +3793,15 @@ mod tests {
         let setsum2 = make_setsum(2);
         let pointer2 = FragmentUuid::generate();
         manager
-            .publish_fragment(&pointer2, "path2", 5, 100, setsum2, &["dummy".to_string()])
+            .publish_fragment(
+                &pointer2,
+                "path2",
+                5,
+                100,
+                setsum2,
+                None,
+                &["dummy".to_string()],
+            )
             .await
             .expect("second publish failed");
 

--- a/rust/wal3/src/interfaces/repl/mod.rs
+++ b/rust/wal3/src/interfaces/repl/mod.rs
@@ -517,6 +517,7 @@ mod tests {
                 10,
                 100,
                 Setsum::default(),
+                None,
                 &["test-region".to_string()],
             )
             .await;

--- a/rust/wal3/src/interfaces/s3/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/s3/manifest_manager.rs
@@ -566,6 +566,7 @@ impl ManifestPublisher<(FragmentSeqNo, LogPosition)> for ManifestManager {
                         .saturating_sub(fragment.start.offset()),
                     fragment.num_bytes,
                     fragment.setsum,
+                    None,
                     &[],
                 )
                 .await
@@ -624,8 +625,19 @@ impl ManifestPublisher<(FragmentSeqNo, LogPosition)> for ManifestManager {
         num_records: u64,
         num_bytes: u64,
         setsum: Setsum,
+        required_fragment_start: Option<LogPosition>,
         _successful_regions: &[String],
     ) -> Result<LogPosition, Error> {
+        if let Some(required_fragment_start) = required_fragment_start {
+            if required_fragment_start != *log_position {
+                tracing::info!(
+                    ?required_fragment_start,
+                    assigned_fragment_start = ?log_position,
+                    "s3 publish_fragment missed required_fragment_start"
+                );
+                return Err(Error::LogContentionRetry);
+            }
+        }
         let (tx, rx) = tokio::sync::oneshot::channel();
         let fragment = Fragment {
             path: path.to_string(),

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -570,8 +570,10 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 if !that.done.load(std::sync::atomic::Ordering::Relaxed) {
                     that.batch_manager.wait_for_writable().await;
                     match that.batch_manager.take_work(&that.manifest_manager).await {
-                        Ok(Some((pointer, work))) => {
-                            Arc::clone(&that).append_batch(pointer, work).await;
+                        Ok(Some((pointer, required_fragment_start, work))) => {
+                            Arc::clone(&that)
+                                .append_batch(pointer, required_fragment_start, work)
+                                .await;
                         }
                         Ok(None) => {
                             let sleep_for = that.batch_manager.until_next_time();
@@ -652,9 +654,13 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 .await;
             match self.batch_manager.take_work(&self.manifest_manager).await {
                 Ok(Some(work)) => {
-                    let (pointer, work) = work;
+                    let (pointer, required_fragment_start, work) = work;
                     {
-                        tokio::task::spawn(Arc::clone(self).append_batch(pointer, work));
+                        tokio::task::spawn(Arc::clone(self).append_batch(
+                            pointer,
+                            required_fragment_start,
+                            work,
+                        ));
                     }
                 }
                 Ok(None) => {}
@@ -671,7 +677,12 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
         .await
     }
 
-    async fn append_batch(self: Arc<Self>, pointer: P, work: Vec<AppendWork>) {
+    async fn append_batch(
+        self: Arc<Self>,
+        pointer: P,
+        required_fragment_start: Option<LogPosition>,
+        work: Vec<AppendWork>,
+    ) {
         let append_batch_span = tracing::info_span!("append_batch");
         let mut messages = Vec::with_capacity(work.len());
         let mut notifies = Vec::with_capacity(work.len());
@@ -694,7 +705,10 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 tracing::error!("somehow got empty messages");
                 return;
             }
-            match self.append_batch_internal(pointer, messages).await {
+            match self
+                .append_batch_internal(pointer, required_fragment_start, messages)
+                .await
+            {
                 Ok(mut log_position) => {
                     for (num_messages, notify) in notifies.into_iter() {
                         if notify.send(Ok(log_position)).is_err() {
@@ -720,6 +734,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
     async fn append_batch_internal(
         &self,
         pointer: P,
+        required_fragment_start: Option<LogPosition>,
         messages: Vec<Vec<u8>>,
     ) -> Result<LogPosition, Error> {
         assert!(!messages.is_empty());
@@ -740,6 +755,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 messages_len as u64,
                 upload_result.num_bytes as u64,
                 upload_result.setsum,
+                required_fragment_start,
                 &upload_result.successful_regions,
             )
             .await
@@ -1674,7 +1690,14 @@ mod tests {
         async fn take_work(
             &self,
             _manifest_manager: &(dyn crate::ManifestPublisher<Self::FragmentPointer> + Sync),
-        ) -> Result<Option<(Self::FragmentPointer, Vec<crate::AppendWork>)>, Error> {
+        ) -> Result<
+            Option<(
+                Self::FragmentPointer,
+                Option<LogPosition>,
+                Vec<crate::AppendWork>,
+            )>,
+            Error,
+        > {
             unreachable!("take_work is not used in this test")
         }
 
@@ -1839,6 +1862,7 @@ mod tests {
             _messages_len: u64,
             _num_bytes: u64,
             _setsum: Setsum,
+            _required_fragment_start: Option<LogPosition>,
             _successful_regions: &[String],
         ) -> Result<LogPosition, Error> {
             unreachable!("publish_fragment is not used in this test")

--- a/rust/wal3/tests/mocks.rs
+++ b/rust/wal3/tests/mocks.rs
@@ -43,6 +43,7 @@ impl ManifestPublisher<(FragmentSeqNo, LogPosition)> for MockManifestPublisher {
         _messages_len: u64,
         _num_bytes: u64,
         _setsum: Setsum,
+        _required_fragment_start: Option<LogPosition>,
         _successful_regions: &[String],
     ) -> Result<LogPosition, wal3::Error> {
         Err(wal3::Error::UninitializedLog)


### PR DESCRIPTION
## Description of changes

Thread a required_fragment_start through the fragment publishing
path so conditional appends can require that the fragment they land
in begins at a specific log position. When the assigned start does
not match the requirement, the batch manager and both manifest
publishers (S3 and repl) reject the write with LogContentionRetry
so the caller can retry.

Changes:
- FragmentPointer gains fragment_start(); AppendWork exposes
  required_fragment_start().
- BatchManager::take_work computes the required start for the
  selected batch, validates it against the assigned pointer, and
  refactors the split/backoff/reject logic into helpers.
- ManifestPublisher::publish_fragment takes required_fragment_start
  and enforces it in the S3 and repl implementations.
- writer.rs threads the value through append_batch and
  append_batch_internal.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
