### PR TITLE
[CHORE](ci): Centralize Rust toolchain and target setup

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -11,6 +11,10 @@ inputs:
   workspaces:
     description: "Workspace paths to cache (see documentation on Swatinem/rust-cache for details)"
     required: false
+  targets:
+    description: "Rust targets to install (comma, whitespace, or newline separated)"
+    required: false
+    default: ""
   install-nextest:
     description: "Install cargo-nextest"
     required: false
@@ -22,12 +26,9 @@ runs:
       shell: bash
       env:
         RUST_TOOLCHAIN: ${{ inputs.toolchain }}
+        RUST_TARGETS: ${{ inputs.targets }}
       run: |
-        rustup set profile minimal
-        rustup update "$RUST_TOOLCHAIN"
-        rustup default "$RUST_TOOLCHAIN"
-        rustc --version
-        cargo --version
+        bash "${GITHUB_ACTION_PATH}/setup-rust.sh"
     - name: Install Protoc
       uses: chroma-core/setup-protoc@v4c
       with:

--- a/.github/actions/rust/setup-rust.sh
+++ b/.github/actions/rust/setup-rust.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+retry() {
+    local attempt=1
+    local max_attempts=5
+    local delay=5
+
+    until "$@"; do
+        local status=$?
+        if (( attempt >= max_attempts )); then
+            echo "::error::Command failed after ${max_attempts} attempts: $*"
+            return "$status"
+        fi
+
+        echo "::warning::Command failed with exit code ${status}; retrying in ${delay}s (attempt ${attempt}/${max_attempts}): $*"
+        sleep "$delay"
+        attempt=$((attempt + 1))
+        delay=$((delay * 2))
+    done
+}
+
+toolchain="${RUST_TOOLCHAIN:-stable}"
+targets="${RUST_TARGETS:-}"
+
+rustup set profile minimal
+
+# Rust's dist server occasionally times out before a download starts. Keep the
+# normal "latest stable" behavior, but do not fail CI if an installed toolchain
+# can be used after transient update failures.
+if retry rustup update "$toolchain"; then
+    :
+elif rustup run "$toolchain" rustc --version > /dev/null 2>&1; then
+    echo "::warning::Could not update Rust toolchain '${toolchain}'; using the installed toolchain"
+else
+    echo "::error::Could not install Rust toolchain '${toolchain}' and no installed copy is available"
+    exit 1
+fi
+
+rustup default "$toolchain"
+
+if [[ -n "$targets" ]]; then
+    for target in ${targets//,/ }; do
+        retry rustup target add "$target"
+    done
+fi
+
+rustc --version
+cargo --version

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -34,10 +34,7 @@ jobs:
         uses: ./.github/actions/rust
         with:
           github-token: ${{ github.token }}
-      - name: Add targets
-        run: |
-          rustup target add x86_64-apple-darwin
-          rustup target add aarch64-apple-darwin
+          targets: x86_64-apple-darwin,aarch64-apple-darwin
       - name: Cache cargo
         uses: actions/cache@v5
         with:
@@ -92,9 +89,7 @@ jobs:
         uses: ./.github/actions/rust
         with:
           github-token: ${{ github.token }}
-      - name: Add target
-        run: rustup target add x86_64-pc-windows-msvc
-        shell: bash
+          targets: x86_64-pc-windows-msvc
       - name: Cache cargo
         uses: actions/cache@v5
         with:
@@ -140,10 +135,7 @@ jobs:
         uses: ./.github/actions/rust
         with:
           github-token: ${{ github.token }}
-      - name: Add targets
-        run: |
-          rustup target add x86_64-unknown-linux-gnu
-          rustup target add aarch64-unknown-linux-gnu
+          targets: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu
       - name: Install ARM64 cross-compilation tools
         run: |
           sudo apt-get update

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -77,12 +77,7 @@ jobs:
         uses: ./.github/actions/rust
         with:
           github-token: ${{ github.token }}
-
-      - name: Add ARM64 target for macOS
-        run: rustup target add aarch64-apple-darwin
-
-      - name: Add Intel target for macOS
-        run: rustup target add x86_64-apple-darwin
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Build macOS Intel binary
         run: cargo build --bin chroma --release --target x86_64-apple-darwin --manifest-path rust/cli/Cargo.toml


### PR DESCRIPTION
## Description of changes

Extract the rust action's toolchain logic into a setup-rust.sh
script and add a 'targets' input so workflows can declare their
targets inline instead of running standalone 'rustup target add'
steps.

The script retries 'rustup update' with backoff and falls back to
an already-installed toolchain when the dist server times out,
making CI more resilient to transient network failures.

Update the JS bindings and CLI release workflows to pass targets
through the action rather than adding them in separate steps.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
