### PR TITLE
[CHORE](worker): Report work-queue readiness via gRPC health

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.89
+version: 0.1.90
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/work-queue-service.yaml
+++ b/k8s/distributed-chroma/templates/work-queue-service.yaml
@@ -43,6 +43,7 @@ spec:
             failureThreshold: 30 # 30 seconds to allow for initial startup
             grpc:
               port: 50051
+              service: chroma.WorkQueueService
           volumeMounts:
             {{if .Values.workQueueService.configuration}}
             - name: work-queue-service-config

--- a/rust/worker/src/work_queue/server.rs
+++ b/rust/worker/src/work_queue/server.rs
@@ -1,10 +1,11 @@
 use crate::config::RootConfig;
-use crate::work_queue::work_queue_manager::WorkQueueManager;
+use crate::work_queue::work_queue_manager::{WorkQueueManager, WorkQueueReadyMessage};
 use crate::work_queue::work_queue_server::WorkQueueServer;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_storage::Storage;
 use chroma_sysdb::SysDb;
+use chroma_types::chroma_proto::work_queue_service_server::WorkQueueServiceServer;
 
 const CONFIG_PATH_ENV_VAR: &str = "CONFIG_PATH";
 
@@ -63,7 +64,28 @@ pub async fn service_entrypoint() {
     let port = service_config.my_port;
 
     // Create health service for readiness probe
-    let (_health_reporter, health_service) = tonic_health::server::health_reporter();
+    let (health_reporter, health_service) = tonic_health::server::health_reporter();
+    health_reporter
+        .set_service_status("", tonic_health::ServingStatus::NotServing)
+        .await;
+    health_reporter
+        .set_not_serving::<WorkQueueServiceServer<WorkQueueServer>>()
+        .await;
+    tokio::spawn(async move {
+        match work_queue_handle.request(WorkQueueReadyMessage, None).await {
+            Ok(()) => {
+                health_reporter
+                    .set_service_status("", tonic_health::ServingStatus::Serving)
+                    .await;
+                health_reporter
+                    .set_serving::<WorkQueueServiceServer<WorkQueueServer>>()
+                    .await;
+            }
+            Err(err) => {
+                tracing::error!("Work queue manager failed readiness check: {:?}", err);
+            }
+        }
+    });
 
     let addr = format!("0.0.0.0:{}", port).parse().unwrap();
 

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -50,6 +50,9 @@ pub struct GetWorkMessage {
     pub response_tx: oneshot::Sender<Result<Vec<WorkQueueRecord>, WorkQueueError>>,
 }
 
+#[derive(Debug)]
+pub(crate) struct WorkQueueReadyMessage;
+
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct PeriodicPersistMessage;
@@ -632,6 +635,18 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
         if msg.response_tx.send(Ok(filtered)).is_err() {
             tracing::warn!("Failed to send get work response - receiver dropped");
         }
+    }
+}
+
+#[async_trait]
+impl Handler<WorkQueueReadyMessage> for WorkQueueManager {
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        _msg: WorkQueueReadyMessage,
+        _ctx: &ComponentContext<WorkQueueManager>,
+    ) {
     }
 }
 


### PR DESCRIPTION
## Description of changes

Wire the gRPC health service to the work queue manager so the
readiness probe reflects actual manager state instead of defaulting
to serving immediately.

- Start the service in NotServing, then flip to Serving once the
  manager handles a WorkQueueReadyMessage.
- Add a WorkQueueReadyMessage handler to WorkQueueManager.
- Set the readiness probe's grpc service to chroma.WorkQueueService.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
