### PR TITLE
[ENH] Add HuggingFace Inference API embedding function (JS)

### DIFF
--- a/clients/new-js/packages/ai-embeddings/all/package.json
+++ b/clients/new-js/packages/ai-embeddings/all/package.json
@@ -40,6 +40,7 @@
     "@chroma-core/cohere": "workspace:^",
     "@chroma-core/default-embed": "workspace:^",
     "@chroma-core/google-gemini": "workspace:^",
+    "@chroma-core/huggingface": "workspace:^",
     "@chroma-core/huggingface-server": "workspace:^",
     "@chroma-core/jina": "workspace:^",
     "@chroma-core/mistral": "workspace:^",

--- a/clients/new-js/packages/ai-embeddings/all/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/all/src/index.ts
@@ -2,6 +2,7 @@ export * from "@chroma-core/cloudflare-worker-ai";
 export * from "@chroma-core/cohere";
 export * from "@chroma-core/default-embed";
 export * from "@chroma-core/google-gemini";
+export * from "@chroma-core/huggingface";
 export * from "@chroma-core/huggingface-server";
 export * from "@chroma-core/jina";
 export * from "@chroma-core/mistral";

--- a/clients/new-js/packages/ai-embeddings/huggingface/README.md
+++ b/clients/new-js/packages/ai-embeddings/huggingface/README.md
@@ -1,0 +1,62 @@
+# HuggingFace Embedding Function for Chroma
+
+This package provides a [HuggingFace Inference API](https://huggingface.co/docs/api-inference/index)
+embedding provider for Chroma. It calls the hosted feature-extraction pipeline, bringing the JS
+client to parity with the Python `HuggingFaceEmbeddingFunction`.
+
+For a self-hosted [text-embeddings-inference](https://github.com/huggingface/text-embeddings-inference)
+server, use [`@chroma-core/huggingface-server`](../huggingface-server) instead.
+
+## Installation
+
+```bash
+npm install @chroma-core/huggingface
+```
+
+## Usage
+
+```typescript
+import { ChromaClient } from "chromadb";
+import { HuggingfaceEmbeddingFunction } from "@chroma-core/huggingface";
+
+// Initialize the embedder
+const embedder = new HuggingfaceEmbeddingFunction({
+  apiKey: "your-api-key", // Or set CHROMA_HUGGINGFACE_API_KEY env var
+  modelName: "sentence-transformers/all-MiniLM-L6-v2",
+});
+
+const client = new ChromaClient({ path: "http://localhost:8000" });
+
+const collection = await client.createCollection({
+  name: "my-collection",
+  embeddingFunction: embedder,
+});
+
+await collection.add({
+  ids: ["1", "2", "3"],
+  documents: ["Document 1", "Document 2", "Document 3"],
+});
+
+const results = await collection.query({
+  queryTexts: ["Sample query"],
+  nResults: 2,
+});
+```
+
+## Configuration
+
+Set your HuggingFace API key as an environment variable:
+
+```bash
+export CHROMA_HUGGINGFACE_API_KEY=your-api-key
+```
+
+Get your API key from [HuggingFace](https://huggingface.co/settings/tokens).
+
+## Configuration Options
+
+- **apiKey**: Your HuggingFace API key (or set via environment variable)
+- **apiKeyEnvVar**: Environment variable name for the API key (default: `CHROMA_HUGGINGFACE_API_KEY`)
+- **modelName**: Model to use for embeddings (default: `sentence-transformers/all-MiniLM-L6-v2`)
+
+See the list of available models on [HuggingFace](https://huggingface.co/models?pipeline_tag=feature-extraction).

--- a/clients/new-js/packages/ai-embeddings/huggingface/jest.config.ts
+++ b/clients/new-js/packages/ai-embeddings/huggingface/jest.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+      },
+    ],
+  },
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  setupFiles: ["./jest.setup.ts"],
+};
+
+export default config;

--- a/clients/new-js/packages/ai-embeddings/huggingface/jest.setup.ts
+++ b/clients/new-js/packages/ai-embeddings/huggingface/jest.setup.ts
@@ -1,0 +1,3 @@
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: "../../../.env" });

