### PR TITLE
[ENH](python): add run() retry helper for conditional txns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,6 +1902,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytemuck",
+ "chroma-api-types",
  "chroma-config",
  "chroma-error",
  "chroma-memberlist",

--- a/chromadb/api/models/AsyncConditionalCollectionTransaction.py
+++ b/chromadb/api/models/AsyncConditionalCollectionTransaction.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Optional, Union
+import inspect
+from typing import TYPE_CHECKING, Awaitable, Callable, Optional, TypeVar, Union, cast
 
 from chromadb.api.types import (
     ConditionalCommitResult,
@@ -15,15 +16,80 @@ from chromadb.api.types import (
     Where,
     WhereDocument,
 )
+from chromadb.api.models.ConditionalCollectionTransaction import (
+    _RUN_RETRYABLE_ERRORS,
+    _validate_max_retries,
+)
 
 if TYPE_CHECKING:
     from chromadb.api.models.AsyncCollection import AsyncCollection
+
+
+T = TypeVar("T")
 
 
 class AsyncConditionalCollectionTransaction:
     def __init__(self, collection: "AsyncCollection", transaction: object) -> None:
         self._collection = collection
         self._transaction = transaction
+        self._commit_blocked_by_run = False
+        self._retryable_operation_exception: Optional[Exception] = None
+
+    async def _run_transaction_operation(self, operation: Awaitable[T]) -> T:
+        try:
+            return await operation
+        except _RUN_RETRYABLE_ERRORS as exc:
+            self._retryable_operation_exception = exc
+            raise
+
+    async def _new_attempt(
+        self, attempt: int
+    ) -> "AsyncConditionalCollectionTransaction":
+        if attempt == 0:
+            return self
+        return await self._collection.conditional()
+
+    async def _commit_after_run(self) -> ConditionalCommitResult:
+        return await self._collection._client._conditional_commit(
+            transaction=self._transaction
+        )
+
+    async def run(
+        self,
+        callback: Callable[
+            ["AsyncConditionalCollectionTransaction"], Union[T, Awaitable[T]]
+        ],
+        max_retries: int = 3,
+    ) -> T:
+        _validate_max_retries(max_retries)
+
+        attempt = 0
+        while True:
+            txn = await self._new_attempt(attempt)
+            txn._commit_blocked_by_run = True
+            try:
+                result = callback(txn)
+                if inspect.isawaitable(result):
+                    value = await cast(Awaitable[T], result)
+                else:
+                    value = cast(T, result)
+            except Exception as exc:
+                if txn._retryable_operation_exception is exc and attempt < max_retries:
+                    attempt += 1
+                    continue
+                raise
+            finally:
+                txn._commit_blocked_by_run = False
+
+            try:
+                await txn._commit_after_run()
+            except _RUN_RETRYABLE_ERRORS:
+                if attempt < max_retries:
+                    attempt += 1
+                    continue
+                raise
+
+            return value
 
     async def get(
         self,
@@ -41,17 +107,19 @@ class AsyncConditionalCollectionTransaction:
             include=include,
         )
 
-        get_results = await self._collection._client._conditional_get(
-            transaction=self._transaction,
-            collection_id=self._collection.id,
-            ids=get_request["ids"],
-            where=get_request["where"],
-            where_document=get_request["where_document"],
-            include=get_request["include"],
-            limit=limit,
-            offset=offset,
-            tenant=self._collection.tenant,
-            database=self._collection.database,
+        get_results = await self._run_transaction_operation(
+            self._collection._client._conditional_get(
+                transaction=self._transaction,
+                collection_id=self._collection.id,
+                ids=get_request["ids"],
+                where=get_request["where"],
+                where_document=get_request["where_document"],
+                include=get_request["include"],
+                limit=limit,
+                offset=offset,
+                tenant=self._collection.tenant,
+                database=self._collection.database,
+            )
         )
         return self._collection._transform_get_response(
             response=get_results, include=get_request["include"]
@@ -80,16 +148,18 @@ class AsyncConditionalCollectionTransaction:
             uris=uris,
         )
 
-        await self._collection._client._conditional_add(
-            transaction=self._transaction,
-            collection_id=self._collection.id,
-            ids=add_request["ids"],
-            embeddings=add_request["embeddings"],
-            metadatas=add_request["metadatas"],
-            documents=add_request["documents"],
-            uris=add_request["uris"],
-            tenant=self._collection.tenant,
-            database=self._collection.database,
+        await self._run_transaction_operation(
+            self._collection._client._conditional_add(
+                transaction=self._transaction,
+                collection_id=self._collection.id,
+                ids=add_request["ids"],
+                embeddings=add_request["embeddings"],
+                metadatas=add_request["metadatas"],
+                documents=add_request["documents"],
+                uris=add_request["uris"],
+                tenant=self._collection.tenant,
+                database=self._collection.database,
+            )
         )
 
     async def update(
@@ -115,16 +185,18 @@ class AsyncConditionalCollectionTransaction:
             uris=uris,
         )
 
-        await self._collection._client._conditional_update(
-            transaction=self._transaction,
-            collection_id=self._collection.id,
-            ids=update_request["ids"],
-            embeddings=update_request["embeddings"],
-            metadatas=update_request["metadatas"],
-            documents=update_request["documents"],
-            uris=update_request["uris"],
-            tenant=self._collection.tenant,
-            database=self._collection.database,
+        await self._run_transaction_operation(
+            self._collection._client._conditional_update(
+                transaction=self._transaction,
+                collection_id=self._collection.id,
+                ids=update_request["ids"],
+                embeddings=update_request["embeddings"],
+                metadatas=update_request["metadatas"],
+                documents=update_request["documents"],
+                uris=update_request["uris"],
+                tenant=self._collection.tenant,
+                database=self._collection.database,
+            )
         )
 
     async def upsert(
@@ -150,16 +222,18 @@ class AsyncConditionalCollectionTransaction:
             uris=uris,
         )
 
-        await self._collection._client._conditional_upsert(
-            transaction=self._transaction,
-            collection_id=self._collection.id,
-            ids=upsert_request["ids"],
-            embeddings=upsert_request["embeddings"],
-            metadatas=upsert_request["metadatas"],
-            documents=upsert_request["documents"],
-            uris=upsert_request["uris"],
-            tenant=self._collection.tenant,
-            database=self._collection.database,
+        await self._run_transaction_operation(
+            self._collection._client._conditional_upsert(
+                transaction=self._transaction,
+                collection_id=self._collection.id,
+                ids=upsert_request["ids"],
+                embeddings=upsert_request["embeddings"],
+                metadatas=upsert_request["metadatas"],
+                documents=upsert_request["documents"],
+                uris=upsert_request["uris"],
+                tenant=self._collection.tenant,
+                database=self._collection.database,
+            )
         )
 
     async def delete(self, ids: OneOrMany[ID]) -> None:
@@ -169,15 +243,17 @@ class AsyncConditionalCollectionTransaction:
         if delete_request["ids"] is None:
             raise ValueError("ids must be provided for transactional delete")
 
-        await self._collection._client._conditional_delete(
-            transaction=self._transaction,
-            collection_id=self._collection.id,
-            ids=delete_request["ids"],
-            tenant=self._collection.tenant,
-            database=self._collection.database,
+        await self._run_transaction_operation(
+            self._collection._client._conditional_delete(
+                transaction=self._transaction,
+                collection_id=self._collection.id,
+                ids=delete_request["ids"],
+                tenant=self._collection.tenant,
+                database=self._collection.database,
+            )
         )
 
     async def commit(self) -> ConditionalCommitResult:
-        return await self._collection._client._conditional_commit(
-            transaction=self._transaction
-        )
+        if self._commit_blocked_by_run:
+            raise ValueError("txn.commit() cannot be called inside run()")
+        return await self._commit_after_run()

--- a/chromadb/api/models/AsyncConditionalCollectionTransaction.py
+++ b/chromadb/api/models/AsyncConditionalCollectionTransaction.py
@@ -32,6 +32,7 @@ class AsyncConditionalCollectionTransaction:
     def __init__(self, collection: "AsyncCollection", transaction: object) -> None:
         self._collection = collection
         self._transaction = transaction
+        # True iff within a `run` block and therefore explicit commit shall be disallowed.
         self._commit_blocked_by_run = False
         self._retryable_operation_exception: Optional[Exception] = None
 

--- a/chromadb/api/models/ConditionalCollectionTransaction.py
+++ b/chromadb/api/models/ConditionalCollectionTransaction.py
@@ -1,5 +1,10 @@
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
 
+from chromadb.errors import (
+    BackoffError,
+    ConditionalWriteConflictError,
+    StaleReadError,
+)
 from chromadb.api.types import (
     ConditionalCommitResult,
     Document,
@@ -20,10 +25,73 @@ if TYPE_CHECKING:
     from chromadb.api.models.Collection import Collection
 
 
+T = TypeVar("T")
+_RUN_RETRYABLE_ERRORS = (
+    ConditionalWriteConflictError,
+    StaleReadError,
+    BackoffError,
+)
+
+
+def _validate_max_retries(max_retries: int) -> None:
+    if not isinstance(max_retries, int) or max_retries < 0:
+        raise ValueError("max_retries must be a non-negative integer")
+
+
 class ConditionalCollectionTransaction:
     def __init__(self, collection: "Collection") -> None:
         self._collection = collection
         self._transaction = collection._client._begin_conditional_transaction()
+        self._commit_blocked_by_run = False
+        self._retryable_operation_exception: Optional[Exception] = None
+
+    def _run_transaction_operation(self, operation: Callable[[], T]) -> T:
+        try:
+            return operation()
+        except _RUN_RETRYABLE_ERRORS as exc:
+            self._retryable_operation_exception = exc
+            raise
+
+    def _new_attempt(self, attempt: int) -> "ConditionalCollectionTransaction":
+        if attempt == 0:
+            return self
+        return ConditionalCollectionTransaction(self._collection)
+
+    def _commit_after_run(self) -> ConditionalCommitResult:
+        return self._collection._client._conditional_commit(
+            transaction=self._transaction
+        )
+
+    def run(
+        self,
+        callback: Callable[["ConditionalCollectionTransaction"], T],
+        max_retries: int = 3,
+    ) -> T:
+        _validate_max_retries(max_retries)
+
+        attempt = 0
+        while True:
+            txn = self._new_attempt(attempt)
+            txn._commit_blocked_by_run = True
+            try:
+                result = callback(txn)
+            except Exception as exc:
+                if txn._retryable_operation_exception is exc and attempt < max_retries:
+                    attempt += 1
+                    continue
+                raise
+            finally:
+                txn._commit_blocked_by_run = False
+
+            try:
+                txn._commit_after_run()
+            except _RUN_RETRYABLE_ERRORS:
+                if attempt < max_retries:
+                    attempt += 1
+                    continue
+                raise
+
+            return result
 
     def get(
         self,
@@ -41,17 +109,19 @@ class ConditionalCollectionTransaction:
             include=include,
         )
 
-        get_results = self._collection._client._conditional_get(
-            transaction=self._transaction,
-            collection_id=self._collection.id,
-            ids=get_request["ids"],
-            where=get_request["where"],
-            where_document=get_request["where_document"],
-            include=get_request["include"],
-            limit=limit,
-            offset=offset,
-            tenant=self._collection.tenant,
-            database=self._collection.database,
+        get_results = self._run_transaction_operation(
+            lambda: self._collection._client._conditional_get(
+                transaction=self._transaction,
+                collection_id=self._collection.id,
+                ids=get_request["ids"],
+                where=get_request["where"],
+                where_document=get_request["where_document"],
+                include=get_request["include"],
+                limit=limit,
+                offset=offset,
+                tenant=self._collection.tenant,
+                database=self._collection.database,
+            )
         )
         return self._collection._transform_get_response(
             response=get_results, include=get_request["include"]
@@ -80,16 +150,18 @@ class ConditionalCollectionTransaction:
             uris=uris,
         )
 
-        self._collection._client._conditional_add(
-            transaction=self._transaction,
-            collection_id=self._collection.id,
-            ids=add_request["ids"],
-            embeddings=add_request["embeddings"],
-            metadatas=add_request["metadatas"],
-            documents=add_request["documents"],
-            uris=add_request["uris"],
-            tenant=self._collection.tenant,
-            database=self._collection.database,
+        self._run_transaction_operation(
+            lambda: self._collection._client._conditional_add(
+                transaction=self._transaction,
+                collection_id=self._collection.id,
+                ids=add_request["ids"],
+                embeddings=add_request["embeddings"],
+                metadatas=add_request["metadatas"],
+                documents=add_request["documents"],
+                uris=add_request["uris"],
+                tenant=self._collection.tenant,
+                database=self._collection.database,
+            )
         )
 
     def update(
@@ -115,16 +187,18 @@ class ConditionalCollectionTransaction:
             uris=uris,
         )
 
-        self._collection._client._conditional_update(
-            transaction=self._transaction,
-            collection_id=self._collection.id,
-            ids=update_request["ids"],
-            embeddings=update_request["embeddings"],
-            metadatas=update_request["metadatas"],
-            documents=update_request["documents"],
-            uris=update_request["uris"],
-            tenant=self._collection.tenant,
-            database=self._collection.database,
+        self._run_transaction_operation(
+            lambda: self._collection._client._conditional_update(
+                transaction=self._transaction,
+                collection_id=self._collection.id,
+                ids=update_request["ids"],
+                embeddings=update_request["embeddings"],
+                metadatas=update_request["metadatas"],
+                documents=update_request["documents"],
+                uris=update_request["uris"],
+                tenant=self._collection.tenant,
+                database=self._collection.database,
+            )
         )
 
     def upsert(
@@ -150,16 +224,18 @@ class ConditionalCollectionTransaction:
             uris=uris,
         )
 
-        self._collection._client._conditional_upsert(
-            transaction=self._transaction,
-            collection_id=self._collection.id,
-            ids=upsert_request["ids"],
-            embeddings=upsert_request["embeddings"],
-            metadatas=upsert_request["metadatas"],
-            documents=upsert_request["documents"],
-            uris=upsert_request["uris"],
-            tenant=self._collection.tenant,
-            database=self._collection.database,
+        self._run_transaction_operation(
+            lambda: self._collection._client._conditional_upsert(
+                transaction=self._transaction,
+                collection_id=self._collection.id,
+                ids=upsert_request["ids"],
+                embeddings=upsert_request["embeddings"],
+                metadatas=upsert_request["metadatas"],
+                documents=upsert_request["documents"],
+                uris=upsert_request["uris"],
+                tenant=self._collection.tenant,
+                database=self._collection.database,
+            )
         )
 
     def delete(self, ids: OneOrMany[ID]) -> None:
@@ -169,15 +245,17 @@ class ConditionalCollectionTransaction:
         if delete_request["ids"] is None:
             raise ValueError("ids must be provided for transactional delete")
 
-        self._collection._client._conditional_delete(
-            transaction=self._transaction,
-            collection_id=self._collection.id,
-            ids=delete_request["ids"],
-            tenant=self._collection.tenant,
-            database=self._collection.database,
+        self._run_transaction_operation(
+            lambda: self._collection._client._conditional_delete(
+                transaction=self._transaction,
+                collection_id=self._collection.id,
+                ids=delete_request["ids"],
+                tenant=self._collection.tenant,
+                database=self._collection.database,
+            )
         )
 
     def commit(self) -> ConditionalCommitResult:
-        return self._collection._client._conditional_commit(
-            transaction=self._transaction
-        )
+        if self._commit_blocked_by_run:
+            raise ValueError("txn.commit() cannot be called inside run()")
+        return self._commit_after_run()

--- a/chromadb/api/models/ConditionalCollectionTransaction.py
+++ b/chromadb/api/models/ConditionalCollectionTransaction.py
@@ -42,6 +42,7 @@ class ConditionalCollectionTransaction:
     def __init__(self, collection: "Collection") -> None:
         self._collection = collection
         self._transaction = collection._client._begin_conditional_transaction()
+        # True iff within a `run` block and therefore explicit commit shall be disallowed.
         self._commit_blocked_by_run = False
         self._retryable_operation_exception: Optional[Exception] = None
 

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -162,6 +162,17 @@ class RateLimitError(ChromaError):
         return "RateLimitError"
 
 
+class BackoffError(ChromaError):
+    @overrides
+    def code(self) -> int:
+        return 429
+
+    @classmethod
+    @overrides
+    def name(cls) -> str:
+        return "Backoff"
+
+
 class QuotaError(ChromaError):
     @overrides
     def code(self) -> int:
@@ -207,6 +218,7 @@ error_types: Dict[str, Type[ChromaError]] = {
     "BatchSizeExceededError": BatchSizeExceededError,
     "VersionMismatchError": VersionMismatchError,
     "RateLimitError": RateLimitError,
+    "Backoff": BackoffError,
     "AuthError": ChromaAuthError,
     "UniqueConstraintError": UniqueConstraintError,
     "QuotaError": QuotaError,

--- a/chromadb/test/api/test_conditional_transaction.py
+++ b/chromadb/test/api/test_conditional_transaction.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 from uuid import uuid4
 
 import pytest
@@ -8,6 +8,7 @@ from chromadb.api.models.AsyncCollection import AsyncCollection
 from chromadb.api.models.Collection import Collection
 from chromadb.api.types import ConditionalCommitResult, GetResult
 from chromadb.config import System
+from chromadb.errors import BackoffError, ConditionalWriteConflictError, StaleReadError
 from chromadb.types import Collection as CollectionModel
 
 
@@ -39,14 +40,24 @@ def _get_result(include: List[str]) -> GetResult:
 class FakeConditionalClient:
     def __init__(self) -> None:
         self.transaction = object()
+        self.transactions: List[object] = []
         self.calls: List[tuple[str, Dict[str, Any]]] = []
+        self.get_outcomes: List[Union[GetResult, BaseException]] = []
+        self.commit_outcomes: List[Union[ConditionalCommitResult, BaseException]] = []
 
     def _begin_conditional_transaction(self) -> object:
+        self.transaction = object()
+        self.transactions.append(self.transaction)
         self.calls.append(("begin", {}))
         return self.transaction
 
     def _conditional_get(self, **kwargs: Any) -> GetResult:
         self.calls.append(("get", kwargs))
+        if self.get_outcomes:
+            outcome = self.get_outcomes.pop(0)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
         return _get_result(kwargs["include"])
 
     def _conditional_add(self, **kwargs: Any) -> bool:
@@ -67,6 +78,11 @@ class FakeConditionalClient:
 
     def _conditional_commit(self, **kwargs: Any) -> ConditionalCommitResult:
         self.calls.append(("commit", kwargs))
+        if self.commit_outcomes:
+            outcome = self.commit_outcomes.pop(0)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
         return ConditionalCommitResult(
             first_inserted_record_offset=42,
             record_count=4,
@@ -173,3 +189,257 @@ def test_embedded_conditional_transaction_reports_unsupported(
             collection.conditional()
     finally:
         client.clear_system_cache()
+
+
+def test_sync_conditional_run_does_not_retry_callback_errors() -> None:
+    client = FakeConditionalClient()
+    collection = Collection(
+        client=client,  # type: ignore[arg-type]
+        model=_collection_model(),
+        embedding_function=None,
+    )
+    attempts = 0
+
+    def callback(txn: object) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("callback failed")
+
+    with pytest.raises(RuntimeError, match="callback failed"):
+        collection.conditional().run(callback)
+
+    assert attempts == 1
+    assert [name for name, _ in client.calls] == ["begin"]
+
+
+def test_sync_conditional_run_does_not_retry_user_raised_retryable_error() -> None:
+    client = FakeConditionalClient()
+    collection = Collection(
+        client=client,  # type: ignore[arg-type]
+        model=_collection_model(),
+        embedding_function=None,
+    )
+    attempts = 0
+
+    def callback(txn: object) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise ConditionalWriteConflictError("user-raised conflict")
+
+    with pytest.raises(ConditionalWriteConflictError, match="user-raised conflict"):
+        collection.conditional().run(callback)
+
+    assert attempts == 1
+    assert [name for name, _ in client.calls] == ["begin"]
+
+
+def test_sync_conditional_run_retries_occ_conflict_with_fresh_transaction() -> None:
+    client = FakeConditionalClient()
+    client.commit_outcomes = [
+        ConditionalWriteConflictError("conflict"),
+        ConditionalCommitResult(
+            first_inserted_record_offset=84,
+            record_count=1,
+        ),
+    ]
+    collection = Collection(
+        client=client,  # type: ignore[arg-type]
+        model=_collection_model(),
+        embedding_function=None,
+    )
+    attempt_transactions: List[object] = []
+
+    def callback(txn: Any) -> str:
+        attempt_transactions.append(txn._transaction)
+        txn.add(ids=f"id-{len(attempt_transactions)}", embeddings=[1.0])
+        return f"value-{len(attempt_transactions)}"
+
+    result = collection.conditional().run(callback, max_retries=1)
+
+    assert result == "value-2"
+    assert len(attempt_transactions) == 2
+    assert attempt_transactions == client.transactions
+    assert attempt_transactions[0] is not attempt_transactions[1]
+    assert [name for name, _ in client.calls] == [
+        "begin",
+        "add",
+        "commit",
+        "begin",
+        "add",
+        "commit",
+    ]
+
+
+def test_sync_conditional_run_retries_stale_read_with_fresh_transaction() -> None:
+    client = FakeConditionalClient()
+    client.get_outcomes = [
+        StaleReadError("stale read"),
+        _get_result(["documents"]),
+    ]
+    collection = Collection(
+        client=client,  # type: ignore[arg-type]
+        model=_collection_model(),
+        embedding_function=None,
+    )
+    attempt_transactions: List[object] = []
+
+    def callback(txn: Any) -> str:
+        attempt_transactions.append(txn._transaction)
+        result = txn.get(ids="id-1", include=["documents"])
+        return result["ids"][0]
+
+    result = collection.conditional().run(callback, max_retries=1)
+
+    assert result == "id-1"
+    assert len(attempt_transactions) == 2
+    assert attempt_transactions == client.transactions
+    assert attempt_transactions[0] is not attempt_transactions[1]
+    assert [name for name, _ in client.calls] == [
+        "begin",
+        "get",
+        "begin",
+        "get",
+        "commit",
+    ]
+
+
+def test_sync_conditional_run_retries_backoff() -> None:
+    client = FakeConditionalClient()
+    client.commit_outcomes = [
+        BackoffError("Backoff and retry"),
+        ConditionalCommitResult(
+            first_inserted_record_offset=84,
+            record_count=1,
+        ),
+    ]
+    collection = Collection(
+        client=client,  # type: ignore[arg-type]
+        model=_collection_model(),
+        embedding_function=None,
+    )
+    attempts = 0
+
+    def callback(txn: Any) -> str:
+        nonlocal attempts
+        attempts += 1
+        txn.add(ids=f"id-{attempts}", embeddings=[1.0])
+        return f"attempt-{attempts}"
+
+    result = collection.conditional().run(callback, max_retries=1)
+
+    assert result == "attempt-2"
+    assert attempts == 2
+    assert [name for name, _ in client.calls] == [
+        "begin",
+        "add",
+        "commit",
+        "begin",
+        "add",
+        "commit",
+    ]
+
+
+def test_sync_conditional_run_treats_durable_contention_as_success() -> None:
+    client = FakeConditionalClient()
+    client.commit_outcomes = [
+        ConditionalCommitResult(
+            first_inserted_record_offset=None,
+            record_count=1,
+        )
+    ]
+    collection = Collection(
+        client=client,  # type: ignore[arg-type]
+        model=_collection_model(),
+        embedding_function=None,
+    )
+    callback_value = {"status": "committed"}
+    attempts = 0
+
+    def callback(txn: Any) -> Dict[str, str]:
+        nonlocal attempts
+        attempts += 1
+        txn.add(ids="id-1", embeddings=[1.0])
+        return callback_value
+
+    result = collection.conditional().run(callback, max_retries=3)
+
+    assert result is callback_value
+    assert attempts == 1
+    assert [name for name, _ in client.calls] == ["begin", "add", "commit"]
+
+
+def test_sync_conditional_run_rejects_commit_inside_callback() -> None:
+    client = FakeConditionalClient()
+    collection = Collection(
+        client=client,  # type: ignore[arg-type]
+        model=_collection_model(),
+        embedding_function=None,
+    )
+
+    def callback(txn: Any) -> None:
+        txn.commit()
+
+    with pytest.raises(ValueError, match="cannot be called inside run"):
+        collection.conditional().run(callback)
+
+    assert [name for name, _ in client.calls] == ["begin"]
+
+
+def test_async_conditional_run_retries_occ_conflict_with_fresh_transaction() -> None:
+    async def run() -> None:
+        client = AsyncFakeConditionalClient()
+        client.commit_outcomes = [
+            ConditionalWriteConflictError("conflict"),
+            ConditionalCommitResult(
+                first_inserted_record_offset=84,
+                record_count=1,
+            ),
+        ]
+        collection = AsyncCollection(
+            client=client,  # type: ignore[arg-type]
+            model=_collection_model(),
+            embedding_function=None,
+        )
+        attempt_transactions: List[object] = []
+
+        async def callback(txn: Any) -> str:
+            attempt_transactions.append(txn._transaction)
+            await txn.add(ids=f"id-{len(attempt_transactions)}", embeddings=[1.0])
+            return f"value-{len(attempt_transactions)}"
+
+        result = await (await collection.conditional()).run(callback, max_retries=1)
+
+        assert result == "value-2"
+        assert len(attempt_transactions) == 2
+        assert attempt_transactions == client.transactions
+        assert attempt_transactions[0] is not attempt_transactions[1]
+        assert [name for name, _ in client.calls] == [
+            "begin",
+            "add",
+            "commit",
+            "begin",
+            "add",
+            "commit",
+        ]
+
+    asyncio.run(run())
+
+
+def test_async_conditional_run_rejects_commit_inside_callback() -> None:
+    async def run() -> None:
+        client = AsyncFakeConditionalClient()
+        collection = AsyncCollection(
+            client=client,  # type: ignore[arg-type]
+            model=_collection_model(),
+            embedding_function=None,
+        )
+
+        async def callback(txn: Any) -> None:
+            await txn.commit()
+
+        with pytest.raises(ValueError, match="cannot be called inside run"):
+            await (await collection.conditional()).run(callback)
+
+        assert [name for name, _ in client.calls] == ["begin"]
+
+    asyncio.run(run())

--- a/rust/log/Cargo.toml
+++ b/rust/log/Cargo.toml
@@ -21,6 +21,7 @@ opentelemetry = { workspace = true }
 hyper = { workspace = true }
 
 chroma-tracing = { workspace = true, features = ["grpc"] }
+chroma-api-types = { workspace = true }
 chroma-config = { workspace = true }
 chroma-error = { workspace = true, features = ["sqlx"] }
 chroma-segment = { workspace = true }

--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -2,6 +2,7 @@ use crate::grpc_log::{GrpcLog, GrpcPushLogsError, GrpcSealLogError, ScoutLogFrag
 use crate::in_memory_log::InMemoryLog;
 use crate::sqlite_log::SqliteLog;
 use crate::types::CollectionInfo;
+use chroma_api_types::CONDITIONAL_WRITE_CONFLICT_MESSAGE;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_memberlist::client_manager::ClientAssignmentError;
 use chroma_types::{
@@ -57,6 +58,9 @@ pub enum PushLogsError {
     /// Conditional writes are not supported by this log implementation.
     #[error("conditional writes are not supported by {0} log")]
     ConditionalWritesUnsupported(&'static str),
+    /// The conditional write was rejected because the observed log state changed.
+    #[error("conditional write conflict")]
+    ConditionalWriteConflict,
     /// The record count cannot be represented by the log-service API.
     #[error("too many records in push_logs request: {0}")]
     RecordCountOutOfRange(usize),
@@ -71,6 +75,7 @@ impl ChromaError for PushLogsError {
             PushLogsError::Backoff => ErrorCodes::ResourceExhausted,
             PushLogsError::BackoffCompaction => ErrorCodes::ResourceExhausted,
             PushLogsError::ConditionalWritesUnsupported(_) => ErrorCodes::Unimplemented,
+            PushLogsError::ConditionalWriteConflict => ErrorCodes::AlreadyExists,
             PushLogsError::RecordCountOutOfRange(_) => ErrorCodes::InvalidArgument,
             PushLogsError::Other(e) => e.code(),
         }
@@ -82,6 +87,12 @@ impl From<GrpcPushLogsError> for PushLogsError {
         match err {
             GrpcPushLogsError::Backoff => PushLogsError::Backoff,
             GrpcPushLogsError::BackoffCompaction => PushLogsError::BackoffCompaction,
+            GrpcPushLogsError::FailedToPushLogs(status)
+                if status.code() == tonic::Code::Aborted
+                    && status.message() == CONDITIONAL_WRITE_CONFLICT_MESSAGE =>
+            {
+                PushLogsError::ConditionalWriteConflict
+            }
             other => PushLogsError::Other(Box::new(other)),
         }
     }
@@ -96,6 +107,18 @@ pub enum Log {
 }
 
 impl Log {
+    pub fn implementation_name(&self) -> &'static str {
+        match self {
+            Log::Sqlite(_) => "sqlite",
+            Log::Grpc(_) => "grpc",
+            Log::InMemory(_) => "in-memory",
+        }
+    }
+
+    pub fn supports_conditional_transactions(&self) -> bool {
+        matches!(self, Log::Grpc(_))
+    }
+
     #[tracing::instrument(skip(self))]
     pub async fn read(
         &mut self,
@@ -465,5 +488,15 @@ mod tests {
             PushLogsError::ConditionalWritesUnsupported("in-memory")
         ));
         assert_eq!(ErrorCodes::Unimplemented, err.code());
+    }
+
+    #[test]
+    fn grpc_conditional_write_conflict_maps_to_typed_error() {
+        let status = tonic::Status::aborted(CONDITIONAL_WRITE_CONFLICT_MESSAGE);
+        let err = PushLogsError::from(GrpcPushLogsError::FailedToPushLogs(status));
+
+        assert!(matches!(err, PushLogsError::ConditionalWriteConflict));
+        assert_eq!(ErrorCodes::AlreadyExists, err.code());
+        assert_eq!(CONDITIONAL_WRITE_CONFLICT_MESSAGE, err.to_string());
     }
 }

--- a/rust/python_bindings/src/errors.rs
+++ b/rust/python_bindings/src/errors.rs
@@ -10,6 +10,7 @@ pyo3::import_exception!(chromadb.errors, NotFoundError);
 pyo3::import_exception!(chromadb.errors, UniqueConstraintError);
 pyo3::import_exception!(chromadb.errors, InternalError);
 pyo3::import_exception!(chromadb.errors, RateLimitError);
+pyo3::import_exception!(chromadb.errors, BackoffError);
 pyo3::import_exception!(chromadb.errors, StaleReadError);
 
 #[derive(Error, Debug)]
@@ -21,6 +22,9 @@ impl From<ChromaPyError> for PyErr {
         let message = value.to_string();
         if value.0.code().name() == STALE_READ_ERROR_NAME {
             return StaleReadError::new_err(message);
+        }
+        if value.0.name() == "Backoff" {
+            return BackoffError::new_err(message);
         }
         match value.0.code() {
             ErrorCodes::InvalidArgument => InvalidArgumentError::new_err(message),

--- a/rust/python_bindings/src/errors.rs
+++ b/rust/python_bindings/src/errors.rs
@@ -1,5 +1,7 @@
-use chroma_api_types::STALE_READ_ERROR_NAME;
-use chroma_error::{ChromaError, ErrorCodes};
+use chroma_api_types::{StaleReadError as ApiStaleReadError, CONDITIONAL_WRITE_CONFLICT_MESSAGE};
+use chroma_error::{source_chain_contains, ChromaError, ErrorCodes};
+use chroma_log::PushLogsError;
+use chroma_types::ConditionalCommitError;
 use pyo3::PyErr;
 use thiserror::Error;
 
@@ -11,6 +13,7 @@ pyo3::import_exception!(chromadb.errors, UniqueConstraintError);
 pyo3::import_exception!(chromadb.errors, InternalError);
 pyo3::import_exception!(chromadb.errors, RateLimitError);
 pyo3::import_exception!(chromadb.errors, BackoffError);
+pyo3::import_exception!(chromadb.errors, ConditionalWriteConflictError);
 pyo3::import_exception!(chromadb.errors, StaleReadError);
 
 #[derive(Error, Debug)]
@@ -20,13 +23,30 @@ pub(crate) struct ChromaPyError(Box<dyn ChromaError>);
 impl From<ChromaPyError> for PyErr {
     fn from(value: ChromaPyError) -> Self {
         let message = value.to_string();
-        if value.0.code().name() == STALE_READ_ERROR_NAME {
+        let chroma_error = value.0.as_ref();
+        if (chroma_error.code() == ErrorCodes::Aborted
+            && message.contains(CONDITIONAL_WRITE_CONFLICT_MESSAGE))
+            || source_chain_contains(chroma_error, |err| {
+                matches!(
+                    err.downcast_ref::<PushLogsError>(),
+                    Some(PushLogsError::ConditionalWriteConflict)
+                )
+            })
+        {
+            return ConditionalWriteConflictError::new_err(message);
+        }
+        if source_chain_contains(chroma_error, |err| err.is::<ApiStaleReadError>()) {
             return StaleReadError::new_err(message);
         }
-        if value.0.name() == "Backoff" {
+        if source_chain_contains(chroma_error, |err| {
+            matches!(
+                err.downcast_ref::<ConditionalCommitError>(),
+                Some(ConditionalCommitError::Backoff)
+            )
+        }) {
             return BackoffError::new_err(message);
         }
-        match value.0.code() {
+        match chroma_error.code() {
             ErrorCodes::InvalidArgument => InvalidArgumentError::new_err(message),
             ErrorCodes::Unauthenticated => ChromaAuthError::new_err(message),
             ErrorCodes::PermissionDenied => AuthorizationError::new_err(message),


### PR DESCRIPTION
## Description of changes

Add a run() method to ConditionalCollectionTransaction and its async
counterpart that executes a callback and commits, retrying on
retryable errors up to max_retries. Block explicit commit() inside
run() and start a fresh transaction on each retry attempt.

Introduce a BackoffError (code 429, name "Backoff") and wire it
through the python bindings so backoff signals from Rust surface as a
retryable error.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
