### PR TITLE
[ENH](frontend): commit conditional transactions

### DIFF
--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -20,38 +20,40 @@ use chroma_sysdb::{DatabaseOrTopology, GetCollectionsOptions, SysDb};
 use chroma_system::System;
 use chroma_types::chroma_proto::PushLogsCondition;
 use chroma_types::{
+    buffered_write_to_records,
     operator::{
         Aggregate, CountResult, Filter, GetResult, GroupBy, Key, KnnBatch, KnnBatchResult,
         KnnProjection, KnnProjectionOutput, Limit, Projection, ProjectionOutput, Scan,
         SearchPayloadResult, SearchRecord, SearchResult, Select,
     },
     plan::{Count, Get, Knn, Search, SearchPayload},
-    AddAttachedFunctionInputRequest, AddAttachedFunctionInputResponse, AddCollectionRecordsError,
-    AddCollectionRecordsRequest, AddCollectionRecordsResponse, AttachFunctionRequest,
-    AttachFunctionResponse, AttachedFunctionApiResponse, Cmek, Collection, CollectionAndSegments,
-    CollectionUuid, ConditionalBufferedWrite, ConditionalCommitAction, ConditionalCommitError,
-    ConditionalCommitRequest, ConditionalCommitResult, ConditionalTransactionState,
-    CountCollectionsError, CountCollectionsRequest, CountCollectionsResponse, CountRequest,
-    CountResponse, CreateCollectionError, CreateCollectionRequest, CreateCollectionResponse,
-    CreateDatabaseError, CreateDatabaseRequest, CreateDatabaseResponse, CreateTenantError,
-    CreateTenantRequest, CreateTenantResponse, DatabaseName, DeleteCollectionError,
-    DeleteCollectionRecordsError, DeleteCollectionRecordsRequest, DeleteCollectionRecordsResponse,
-    DeleteCollectionRequest, DeleteCollectionResponse, DeleteDatabaseError, DeleteDatabaseRequest,
-    DeleteDatabaseResponse, DetachFunctionError, DetachFunctionRequest, DetachFunctionResponse,
-    ExecutorError, ForkCollectionError, ForkCollectionRequest, ForkCollectionResponse,
-    GetCollectionByCrnError, GetCollectionByCrnRequest, GetCollectionByCrnResponse,
-    GetCollectionByIdError, GetCollectionByIdRequest, GetCollectionByIdResponse,
-    GetCollectionError, GetCollectionRequest, GetCollectionResponse, GetCollectionsError,
-    GetDatabaseError, GetDatabaseRequest, GetDatabaseResponse, GetRequest, GetResponse,
-    GetTenantError, GetTenantRequest, GetTenantResponse, HealthCheckResponse, HeartbeatError,
-    Include, IndexStatusError, IndexStatusResponse, KnnIndex, ListCollectionsRequest,
-    ListCollectionsResponse, ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse,
-    OccReadMode, OccReadToken, Operation, OperationRecord, QueryError, QueryRequest, QueryResponse,
-    ResetError, ResetResponse, Schema, SearchRequest, SearchResponse, SegmentType, StaleReadError,
-    UpdateCollectionError, UpdateCollectionRecordsError, UpdateCollectionRecordsRequest,
-    UpdateCollectionRecordsResponse, UpdateCollectionRequest, UpdateCollectionResponse,
-    UpdateTenantError, UpdateTenantRequest, UpdateTenantResponse, UpsertCollectionRecordsError,
-    UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, Where,
+    validate_conditional_commit_scope, AddAttachedFunctionInputRequest,
+    AddAttachedFunctionInputResponse, AddCollectionRecordsError, AddCollectionRecordsRequest,
+    AddCollectionRecordsResponse, AttachFunctionRequest, AttachFunctionResponse,
+    AttachedFunctionApiResponse, Cmek, Collection, CollectionAndSegments, CollectionUuid,
+    ConditionalBufferedWrite, ConditionalCommitAction, ConditionalCommitError,
+    ConditionalCommitResult, ConditionalTransactionState, CountCollectionsError,
+    CountCollectionsRequest, CountCollectionsResponse, CountRequest, CountResponse,
+    CreateCollectionError, CreateCollectionRequest, CreateCollectionResponse, CreateDatabaseError,
+    CreateDatabaseRequest, CreateDatabaseResponse, CreateTenantError, CreateTenantRequest,
+    CreateTenantResponse, DatabaseName, DeleteCollectionError, DeleteCollectionRecordsError,
+    DeleteCollectionRecordsRequest, DeleteCollectionRecordsResponse, DeleteCollectionRequest,
+    DeleteCollectionResponse, DeleteDatabaseError, DeleteDatabaseRequest, DeleteDatabaseResponse,
+    DetachFunctionError, DetachFunctionRequest, DetachFunctionResponse, ExecutorError,
+    ForkCollectionError, ForkCollectionRequest, ForkCollectionResponse, GetCollectionByCrnError,
+    GetCollectionByCrnRequest, GetCollectionByCrnResponse, GetCollectionByIdError,
+    GetCollectionByIdRequest, GetCollectionByIdResponse, GetCollectionError, GetCollectionRequest,
+    GetCollectionResponse, GetCollectionsError, GetDatabaseError, GetDatabaseRequest,
+    GetDatabaseResponse, GetRequest, GetResponse, GetTenantError, GetTenantRequest,
+    GetTenantResponse, HealthCheckResponse, HeartbeatError, Include, IndexStatusError,
+    IndexStatusResponse, KnnIndex, ListCollectionsRequest, ListCollectionsResponse,
+    ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse, OccReadMode, OccReadToken,
+    Operation, OperationRecord, QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse,
+    Schema, SearchRequest, SearchResponse, SegmentType, StaleReadError, UpdateCollectionError,
+    UpdateCollectionRecordsError, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
+    UpdateCollectionRequest, UpdateCollectionResponse, UpdateTenantError, UpdateTenantRequest,
+    UpdateTenantResponse, UpsertCollectionRecordsError, UpsertCollectionRecordsRequest,
+    UpsertCollectionRecordsResponse, Where,
 };
 use opentelemetry::global;
 use opentelemetry::metrics::Counter;
@@ -1573,131 +1575,6 @@ impl ServiceBasedFrontend {
             .await
     }
 
