### PR TITLE
[CHORE](ci): Batch tilt image builds and add minikube checks

### DIFF
--- a/.github/actions/tilt-setup-prebuild/action.yaml
+++ b/.github/actions/tilt-setup-prebuild/action.yaml
@@ -3,15 +3,12 @@ description: Set up Tilt prereqs and pre-build/pull images
 runs:
   using: "composite"
   steps:
-    - name: Start minikube
-      uses: medyagh/setup-minikube@latest
-      with:
-        driver: none # uses Docker engine on host instead of Docker-in-Docker
     # tilt ci can automatically build images while bringing up the cluster. However, this results in flaky runs for our usage so we split up image building and pod deployment into separate steps. See https://github.com/chroma-core/chroma/pull/4720.
     - name: Install Tilt, bake images, pre-pull external images
       shell: bash
       env:
         TILT_VERSION: "0.34.2"
+        IMAGE_BUILD_PARALLELISM: "4"
       run: |
         install_tilt() (
           set -euo pipefail
@@ -32,8 +29,44 @@ runs:
         )
         export -f install_tilt
 
+        bake_images() (
+          set -euo pipefail
+
+          local targets=(
+            rust-log-service
+            rust-sysdb-service
+            sysdb
+            sysdb-migration
+            rust-sysdb-migration
+            rust-frontend-service
+            query-service
+            compactor-service
+            garbage-collector
+            load-service
+            work-queue-service
+            fn-consumer
+          )
+
+          if ! [[ "${IMAGE_BUILD_PARALLELISM}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "IMAGE_BUILD_PARALLELISM must be a positive integer, got '${IMAGE_BUILD_PARALLELISM}'" >&2
+            exit 1
+          fi
+
+          local total="${#targets[@]}"
+          for ((i = 0; i < total; i += IMAGE_BUILD_PARALLELISM)); do
+            local batch=("${targets[@]:i:IMAGE_BUILD_PARALLELISM}")
+            echo "Building image batch: ${batch[*]}"
+            docker buildx bake -f "${{ github.action_path }}/docker-bake.hcl" --load "${batch[@]}"
+          done
+        )
+        export -f bake_images
+
         parallel --tag --linebuffer ::: \
           "bash -c install_tilt" \
-          "docker buildx bake -f ${{ github.action_path }}/docker-bake.hcl --load" \
+          "bash -c bake_images" \
           "bash ${{ github.action_path }}/pull_external_images.sh"
       working-directory: ${{ github.action_path }}/../../../ # this allows other repos to reuse this workflow when this repo may not be the current working directory
+    - name: Start minikube
+      uses: medyagh/setup-minikube@latest
+      with:
+        driver: none # uses Docker engine on host instead of Docker-in-Docker

--- a/.github/actions/tilt-setup-prebuild/action.yaml
+++ b/.github/actions/tilt-setup-prebuild/action.yaml
@@ -32,20 +32,13 @@ runs:
         bake_images() (
           set -euo pipefail
 
-          local targets=(
-            rust-log-service
-            rust-sysdb-service
-            sysdb
-            sysdb-migration
-            rust-sysdb-migration
-            rust-frontend-service
-            query-service
-            compactor-service
-            garbage-collector
-            load-service
-            work-queue-service
-            fn-consumer
-          )
+          local bake_file="${{ github.action_path }}/docker-bake.hcl"
+          mapfile -t targets < <(grep '^target' "${bake_file}" | awk '{ gsub(/"/, "", $2); print $2 }')
+
+          if [[ "${#targets[@]}" -eq 0 ]]; then
+            echo "No docker bake targets found in ${bake_file}" >&2
+            exit 1
+          fi
 
           if ! [[ "${IMAGE_BUILD_PARALLELISM}" =~ ^[1-9][0-9]*$ ]]; then
             echo "IMAGE_BUILD_PARALLELISM must be a positive integer, got '${IMAGE_BUILD_PARALLELISM}'" >&2
@@ -56,7 +49,7 @@ runs:
           for ((i = 0; i < total; i += IMAGE_BUILD_PARALLELISM)); do
             local batch=("${targets[@]:i:IMAGE_BUILD_PARALLELISM}")
             echo "Building image batch: ${batch[*]}"
-            docker buildx bake -f "${{ github.action_path }}/docker-bake.hcl" --load "${batch[@]}"
+            docker buildx bake -f "${bake_file}" --load "${batch[@]}"
           done
         )
         export -f bake_images

--- a/.github/actions/tilt-setup-prebuild/action.yaml
+++ b/.github/actions/tilt-setup-prebuild/action.yaml
@@ -4,6 +4,12 @@ runs:
   using: "composite"
   steps:
     # tilt ci can automatically build images while bringing up the cluster. However, this results in flaky runs for our usage so we split up image building and pod deployment into separate steps. See https://github.com/chroma-core/chroma/pull/4720.
+    # NOTE(rescrv):  This breaks up the build into chunks of IMAGE_BUILD_PARALLELISM images at a
+    # time.  Empirically it makes a difference to the reliability of the start tilt.  Prior to this
+    # change a 16 PR stack would fail to bring up tilt on at least one test for most PRs in the
+    # stack, with some PRs having multiple flakes.  With this change I've restacked the same PRs
+    # several times and have had just one flake.  A 10-20x reduction for making bake_images below
+    # invoke docker buildx bake in chunks.
     - name: Install Tilt, bake images, pre-pull external images
       shell: bash
       env:

--- a/.github/actions/tilt/action.yaml
+++ b/.github/actions/tilt/action.yaml
@@ -5,6 +5,24 @@ runs:
   steps:
     - name: Tilt Setup & Pre-Build
       uses: ./.github/actions/tilt-setup-prebuild
+    - name: Check minikube status
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        dump_status() {
+          echo "::group::minikube diagnostics"
+          minikube status || true
+          kubectl cluster-info || true
+          kubectl get nodes -o wide || true
+          kubectl get pods --all-namespaces || true
+          echo "::endgroup::"
+        }
+        trap dump_status ERR
+
+        minikube status
+        kubectl version --request-timeout=30s
+        kubectl wait --for=condition=Ready node --all --timeout=120s
     - name: Start Tilt
       shell: bash
       run: tilt ci --timeout 10m


### PR DESCRIPTION
## Description of changes

Split the monolithic docker buildx bake into batched builds with a
configurable IMAGE_BUILD_PARALLELISM to reduce flakiness and resource
pressure during Tilt CI runs. Move minikube startup after image
baking/pulling so the cluster is brought up once images are ready.

Add a minikube status check step to the tilt action that waits for
nodes to be Ready and dumps diagnostics on failure, making CI cluster
bring-up issues easier to debug.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
