### PR TITLE
[CHORE](wal3): Carry a list of admission metadata per append

### DIFF
--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -25,7 +25,7 @@ struct ManagerState {
     next_write: Instant,
     writers_active: usize,
     enqueued: Vec<AppendWork>,
-    admission_metadata: Vec<Arc<[u8]>>,
+    admission_metadata: Vec<Vec<Arc<[u8]>>>,
     tearing_down: bool,
 }
 
@@ -595,6 +595,17 @@ mod tests {
         BatchManager::new(LogWriterOptions::default(), NoopUploader).unwrap()
     }
 
+    fn admission_metadata(metadata: &[&str]) -> Vec<Arc<[u8]>> {
+        metadata
+            .iter()
+            .map(|metadata| Arc::<[u8]>::from(metadata.as_bytes()))
+            .collect()
+    }
+
+    fn append_options(metadata: &[&str]) -> AppendOptions {
+        AppendOptions::new(admission_metadata(metadata))
+    }
+
     struct NoopS3Uploader;
 
     #[async_trait::async_trait]
@@ -822,42 +833,51 @@ mod tests {
         let _first_rx = enqueue(
             &batch_manager,
             Vec::from("first"),
-            Some(AppendOptions::new(Vec::from("metadata-1"))),
+            Some(append_options(&["metadata-1", "metadata-1b"])),
         )
         .await;
 
-        let observed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let observed = Arc::new(std::sync::Mutex::new(Vec::<Vec<Vec<u8>>>::new()));
         let observed_clone = Arc::clone(&observed);
-        let predicate = Arc::new(move |earlier_metadata: &[Arc<[u8]>]| {
+        let predicate = Arc::new(move |earlier_metadata: &[Vec<Arc<[u8]>>]| {
             *observed_clone.lock().unwrap() = earlier_metadata
                 .iter()
-                .map(|metadata| metadata.as_ref().to_vec())
+                .map(|entry_metadata| {
+                    entry_metadata
+                        .iter()
+                        .map(|metadata| metadata.as_ref().to_vec())
+                        .collect()
+                })
                 .collect();
             true
         });
         let _second_rx = enqueue(
             &batch_manager,
             Vec::from("second"),
-            Some(AppendOptions::new(Vec::from("metadata-2")).with_admission_predicate(predicate)),
+            Some(append_options(&["metadata-2"]).with_admission_predicate(predicate)),
         )
         .await;
 
-        assert_eq!(*observed.lock().unwrap(), vec![Vec::from("metadata-1")]);
+        assert_eq!(
+            *observed.lock().unwrap(),
+            vec![vec![Vec::from("metadata-1"), Vec::from("metadata-1b")]]
+        );
         assert_eq!(2, batch_manager.count_waiters());
     }
 
     #[tokio::test]
     async fn admission_predicate_does_not_see_candidate_metadata() {
         let batch_manager = admission_batch_manager();
-        let predicate = Arc::new(move |earlier_metadata: &[Arc<[u8]>]| {
+        let predicate = Arc::new(move |earlier_metadata: &[Vec<Arc<[u8]>>]| {
             !earlier_metadata
                 .iter()
+                .flatten()
                 .any(|metadata| metadata.as_ref() == b"candidate")
         });
         let mut rx = enqueue(
             &batch_manager,
             Vec::from("candidate"),
-            Some(AppendOptions::new(Vec::from("candidate")).with_admission_predicate(predicate)),
+            Some(append_options(&["candidate"]).with_admission_predicate(predicate)),
         )
         .await;
 
@@ -874,23 +894,20 @@ mod tests {
         let mut first_rx = enqueue(
             &batch_manager,
             Vec::from("first"),
-            Some(AppendOptions::new(Vec::from("first"))),
+            Some(append_options(&["first"])),
         )
         .await;
-        let rejecting_predicate = Arc::new(|_earlier_metadata: &[Arc<[u8]>]| false);
+        let rejecting_predicate = Arc::new(|_earlier_metadata: &[Vec<Arc<[u8]>>]| false);
         let rejected_rx = enqueue(
             &batch_manager,
             Vec::from("reject"),
-            Some(
-                AppendOptions::new(Vec::from("reject"))
-                    .with_admission_predicate(rejecting_predicate),
-            ),
+            Some(append_options(&["reject"]).with_admission_predicate(rejecting_predicate)),
         )
         .await;
         let mut third_rx = enqueue(
             &batch_manager,
             Vec::from("third"),
-            Some(AppendOptions::new(Vec::from("third"))),
+            Some(append_options(&["third"])),
         )
         .await;
 
@@ -912,23 +929,28 @@ mod tests {
         let batch_manager = admission_batch_manager();
         let _first_rx = enqueue(&batch_manager, Vec::from("normal"), None).await;
 
-        let observed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let observed = Arc::new(std::sync::Mutex::new(Vec::<Vec<Vec<u8>>>::new()));
         let observed_clone = Arc::clone(&observed);
-        let predicate = Arc::new(move |earlier_metadata: &[Arc<[u8]>]| {
+        let predicate = Arc::new(move |earlier_metadata: &[Vec<Arc<[u8]>>]| {
             *observed_clone.lock().unwrap() = earlier_metadata
                 .iter()
-                .map(|metadata| metadata.as_ref().to_vec())
+                .map(|entry_metadata| {
+                    entry_metadata
+                        .iter()
+                        .map(|metadata| metadata.as_ref().to_vec())
+                        .collect()
+                })
                 .collect();
             true
         });
         let _second_rx = enqueue(
             &batch_manager,
             Vec::from("conditional"),
-            Some(AppendOptions::new(Vec::from("conditional")).with_admission_predicate(predicate)),
+            Some(append_options(&["conditional"]).with_admission_predicate(predicate)),
         )
         .await;
 
-        assert_eq!(*observed.lock().unwrap(), vec![Vec::<u8>::new()]);
+        assert_eq!(*observed.lock().unwrap(), vec![Vec::<Vec<u8>>::new()]);
         assert_eq!(2, batch_manager.count_waiters());
     }
 
@@ -939,7 +961,7 @@ mod tests {
             &batch_manager,
             Vec::from("first"),
             Some(
-                AppendOptions::new(Vec::from("first"))
+                append_options(&["first"])
                     .with_required_fragment_start(LogPosition::from_offset(10)),
             ),
         )
@@ -948,7 +970,7 @@ mod tests {
             &batch_manager,
             Vec::from("second"),
             Some(
-                AppendOptions::new(Vec::from("second"))
+                append_options(&["second"])
                     .with_required_fragment_start(LogPosition::from_offset(11)),
             ),
         )
@@ -982,7 +1004,7 @@ mod tests {
             &batch_manager,
             Vec::from("record"),
             Some(
-                AppendOptions::new(Vec::from("record"))
+                append_options(&["record"])
                     .with_required_fragment_start(LogPosition::from_offset(42)),
             ),
         )
@@ -1081,7 +1103,7 @@ mod tests {
         .await
         .unwrap();
         let (tx, _rx1) = tokio::sync::oneshot::channel();
-        let options1 = AppendOptions::new(Vec::from("metadata-1"));
+        let options1 = append_options(&["metadata-1"]);
         batch_manager
             .push_work(AppendWork::new(
                 vec![vec![1]],
@@ -1120,11 +1142,11 @@ mod tests {
         // Check batch 1
         assert_eq!(vec![vec![1]], work[0].messages);
         assert_eq!(
-            Some(options1.admission_metadata.as_ref()),
+            Some(options1.admission_metadata.as_slice()),
             work[0]
                 .options
                 .as_ref()
-                .map(|options| options.admission_metadata.as_ref())
+                .map(|options| options.admission_metadata.as_slice())
         );
         // Check batch 2
         assert_eq!(vec![vec![2, 3]], work[1].messages);

--- a/rust/wal3/src/interfaces/mod.rs
+++ b/rust/wal3/src/interfaces/mod.rs
@@ -532,11 +532,11 @@ impl AppendWork {
 
     /// Return the admission metadata for this append, using empty metadata for appends without
     /// explicit options.
-    pub fn admission_metadata(&self) -> Arc<[u8]> {
+    pub fn admission_metadata(&self) -> Vec<Arc<[u8]>> {
         self.options
             .as_ref()
-            .map(|options| Arc::clone(&options.admission_metadata))
-            .unwrap_or_else(|| Arc::<[u8]>::from([]))
+            .map(|options| options.admission_metadata.clone())
+            .unwrap_or_default()
     }
 
     /// Return the required fragment start, if this append has one.

--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -552,13 +552,13 @@ impl Default for SnapshotOptions {
 /// The predicate runs while the batch manager holds its admission state lock.  It receives only
 /// metadata for earlier enqueued work, not the candidate append, and should not perform storage or
 /// other blocking I/O.
-pub type AdmissionPredicate = Arc<dyn Fn(&[Arc<[u8]>]) -> bool + Send + Sync + 'static>;
+pub type AdmissionPredicate = Arc<dyn Fn(&[Vec<Arc<[u8]>>]) -> bool + Send + Sync + 'static>;
 
 /// Optional controls that travel with one append request.
 #[derive(Clone)]
 pub struct AppendOptions {
     /// Opaque metadata exposed to later admission predicates.
-    pub admission_metadata: Arc<[u8]>,
+    pub admission_metadata: Vec<Arc<[u8]>>,
     /// Optional admission predicate evaluated before the append is admitted to the batch.
     pub admission_predicate: Option<AdmissionPredicate>,
     /// Optional requirement for the fragment start position selected for this append.
@@ -568,12 +568,17 @@ pub struct AppendOptions {
 impl AppendOptions {
     /// Create append options with admission metadata and no predicate or fragment-start
     /// requirement.
-    pub fn new(admission_metadata: impl Into<Arc<[u8]>>) -> Self {
+    pub fn new(admission_metadata: Vec<Arc<[u8]>>) -> Self {
         Self {
-            admission_metadata: admission_metadata.into(),
+            admission_metadata,
             admission_predicate: None,
             required_fragment_start: None,
         }
+    }
+
+    /// Create append options with a single admission metadata item.
+    pub fn from_single_admission_metadata(admission_metadata: impl Into<Arc<[u8]>>) -> Self {
+        Self::new(vec![admission_metadata.into()])
     }
 
     /// Attach an admission predicate.
@@ -591,14 +596,14 @@ impl AppendOptions {
 
 impl Default for AppendOptions {
     fn default() -> Self {
-        Self::new(Arc::<[u8]>::from([]))
+        Self::new(Vec::new())
     }
 }
 
 impl std::fmt::Debug for AppendOptions {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fmt.debug_struct("AppendOptions")
-            .field("admission_metadata_len", &self.admission_metadata.len())
+            .field("admission_metadata_count", &self.admission_metadata.len())
             .field(
                 "has_admission_predicate",
                 &self.admission_predicate.is_some(),


### PR DESCRIPTION
## Description of changes

Change AppendOptions::admission_metadata from a single Arc<[u8]> to a
Vec<Arc<[u8]>> so an append can carry multiple opaque metadata items.
Admission predicates now receive &[Vec<Arc<[u8]>>], one metadata list
per earlier enqueued append, instead of a flat &[Arc<[u8]>].

Add AppendOptions::from_single_admission_metadata for the common
single-item case, and update AppendWork::admission_metadata and the
batch manager's admission state to track lists. Tests gain
admission_metadata and append_options helpers and are updated for the
nested shape.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
