### PR TITLE
[ENH] Support multiple SV in all clients

### DIFF
--- a/chromadb/test/api/test_schema_e2e.py
+++ b/chromadb/test/api/test_schema_e2e.py
@@ -563,22 +563,36 @@ def test_sparse_vector_source_key_and_index_constraints(
     assert len(search_result["ids"]) == 1
     assert "sparse-1" in search_result["ids"][0]
 
+    # The following exercise client-side Schema *builder* validation. Indexes
+    # cannot be added to an existing collection (schemas are fixed at creation),
+    # so these operate on a fresh Schema rather than mutating collection.schema.
+
     # source_key without an embedding function is still rejected.
     with pytest.raises(ValueError):
-        collection.schema.create_index(
+        Schema().create_index(
             key="invalid_sparse",
             config=SparseVectorIndexConfig(source_key="raw_text"),
         )
 
-    # A second sparse vector index is now allowed (multiple sparse indices).
-    collection.schema.create_index(
+    # Multiple sparse vector indices are allowed in a single schema (the old
+    # "one sparse index per collection" restriction has been removed).
+    multi_sparse_schema = Schema()
+    multi_sparse_schema.create_index(
+        key="sparse_metadata",
+        config=SparseVectorIndexConfig(
+            source_key="raw_text",
+            embedding_function=sparse_ef,
+        ),
+    )
+    multi_sparse_schema.create_index(
         key="another_sparse",
         config=SparseVectorIndexConfig(
             source_key="raw_text",
             embedding_function=sparse_ef,
         ),
     )
-    assert "another_sparse" in collection.schema.keys
+    assert "sparse_metadata" in multi_sparse_schema.keys
+    assert "another_sparse" in multi_sparse_schema.keys
 
     string_filter = collection.get(where={"tag_b": "fruit"})
     assert set(string_filter["ids"]) == {"sparse-1"}

--- a/chromadb/test/api/test_schema_e2e.py
+++ b/chromadb/test/api/test_schema_e2e.py
@@ -33,7 +33,7 @@ from chromadb.utils.embedding_functions import (
 from chromadb.api.models.Collection import Collection
 from chromadb.api.models.CollectionCommon import CollectionCommon
 from chromadb.errors import InvalidArgumentError
-from chromadb.execution.expression import Knn, Search
+from chromadb.execution.expression import Knn, Rrf, Search
 from chromadb.types import Collection as CollectionModel
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, cast
 from uuid import uuid4
@@ -519,7 +519,7 @@ def test_sparse_vector_not_allowed_locally(
 def test_sparse_vector_source_key_and_index_constraints(
     client_factories: "ClientFactories",
 ) -> None:
-    """Sparse vector configs honor source key embedding and single-index enforcement."""
+    """Sparse vector configs honor source key embedding; multiple indices allowed."""
     sparse_ef = DeterministicSparseEmbeddingFunction(label="source-test")
 
     schema = Schema()
@@ -563,11 +563,22 @@ def test_sparse_vector_source_key_and_index_constraints(
     assert len(search_result["ids"]) == 1
     assert "sparse-1" in search_result["ids"][0]
 
+    # source_key without an embedding function is still rejected.
     with pytest.raises(ValueError):
         collection.schema.create_index(
-            key="another_sparse",
+            key="invalid_sparse",
             config=SparseVectorIndexConfig(source_key="raw_text"),
         )
+
+    # A second sparse vector index is now allowed (multiple sparse indices).
+    collection.schema.create_index(
+        key="another_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="raw_text",
+            embedding_function=sparse_ef,
+        ),
+    )
+    assert "another_sparse" in collection.schema.keys
 
     string_filter = collection.get(where={"tag_b": "fruit"})
     assert set(string_filter["ids"]) == {"sparse-1"}
@@ -1139,6 +1150,139 @@ def test_schema_embedding_configuration_enforced(
     numeric_metadata = numeric_meta["metadatas"][0]
     assert numeric_metadata is not None
     assert "sparse_auto" not in numeric_metadata
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_multiple_sparse_vector_indices_e2e(
+    client_factories: "ClientFactories",
+) -> None:
+    """Two sparse indices coexist, index independently, and fuse via arithmetic/RRF."""
+    schema = Schema()
+    schema.create_index(key="sparse_a", config=SparseVectorIndexConfig())
+    schema.create_index(key="sparse_b", config=SparseVectorIndexConfig())
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    assert collection.schema is not None
+    assert "sparse_a" in collection.schema.keys
+    assert "sparse_b" in collection.schema.keys
+
+    # doc-1 is the strong match on sparse_a and weak on sparse_b; doc-2 is the
+    # inverse. The query vector is identical for both keys, so any difference in
+    # ranking proves each key is backed by an independent sparse index.
+    collection.add(
+        ids=["doc-1", "doc-2"],
+        documents=["first", "second"],
+        metadatas=[
+            {
+                "sparse_a": SparseVector(indices=[0], values=[5.0]),
+                "sparse_b": SparseVector(indices=[0], values=[1.0]),
+            },
+            {
+                "sparse_a": SparseVector(indices=[0], values=[1.0]),
+                "sparse_b": SparseVector(indices=[0], values=[5.0]),
+            },
+        ],
+    )
+
+    # Both records should carry both sparse vectors.
+    stored = collection.get(ids=["doc-1"], include=["metadatas"])
+    assert stored["metadatas"] is not None
+    stored_meta = stored["metadatas"][0]
+    assert stored_meta is not None
+    assert "sparse_a" in stored_meta
+    assert "sparse_b" in stored_meta
+
+    query = SparseVector(indices=[0], values=[1.0])
+
+    result_a = collection.search(
+        Search().rank(Knn(key="sparse_a", query=cast(Any, query))).limit(10)
+    )
+    ids_a = result_a["ids"][0]
+    assert set(ids_a) == {"doc-1", "doc-2"}
+    assert ids_a.index("doc-1") < ids_a.index("doc-2")
+
+    result_b = collection.search(
+        Search().rank(Knn(key="sparse_b", query=cast(Any, query))).limit(10)
+    )
+    ids_b = result_b["ids"][0]
+    assert set(ids_b) == {"doc-1", "doc-2"}
+    assert ids_b.index("doc-2") < ids_b.index("doc-1")
+
+    # Arithmetic fusion across both sparse indices returns both records.
+    fused = collection.search(
+        Search()
+        .rank(
+            Knn(key="sparse_a", query=cast(Any, query)) * 0.7
+            + Knn(key="sparse_b", query=cast(Any, query)) * 0.3
+        )
+        .limit(10)
+    )
+    assert set(fused["ids"][0]) == {"doc-1", "doc-2"}
+
+    # RRF fusion across both sparse indices also returns both records.
+    rrf_result = collection.search(
+        Search()
+        .rank(
+            Rrf(
+                ranks=[
+                    Knn(key="sparse_a", query=cast(Any, query), return_rank=True),
+                    Knn(key="sparse_b", query=cast(Any, query), return_rank=True),
+                ]
+            )
+        )
+        .limit(10)
+    )
+    assert set(rrf_result["ids"][0]) == {"doc-1", "doc-2"}
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_combined_sparse_knn_rejects_unindexed_key(
+    client_factories: "ClientFactories",
+) -> None:
+    """A rank combining an indexed sparse key with an unindexed key is rejected."""
+    schema = Schema()
+    schema.create_index(key="sparse_indexed", config=SparseVectorIndexConfig())
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    assert collection.schema is not None
+    assert "sparse_indexed" in collection.schema.keys
+    assert "sparse_unindexed" not in collection.schema.keys
+
+    collection.add(
+        ids=["doc-1"],
+        documents=["first"],
+        metadatas=[{"sparse_indexed": SparseVector(indices=[0], values=[1.0])}],
+    )
+
+    query = SparseVector(indices=[0], values=[1.0])
+
+    # The indexed key alone is queryable.
+    indexed_only = collection.search(
+        Search().rank(Knn(key="sparse_indexed", query=cast(Any, query))).limit(10)
+    )
+    assert "doc-1" in indexed_only["ids"][0]
+
+    # Combining the indexed key with an unindexed key rejects the whole search,
+    # naming the unindexed key.
+    with pytest.raises(InvalidArgumentError) as combined_exc:
+        collection.search(
+            Search()
+            .rank(
+                Knn(key="sparse_indexed", query=cast(Any, query))
+                + Knn(key="sparse_unindexed", query=cast(Any, query))
+            )
+            .limit(10)
+        )
+    assert "sparse_unindexed" in str(combined_exc.value)
+
+    # Querying the unindexed key on its own is rejected as well.
+    with pytest.raises(InvalidArgumentError) as single_exc:
+        collection.search(
+            Search().rank(Knn(key="sparse_unindexed", query=cast(Any, query))).limit(10)
+        )
+    assert "sparse_unindexed" in str(single_exc.value)
 
 
 def test_schema_precedence_for_overrides_discoverables_and_defaults(
@@ -2837,7 +2981,5 @@ def test_fts_disabled_search_api_blocks_document_filter(
     )
 
     with pytest.raises(InvalidArgumentError) as exc_info:
-        collection.search(
-            Search(where=Key.DOCUMENT.contains("alpha"))
-        )
+        collection.search(Search(where=Key.DOCUMENT.contains("alpha")))
     assert "fts" in str(exc_info.value).lower()

--- a/clients/new-js/packages/chromadb/test/search.expression.test.ts
+++ b/clients/new-js/packages/chromadb/test/search.expression.test.ts
@@ -26,6 +26,20 @@ class QueryMockEmbedding implements EmbeddingFunction {
   }
 }
 
+const collectKnnLeaves = (node: unknown): Record<string, any>[] => {
+  if (node === null || typeof node !== "object") {
+    return [];
+  }
+  if (Array.isArray(node)) {
+    return node.flatMap((child) => collectKnnLeaves(child));
+  }
+  const record = node as Record<string, unknown>;
+  if ("$knn" in record) {
+    return [record["$knn"] as Record<string, any>];
+  }
+  return Object.values(record).flatMap((child) => collectKnnLeaves(child));
+};
+
 describe("search expression DSL", () => {
   test("builder chain converts to API payload", () => {
     const search = new Search()
@@ -662,5 +676,149 @@ describe("search expression DSL", () => {
 
     expect(mockApiClient.post).toHaveBeenCalledTimes(1);
     expect(capturedBody.read_level).toBeUndefined();
+  });
+
+  test("search fuses string knn queries across multiple sparse indices", async () => {
+    class KeyedSparseEmbedding implements SparseEmbeddingFunction {
+      public readonly name = "keyed_sparse";
+
+      constructor(private readonly index: number) {}
+
+      async generate(texts: string[]): Promise<SparseVector[]> {
+        return texts.map(() => ({ indices: [this.index], values: [1.0] }));
+      }
+
+      getConfig(): Record<string, any> {
+        return { index: this.index };
+      }
+
+      static buildFromConfig(
+        config: Record<string, any>,
+      ): KeyedSparseEmbedding {
+        return new KeyedSparseEmbedding(config.index);
+      }
+    }
+
+    const sparseEfA = new KeyedSparseEmbedding(0);
+    const sparseEfB = new KeyedSparseEmbedding(1);
+    const generateSpyA = jest.spyOn(sparseEfA, "generate");
+    const generateSpyB = jest.spyOn(sparseEfB, "generate");
+
+    const { Schema, SparseVectorIndexConfig } = await import("../src/schema");
+    const schema = new Schema()
+      .createIndex(
+        new SparseVectorIndexConfig({
+          sourceKey: "text_a",
+          embeddingFunction: sparseEfA,
+        }),
+        "sparse_a",
+      )
+      .createIndex(
+        new SparseVectorIndexConfig({
+          sourceKey: "text_b",
+          embeddingFunction: sparseEfB,
+        }),
+        "sparse_b",
+      );
+
+    let capturedBody: any;
+    const mockChromaClient = {
+      getMaxBatchSize: jest.fn<() => Promise<number>>().mockResolvedValue(1000),
+      supportsBase64Encoding: jest
+        .fn<() => Promise<boolean>>()
+        .mockResolvedValue(false),
+      _path: jest
+        .fn<() => Promise<{ path: string; tenant: string; database: string }>>()
+        .mockResolvedValue({
+          path: "/api/v1",
+          tenant: "default_tenant",
+          database: "default_database",
+        }),
+    };
+
+    const mockApiClient = {
+      post: jest.fn().mockImplementation(async (options: any) => {
+        capturedBody = options.body;
+        return {
+          data: {
+            ids: [],
+            documents: [],
+            embeddings: [],
+            metadatas: [],
+            scores: [],
+            select: [],
+          } as SearchResponse,
+        };
+      }),
+    };
+
+    const collection = new CollectionImpl({
+      chromaClient: mockChromaClient as unknown as ChromaClient,
+      apiClient: mockApiClient as any,
+      id: "col-id",
+      name: "test",
+      tenant: "default_tenant",
+      database: "default_database",
+      configuration: {} as CollectionConfiguration,
+      metadata: undefined,
+      embeddingFunction: undefined,
+      schema,
+    });
+
+    // Weighted arithmetic fusion across two distinct sparse indices.
+    await collection.search(
+      new Search().rank(
+        Knn({ key: "sparse_a", query: "alpha", limit: 10 })
+          .multiply(0.7)
+          .add(
+            Knn({ key: "sparse_b", query: "beta", limit: 10 }).multiply(0.3),
+          ),
+      ),
+    );
+
+    // Each key's embedding function embeds only its own query string.
+    expect(generateSpyA).toHaveBeenCalledTimes(1);
+    expect(generateSpyA).toHaveBeenCalledWith(["alpha"]);
+    expect(generateSpyB).toHaveBeenCalledTimes(1);
+    expect(generateSpyB).toHaveBeenCalledWith(["beta"]);
+
+    const leaves = collectKnnLeaves(capturedBody.searches[0].rank);
+    const byKey = Object.fromEntries(leaves.map((leaf) => [leaf.key, leaf]));
+    expect(Object.keys(byKey).sort()).toEqual(["sparse_a", "sparse_b"]);
+    expect(byKey["sparse_a"].query).toEqual({ indices: [0], values: [1.0] });
+    expect(byKey["sparse_b"].query).toEqual({ indices: [1], values: [1.0] });
+
+    // RRF fusion across the same two sparse indices surfaces both leaves too.
+    capturedBody = undefined;
+    generateSpyA.mockClear();
+    generateSpyB.mockClear();
+
+    await collection.search(
+      new Search().rank(
+        Rrf({
+          ranks: [
+            Knn({
+              key: "sparse_a",
+              query: "alpha",
+              limit: 10,
+              returnRank: true,
+            }),
+            Knn({
+              key: "sparse_b",
+              query: "beta",
+              limit: 10,
+              returnRank: true,
+            }),
+          ],
+        }),
+      ),
+    );
+
+    expect(generateSpyA).toHaveBeenCalledWith(["alpha"]);
+    expect(generateSpyB).toHaveBeenCalledWith(["beta"]);
+
+    const rrfLeaves = collectKnnLeaves(capturedBody.searches[0].rank);
+    const rrfKeys = rrfLeaves.map((leaf) => leaf.key).sort();
+    expect(rrfKeys).toEqual(["sparse_a", "sparse_b"]);
   });
 });

--- a/docs/mintlify/cloud/search-api/ranking.mdx
+++ b/docs/mintlify/cloud/search-api/ranking.mdx
@@ -266,11 +266,11 @@ Knn({ query: "machine learning", key: "sparse_embedding" });  // Search sparse e
 </CodeGroup>
 
 <Warning>
-Currently, dense embeddings can only be stored in the default embedding field (`#embedding`). Only sparse vector embeddings can be stored in metadata, and they must be stored consistently under the same key across all documents. Additionally, only one sparse vector index is allowed per collection in metadata.
+Currently, dense embeddings can only be stored in the default embedding field (`#embedding`). Only sparse vector embeddings can be stored in metadata, and each one must be stored consistently under the same key across all documents. A collection may declare multiple sparse vector indices (one per metadata key); they must be declared at collection creation and cannot be added later.
 </Warning>
 
 <Callout>
-Support for multiple dense embedding fields and multiple sparse vector indices is coming in a future release. This will allow you to store and query multiple embeddings per document, with optimized indexing for each field.
+Multiple sparse vector indices per collection are supported: store and query several sparse embeddings per document, each under its own metadata key, and fuse their scores with arithmetic operations or RRF. Support for multiple dense embedding fields is coming in a future release.
 </Callout>
 
 ## Arithmetic Operations

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -3988,6 +3988,77 @@ mod tests {
     }
 
     #[test]
+    fn test_combined_knn_rejects_unindexed_sparse_key() {
+        // A rank expression may target an indexed sparse key and an unindexed key
+        // in the same search. The frontend validates every $knn leaf
+        // independently (see service_based_frontend.rs), so the indexed leaf must
+        // be accepted while the unindexed leaf is rejected.
+        use crate::operator::{Key, RankExpr};
+
+        let mut schema = Schema::new_default(KnnIndex::Spann);
+        schema.keys.insert(
+            "sparse_indexed".to_string(),
+            ValueTypes {
+                sparse_vector: Some(SparseVectorValueType {
+                    sparse_vector_index: Some(SparseVectorIndexType {
+                        enabled: true,
+                        config: SparseVectorIndexConfig {
+                            embedding_function: Some(EmbeddingFunctionConfiguration::Legacy),
+                            source_key: None,
+                            bm25: None,
+                            algorithm: SparseIndexAlgorithm::Wand,
+                        },
+                    }),
+                }),
+                ..Default::default()
+            },
+        );
+
+        let sparse_leaf = |key: &str| RankExpr::Knn {
+            query: QueryVector::Sparse(SparseVector::new(vec![0_u32], vec![1.0_f32]).unwrap()),
+            key: Key::field(key),
+            limit: 10,
+            default: None,
+            return_rank: false,
+        };
+
+        // Combined rank: one indexed sparse leaf + one unindexed leaf.
+        let expr = RankExpr::Summation(vec![
+            sparse_leaf("sparse_indexed"),
+            sparse_leaf("sparse_unindexed"),
+        ]);
+
+        // Mirror the frontend's per-leaf validation loop.
+        let mut results: Vec<(String, Result<(), FilterValidationError>)> = expr
+            .knn_queries()
+            .into_iter()
+            .map(|knn| {
+                let key = knn.key.to_string();
+                let result = schema.is_knn_key_indexing_enabled(&key, &knn.query);
+                (key, result)
+            })
+            .collect();
+
+        assert_eq!(results.len(), 2);
+
+        // The indexed leaf is accepted.
+        let (indexed_key, indexed_result) = results.remove(0);
+        assert_eq!(indexed_key, "sparse_indexed");
+        assert!(indexed_result.is_ok());
+
+        // The unindexed leaf is rejected with an indexing-disabled error.
+        let (unindexed_key, unindexed_result) = results.remove(0);
+        assert_eq!(unindexed_key, "sparse_unindexed");
+        match unindexed_result.expect_err("expected unindexed sparse leaf to be rejected") {
+            FilterValidationError::IndexingDisabled { key, value_type } => {
+                assert_eq!(key, "sparse_unindexed");
+                assert_eq!(value_type, crate::metadata::MetadataValueType::SparseVector);
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_merge_hnsw_configs_field_level() {
         // Test field-level merging for HNSW configurations
         let default_hnsw = HnswIndexConfig {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

Client end-to-end coverage and docs for multiple sparse vector indices, completing the stack (#7305 engine, #7306 enable, #7307 fusion). The Python and TS clients were already key-aware — each iterates every enabled sparse key when generating embeddings, and `Knn(key=...)` targets a specific key — so this PR is primarily tests + docs, plus one focused validation test and a stale-test fix.

- New functionality
  - Python e2e (`test_schema_e2e.py`): create a collection with multiple sparse keys, ingest records carrying multiple sparse vectors, query each key independently (proving per-key index isolation), and fuse scores via arithmetic (`Knn(a)*0.7 + Knn(b)*0.3`) and `Rrf`.
  - TS (`search.expression.test.ts`): multiple sparse `$knn` leaves compose correctly into arithmetic/RRF payloads, and each key's embedding function embeds only its own query string.
  - Validation: a rank combining an indexed sparse key with an unindexed key rejects the unindexed leaf — covered as a Rust unit test (`collection_schema.rs`, mirroring the frontend's per-leaf `is_knn_key_indexing_enabled` loop) and a Python e2e test (`InvalidArgumentError` naming the unindexed key).
- Improvements & Bug fixes
  - Update the now-stale `test_sparse_vector_source_key_and_index_constraints`: it asserted a second sparse index raises (true only under the old cap). It now asserts a second sparse index *with* an embedding function is allowed, while keeping the `source_key`-without-EF rejection.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
- `cargo test -p chroma-types test_combined_knn_rejects_unindexed_sparse_key` — passes locally.
- `pytest chromadb/test/api/test_schema_e2e.py` — `test_multiple_sparse_vector_indices_e2e` and `test_combined_sparse_knn_rejects_unindexed_key` (distributed-only via `skipif(is_spann_disabled_mode)`; run in the cluster suite).
- TS `search.expression.test.ts` — type-checked and prettier-clean; runs in CI (local `jest` is blocked by the unrelated usearch/simsimd native-binding build).

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

None — additive client tests, one Rust validation test, and a docs update. No behavior change.

## Observability plan

_What is the plan to instrument and monitor this change?_

N/A.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

Updated `docs/mintlify/cloud/search-api/ranking.mdx`: replaced the "only one sparse vector index per collection" limitation and the "coming in a future release" callout with the now-supported multiple-sparse-indices wording (multiple sparse keys per collection, fused via arithmetic or RRF, declared at collection creation).
