### PR TITLE
[ENH](docs): document conditional transaction limitations

### DIFF
--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -37,6 +37,17 @@ from chromadb.api.models.AsyncConditionalCollectionTransaction import (
 
 class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
     async def conditional(self) -> "AsyncConditionalCollectionTransaction":
+        """Start a collection-scoped conditional transaction.
+
+        Conditional transactions read from a stable snapshot, buffer writes
+        locally, and commit them with optimistic conflict detection.
+
+        Current limitations: transactions cannot span collections, nested
+        transaction guarantees are not provided, ``txn.query(...)`` and
+        predicate deletes are not supported, reading an ID after buffering a
+        write for that ID is an explicit transaction error, only one write per
+        ID can be buffered, and filter reads protect only returned IDs.
+        """
         transaction = await self._client._begin_conditional_transaction()
         return AsyncConditionalCollectionTransaction(self, transaction)
 

--- a/chromadb/api/models/AsyncConditionalCollectionTransaction.py
+++ b/chromadb/api/models/AsyncConditionalCollectionTransaction.py
@@ -29,6 +29,19 @@ T = TypeVar("T")
 
 
 class AsyncConditionalCollectionTransaction:
+    """Collection-scoped optimistic transaction.
+
+    Reads execute immediately and capture the transaction snapshot. Writes are
+    buffered locally until ``commit()`` or until ``run(...)`` commits after a
+    successful callback.
+
+    Current limitations: transactions cannot span collections, nested
+    transaction guarantees are not provided, ``txn.query(...)`` and predicate
+    deletes are not supported, reading an ID after buffering a write for that
+    ID is an explicit transaction error, only one write per ID can be buffered,
+    and filter reads protect only returned IDs.
+    """
+
     def __init__(self, collection: "AsyncCollection", transaction: object) -> None:
         self._collection = collection
         self._transaction = transaction

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -45,6 +45,17 @@ if TYPE_CHECKING:
 
 class Collection(CollectionCommon["ServerAPI"]):
     def conditional(self) -> "ConditionalCollectionTransaction":
+        """Start a collection-scoped conditional transaction.
+
+        Conditional transactions read from a stable snapshot, buffer writes
+        locally, and commit them with optimistic conflict detection.
+
+        Current limitations: transactions cannot span collections, nested
+        transaction guarantees are not provided, ``txn.query(...)`` and
+        predicate deletes are not supported, reading an ID after buffering a
+        write for that ID is an explicit transaction error, only one write per
+        ID can be buffered, and filter reads protect only returned IDs.
+        """
         return ConditionalCollectionTransaction(self)
 
     def count(self, read_level: ReadLevel = ReadLevel.INDEX_AND_WAL) -> int:

--- a/chromadb/api/models/ConditionalCollectionTransaction.py
+++ b/chromadb/api/models/ConditionalCollectionTransaction.py
@@ -39,6 +39,19 @@ def _validate_max_retries(max_retries: int) -> None:
 
 
 class ConditionalCollectionTransaction:
+    """Collection-scoped optimistic transaction.
+
+    Reads execute immediately and capture the transaction snapshot. Writes are
+    buffered locally until ``commit()`` or until ``run(...)`` commits after a
+    successful callback.
+
+    Current limitations: transactions cannot span collections, nested
+    transaction guarantees are not provided, ``txn.query(...)`` and predicate
+    deletes are not supported, reading an ID after buffering a write for that
+    ID is an explicit transaction error, only one write per ID can be buffered,
+    and filter reads protect only returned IDs.
+    """
+
     def __init__(self, collection: "Collection") -> None:
         self._collection = collection
         self._transaction = collection._client._begin_conditional_transaction()

--- a/docs/mintlify/docs.json
+++ b/docs/mintlify/docs.json
@@ -43,6 +43,7 @@
               "docs/collections/manage-collections",
               "docs/collections/add-data",
               "docs/collections/update-data",
+              "docs/collections/conditional-transactions",
               "docs/collections/delete-data",
               "docs/collections/configure"
             ]

