### PR TITLE
[ENH](embeddings): Add TwelveLabs Marengo embedding function

### DIFF
--- a/chromadb/test/ef/test_twelvelabs_ef.py
+++ b/chromadb/test/ef/test_twelvelabs_ef.py
@@ -1,0 +1,60 @@
+import os
+import pytest
+from chromadb.utils.embedding_functions.twelvelabs_embedding_function import (
+    TwelveLabsEmbeddingFunction,
+)
+
+httpx = pytest.importorskip("httpx", reason="httpx not installed")
+
+MARENGO_DIM = 512
+
+
+def test_config_roundtrip() -> None:
+    """get_config / build_from_config should round-trip without network."""
+    ef = TwelveLabsEmbeddingFunction(
+        api_key="dummy", api_key_env_var="TWELVELABS_API_KEY"
+    )
+    config = ef.get_config()
+    assert config == {
+        "api_key_env_var": "TWELVELABS_API_KEY",
+        "model_name": "marengo3.0",
+    }
+    rebuilt = TwelveLabsEmbeddingFunction.build_from_config(config)
+    assert rebuilt.get_config() == config
+
+
+def test_model_name_immutable() -> None:
+    ef = TwelveLabsEmbeddingFunction(api_key="dummy")
+    with pytest.raises(ValueError):
+        ef.validate_config_update(ef.get_config(), {"model_name": "other"})
+
+
+def test_media_routing() -> None:
+    """Documents are routed to text vs. image/audio URL params correctly."""
+    ef = TwelveLabsEmbeddingFunction(api_key="dummy")
+    assert ef._media_kind("a cat playing piano") is None
+    assert ef._media_kind("https://example.com/cat.jpg") == "image"
+    assert ef._media_kind("https://example.com/clip.mp3?sig=abc") == "audio"
+    assert ef._media_kind("image:https://cdn.example.com/x") == "image"
+    assert ef._media_kind("audio:https://cdn.example.com/y") == "audio"
+
+
+def test_missing_api_key() -> None:
+    saved = os.environ.pop("TWELVELABS_API_KEY", None)
+    try:
+        with pytest.raises(ValueError):
+            TwelveLabsEmbeddingFunction(api_key_env_var="TWELVELABS_API_KEY")
+    finally:
+        if saved is not None:
+            os.environ["TWELVELABS_API_KEY"] = saved
+
+
+def test_marengo_text_embedding() -> None:
+    """Live smoke test: a text document yields a 512-dim Marengo embedding."""
+    if os.environ.get("TWELVELABS_API_KEY") is None:
+        pytest.skip("TWELVELABS_API_KEY not set")
+    ef = TwelveLabsEmbeddingFunction()
+    embeddings = ef(["a cat playing piano"])
+    assert embeddings is not None
+    assert len(embeddings) == 1
+    assert len(embeddings[0]) == MARENGO_DIM

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -95,6 +95,9 @@ from chromadb.utils.embedding_functions.chroma_bm25_embedding_function import (
 from chromadb.utils.embedding_functions.perplexity_embedding_function import (
     PerplexityEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.twelvelabs_embedding_function import (
+    TwelveLabsEmbeddingFunction,
+)
 
 
 # Get all the class names for backward compatibility
@@ -132,7 +135,8 @@ _all_classes: Set[str] = {
     "ChromaCloudQwenEmbeddingFunction",
     "ChromaCloudSpladeEmbeddingFunction",
     "ChromaBm25EmbeddingFunction",
-    "PerplexityEmbeddingFunction"
+    "PerplexityEmbeddingFunction",
+    "TwelveLabsEmbeddingFunction",
 }
 
 
@@ -171,6 +175,7 @@ known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignor
     "together_ai": TogetherAIEmbeddingFunction,
     "chroma-cloud-qwen": ChromaCloudQwenEmbeddingFunction,
     "perplexity": PerplexityEmbeddingFunction,
+    "twelvelabs": TwelveLabsEmbeddingFunction,
 }
 
 sparse_known_embedding_functions: Dict[str, Type[SparseEmbeddingFunction]] = {  # type: ignore
@@ -301,6 +306,7 @@ __all__ = [
     "ChromaCloudSpladeEmbeddingFunction",
     "ChromaBm25EmbeddingFunction",
     "PerplexityEmbeddingFunction",
+    "TwelveLabsEmbeddingFunction",
     "register_embedding_function",
     "config_to_embedding_function",
     "known_embedding_functions",

--- a/chromadb/utils/embedding_functions/twelvelabs_embedding_function.py
+++ b/chromadb/utils/embedding_functions/twelvelabs_embedding_function.py
@@ -1,0 +1,195 @@
+from chromadb.api.types import (
+    Embeddings,
+    EmbeddingFunction,
+    Space,
+    Embeddable,
+    is_document,
+)
+from chromadb.utils.embedding_functions.schemas import validate_config_schema
+from typing import List, Dict, Any, Optional, cast
+import os
+import warnings
+import numpy as np
+
+# Media file extensions that Marengo can embed when a document is a public URL.
+_IMAGE_EXTS = (".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp")
+_AUDIO_EXTS = (".mp3", ".wav", ".m4a", ".flac", ".ogg", ".aac")
+
+
+class TwelveLabsEmbeddingFunction(EmbeddingFunction[Embeddable]):
+    """
+    Embedding function for the TwelveLabs Marengo multimodal model.
+
+    Marengo embeds text, images, and audio into a single 512-dimensional space,
+    so text queries can retrieve media stored in the same Chroma collection.
+
+    Each input document is either plain text or a publicly accessible media URL.
+    Documents ending in a known image/audio extension (or carrying an explicit
+    ``image:``/``audio:`` prefix) are sent as media URLs; everything else is sent
+    as text. Marengo ingests media by URL only, so local image arrays are not
+    supported here -- host the media and pass its URL as a document instead.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model_name: str = "marengo3.0",
+        api_key_env_var: str = "TWELVELABS_API_KEY",
+    ):
+        """
+        Initialize the TwelveLabsEmbeddingFunction.
+
+        Args:
+            api_key (str, optional): Your TwelveLabs API key. Prefer setting the
+                environment variable named by ``api_key_env_var`` so the key is
+                not persisted in the collection config.
+            model_name (str, optional): The Marengo model to use.
+                Defaults to "marengo3.0".
+            api_key_env_var (str, optional): Environment variable name that holds
+                your TwelveLabs API key. Defaults to "TWELVELABS_API_KEY".
+        """
+        try:
+            import httpx
+        except ImportError:
+            raise ValueError(
+                "The httpx python package is not installed. Please install it with `pip install httpx`"
+            )
+
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
+
+        self.api_key_env_var = api_key_env_var
+        self.api_key = api_key or os.getenv(api_key_env_var)
+        if not self.api_key:
+            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+
+        self.model_name = model_name
+        self._api_url = "https://api.twelvelabs.io/v1.3/embed"
+        self._session = httpx.Client()
+        self._session.headers.update({"x-api-key": self.api_key})
+
+    def _media_kind(self, item: str) -> Optional[str]:
+        """Return "image" or "audio" if the document is a media URL, else None."""
+        lowered = item.lower()
+        if lowered.startswith("image:"):
+            return "image"
+        if lowered.startswith("audio:"):
+            return "audio"
+        if not (lowered.startswith("http://") or lowered.startswith("https://")):
+            return None
+        # Strip query string before checking the extension.
+        path = lowered.split("?", 1)[0]
+        if path.endswith(_IMAGE_EXTS):
+            return "image"
+        if path.endswith(_AUDIO_EXTS):
+            return "audio"
+        return None
+
+    def _embed_one(self, item: str) -> np.ndarray:
+        data: Dict[str, Any] = {"model_name": self.model_name}
+        kind = self._media_kind(item)
+        if kind == "image":
+            data["image_url"] = (
+                item.split(":", 1)[1] if item.lower().startswith("image:") else item
+            )
+        elif kind == "audio":
+            data["audio_url"] = (
+                item.split(":", 1)[1] if item.lower().startswith("audio:") else item
+            )
+        else:
+            data["text"] = item
+
+        # An empty `files` entry forces a multipart/form-data request, which the
+        # /embed endpoint requires.
+        resp = self._session.post(
+            self._api_url, data=data, files={"_": (None, "")}, timeout=60
+        ).json()
+
+        if "text_embedding" in resp:
+            segments = resp["text_embedding"]["segments"]
+        elif "image_embedding" in resp:
+            segments = resp["image_embedding"]["segments"]
+        elif "audio_embedding" in resp:
+            segments = resp["audio_embedding"]["segments"]
+        else:
+            raise RuntimeError(resp.get("message", f"Unexpected response: {resp}"))
+
+        return np.array(segments[0]["float"], dtype=np.float32)
+
+    def __call__(self, input: Embeddable) -> Embeddings:
+        """
+        Get Marengo embeddings for a list of text and/or media-URL documents.
+
+        Args:
+            input (Embeddable): A list of text strings and/or media URLs.
+
+        Returns:
+            Embeddings: A list of 512-dimensional embeddings.
+
+        Example:
+            >>> ef = TwelveLabsEmbeddingFunction()
+            >>> ef(["a cat playing piano", "https://example.com/cat.jpg"])
+        """
+        embeddings: Embeddings = []
+        for item in input:
+            if not is_document(item):
+                raise ValueError(
+                    "TwelveLabsEmbeddingFunction only supports text and media-URL "
+                    "documents. Host images/audio and pass their URLs as documents."
+                )
+            embeddings.append(self._embed_one(cast(str, item)))
+        return embeddings
+
+    @staticmethod
+    def name() -> str:
+        return "twelvelabs"
+
+    def default_space(self) -> Space:
+        return "cosine"
+
+    def supported_spaces(self) -> List[Space]:
+        return ["cosine", "l2", "ip"]
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
+        api_key_env_var = config.get("api_key_env_var")
+        model_name = config.get("model_name")
+
+        if api_key_env_var is None or model_name is None:
+            assert False, "This code should not be reached"  # this is for type checking
+
+        return TwelveLabsEmbeddingFunction(
+            api_key_env_var=api_key_env_var,
+            model_name=model_name,
+        )
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "api_key_env_var": self.api_key_env_var,
+            "model_name": self.model_name,
+        }
+
+    def validate_config_update(
+        self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+    ) -> None:
+        if "model_name" in new_config:
+            raise ValueError(
+                "The model name cannot be changed after the embedding function has been initialized."
+            )
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        """
+        Validate the configuration using the JSON schema.
+
+        Args:
+            config: Configuration to validate
+
+        Raises:
+            ValidationError: If the configuration does not match the schema
+        """
+        validate_config_schema(config, "twelvelabs")

--- a/docs/mintlify/docs.json
+++ b/docs/mintlify/docs.json
@@ -220,6 +220,7 @@
               "integrations/embedding-models/sentence-transformer",
               "integrations/embedding-models/text2vec",
               "integrations/embedding-models/together-ai",
+              "integrations/embedding-models/twelvelabs",
               "integrations/embedding-models/voyageai",
               "integrations/embedding-models/cloudflare-workers-ai",
               "integrations/embedding-models/amazon-bedrock",

--- a/docs/mintlify/integrations/chroma-integrations.mdx
+++ b/docs/mintlify/integrations/chroma-integrations.mdx
@@ -25,6 +25,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [Together AI](/integrations/embedding-models/together-ai) | <Icon icon="check" /> | <Icon icon="check" /> |
 | [Mistral](/integrations/embedding-models/mistral) | <Icon icon="check" /> | <Icon icon="check" /> |
 | [Morph](/integrations/embedding-models/morph) | <Icon icon="check" /> | <Icon icon="check" /> |
+| [TwelveLabs](/integrations/embedding-models/twelvelabs) | <Icon icon="check" /> | <Icon icon="hyphen" /> |
 
 
 ### Framework Integrations

--- a/docs/mintlify/integrations/embedding-models/twelvelabs.mdx
+++ b/docs/mintlify/integrations/embedding-models/twelvelabs.mdx
@@ -1,0 +1,61 @@
+---
+title: TwelveLabs
+---
+
+Chroma provides a convenient wrapper around [TwelveLabs](https://twelvelabs.io)'
+Marengo embedding model. Marengo is a multimodal model that embeds text,
+images, and audio into a single 512-dimensional space, so a text query can
+retrieve media stored in the same collection. This embedding function runs
+remotely on TwelveLabs' servers and requires an API key — you can grab one
+(with a generous free tier) at [twelvelabs.io](https://twelvelabs.io).
+
+```python Python
+from chromadb.utils.embedding_functions import TwelveLabsEmbeddingFunction
+
+twelvelabs_ef = TwelveLabsEmbeddingFunction(
+    api_key="YOUR_API_KEY",
+    model_name="marengo3.0",
+)
+
+twelvelabs_ef(input=["a cat playing piano", "https://example.com/cat.jpg"])
+```
+
+We recommend storing your key in the `TWELVELABS_API_KEY` environment variable
+(or any name you pass via `api_key_env_var`) instead of passing it inline, so it
+is not persisted in your collection's configuration:
+
+```python
+twelvelabs_ef = TwelveLabsEmbeddingFunction()  # reads TWELVELABS_API_KEY
+```
+
+### Multimodal input
+
+Each document is either plain text or a **publicly accessible media URL**.
+Documents ending in a known image extension (`.jpg`, `.png`, `.webp`, …) or
+audio extension (`.mp3`, `.wav`, `.flac`, …) are embedded as media; everything
+else is embedded as text. You can also force the type with an `image:` or
+`audio:` prefix:
+
+```python
+collection.add(
+    ids=["doc1", "img1", "clip1"],
+    documents=[
+        "a short description of a sunset",
+        "https://example.com/sunset.jpg",
+        "audio:https://example.com/birdsong.mp3",
+    ],
+)
+
+# Query the same multimodal space with text:
+collection.query(query_texts=["birds singing at dawn"], n_results=2)
+```
+
+Because the same model embeds every modality, text queries, image documents,
+and audio clips all live in one comparable 512-dimensional space.
+
+<br />
+
+Marengo ingests media by URL only — host your images/audio somewhere publicly
+reachable and pass the URL as a document. See the
+[TwelveLabs embedding docs](https://docs.twelvelabs.io/v1.3/docs/concepts/models/marengo)
+for media format requirements.

--- a/schemas/embedding_functions/twelvelabs.json
+++ b/schemas/embedding_functions/twelvelabs.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TwelveLabs Embedding Function Schema",
+  "description": "Schema for the twelvelabs embedding function configuration",
+  "version": "1.0.0",
+  "type": "object",
+  "properties": {
+    "model_name": {
+      "type": "string",
+      "description": "Parameter model_name for the twelvelabs embedding function"
+    },
+    "api_key_env_var": {
+      "type": "string",
+      "description": "Parameter api_key_env_var for the twelvelabs embedding function"
+    }
+  },
+  "required": [
+    "api_key_env_var",
+    "model_name"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Description of changes

This PR adds `TwelveLabsEmbeddingFunction`, a remote embedding function backed by TwelveLabs' [Marengo](https://docs.twelvelabs.io/v1.3/docs/concepts/models/marengo) multimodal model. Marengo embeds text, images, and audio into a single **512-dimensional** space, so a text query can retrieve image/audio documents stored in the same Chroma collection.

- New functionality
  - `chromadb/utils/embedding_functions/twelvelabs_embedding_function.py` — the embedding function, mirroring the existing Jina provider's conventions (`api_key` / `api_key_env_var`, `get_config`/`build_from_config`/`validate_config`, `default_space`/`supported_spaces`).
  - Each document is plain text or a publicly accessible media URL; it's routed to the `text`/`image_url`/`audio_url` form field by extension or an explicit `image:`/`audio:` prefix. (Marengo ingests media by URL, so local image arrays aren't supported here — host the media and pass the URL.)
  - Registered as the opt-in `"twelvelabs"` provider in `known_embedding_functions`; added the JSON schema at `schemas/embedding_functions/twelvelabs.json`.
  - Docs page + integrations table + nav entry.

Why it helps: Chroma users get a turnkey multimodal embedding provider that puts text and media in one comparable vector space without standing up a local model.

This is **opt-in and non-breaking** — no defaults change; the provider is only used if you explicitly construct it. It reuses `httpx`, which is already a core dependency (no new deps).

## Test plan

- [x] Tests pass locally with `pytest`
- `chromadb/test/ef/test_twelvelabs_ef.py`: no-network unit tests (config roundtrip, model-name immutability, media routing, missing-key error) plus a live smoke test gated on `TWELVELABS_API_KEY` (skips without it) asserting a text document yields a 512-dim embedding.
- Verified the live Marengo call returns a 512-dim vector. The new EF also passes the repo-wide `test_embedding_function_config_roundtrip` and schema validation tests. `flake8` (repo config) and `mypy --strict` are clean on the new file.

## Migration plan

None — additive, opt-in provider.

## Observability plan

None beyond the existing embedding-function path; errors surface as `RuntimeError` with the API's message.

## Documentation Changes

Added `docs/mintlify/integrations/embedding-models/twelvelabs.mdx`, a nav entry in `docs.json`, and a row in the integrations table.

---

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.