### PR TITLE
[CHORE] Vendor utoipa swagger UI assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10687,8 +10687,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip 3.0.0",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -49,7 +49,7 @@ chroma-sqlite = { workspace = true }
 frontend-core = { workspace = true }
 utoipa = { workspace = true }
 utoipa-axum = { version = "0.2.0", features = ["debug"] }
-utoipa-swagger-ui = { version = "9", features = ["axum"] }
+utoipa-swagger-ui = { version = "9", features = ["axum", "vendored"] }
 strum = "0.27.1"
 strum_macros = "0.27.1"
 


### PR DESCRIPTION
## Description of changes

Enable the "vendored" feature on utoipa-swagger-ui so the Swagger
UI assets are bundled at build time instead of fetched from the
network. This pulls in the utoipa-swagger-ui-vendored crate and
makes builds hermetic and reproducible.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