--- a/docs/mintlify/docs/collections/conditional-transactions.mdx
+++ b/docs/mintlify/docs/collections/conditional-transactions.mdx
@@ -1,0 +1,94 @@
+---
+title: "Conditional Transactions"
+description: "Use optimistic, collection-scoped transactions for read-check-write workflows."
+---
+
+Conditional transactions let you read records, buffer writes locally, and commit those writes only if the records you read have not changed since your read snapshot. They are optimistic: conflicts are detected at commit time instead of locking records while your code runs.
+
+Use manual transactions when you want to decide exactly when to commit:
+
+<CodeGroup>
+```python Python
+txn = collection.conditional()
+
+existing = txn.get(ids=["doc-1"])
+if existing["ids"]:
+    txn.update(
+        ids=["doc-1"],
+        documents=["updated document"],
+    )
+
+result = txn.commit()
+```
+
+```rust Rust
+let mut txn = collection.conditional();
+
+let existing = txn
+    .get(Some(vec!["doc-1".to_string()]), None, None, None, None)
+    .await?;
+
+if !existing.ids.is_empty() {
+    txn.update(
+        vec!["doc-1".to_string()],
+        None,
+        Some(vec![Some("updated document".to_string())]),
+        None,
+        None,
+    )
+    .await?;
+}
+
+let result = txn.commit().await?;
+```
+</CodeGroup>
+
+Use `run` when the whole transaction can be retried after a safe optimistic-concurrency conflict:
+
+<CodeGroup>
+```python Python
+def update_doc(txn):
+    existing = txn.get(ids=["doc-1"])
+    if existing["ids"]:
+        txn.update(ids=["doc-1"], documents=["updated document"])
+
+collection.conditional().run(update_doc, max_retries=3)
+```
+
+```rust Rust
+collection
+    .conditional()
+    .run(
+        async |txn| {
+            let existing = txn
+                .get(Some(vec!["doc-1".to_string()]), None, None, None, None)
+                .await?;
+            if !existing.ids.is_empty() {
+                txn.update(
+                    vec!["doc-1".to_string()],
+                    None,
+                    Some(vec![Some("updated document".to_string())]),
+                    None,
+                    None,
+                )
+                .await?;
+            }
+            Ok(())
+        },
+        3,
+    )
+    .await?;
+```
+</CodeGroup>
+
+## Limitations
+
+Conditional transactions currently have these limitations:
+
+- Transactions are collection-scoped. A single transaction cannot span multiple collections.
+- Nested transaction guarantees are not provided. Start and commit one transaction at a time.
+- `txn.query(...)` is not supported. Use transactional `get(...)` for reads.
+- Predicate deletes are not supported. Transactional deletes must provide explicit IDs.
+- Reading an ID after buffering a write for that ID is an explicit transaction error.
+- Each transaction can buffer at most one write for a given ID.
+- Filter reads protect only the IDs returned by the filter read. Records that matched the filter later, but were not returned by the original read, are not part of the read set.

--- a/docs/mintlify/reference/python/collection.mdx
+++ b/docs/mintlify/reference/python/collection.mdx
@@ -4,6 +4,23 @@ title: "Collection"
 
 ## Collection Methods
 
+### conditional
+
+Start a collection-scoped conditional transaction.
+
+Conditional transactions read from a stable snapshot, buffer writes locally, and commit those writes with optimistic conflict detection. Use `txn.commit()` for manual transactions, or `txn.run(callback, max_retries=3)` to rerun the whole callback after retryable optimistic-concurrency conflicts.
+
+**Limitations:**
+
+- Transactions cannot span collections.
+- Nested transaction guarantees are not provided.
+- `txn.query(...)` is not supported.
+- Predicate deletes are not supported; transactional deletes must provide explicit IDs.
+- Reading an ID after buffering a write for that ID is an explicit transaction error.
+- Only one write per ID can be buffered in a transaction.
+- Filter reads protect only returned IDs.
+
+
 ### count
 
 Return the number of records in the collection.

