### PR TITLE
fix: respect settings.persist_directory in PersistentClient (#7277)

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -197,7 +197,7 @@ def EphemeralClient(
 
 
 def PersistentClient(
-    path: Union[str, Path] = "./chroma",
+    path: Optional[Union[str, Path]] = None,
     settings: Optional[Settings] = None,
     tenant: str = DEFAULT_TENANT,
     database: str = DEFAULT_DATABASE,
@@ -208,7 +208,8 @@ def PersistentClient(
     prefer a server-backed Chroma instance.
 
     Args:
-        path: Directory to store persisted data.
+        path: Directory to store persisted data. If not provided, uses
+            settings.persist_directory when set, otherwise defaults to "./chroma".
         settings: Optional settings to override defaults.
         tenant: Tenant name to use for requests.
         database: Database name to use for requests.
@@ -218,7 +219,10 @@ def PersistentClient(
     """
     if settings is None:
         settings = Settings()
-    settings.persist_directory = str(path)
+    if path is not None:
+        settings.persist_directory = str(path)
+    elif settings.persist_directory is None:
+        settings.persist_directory = "./chroma"
     settings.is_persistent = True
 
     # Make sure paramaters are the correct types -- users can pass anything.


### PR DESCRIPTION
Fixes #7277

## Problem
 silently ignores  because the  parameter defaults to , which always overwrites whatever was configured in settings.

## Fix
- Change  default from  to 
- Implement priority logic:
  - If  is explicitly provided → use 
  - If  is  and  was set → use 
  - If both are unset → default to 

This ensures users who configure  have their configuration respected when they don't explicitly pass .