--- a/clients/new-js/packages/ai-embeddings/huggingface/package.json
+++ b/clients/new-js/packages/ai-embeddings/huggingface/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@chroma-core/huggingface",
+  "version": "0.1.0",
+  "private": false,
+  "description": "HuggingFace Inference API embedding provider for Chroma",
+  "main": "dist/cjs/huggingface.cjs",
+  "types": "dist/huggingface.d.ts",
+  "module": "dist/huggingface.legacy-esm.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/huggingface.d.ts",
+        "default": "./dist/huggingface.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/huggingface.d.cts",
+        "default": "./dist/cjs/huggingface.cjs"
+      }
+    }
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rimraf dist",
+    "prebuild": "rimraf dist",
+    "build": "tsup",
+    "watch": "tsup --watch",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "dotenv": "^16.3.1",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.0",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "tsup": "^8.3.5"
+  },
+  "peerDependencies": {
+    "chromadb": "workspace:^"
+  },
+  "dependencies": {
+    "@chroma-core/ai-embeddings-common": "workspace:^"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/clients/new-js/packages/ai-embeddings/huggingface/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/huggingface/src/index.test.ts
@@ -1,0 +1,74 @@
+import { HuggingfaceEmbeddingFunction } from "./index";
+import { afterEach, describe, expect, it } from "@jest/globals";
+
+describe("HuggingfaceEmbeddingFunction", () => {
+  afterEach(() => {
+    delete process.env.CHROMA_HUGGINGFACE_API_KEY;
+    delete process.env.CUSTOM_HF_API_KEY;
+  });
+
+  it("initializes with default model and env var (matching the Python provider)", () => {
+    const embedder = new HuggingfaceEmbeddingFunction({ apiKey: "test-key" });
+    expect(embedder.name).toBe("huggingface");
+
+    expect(embedder.getConfig()).toEqual({
+      api_key_env_var: "CHROMA_HUGGINGFACE_API_KEY",
+      model_name: "sentence-transformers/all-MiniLM-L6-v2",
+    });
+  });
+
+  it("honors a custom model name", () => {
+    const embedder = new HuggingfaceEmbeddingFunction({
+      apiKey: "test-key",
+      modelName: "BAAI/bge-small-en-v1.5",
+    });
+    expect(embedder.getConfig().model_name).toBe("BAAI/bge-small-en-v1.5");
+  });
+
+  it("throws when no API key is provided or set in the environment", () => {
+    delete process.env.CHROMA_HUGGINGFACE_API_KEY;
+    expect(() => {
+      new HuggingfaceEmbeddingFunction();
+    }).toThrow("HuggingFace API key is required");
+  });
+
+  it("resolves the API key from a custom environment variable", () => {
+    process.env.CUSTOM_HF_API_KEY = "env-key";
+    const embedder = new HuggingfaceEmbeddingFunction({
+      apiKeyEnvVar: "CUSTOM_HF_API_KEY",
+    });
+    expect(embedder.getConfig().api_key_env_var).toBe("CUSTOM_HF_API_KEY");
+  });
+
+  it("round-trips through buildFromConfig", () => {
+    const config = {
+      api_key_env_var: "CHROMA_HUGGINGFACE_API_KEY",
+      model_name: "sentence-transformers/all-MiniLM-L6-v2",
+    };
+    process.env.CHROMA_HUGGINGFACE_API_KEY = "env-key";
+
+    const embedder = HuggingfaceEmbeddingFunction.buildFromConfig(config);
+    expect(embedder.getConfig()).toEqual(config);
+  });
+
+  it("validates a well-formed config and rejects model_name changes", () => {
+    const embedder = new HuggingfaceEmbeddingFunction({ apiKey: "test-key" });
+    const config = embedder.getConfig();
+
+    expect(() =>
+      HuggingfaceEmbeddingFunction.validateConfig(config),
+    ).not.toThrow();
+    expect(() =>
+      embedder.validateConfigUpdate({
+        ...config,
+        model_name: "different-model",
+      }),
+    ).toThrow("Model name cannot be updated");
+  });
+
+  it("reports cosine as the default space", () => {
+    const embedder = new HuggingfaceEmbeddingFunction({ apiKey: "test-key" });
+    expect(embedder.defaultSpace()).toBe("cosine");
+    expect(embedder.supportedSpaces()).toEqual(["cosine", "l2", "ip"]);
+  });
+});

--- a/clients/new-js/packages/ai-embeddings/huggingface/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/huggingface/src/index.ts
@@ -1,0 +1,127 @@
+import {
+  ChromaValueError,
+  EmbeddingFunction,
+  EmbeddingFunctionSpace,
+  registerEmbeddingFunction,
+} from "chromadb";
+import { validateConfigSchema } from "@chroma-core/ai-embeddings-common";
+
+const NAME = "huggingface";
+
+export interface HuggingfaceConfig {
+  api_key_env_var: string;
+  model_name: string;
+}
+
+export interface HuggingfaceArgs {
+  apiKey?: string;
+  apiKeyEnvVar?: string;
+  modelName?: string;
+}
+
+/**
+ * Embeddings via the hosted HuggingFace Inference API (feature-extraction
+ * pipeline). Brings the JS client to parity with the Python
+ * `HuggingFaceEmbeddingFunction`. For a self-hosted text-embeddings-inference
+ * server, use `@chroma-core/huggingface-server` instead.
+ */
+export class HuggingfaceEmbeddingFunction implements EmbeddingFunction {
+  public readonly name = NAME;
+
+  private readonly apiKeyEnvVar: string;
+  private readonly modelName: string;
+  private readonly url: string;
+  private readonly headers: { [key: string]: string };
+
+  constructor(args: Partial<HuggingfaceArgs> = {}) {
+    const {
+      apiKeyEnvVar = "CHROMA_HUGGINGFACE_API_KEY",
+      modelName = "sentence-transformers/all-MiniLM-L6-v2",
+    } = args;
+
+    const apiKey = args.apiKey || process.env[apiKeyEnvVar];
+    if (!apiKey) {
+      throw new Error(
+        `HuggingFace API key is required. Please provide it in the constructor or set the environment variable ${apiKeyEnvVar}.`,
+      );
+    }
+
+    this.modelName = modelName;
+    this.apiKeyEnvVar = apiKeyEnvVar;
+    // The legacy api-inference.huggingface.co host is deprecated; the hosted
+    // Inference API is now served through the router (see chroma-core/chroma#6770,
+    // #6907 for the equivalent Python migration).
+    this.url = `https://router.huggingface.co/hf-inference/models/${modelName}/pipeline/feature-extraction`;
+    this.headers = {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    };
+  }
+
+  public async generate(texts: string[]): Promise<number[][]> {
+    try {
+      const response = await fetch(this.url, {
+        method: "POST",
+        headers: this.headers,
+        body: JSON.stringify({
+          inputs: texts,
+          options: { wait_for_model: true },
+        }),
+      });
+
+      const data = (await response.json()) as
+        | number[][]
+        | { error?: string; message?: string };
+
+      if (!response.ok || !Array.isArray(data)) {
+        const message =
+          (!Array.isArray(data) && (data.error || data.message)) ||
+          response.statusText;
+        throw new Error(message);
+      }
+
+      return data;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Error calling HuggingFace API: ${error.message}`);
+      }
+      throw new Error(`Error calling HuggingFace API: ${error}`);
+    }
+  }
+
+  public defaultSpace(): EmbeddingFunctionSpace {
+    return "cosine";
+  }
+
+  public supportedSpaces(): EmbeddingFunctionSpace[] {
+    return ["cosine", "l2", "ip"];
+  }
+
+  public static buildFromConfig(
+    config: HuggingfaceConfig,
+  ): HuggingfaceEmbeddingFunction {
+    return new HuggingfaceEmbeddingFunction({
+      modelName: config.model_name,
+      apiKeyEnvVar: config.api_key_env_var,
+    });
+  }
+
+  public getConfig(): HuggingfaceConfig {
+    return {
+      api_key_env_var: this.apiKeyEnvVar,
+      model_name: this.modelName,
+    };
+  }
+
+  public validateConfigUpdate(newConfig: Record<string, any>): void {
+    if (this.getConfig().model_name !== newConfig.model_name) {
+      throw new ChromaValueError("Model name cannot be updated");
+    }
+  }
+
+  public static validateConfig(config: HuggingfaceConfig): void {
+    validateConfigSchema(config, NAME);
+  }
+}
+
+registerEmbeddingFunction(NAME, HuggingfaceEmbeddingFunction);

--- a/clients/new-js/packages/ai-embeddings/huggingface/tsconfig.json
+++ b/clients/new-js/packages/ai-embeddings/huggingface/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./src",
+    "stripInternal": true,
+    "composite": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test",
+    "**/*.test.ts"
+  ],
+  "references": [
+    {
+      "path": "../common"
+    },
+    {
+      "path": "../../chromadb"
+    }
+  ]
+}

--- a/clients/new-js/packages/ai-embeddings/huggingface/tsup.config.ts
+++ b/clients/new-js/packages/ai-embeddings/huggingface/tsup.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, Options } from "tsup";
+import * as fs from "fs";
+
+export default defineConfig((options: Options) => {
+  const commonOptions: Partial<Options> = {
+    entry: {
+      huggingface: "src/index.ts",
+    },
+    sourcemap: true,
+    dts: {
+      compilerOptions: {
+        composite: false,
+        declaration: true,
+        emitDeclarationOnly: false,
+      },
+    },
+    ...options,
+  };
+
+  return [
+    {
+      ...commonOptions,
+      format: ["esm"],
+      outExtension: () => ({ js: ".mjs" }),
+      clean: true,
+      async onSuccess() {
+        // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
+        fs.copyFileSync(
+          "dist/huggingface.mjs",
+          "dist/huggingface.legacy-esm.js",
+        );
+      },
+    },
+    {
+      ...commonOptions,
+      format: "cjs",
+      outDir: "./dist/cjs/",
+      outExtension: () => ({ js: ".cjs" }),
+    },
+  ];
+});

--- a/clients/new-js/pnpm-lock.yaml
+++ b/clients/new-js/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@chroma-core/google-gemini':
         specifier: workspace:^
         version: link:../google-gemini
+      '@chroma-core/huggingface':
+        specifier: workspace:^
+        version: link:../huggingface
       '@chroma-core/huggingface-server':
         specifier: workspace:^
         version: link:../huggingface-server
@@ -301,6 +304,37 @@ importers:
       '@google/genai':
         specifier: ^0.14.1
         version: 0.14.1
+      chromadb:
+        specifier: workspace:^
+        version: link:../../chromadb
+    devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.5.0
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3))
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.46)(typescript@5.8.3)
+      tsup:
+        specifier: ^8.3.5
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+
+  packages/ai-embeddings/huggingface:
+    dependencies:
+      '@chroma-core/ai-embeddings-common':
+        specifier: workspace:^
+        version: link:../common
       chromadb:
         specifier: workspace:^
         version: link:../../chromadb
@@ -744,20 +778,20 @@ importers:
         version: 8.0.3
     optionalDependencies:
       chromadb-js-bindings-darwin-arm64:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
       chromadb-js-bindings-darwin-x64:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
       chromadb-js-bindings-linux-arm64-gnu:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
       chromadb-js-bindings-linux-x64-gnu:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
       chromadb-js-bindings-win32-x64-msvc:
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
 
   packages/integration-test:
     dependencies:
@@ -2406,34 +2440,34 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  chromadb-js-bindings-darwin-arm64@1.3.3:
-    resolution: {integrity: sha512-fygMqw+Qsnc7zlh59tYAUfW5g859ZVLnA5cG0tyO7NZG2lQz1QKZCTqG49TVU7vfmeC7LzjIZvEQ0jrTqFKaMQ==}
+  chromadb-js-bindings-darwin-arm64@1.3.4:
+    resolution: {integrity: sha512-pDdWCcR0hCz3pSDiIijBito7YG6FumewfzYE2mIjSwjrO1CKSfQKLwDdTVK4ZNpVGQa16ePoMX+pg7ShSUARJg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  chromadb-js-bindings-darwin-x64@1.3.3:
-    resolution: {integrity: sha512-OwaNmkEo8gYp5inp88pa0vLUSNYs9nBouvumbt+YI1JYShpDs6cnBKAOfNCFbljjBunqCsv70PPxQqZmkyEzlQ==}
+  chromadb-js-bindings-darwin-x64@1.3.4:
+    resolution: {integrity: sha512-5vKVFXSFo+S9qC9by/7oofjcXqQK4IGHiUnPrvTfc7B52gNlPSKeyDO1wha556COc3KtXSZjICEH0nYBJ8UXng==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  chromadb-js-bindings-linux-arm64-gnu@1.3.3:
-    resolution: {integrity: sha512-98O7kBw2z9kLCbQqElebrV9SAcKf5QKDI9yD144ooLz+jOgj39ccF6q0R13FB3AwYxVvHhKiIKMjO3hOFCx5iw==}
+  chromadb-js-bindings-linux-arm64-gnu@1.3.4:
+    resolution: {integrity: sha512-ELiqDZzU5mZd1BvZugGrhoMkVeNyQaa+PGizd06WIpIJVoHY+S+9ZBjdeM6ZkRnL3vTxD79XBrosxNWhzqy/kg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  chromadb-js-bindings-linux-x64-gnu@1.3.3:
-    resolution: {integrity: sha512-yqJRHDiLNQFfNcCDm/iILdf5gCBR0BxG1d+esX4ViHAP41h4WqbWq9MIAla+OKHKlyMpSq9BiqSfHBaL8rr5nQ==}
+  chromadb-js-bindings-linux-x64-gnu@1.3.4:
+    resolution: {integrity: sha512-HmTUe7PEIaBngCQ70Yyle81z2wYyg9OMgJYyRUNBYCBp4ED6zTmdaOro41Vs/c/h2UyQeBXFIKNmHDeD2Nr2fw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  chromadb-js-bindings-win32-x64-msvc@1.3.3:
-    resolution: {integrity: sha512-X5zuolLBqh3+2GFh9BbjkBPFhPsmezc/HkYAk/rQvYayBqD39e/BT0JwYVbGr+gcqsZI3QO87xZ2FyHL8g8f9Q==}
+  chromadb-js-bindings-win32-x64-msvc@1.3.4:
+    resolution: {integrity: sha512-punrofQRzKspNMxHmv24qoPeRycV2T3KfedekGV4lOuPPG14i6qggS4x/OWLSAK7ozPfBbrzCejvCa5wfvujhQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2939,11 +2973,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -4368,10 +4403,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -4596,10 +4633,12 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -6822,19 +6861,19 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  chromadb-js-bindings-darwin-arm64@1.3.3:
+  chromadb-js-bindings-darwin-arm64@1.3.4:
     optional: true
 
-  chromadb-js-bindings-darwin-x64@1.3.3:
+  chromadb-js-bindings-darwin-x64@1.3.4:
     optional: true
 
-  chromadb-js-bindings-linux-arm64-gnu@1.3.3:
+  chromadb-js-bindings-linux-arm64-gnu@1.3.4:
     optional: true
 
-  chromadb-js-bindings-linux-x64-gnu@1.3.3:
+  chromadb-js-bindings-linux-x64-gnu@1.3.4:
     optional: true
 
-  chromadb-js-bindings-win32-x64-msvc@1.3.3:
+  chromadb-js-bindings-win32-x64-msvc@1.3.4:
     optional: true
 
   ci-info@3.9.0: {}

--- a/docs/mintlify/integrations/embedding-models/hugging-face.mdx
+++ b/docs/mintlify/integrations/embedding-models/hugging-face.mdx
@@ -8,13 +8,30 @@ Chroma provides wrappers for both dense and sparse embedding models from Hugging
 
 Chroma provides a convenient wrapper around HuggingFace's embedding API. This embedding function runs remotely on HuggingFace's servers, and requires an API key. You can get an API key by signing up for an account at [HuggingFace](https://huggingface.co/).
 
-```python
+<CodeGroup>
+
+```python Python
 import chromadb.utils.embedding_functions as embedding_functions
 huggingface_ef = embedding_functions.HuggingFaceEmbeddingFunction(
     api_key="YOUR_API_KEY",
     model_name="sentence-transformers/all-MiniLM-L6-v2"
 )
 ```
+
+```typescript TypeScript
+// npm install @chroma-core/huggingface
+
+import { HuggingfaceEmbeddingFunction } from '@chroma-core/huggingface';
+
+const embedder = new HuggingfaceEmbeddingFunction({
+    apiKey: 'YOUR_API_KEY', // Or set the CHROMA_HUGGINGFACE_API_KEY env var
+    modelName: 'sentence-transformers/all-MiniLM-L6-v2',
+});
+
+const embeddings = await embedder.generate(['document1', 'document2']);
+```
+
+</CodeGroup>
 
 You can pass in an optional `model_name` argument, which lets you choose which HuggingFace model to use. By default, Chroma uses `sentence-transformers/all-MiniLM-L6-v2`. You can see a list of all available models [here](https://huggingface.co/models).
 


### PR DESCRIPTION
## Description of changes

Closes #1457.

The Python client ships a `HuggingFaceEmbeddingFunction` for the hosted **HuggingFace Inference API**, but the JS client only had the self-hosted `@chroma-core/huggingface-server`. This adds a new `@chroma-core/huggingface` package to bring the JS client to parity.

The HF feature-extraction pipeline is a simple authenticated POST, so the new package mirrors the existing `@chroma-core/jina` provider and the Python `HuggingFaceEmbeddingFunction`:

- default model `sentence-transformers/all-MiniLM-L6-v2` (matches Python)
- API key from the constructor or the `CHROMA_HUGGINGFACE_API_KEY` env var (throws if absent)
- `{ inputs, options: { wait_for_model: true } }` request body
- cosine default space (`l2` / `ip` also supported); `model_name` immutable on config update
- config `{ api_key_env_var, model_name }`, validated against the shared `huggingface` schema already bundled in `@chroma-core/ai-embeddings-common`
- registered via `registerEmbeddingFunction` and re-exported from `@chroma-core/all`

**Endpoint note:** the legacy `api-inference.huggingface.co` host that the Python EF still uses is deprecated, so this uses the current Inference router endpoint `router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction` — the same migration in flight for Python in #6770 / #6907. Kept the config minimal (`{ api_key_env_var, model_name }`) to match the currently-shipped schema; happy to add a `base_url` option to match #6907 once that lands.

Also adds a `README.md` and a TypeScript tab on the Hugging Face docs page.

## Test plan

New package unit tests (`clients/new-js/packages/ai-embeddings/huggingface/src/index.test.ts`) — network-free, cover defaults, custom model, missing-key guard, custom env var, `buildFromConfig` round-trip, schema `validateConfig`, `validateConfigUpdate` model-name guard, and default space.

Run locally (`clients/new-js`):

```
# build chain: common -> default-embed -> chromadb -> @chroma-core/huggingface -> @chroma-core/all
tsup build: all 18 ai-embeddings packages + @chroma-core/all  -> success (ESM + CJS + DTS)
jest @chroma-core/huggingface:  7 passed, 7 total
prettier --check:               clean
```

- [x] Tests pass locally
- [ ] I have added new tests (added; CI run pending)

## Documentation Changes

Added a TypeScript example to `docs/mintlify/integrations/embedding-models/hugging-face.mdx` (Dense Embeddings).

---

_Prepared with AI assistance (Claude Code); human-reviewed and tested locally. Opened as a **draft** for maintainer review._