--- a/examples/conditional_transactions.py
+++ b/examples/conditional_transactions.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Talk to transactional Chroma with the Python client.
+
+Run against a Chroma server that supports conditional transactions:
+
+    python3 examples/conditional_transactions.py
+
+Optional environment:
+
+    CHROMA_HOST=localhost
+    CHROMA_PORT=8000
+    CHROMA_SSL=false
+    CHROMA_TENANT=default_tenant
+    CHROMA_DATABASE=default_database
+    CHROMA_API_KEY=...
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import chromadb
+
+
+COLLECTION_NAME = "transactional_chroma_python_example"
+RECORD_ID = "txn-doc"
+EMBEDDING = [1.0, 0.0, 0.0]
+
+
+def env_bool(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def headers_from_env() -> Optional[dict[str, str]]:
+    api_key = os.environ.get("CHROMA_API_KEY")
+    if api_key is None:
+        return None
+    return {"x-chroma-token": api_key}
+
+
+def main() -> None:
+    client = chromadb.HttpClient(
+        host=os.environ.get("CHROMA_HOST", "localhost"),
+        port=int(os.environ.get("CHROMA_PORT", "8000")),
+        ssl=env_bool("CHROMA_SSL"),
+        headers=headers_from_env(),
+        tenant=os.environ.get("CHROMA_TENANT", "default_tenant"),
+        database=os.environ.get("CHROMA_DATABASE", "default_database"),
+    )
+
+    try:
+        client.delete_collection(COLLECTION_NAME)
+    except Exception:
+        pass
+
+    collection = client.create_collection(
+        name=COLLECTION_NAME,
+        embedding_function=None,
+    )
+
+    def create_or_update(txn: Any) -> str:
+        existing = txn.get(ids=RECORD_ID, include=["metadatas"])
+        if existing["ids"]:
+            txn.update(
+                ids=RECORD_ID,
+                metadatas={"status": "updated-by-run", "version": 1},
+            )
+            return "updated"
+
+        txn.add(
+            ids=RECORD_ID,
+            embeddings=EMBEDDING,
+            metadatas={"status": "created-by-run", "version": 1},
+        )
+        return "created"
+
+    outcome = collection.conditional().run(create_or_update, max_retries=3)
+    print(f"run() transaction {outcome} {RECORD_ID!r}")
+
+    txn = collection.conditional()
+    before = txn.get(ids=RECORD_ID, include=["metadatas"])
+    if not before["ids"]:
+        raise RuntimeError(f"{RECORD_ID!r} disappeared before manual commit")
+    txn.update(
+        ids=RECORD_ID,
+        metadatas={"status": "updated-by-manual-commit", "version": 2},
+    )
+    committed = txn.commit()
+    print(f"manual commit wrote {committed['record_count']} record(s)")
+
+    after = collection.get(ids=RECORD_ID, include=["metadatas", "embeddings"])
+    print(after)
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/chroma/examples/conditional_transactions.rs
+++ b/rust/chroma/examples/conditional_transactions.rs
@@ -1,0 +1,130 @@
+//! Collection-scoped conditional transaction example.
+//!
+//! Run against a Chroma server that supports conditional transactions:
+//!
+//! ```bash
+//! cargo run -p chroma --example conditional_transactions
+//! ```
+//!
+//! Optional environment:
+//!
+//! ```text
+//! CHROMA_ENDPOINT=http://localhost:8000
+//! CHROMA_TENANT=default_tenant
+//! CHROMA_DATABASE=default_database
+//! CHROMA_API_KEY=...
+//! ```
+
+use std::error::Error;
+
+use chroma::{
+    client::ChromaHttpClientError,
+    types::{IncludeList, Metadata, UpdateMetadata},
+    ChromaHttpClient,
+};
+
+const COLLECTION_NAME: &str = "transactional_chroma_rust_example";
+const RECORD_ID: &str = "txn-doc";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let client = ChromaHttpClient::from_env()?;
+
+    let _ = client.delete_collection(COLLECTION_NAME).await;
+    let collection = client
+        .get_or_create_collection(COLLECTION_NAME, None, None)
+        .await?;
+
+    let outcome = collection
+        .conditional()
+        .run(
+            async |txn| {
+                let existing = txn
+                    .get(
+                        Some(vec![RECORD_ID.to_string()]),
+                        None,
+                        Some(1),
+                        Some(0),
+                        Some(IncludeList::default_get()),
+                    )
+                    .await?;
+
+                if existing.ids.is_empty() {
+                    txn.add(
+                        vec![RECORD_ID.to_string()],
+                        vec![vec![1.0, 0.0, 0.0]],
+                        None,
+                        None,
+                        Some(vec![Some(metadata("created-by-run", 1))]),
+                    )
+                    .await?;
+                    return Ok::<_, ChromaHttpClientError>("created");
+                }
+
+                txn.update(
+                    vec![RECORD_ID.to_string()],
+                    None,
+                    None,
+                    None,
+                    Some(vec![Some(update_metadata("updated-by-run", 1))]),
+                )
+                .await?;
+                Ok::<_, ChromaHttpClientError>("updated")
+            },
+            3,
+        )
+        .await?;
+    println!("run() transaction {outcome} {RECORD_ID:?}");
+
+    let mut txn = collection.conditional();
+    let before = txn
+        .get(
+            Some(vec![RECORD_ID.to_string()]),
+            None,
+            Some(1),
+            Some(0),
+            Some(IncludeList::default_get()),
+        )
+        .await?;
+    if before.ids.is_empty() {
+        return Err(format!("{RECORD_ID:?} disappeared before manual commit").into());
+    }
+
+    txn.update(
+        vec![RECORD_ID.to_string()],
+        None,
+        None,
+        None,
+        Some(vec![Some(update_metadata("updated-by-manual-commit", 2))]),
+    )
+    .await?;
+    let committed = txn.commit().await?;
+    println!("manual commit wrote {} record(s)", committed.record_count);
+
+    let after = collection
+        .get(
+            Some(vec![RECORD_ID.to_string()]),
+            None,
+            Some(1),
+            Some(0),
+            Some(IncludeList::default_get()),
+        )
+        .await?;
+    println!("final metadata: {:?}", after.metadatas);
+
+    Ok(())
+}
+
+fn metadata(status: &str, version: i64) -> Metadata {
+    let mut metadata = Metadata::new();
+    metadata.insert("status".to_string(), status.into());
+    metadata.insert("version".to_string(), version.into());
+    metadata
+}
+
+fn update_metadata(status: &str, version: i64) -> UpdateMetadata {
+    let mut metadata = UpdateMetadata::new();
+    metadata.insert("status".to_string(), status.into());
+    metadata.insert("version".to_string(), version.into());
+    metadata
+}