-    fn conditional_commit_invalid_argument(message: impl Into<String>) -> ConditionalCommitError {
-        ConditionalCommitError::Other(Box::new(ValidationError::InvalidArgument(message.into())))
-    }
-
-    fn buffered_write_scope(write: &ConditionalBufferedWrite) -> (&str, &str, CollectionUuid) {
-        match write {
-            ConditionalBufferedWrite::Add(request) => (
-                &request.tenant_id,
-                &request.database_name,
-                request.collection_id,
-            ),
-            ConditionalBufferedWrite::Update(request) => (
-                &request.tenant_id,
-                &request.database_name,
-                request.collection_id,
-            ),
-            ConditionalBufferedWrite::Upsert(request) => (
-                &request.tenant_id,
-                &request.database_name,
-                request.collection_id,
-            ),
-            ConditionalBufferedWrite::Delete(request) => (
-                &request.tenant_id,
-                &request.database_name,
-                request.collection_id,
-            ),
-        }
-    }
-
-    fn validate_conditional_commit_scope(
-        request: &ConditionalCommitRequest,
-    ) -> Result<(String, DatabaseName, CollectionUuid), ConditionalCommitError> {
-        let Some(first_write) = request.buffered_writes.first() else {
-            return Err(Self::conditional_commit_invalid_argument(
-                "conditional commit append request must contain at least one write",
-            ));
-        };
-        let (tenant_id, database_name, collection_id) = Self::buffered_write_scope(first_write);
-        for write in &request.buffered_writes[1..] {
-            let (write_tenant_id, write_database_name, write_collection_id) =
-                Self::buffered_write_scope(write);
-            if write_tenant_id != tenant_id
-                || write_database_name != database_name
-                || write_collection_id != collection_id
-            {
-                return Err(Self::conditional_commit_invalid_argument(
-                    "conditional transaction contains writes for multiple collection scopes",
-                ));
-            }
-        }
-        let database_name = DatabaseName::new(database_name.to_string())
-            .ok_or(ConditionalCommitError::InvalidDatabaseName)?;
-        Ok((tenant_id.to_string(), database_name, collection_id))
-    }
-
-    fn buffered_write_to_records(
-        write: ConditionalBufferedWrite,
-    ) -> Result<(Vec<OperationRecord>, u64), ConditionalCommitError> {
-        match write {
-            ConditionalBufferedWrite::Add(AddCollectionRecordsRequest {
-                ids,
-                embeddings,
-                documents,
-                uris,
-                metadatas,
-                ..
-            }) => {
-                let embeddings = Some(embeddings.into_iter().map(Some).collect());
-                to_records(ids, embeddings, documents, uris, metadatas, Operation::Add)
-                    .map_err(|err| ConditionalCommitError::Other(Box::new(err)))
-            }
-            ConditionalBufferedWrite::Update(UpdateCollectionRecordsRequest {
-                ids,
-                embeddings,
-                documents,
-                uris,
-                metadatas,
-                ..
-            }) => to_records(
-                ids,
-                embeddings,
-                documents,
-                uris,
-                metadatas,
-                Operation::Update,
-            )
-            .map_err(|err| ConditionalCommitError::Other(Box::new(err))),
-            ConditionalBufferedWrite::Upsert(UpsertCollectionRecordsRequest {
-                ids,
-                embeddings,
-                documents,
-                uris,
-                metadatas,
-                ..
-            }) => {
-                let embeddings = Some(embeddings.into_iter().map(Some).collect());
-                to_records(
-                    ids,
-                    embeddings,
-                    documents,
-                    uris,
-                    metadatas,
-                    Operation::Upsert,
-                )
-                .map_err(|err| ConditionalCommitError::Other(Box::new(err)))
-            }
-            ConditionalBufferedWrite::Delete(DeleteCollectionRecordsRequest { ids, .. }) => {
-                let records = ids
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|id| OperationRecord {
-                        id,
-                        operation: Operation::Delete,
-                        document: None,
-                        embedding: None,
-                        encoding: None,
-                        metadata: None,
-                    })
-                    .collect::<Vec<_>>();
-                let log_size_bytes = records.iter().map(OperationRecord::size_bytes).sum();
-                Ok((records, log_size_bytes))
-            }
-        }
-    }
-
     async fn validate_buffered_write_for_commit(
         &mut self,
         write: &ConditionalBufferedWrite,
@@ -1760,7 +1637,7 @@ impl ServiceBasedFrontend {
             .await
             .map_err(ConditionalCommitError::Other)?;
         i64::try_from(scouted_offset).map_err(|_| {
-            Self::conditional_commit_invalid_argument(format!(
+            ConditionalCommitError::InvalidArgument(format!(
                 "scouted log offset {scouted_offset} exceeds i64 range"
             ))
         })
@@ -1775,7 +1652,7 @@ impl ServiceBasedFrontend {
             ConditionalCommitAction::Append(request) => request,
         };
         let (tenant_id, database_name, collection_id) =
-            Self::validate_conditional_commit_scope(&request)?;
+            validate_conditional_commit_scope(&request)?;
         let collection = self
             .get_cached_collection(database_name.clone(), collection_id)
             .await
@@ -1786,10 +1663,11 @@ impl ServiceBasedFrontend {
                 .await?;
         }
 
-        let mut records = Vec::with_capacity(request.record_count());
+        let expected_record_count = request.record_count();
+        let mut records = Vec::with_capacity(expected_record_count);
         let mut log_size_bytes = 0;
         for write in request.buffered_writes {
-            let (mut write_records, write_log_size_bytes) = Self::buffered_write_to_records(write)?;
+            let (mut write_records, write_log_size_bytes) = buffered_write_to_records(write)?;
             log_size_bytes += write_log_size_bytes;
             records.append(&mut write_records);
         }
@@ -1853,9 +1731,21 @@ impl ServiceBasedFrontend {
         });
 
         match res {
-            Ok(push_result) => state
-                .finish_commit(push_result.first_inserted_record_offset)
-                .map_err(ConditionalCommitError::from),
+            Ok(push_result) => {
+                if usize::try_from(push_result.record_count).ok() != Some(expected_record_count) {
+                    tracing::warn!(
+                        expected_record_count,
+                        reported_record_count = push_result.record_count,
+                        %tenant_id,
+                        ?database_name,
+                        %collection_id,
+                        "Log service reported a different conditional commit record count than requested"
+                    );
+                }
+                state
+                    .finish_commit(push_result.first_inserted_record_offset)
+                    .map_err(ConditionalCommitError::from)
+            }
             Err(PushLogsError::Backoff | PushLogsError::BackoffCompaction) => {
                 Err(ConditionalCommitError::Backoff)
             }
@@ -3355,11 +3245,7 @@ mod tests {
             ConditionalBufferedWrite::Update(update),
             ConditionalBufferedWrite::Delete(delete),
         ] {
-            records.extend(
-                ServiceBasedFrontend::buffered_write_to_records(write)
-                    .unwrap()
-                    .0,
-            );
+            records.extend(buffered_write_to_records(write).unwrap().0);
         }
         let got = records
             .into_iter()

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -18,6 +18,7 @@ use chroma_segment::local_segment_manager::LocalSegmentManager;
 use chroma_sqlite::db::SqliteDb;
 use chroma_sysdb::{DatabaseOrTopology, GetCollectionsOptions, SysDb};
 use chroma_system::System;
+use chroma_types::chroma_proto::PushLogsCondition;
 use chroma_types::{
     operator::{
         Aggregate, CountResult, Filter, GetResult, GroupBy, Key, KnnBatch, KnnBatchResult,
@@ -28,28 +29,29 @@ use chroma_types::{
     AddAttachedFunctionInputRequest, AddAttachedFunctionInputResponse, AddCollectionRecordsError,
     AddCollectionRecordsRequest, AddCollectionRecordsResponse, AttachFunctionRequest,
     AttachFunctionResponse, AttachedFunctionApiResponse, Cmek, Collection, CollectionAndSegments,
-    CollectionUuid, CountCollectionsError, CountCollectionsRequest, CountCollectionsResponse,
-    CountRequest, CountResponse, CreateCollectionError, CreateCollectionRequest,
-    CreateCollectionResponse, CreateDatabaseError, CreateDatabaseRequest, CreateDatabaseResponse,
-    CreateTenantError, CreateTenantRequest, CreateTenantResponse, DatabaseName,
-    DeleteCollectionError, DeleteCollectionRecordsError, DeleteCollectionRecordsRequest,
-    DeleteCollectionRecordsResponse, DeleteCollectionRequest, DeleteCollectionResponse,
-    DeleteDatabaseError, DeleteDatabaseRequest, DeleteDatabaseResponse, DetachFunctionError,
-    DetachFunctionRequest, DetachFunctionResponse, ExecutorError, ForkCollectionError,
-    ForkCollectionRequest, ForkCollectionResponse, GetCollectionByCrnError,
-    GetCollectionByCrnRequest, GetCollectionByCrnResponse, GetCollectionByIdError,
-    GetCollectionByIdRequest, GetCollectionByIdResponse, GetCollectionError, GetCollectionRequest,
-    GetCollectionResponse, GetCollectionsError, GetDatabaseError, GetDatabaseRequest,
-    GetDatabaseResponse, GetRequest, GetResponse, GetTenantError, GetTenantRequest,
-    GetTenantResponse, HealthCheckResponse, HeartbeatError, Include, IndexStatusError,
-    IndexStatusResponse, KnnIndex, ListCollectionsRequest, ListCollectionsResponse,
-    ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse, OccReadMode, OccReadToken,
-    Operation, OperationRecord, QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse,
-    Schema, SearchRequest, SearchResponse, SegmentType, StaleReadError, UpdateCollectionError,
-    UpdateCollectionRecordsError, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
-    UpdateCollectionRequest, UpdateCollectionResponse, UpdateTenantError, UpdateTenantRequest,
-    UpdateTenantResponse, UpsertCollectionRecordsError, UpsertCollectionRecordsRequest,
-    UpsertCollectionRecordsResponse, Where,
+    CollectionUuid, ConditionalBufferedWrite, ConditionalCommitAction, ConditionalCommitError,
+    ConditionalCommitRequest, ConditionalCommitResult, ConditionalTransactionState,
+    CountCollectionsError, CountCollectionsRequest, CountCollectionsResponse, CountRequest,
+    CountResponse, CreateCollectionError, CreateCollectionRequest, CreateCollectionResponse,
+    CreateDatabaseError, CreateDatabaseRequest, CreateDatabaseResponse, CreateTenantError,
+    CreateTenantRequest, CreateTenantResponse, DatabaseName, DeleteCollectionError,
+    DeleteCollectionRecordsError, DeleteCollectionRecordsRequest, DeleteCollectionRecordsResponse,
+    DeleteCollectionRequest, DeleteCollectionResponse, DeleteDatabaseError, DeleteDatabaseRequest,
+    DeleteDatabaseResponse, DetachFunctionError, DetachFunctionRequest, DetachFunctionResponse,
+    ExecutorError, ForkCollectionError, ForkCollectionRequest, ForkCollectionResponse,
+    GetCollectionByCrnError, GetCollectionByCrnRequest, GetCollectionByCrnResponse,
+    GetCollectionByIdError, GetCollectionByIdRequest, GetCollectionByIdResponse,
+    GetCollectionError, GetCollectionRequest, GetCollectionResponse, GetCollectionsError,
+    GetDatabaseError, GetDatabaseRequest, GetDatabaseResponse, GetRequest, GetResponse,
+    GetTenantError, GetTenantRequest, GetTenantResponse, HealthCheckResponse, HeartbeatError,
+    Include, IndexStatusError, IndexStatusResponse, KnnIndex, ListCollectionsRequest,
+    ListCollectionsResponse, ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse,
+    OccReadMode, OccReadToken, Operation, OperationRecord, QueryError, QueryRequest, QueryResponse,
+    ResetError, ResetResponse, Schema, SearchRequest, SearchResponse, SegmentType, StaleReadError,
+    UpdateCollectionError, UpdateCollectionRecordsError, UpdateCollectionRecordsRequest,
+    UpdateCollectionRecordsResponse, UpdateCollectionRequest, UpdateCollectionResponse,
+    UpdateTenantError, UpdateTenantRequest, UpdateTenantResponse, UpsertCollectionRecordsError,
+    UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, Where,
 };
 use opentelemetry::global;
 use opentelemetry::metrics::Counter;
@@ -1571,6 +1573,296 @@ impl ServiceBasedFrontend {
             .await
     }
 
+    fn conditional_commit_invalid_argument(message: impl Into<String>) -> ConditionalCommitError {
+        ConditionalCommitError::Other(Box::new(ValidationError::InvalidArgument(message.into())))
+    }
+
+    fn buffered_write_scope(write: &ConditionalBufferedWrite) -> (&str, &str, CollectionUuid) {
+        match write {
+            ConditionalBufferedWrite::Add(request) => (
+                &request.tenant_id,
+                &request.database_name,
+                request.collection_id,
+            ),
+            ConditionalBufferedWrite::Update(request) => (
+                &request.tenant_id,
+                &request.database_name,
+                request.collection_id,
+            ),
+            ConditionalBufferedWrite::Upsert(request) => (
+                &request.tenant_id,
+                &request.database_name,
+                request.collection_id,
+            ),
+            ConditionalBufferedWrite::Delete(request) => (
+                &request.tenant_id,
+                &request.database_name,
+                request.collection_id,
+            ),
+        }
+    }
+
+    fn validate_conditional_commit_scope(
+        request: &ConditionalCommitRequest,
+    ) -> Result<(String, DatabaseName, CollectionUuid), ConditionalCommitError> {
+        let Some(first_write) = request.buffered_writes.first() else {
+            return Err(Self::conditional_commit_invalid_argument(
+                "conditional commit append request must contain at least one write",
+            ));
+        };
+        let (tenant_id, database_name, collection_id) = Self::buffered_write_scope(first_write);
+        for write in &request.buffered_writes[1..] {
+            let (write_tenant_id, write_database_name, write_collection_id) =
+                Self::buffered_write_scope(write);
+            if write_tenant_id != tenant_id
+                || write_database_name != database_name
+                || write_collection_id != collection_id
+            {
+                return Err(Self::conditional_commit_invalid_argument(
+                    "conditional transaction contains writes for multiple collection scopes",
+                ));
+            }
+        }
+        let database_name = DatabaseName::new(database_name.to_string())
+            .ok_or(ConditionalCommitError::InvalidDatabaseName)?;
+        Ok((tenant_id.to_string(), database_name, collection_id))
+    }
+
+    fn buffered_write_to_records(
+        write: ConditionalBufferedWrite,
+    ) -> Result<(Vec<OperationRecord>, u64), ConditionalCommitError> {
+        match write {
+            ConditionalBufferedWrite::Add(AddCollectionRecordsRequest {
+                ids,
+                embeddings,
+                documents,
+                uris,
+                metadatas,
+                ..
+            }) => {
+                let embeddings = Some(embeddings.into_iter().map(Some).collect());
+                to_records(ids, embeddings, documents, uris, metadatas, Operation::Add)
+                    .map_err(|err| ConditionalCommitError::Other(Box::new(err)))
+            }
+            ConditionalBufferedWrite::Update(UpdateCollectionRecordsRequest {
+                ids,
+                embeddings,
+                documents,
+                uris,
+                metadatas,
+                ..
+            }) => to_records(
+                ids,
+                embeddings,
+                documents,
+                uris,
+                metadatas,
+                Operation::Update,
+            )
+            .map_err(|err| ConditionalCommitError::Other(Box::new(err))),
+            ConditionalBufferedWrite::Upsert(UpsertCollectionRecordsRequest {
+                ids,
+                embeddings,
+                documents,
+                uris,
+                metadatas,
+                ..
+            }) => {
+                let embeddings = Some(embeddings.into_iter().map(Some).collect());
+                to_records(
+                    ids,
+                    embeddings,
+                    documents,
+                    uris,
+                    metadatas,
+                    Operation::Upsert,
+                )
+                .map_err(|err| ConditionalCommitError::Other(Box::new(err)))
+            }
+            ConditionalBufferedWrite::Delete(DeleteCollectionRecordsRequest { ids, .. }) => {
+                let records = ids
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|id| OperationRecord {
+                        id,
+                        operation: Operation::Delete,
+                        document: None,
+                        embedding: None,
+                        encoding: None,
+                        metadata: None,
+                    })
+                    .collect::<Vec<_>>();
+                let log_size_bytes = records.iter().map(OperationRecord::size_bytes).sum();
+                Ok((records, log_size_bytes))
+            }
+        }
+    }
+
+    async fn validate_buffered_write_for_commit(
+        &mut self,
+        write: &ConditionalBufferedWrite,
+        database_name: DatabaseName,
+        collection_id: CollectionUuid,
+    ) -> Result<(), ConditionalCommitError> {
+        match write {
+            ConditionalBufferedWrite::Add(request) => {
+                self.validate_embedding(
+                    database_name,
+                    collection_id,
+                    Some(&request.embeddings),
+                    true,
+                    |embedding: &Vec<f32>| Some(embedding.len()),
+                )
+                .await
+                .map_err(|err| ConditionalCommitError::Other(Box::new(err)))?;
+            }
+            ConditionalBufferedWrite::Update(request) => {
+                self.validate_embedding(
+                    database_name,
+                    collection_id,
+                    request.embeddings.as_ref(),
+                    true,
+                    |embedding| embedding.as_ref().map(|emb| emb.len()),
+                )
+                .await
+                .map_err(|err| ConditionalCommitError::Other(Box::new(err)))?;
+            }
+            ConditionalBufferedWrite::Upsert(request) => {
+                self.validate_embedding(
+                    database_name,
+                    collection_id,
+                    Some(&request.embeddings),
+                    true,
+                    |embedding: &Vec<f32>| Some(embedding.len()),
+                )
+                .await
+                .map_err(|err| ConditionalCommitError::Other(Box::new(err)))?;
+            }
+            ConditionalBufferedWrite::Delete(_) => {}
+        }
+        Ok(())
+    }
+
+    async fn conditional_commit_observed_offset(
+        &mut self,
+        tenant_id: &str,
+        database_name: DatabaseName,
+        collection_id: CollectionUuid,
+        observed_log_offset: Option<i64>,
+    ) -> Result<i64, ConditionalCommitError> {
+        if let Some(observed_log_offset) = observed_log_offset {
+            return Ok(observed_log_offset);
+        }
+
+        let scouted_offset = self
+            .log_client
+            .scout_logs(tenant_id, database_name, collection_id, 0)
+            .await
+            .map_err(ConditionalCommitError::Other)?;
+        i64::try_from(scouted_offset).map_err(|_| {
+            Self::conditional_commit_invalid_argument(format!(
+                "scouted log offset {scouted_offset} exceeds i64 range"
+            ))
+        })
+    }
+
+    pub async fn conditional_commit(
+        &mut self,
+        state: &mut ConditionalTransactionState,
+    ) -> Result<ConditionalCommitResult, ConditionalCommitError> {
+        let request = match state.prepare_commit()? {
+            ConditionalCommitAction::NoOp(result) => return Ok(result),
+            ConditionalCommitAction::Append(request) => request,
+        };
+        let (tenant_id, database_name, collection_id) =
+            Self::validate_conditional_commit_scope(&request)?;
+        let collection = self
+            .get_cached_collection(database_name.clone(), collection_id)
+            .await
+            .map_err(|err| ConditionalCommitError::Other(Box::new(err)))?;
+
+        for write in &request.buffered_writes {
+            self.validate_buffered_write_for_commit(write, database_name.clone(), collection_id)
+                .await?;
+        }
+
+        let mut records = Vec::with_capacity(request.record_count());
+        let mut log_size_bytes = 0;
+        for write in request.buffered_writes {
+            let (mut write_records, write_log_size_bytes) = Self::buffered_write_to_records(write)?;
+            log_size_bytes += write_log_size_bytes;
+            records.append(&mut write_records);
+        }
+
+        let observed_log_offset = self
+            .conditional_commit_observed_offset(
+                &tenant_id,
+                database_name.clone(),
+                collection_id,
+                request.observed_log_offset,
+            )
+            .await?;
+        let condition = PushLogsCondition {
+            observed_log_offset,
+            read_ids: request.read_ids,
+        };
+        let cmek = collection
+            .schema
+            .as_ref()
+            .and_then(|schema| schema.cmek.clone());
+
+        let retries = Arc::new(AtomicUsize::new(0));
+        let commit_to_retry = || {
+            let mut self_clone = self.clone();
+            let tenant_id_clone = tenant_id.clone();
+            let database_name_clone = database_name.clone();
+            let records_clone = records.clone();
+            let cmek_clone = cmek.clone();
+            let condition_clone = condition.clone();
+            async move {
+                self_clone
+                    .log_client
+                    .push_logs_with_result(
+                        &tenant_id_clone,
+                        database_name_clone,
+                        collection_id,
+                        records_clone,
+                        cmek_clone,
+                        Some(condition_clone),
+                    )
+                    .await
+            }
+        };
+        let res = commit_to_retry
+            .retry(self.retries_builder)
+            .when(|e| matches!(e, PushLogsError::Backoff))
+            .notify(|_, _| {
+                let retried = retries.fetch_add(1, Ordering::Relaxed);
+                if retried > 0 {
+                    tracing::info!(
+                        "Retrying conditional commit request for collection {}",
+                        collection_id
+                    );
+                }
+            })
+            .await;
+
+        chroma_metering::with_current(|context| {
+            context.log_size_bytes(log_size_bytes);
+            context.finish_request(Instant::now());
+        });
+
+        match res {
+            Ok(push_result) => state
+                .finish_commit(push_result.first_inserted_record_offset)
+                .map_err(ConditionalCommitError::from),
+            Err(PushLogsError::Backoff | PushLogsError::BackoffCompaction) => {
+                Err(ConditionalCommitError::Backoff)
+            }
+            Err(other) => Err(ConditionalCommitError::Other(Box::new(other))),
+        }
+    }
+
     pub async fn add(
         &mut self,
         AddCollectionRecordsRequest {
@@ -3021,6 +3313,106 @@ mod tests {
     use chroma_types::CreateCollectionPayload;
 
     use super::*;
+
+    #[test]
+    fn conditional_commit_record_conversion_preserves_order_and_delete_shape() {
+        let collection_id = CollectionUuid::default();
+        let add = AddCollectionRecordsRequest::try_new(
+            "tenant".to_string(),
+            "database".to_string(),
+            collection_id,
+            vec!["add-a".to_string(), "add-b".to_string()],
+            vec![vec![1.0], vec![2.0]],
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let update = UpdateCollectionRecordsRequest::try_new(
+            "tenant".to_string(),
+            "database".to_string(),
+            collection_id,
+            vec!["update".to_string()],
+            Some(vec![Some(vec![3.0])]),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let delete = DeleteCollectionRecordsRequest::try_new(
+            "tenant".to_string(),
+            "database".to_string(),
+            collection_id,
+            Some(vec!["delete".to_string()]),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let mut records = Vec::new();
+        for write in [
+            ConditionalBufferedWrite::Add(add),
+            ConditionalBufferedWrite::Update(update),
+            ConditionalBufferedWrite::Delete(delete),
+        ] {
+            records.extend(
+                ServiceBasedFrontend::buffered_write_to_records(write)
+                    .unwrap()
+                    .0,
+            );
+        }
+        let got = records
+            .into_iter()
+            .map(|record| {
+                (
+                    record.id,
+                    record.embedding,
+                    record.encoding,
+                    record.metadata,
+                    record.document,
+                    record.operation,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            got,
+            vec![
+                (
+                    "add-a".to_string(),
+                    Some(vec![1.0]),
+                    Some(chroma_types::ScalarEncoding::FLOAT32),
+                    Some(chroma_types::UpdateMetadata::new()),
+                    None,
+                    Operation::Add,
+                ),
+                (
+                    "add-b".to_string(),
+                    Some(vec![2.0]),
+                    Some(chroma_types::ScalarEncoding::FLOAT32),
+                    Some(chroma_types::UpdateMetadata::new()),
+                    None,
+                    Operation::Add,
+                ),
+                (
+                    "update".to_string(),
+                    Some(vec![3.0]),
+                    Some(chroma_types::ScalarEncoding::FLOAT32),
+                    Some(chroma_types::UpdateMetadata::new()),
+                    None,
+                    Operation::Update,
+                ),
+                (
+                    "delete".to_string(),
+                    None,
+                    None,
+                    None,
+                    None,
+                    Operation::Delete,
+                ),
+            ]
+        );
+    }
 
     #[test]
     fn occ_read_capture_plan_uses_exact_scouted_offset() {

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -29,7 +29,7 @@ use tower::ServiceBuilder;
 use tracing::Level;
 use uuid::Uuid;
 
-use crate::GarbageCollectError;
+use crate::{GarbageCollectError, PushLogsResult};
 
 /// The gRPC metadata key carrying the backoff reason.
 const BACKOFF_REASON_MD_KEY: &str = "backoff-reason";
@@ -473,7 +473,7 @@ impl GrpcLog {
         records: Vec<OperationRecord>,
         cmek: Option<Cmek>,
         condition: Option<PushLogsCondition>,
-    ) -> Result<(), GrpcPushLogsError> {
+    ) -> Result<PushLogsResult, GrpcPushLogsError> {
         let num_records = records.len();
 
         // Convert Cmek to protobuf format
@@ -513,7 +513,10 @@ impl GrpcLog {
         } else {
             self.metrics.total_logs_pushed.add(num_records as u64, &[]);
 
-            Ok(())
+            Ok(PushLogsResult {
+                record_count: resp.record_count,
+                first_inserted_record_offset: resp.first_inserted_record_offset,
+            })
         }
     }
 

--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -10,6 +10,12 @@ use chroma_types::{
 };
 use std::fmt::Debug;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PushLogsResult {
+    pub record_count: i32,
+    pub first_inserted_record_offset: Option<i64>,
+}
+
 #[derive(Clone, Debug)]
 pub struct CollectionRecord {
     pub collection_id: CollectionUuid,
@@ -51,6 +57,9 @@ pub enum PushLogsError {
     /// Conditional writes are not supported by this log implementation.
     #[error("conditional writes are not supported by {0} log")]
     ConditionalWritesUnsupported(&'static str),
+    /// The record count cannot be represented by the log-service API.
+    #[error("too many records in push_logs request: {0}")]
+    RecordCountOutOfRange(usize),
     /// Any other push failure.
     #[error(transparent)]
     Other(Box<dyn ChromaError>),
@@ -62,6 +71,7 @@ impl ChromaError for PushLogsError {
             PushLogsError::Backoff => ErrorCodes::ResourceExhausted,
             PushLogsError::BackoffCompaction => ErrorCodes::ResourceExhausted,
             PushLogsError::ConditionalWritesUnsupported(_) => ErrorCodes::Unimplemented,
+            PushLogsError::RecordCountOutOfRange(_) => ErrorCodes::InvalidArgument,
             PushLogsError::Other(e) => e.code(),
         }
     }
@@ -184,6 +194,30 @@ impl Log {
         cmek: Option<Cmek>,
         condition: Option<PushLogsCondition>,
     ) -> Result<(), PushLogsError> {
+        self.push_logs_with_result(
+            tenant,
+            database_name,
+            collection_id,
+            records,
+            cmek,
+            condition,
+        )
+        .await
+        .map(|_| ())
+    }
+
+    #[tracing::instrument(skip(self, records), err(Display))]
+    pub async fn push_logs_with_result(
+        &mut self,
+        tenant: &str,
+        database_name: DatabaseName,
+        collection_id: CollectionUuid,
+        records: Vec<OperationRecord>,
+        cmek: Option<Cmek>,
+        condition: Option<PushLogsCondition>,
+    ) -> Result<PushLogsResult, PushLogsError> {
+        let record_count = i32::try_from(records.len())
+            .map_err(|_| PushLogsError::RecordCountOutOfRange(records.len()))?;
         match self {
             Log::Sqlite(log) => {
                 if condition.is_some() {
@@ -191,7 +225,11 @@ impl Log {
                 }
                 log.push_logs(collection_id, records)
                     .await
-                    .map_err(|e| PushLogsError::Other(Box::new(e)))
+                    .map_err(|e| PushLogsError::Other(Box::new(e)))?;
+                Ok(PushLogsResult {
+                    record_count,
+                    first_inserted_record_offset: None,
+                })
             }
             Log::Grpc(log) => log
                 .push_logs(database_name, collection_id, records, cmek, condition)

--- a/rust/types/src/conditional_transaction.rs
+++ b/rust/types/src/conditional_transaction.rs
@@ -43,6 +43,34 @@ impl ConditionalBufferedWrite {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConditionalCommitRequest {
+    pub buffered_writes: Vec<ConditionalBufferedWrite>,
+    pub observed_log_offset: Option<i64>,
+    pub read_ids: Vec<String>,
+}
+
+impl ConditionalCommitRequest {
+    pub fn record_count(&self) -> usize {
+        self.buffered_writes
+            .iter()
+            .map(|write| write.ids().len())
+            .sum()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConditionalCommitResult {
+    pub first_inserted_record_offset: Option<i64>,
+    pub record_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConditionalCommitAction {
+    NoOp(ConditionalCommitResult),
+    Append(ConditionalCommitRequest),
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ConditionalTransactionState {
     /// Ids whose values have contributed to the transaction's read snapshot.
@@ -118,6 +146,50 @@ impl ConditionalTransactionState {
 
     pub fn close(&mut self) {
         self.closed = true;
+    }
+
+    pub fn prepare_commit(
+        &mut self,
+    ) -> Result<ConditionalCommitAction, ConditionalTransactionError> {
+        if self.closed {
+            return Err(ConditionalTransactionError::Closed);
+        }
+
+        if self.buffered_writes.is_empty() {
+            self.closed = true;
+            return Ok(ConditionalCommitAction::NoOp(ConditionalCommitResult {
+                first_inserted_record_offset: None,
+                record_count: 0,
+            }));
+        }
+
+        let observed_log_offset = self.read_token.map(observed_log_offset).transpose()?;
+
+        Ok(ConditionalCommitAction::Append(ConditionalCommitRequest {
+            buffered_writes: self.buffered_writes.clone(),
+            observed_log_offset,
+            read_ids: self.read_ids.iter().cloned().collect(),
+        }))
+    }
+
+    pub fn finish_commit(
+        &mut self,
+        first_inserted_record_offset: Option<i64>,
+    ) -> Result<ConditionalCommitResult, ConditionalTransactionError> {
+        if self.closed {
+            return Err(ConditionalTransactionError::Closed);
+        }
+
+        let result = ConditionalCommitResult {
+            first_inserted_record_offset,
+            record_count: self
+                .buffered_writes
+                .iter()
+                .map(|write| write.ids().len())
+                .sum(),
+        };
+        self.closed = true;
+        Ok(result)
     }
 
     /// Buffers an already-normalized add request.
@@ -400,6 +472,29 @@ impl ChromaError for ConditionalTransactionError {
             | ConditionalTransactionError::ReadTokenOutOfRange { .. } => {
                 ErrorCodes::FailedPrecondition
             }
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ConditionalCommitError {
+    #[error(transparent)]
+    Transaction(#[from] ConditionalTransactionError),
+    #[error("Backoff and retry")]
+    Backoff,
+    #[error("Invalid database name")]
+    InvalidDatabaseName,
+    #[error(transparent)]
+    Other(#[from] Box<dyn ChromaError>),
+}
+
+impl ChromaError for ConditionalCommitError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            ConditionalCommitError::Transaction(err) => err.code(),
+            ConditionalCommitError::Backoff => ErrorCodes::ResourceExhausted,
+            ConditionalCommitError::InvalidDatabaseName => ErrorCodes::InvalidArgument,
+            ConditionalCommitError::Other(err) => err.code(),
         }
     }
 }
@@ -978,6 +1073,103 @@ mod tests {
                 ]),
                 closed: false,
             }
+        );
+    }
+
+    #[test]
+    fn no_pending_writes_commit_is_successful_noop_and_closes() {
+        let mut state = ConditionalTransactionState::new();
+        record_point_read(&mut state, &["present"], &["present"]);
+
+        let action = state.prepare_commit().unwrap();
+
+        assert_eq!(
+            action,
+            ConditionalCommitAction::NoOp(ConditionalCommitResult {
+                first_inserted_record_offset: None,
+                record_count: 0,
+            })
+        );
+        assert!(state.is_closed());
+    }
+
+    #[test]
+    fn prepare_commit_carries_buffered_writes_condition_inputs_and_record_count() {
+        let mut state = ConditionalTransactionState::new();
+        record_point_read(
+            &mut state,
+            &["present", "absent-a", "absent-b"],
+            &["present"],
+        );
+        let add = add_request(&["absent-a", "absent-b"]);
+        let update = update_request(&["present"]);
+        state.buffer_add(add.clone()).unwrap();
+        state.buffer_update(update.clone()).unwrap();
+
+        let action = state.prepare_commit().unwrap();
+
+        assert_eq!(
+            action,
+            ConditionalCommitAction::Append(ConditionalCommitRequest {
+                buffered_writes: vec![
+                    ConditionalBufferedWrite::Add(add),
+                    ConditionalBufferedWrite::Update(update),
+                ],
+                observed_log_offset: Some(42),
+                read_ids: vec![
+                    "absent-a".to_string(),
+                    "absent-b".to_string(),
+                    "present".to_string(),
+                ],
+            })
+        );
+        match action {
+            ConditionalCommitAction::Append(request) => assert_eq!(request.record_count(), 3),
+            ConditionalCommitAction::NoOp(_) => panic!("pending writes should require append"),
+        }
+        assert!(!state.is_closed());
+    }
+
+    #[test]
+    fn finish_commit_returns_result_and_closes_transaction() {
+        let mut state = ConditionalTransactionState::new();
+        state
+            .buffer_upsert(upsert_request(&["first", "second"]))
+            .unwrap();
+
+        let result = state.finish_commit(Some(123)).unwrap();
+
+        assert_eq!(
+            result,
+            ConditionalCommitResult {
+                first_inserted_record_offset: Some(123),
+                record_count: 2,
+            }
+        );
+        assert!(state.is_closed());
+    }
+
+    #[test]
+    fn operations_after_successful_commit_fail_as_closed() {
+        let mut state = ConditionalTransactionState::new();
+        state.buffer_upsert(upsert_request(&["written"])).unwrap();
+        state.finish_commit(None).unwrap();
+
+        assert!(matches!(
+            state.prepare_get_request(request(Some(vec!["other"]), None, None)),
+            Err(ConditionalTransactionError::Closed)
+        ));
+        assert_eq!(
+            state.buffer_upsert(upsert_request(&["other"])),
+            Err(ConditionalTransactionError::Closed)
+        );
+        assert_eq!(
+            state.prepare_commit(),
+            Err(ConditionalTransactionError::Closed)
+        );
+        assert_eq!(
+            state.finish_commit(None),
+            Err(ConditionalTransactionError::Closed)
         );
     }
 }

--- a/rust/types/src/conditional_transaction.rs
+++ b/rust/types/src/conditional_transaction.rs
@@ -4,9 +4,10 @@ use chroma_error::{ChromaError, ErrorCodes};
 use thiserror::Error;
 
 use crate::{
-    AddCollectionRecordsRequest, DeleteCollectionRecordsRequest, GetRequest, GetResponse,
-    OccReadMode, OccReadToken, Operation, UpdateCollectionRecordsRequest,
-    UpsertCollectionRecordsRequest,
+    AddCollectionRecordsRequest, CollectionUuid, DatabaseName, DeleteCollectionRecordsRequest,
+    GetRequest, GetResponse, OccReadMode, OccReadToken, Operation, OperationRecord, ScalarEncoding,
+    UpdateCollectionRecordsRequest, UpdateMetadata, UpdateMetadataValue,
+    UpsertCollectionRecordsRequest, CHROMA_DOCUMENT_KEY, CHROMA_URI_KEY,
 };
 
 /// One buffered write operation in transaction call order.
@@ -484,6 +485,8 @@ pub enum ConditionalCommitError {
     Backoff,
     #[error("Invalid database name")]
     InvalidDatabaseName,
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
     #[error(transparent)]
     Other(#[from] Box<dyn ChromaError>),
 }
@@ -494,9 +497,204 @@ impl ChromaError for ConditionalCommitError {
             ConditionalCommitError::Transaction(err) => err.code(),
             ConditionalCommitError::Backoff => ErrorCodes::ResourceExhausted,
             ConditionalCommitError::InvalidDatabaseName => ErrorCodes::InvalidArgument,
+            ConditionalCommitError::InvalidArgument(_) => ErrorCodes::InvalidArgument,
             ConditionalCommitError::Other(err) => err.code(),
         }
     }
+}
+
+fn conditional_commit_invalid_argument(message: impl Into<String>) -> ConditionalCommitError {
+    ConditionalCommitError::InvalidArgument(message.into())
+}
+
+fn buffered_write_scope(write: &ConditionalBufferedWrite) -> (&str, &str, CollectionUuid) {
+    match write {
+        ConditionalBufferedWrite::Add(request) => (
+            &request.tenant_id,
+            &request.database_name,
+            request.collection_id,
+        ),
+        ConditionalBufferedWrite::Update(request) => (
+            &request.tenant_id,
+            &request.database_name,
+            request.collection_id,
+        ),
+        ConditionalBufferedWrite::Upsert(request) => (
+            &request.tenant_id,
+            &request.database_name,
+            request.collection_id,
+        ),
+        ConditionalBufferedWrite::Delete(request) => (
+            &request.tenant_id,
+            &request.database_name,
+            request.collection_id,
+        ),
+    }
+}
+
+pub fn validate_conditional_commit_scope(
+    request: &ConditionalCommitRequest,
+) -> Result<(String, DatabaseName, CollectionUuid), ConditionalCommitError> {
+    let Some(first_write) = request.buffered_writes.first() else {
+        return Err(conditional_commit_invalid_argument(
+            "conditional commit append request must contain at least one write",
+        ));
+    };
+    let (tenant_id, database_name, collection_id) = buffered_write_scope(first_write);
+    for write in &request.buffered_writes[1..] {
+        let (write_tenant_id, write_database_name, write_collection_id) =
+            buffered_write_scope(write);
+        if write_tenant_id != tenant_id
+            || write_database_name != database_name
+            || write_collection_id != collection_id
+        {
+            return Err(conditional_commit_invalid_argument(
+                "conditional transaction contains writes for multiple collection scopes",
+            ));
+        }
+    }
+    let database_name = DatabaseName::new(database_name.to_string())
+        .ok_or(ConditionalCommitError::InvalidDatabaseName)?;
+    Ok((tenant_id.to_string(), database_name, collection_id))
+}
+
+pub fn buffered_write_to_records(
+    write: ConditionalBufferedWrite,
+) -> Result<(Vec<OperationRecord>, u64), ConditionalCommitError> {
+    match write {
+        ConditionalBufferedWrite::Add(AddCollectionRecordsRequest {
+            ids,
+            embeddings,
+            documents,
+            uris,
+            metadatas,
+            ..
+        }) => {
+            let embeddings = Some(embeddings.into_iter().map(Some).collect());
+            to_records(ids, embeddings, documents, uris, metadatas, Operation::Add)
+        }
+        ConditionalBufferedWrite::Update(UpdateCollectionRecordsRequest {
+            ids,
+            embeddings,
+            documents,
+            uris,
+            metadatas,
+            ..
+        }) => to_records(
+            ids,
+            embeddings,
+            documents,
+            uris,
+            metadatas,
+            Operation::Update,
+        ),
+        ConditionalBufferedWrite::Upsert(UpsertCollectionRecordsRequest {
+            ids,
+            embeddings,
+            documents,
+            uris,
+            metadatas,
+            ..
+        }) => {
+            let embeddings = Some(embeddings.into_iter().map(Some).collect());
+            to_records(
+                ids,
+                embeddings,
+                documents,
+                uris,
+                metadatas,
+                Operation::Upsert,
+            )
+        }
+        ConditionalBufferedWrite::Delete(DeleteCollectionRecordsRequest { ids, .. }) => {
+            let records = ids
+                .unwrap_or_default()
+                .into_iter()
+                .map(|id| OperationRecord {
+                    id,
+                    operation: Operation::Delete,
+                    document: None,
+                    embedding: None,
+                    encoding: None,
+                    metadata: None,
+                })
+                .collect::<Vec<_>>();
+            let log_size_bytes = records.iter().map(OperationRecord::size_bytes).sum();
+            Ok((records, log_size_bytes))
+        }
+    }
+}
+
+fn to_records<V: Into<UpdateMetadataValue>, M: IntoIterator<Item = (String, V)>>(
+    ids: Vec<String>,
+    embeddings: Option<Vec<Option<Vec<f32>>>>,
+    documents: Option<Vec<Option<String>>>,
+    uris: Option<Vec<Option<String>>>,
+    metadatas: Option<Vec<Option<M>>>,
+    operation: Operation,
+) -> Result<(Vec<OperationRecord>, u64), ConditionalCommitError> {
+    let mut total_bytes = 0;
+    let len = ids.len();
+
+    if embeddings.as_ref().is_some_and(|v| v.len() != len)
+        || documents.as_ref().is_some_and(|v| v.len() != len)
+        || uris.as_ref().is_some_and(|v| v.len() != len)
+        || metadatas.as_ref().is_some_and(|v| v.len() != len)
+    {
+        return Err(conditional_commit_invalid_argument(
+            "inconsistent number of IDs, embeddings, documents, URIs and metadatas",
+        ));
+    }
+
+    let mut embeddings_iter = embeddings.into_iter().flatten();
+    let mut documents_iter = documents.into_iter().flatten();
+    let mut uris_iter = uris.into_iter().flatten();
+    let mut metadatas_iter = metadatas.into_iter().flatten();
+    let mut records = Vec::with_capacity(len);
+
+    for id in ids {
+        if id.is_empty() {
+            return Err(conditional_commit_invalid_argument(
+                "empty ID, ID must have at least one character",
+            ));
+        }
+
+        let embedding = embeddings_iter.next().flatten();
+        let document = documents_iter.next().flatten();
+        let uri = uris_iter.next().flatten();
+        let metadata = metadatas_iter.next().flatten();
+        let encoding = embedding.as_ref().map(|_| ScalarEncoding::FLOAT32);
+
+        let mut metadata = metadata
+            .map(|m| {
+                m.into_iter()
+                    .map(|(key, value)| (key, value.into()))
+                    .collect::<UpdateMetadata>()
+            })
+            .unwrap_or_default();
+        if let Some(document) = document.clone() {
+            metadata.insert(
+                CHROMA_DOCUMENT_KEY.to_string(),
+                UpdateMetadataValue::Str(document),
+            );
+        }
+        if let Some(uri) = uri {
+            metadata.insert(CHROMA_URI_KEY.to_string(), UpdateMetadataValue::Str(uri));
+        }
+
+        let record = OperationRecord {
+            id,
+            embedding,
+            encoding,
+            metadata: Some(metadata),
+            document,
+            operation,
+        };
+        total_bytes += record.size_bytes();
+        records.push(record);
+    }
+
+    Ok((records, total_bytes))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of changes

Add a conditional_commit path that drains buffered writes from a
ConditionalTransactionState and applies them atomically against the
log.  The frontend validates that all buffered writes target a single
collection scope, normalizes them into operation records, and pushes
them with the observed log offset as the conditional predicate.

Supporting changes:
- types: add ConditionalCommitAction/Request/Result and the
  prepare_commit/finish_commit state machine, plus a
  ConditionalCommitError; observed_log_offset now tracks the minimum
  observed offset across reads.
- log: add push_logs_with_result returning a PushLogsResult so callers
  can recover the first inserted record offset and record count, and
  surface RecordCountOutOfRange for oversized requests.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