--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -254,6 +254,10 @@ impl ChromaCollection {
     /// Reads execute immediately and capture a stable OCC read token. Writes are
     /// buffered locally until [`commit`](ConditionalCollectionTransaction::commit)
     /// is awaited. Dropping the returned transaction discards uncommitted writes.
+    ///
+    /// Current conditional transactions are limited to this collection, reject
+    /// reads for IDs with buffered writes, and do not support queries or
+    /// predicate deletes.
     pub fn conditional(&self) -> ConditionalCollectionTransaction {
         ConditionalCollectionTransaction::new(self.clone())
     }

--- a/rust/chroma/src/conditional_transaction.rs
+++ b/rust/chroma/src/conditional_transaction.rs
@@ -1,4 +1,19 @@
 //! Conditional transaction support for collection-scoped optimistic writes.
+//!
+//! Conditional transactions provide optimistic read-check-write behavior for a
+//! single collection. Reads execute immediately and writes are buffered until an
+//! explicit commit or an implicit [`run`](ConditionalCollectionTransaction::run)
+//! commit succeeds.
+//!
+//! # Current limitations
+//!
+//! - Transactions are scoped to one collection.
+//! - Nested transaction guarantees are not provided.
+//! - Query operations are not supported inside transactions.
+//! - Predicate deletes are not supported; deletes must name explicit IDs.
+//! - Reading an ID after buffering a write for that ID is an explicit error.
+//! - Each transaction can buffer at most one write for a given ID.
+//! - Filter reads protect only the IDs returned by the filter read.
 
 use std::ops::AsyncFn;
 
@@ -21,6 +36,10 @@ use crate::{client::ChromaHttpClientError, ChromaCollection, IntoOptionalEmbeddi
 /// capture a stable read token. Writes are buffered locally and sent only when
 /// [`commit`](Self::commit) is awaited. Dropping this value does not commit;
 /// any uncommitted buffered writes are discarded with the transaction.
+///
+/// Reading an ID after buffering a write for that ID is an explicit error.
+/// Queries and predicate deletes are not supported, and only one write can be
+/// buffered per ID.
 pub struct ConditionalCollectionTransaction {
     collection: ChromaCollection,
     state: ConditionalTransactionState,


### PR DESCRIPTION
## Description of changes

Add docstrings and reference docs for collection-scoped conditional
transactions, covering the optimistic read-check-write model and the
current limitations shared across the Rust client and Python API.

Add a Mintlify guide with manual commit and run() retry examples,
plus a limitations section, and link it from the collections nav.

## Test plan

CI

## Migration plan

N/A

## Observability plan

See mintlify deploy before merging.

## Documentation Changes

Whole PR.

Co-authored-by: AI
