### PR TITLE
[ENH](foundation-api): Link agent-cited pages

### DIFF
--- a/rust/foundation-api/src/agent_tools/search_tool.rs
+++ b/rust/foundation-api/src/agent_tools/search_tool.rs
@@ -15,7 +15,9 @@ use serde::Deserialize;
 
 use chroma_agent::{AgentError, Tool, ToolCallMetadata};
 
+use crate::routes::links::page_url;
 use crate::routes::search::{default_limit, run_hybrid_search};
+use crate::wiki::chunking::ChunkRecordId;
 use crate::wiki::embed::WikiEmbedder;
 use crate::wiki::page::meta_str;
 
@@ -30,19 +32,30 @@ pub(crate) struct SearchToolParams {
     pub limit: Option<u32>,
 }
 
-/// A retrieval tool bound to one request's collection, token, and embedder.
+/// A retrieval tool bound to one request's collection, token, embedder,
+/// tenant, and UI origin (used to stamp page links on hits).
 pub(crate) struct SearchTool {
     collection: ChromaCollection,
     embedder: WikiEmbedder,
     token: String,
+    tenant: String,
+    ui_origin: Option<String>,
 }
 
 impl SearchTool {
-    pub(crate) fn new(collection: ChromaCollection, embedder: WikiEmbedder, token: String) -> Self {
+    pub(crate) fn new(
+        collection: ChromaCollection,
+        embedder: WikiEmbedder,
+        token: String,
+        tenant: String,
+        ui_origin: Option<String>,
+    ) -> Self {
         Self {
             collection,
             embedder,
             token,
+            tenant,
+            ui_origin,
         }
     }
 }
@@ -59,7 +72,7 @@ impl Tool for SearchTool {
     fn description(&self) -> &str {
         "Search the knowledge base for documents relevant to a query. Runs a \
          hybrid dense+sparse retrieval and returns the most relevant documents \
-         with their ids, page slugs, and scores."
+         with their ids, page slugs, page links, page titles, and scores."
     }
 
     async fn call(
@@ -79,14 +92,21 @@ impl Tool for SearchTool {
         .await
         .map_err(|err| AgentError::Tool(err.to_string()))?;
 
-        Ok((format_hits(&hits), None))
+        Ok((
+            format_hits(&hits, self.ui_origin.as_deref(), &self.tenant),
+            None,
+        ))
     }
 }
 
 /// Renders search hits into a numbered text block the model can read: each hit
-/// is its id, page slug (when present), and score, followed by the document
-/// text.
-fn format_hits(hits: &[SearchRecord]) -> String {
+/// is its id, page slug, `url=` page link, and `title=` (when present), and
+/// score, followed by the document text. The url is stamped from the UI origin
+/// and the title read from hit metadata so the model cites pages without
+/// constructing links or guessing titles itself. The slug comes from hit
+/// metadata, falling back to the chunk record id so a hit missing the
+/// metadata field is still linkable (matching the subagent_search path).
+fn format_hits(hits: &[SearchRecord], ui_origin: Option<&str>, tenant: &str) -> String {
     if hits.is_empty() {
         return "No results found.".to_string();
     }
@@ -97,14 +117,40 @@ fn format_hits(hits: &[SearchRecord]) -> String {
                 .metadata
                 .as_ref()
                 .and_then(|meta| meta_str(meta, "slug"))
-                .map(|slug| format!(" slug={slug}"))
+                .or_else(|| ChunkRecordId::slug_from_id(&hit.id).map(str::to_string));
+            let url = slug
+                .as_deref()
+                .and_then(|slug| page_url(ui_origin, tenant, slug))
+                .map(|url| format!(" url={url}"))
+                .unwrap_or_default();
+            let slug = slug.map(|slug| format!(" slug={slug}")).unwrap_or_default();
+            let title = hit
+                .metadata
+                .as_ref()
+                .and_then(|meta| meta_str(meta, "title"))
+                .map(|title| {
+                    // Keep the quoted field intact: flatten line breaks and
+                    // escape embedded quotes so an unusual title can't split
+                    // the hit line or close the field early.
+                    let title = title.replace(['\n', '\r'], " ").replace('"', "\\\"");
+                    format!(" title=\"{title}\"")
+                })
                 .unwrap_or_default();
             let score = hit
                 .score
                 .map(|s| format!(" (score {s:.4})"))
                 .unwrap_or_default();
             let document = hit.document.as_deref().unwrap_or("");
-            format!("[{}] {}{}{}\n{}", i + 1, hit.id, slug, score, document)
+            format!(
+                "[{}] {}{}{}{}{}\n{}",
+                i + 1,
+                hit.id,
+                slug,
+                url,
+                title,
+                score,
+                document
+            )
         })
         .collect::<Vec<_>>()
         .join("\n\n")
@@ -124,13 +170,22 @@ mod tests {
         }
     }
 
+    fn slugged(id: &str, slug: &str) -> SearchRecord {
+        use chroma_types::{Metadata, MetadataValue};
+        let mut record = hit(id, Some("body"), Some(0.5));
+        let mut meta = Metadata::new();
+        meta.insert("slug".to_string(), MetadataValue::Str(slug.to_string()));
+        record.metadata = Some(meta);
+        record
+    }
+
     #[test]
     fn formats_hits_with_id_score_and_document() {
         let hits = vec![
             hit("doc-a", Some("alpha body"), Some(0.9123)),
             hit("doc-b", Some("beta body"), None),
         ];
-        let text = format_hits(&hits);
+        let text = format_hits(&hits, None, "t-1");
         assert!(text.contains("[1] doc-a (score 0.9123)"));
         assert!(text.contains("alpha body"));
         assert!(text.contains("[2] doc-b"));
@@ -139,21 +194,79 @@ mod tests {
 
     #[test]
     fn formats_hits_surfaces_slug_when_present() {
-        use chroma_types::{Metadata, MetadataValue};
-        let mut record = hit("onboarding-0", Some("body"), Some(0.5));
-        let mut meta = Metadata::new();
-        meta.insert(
-            "slug".to_string(),
-            MetadataValue::Str("onboarding".to_string()),
-        );
-        record.metadata = Some(meta);
-
-        let text = format_hits(&[record]);
+        let text = format_hits(&[slugged("onboarding-0", "onboarding")], None, "t-1");
         assert!(text.contains("slug=onboarding"), "got: {text}");
+        // Without a UI origin there is no url to stamp.
+        assert!(!text.contains("url="), "got: {text}");
+    }
+
+    #[test]
+    fn formats_hits_stamps_url_when_origin_configured() {
+        let text = format_hits(
+            &[slugged("onboarding-0", "onboarding")],
+            Some("https://wiki.example.com"),
+            "t-1",
+        );
+        assert!(
+            text.contains(
+                " url=https://wiki.example.com/~/page-redirect?tenant_uuid=t-1&slug=onboarding"
+            ),
+            "got: {text}"
+        );
+    }
+
+    #[test]
+    fn formats_hits_surfaces_title_when_present() {
+        use chroma_types::MetadataValue;
+        let mut record = slugged("onboarding-0", "onboarding");
+        record.metadata.as_mut().expect("metadata").insert(
+            "title".to_string(),
+            MetadataValue::Str("Engineering Onboarding".to_string()),
+        );
+
+        let text = format_hits(&[record], None, "t-1");
+        assert!(
+            text.contains(" title=\"Engineering Onboarding\""),
+            "got: {text}"
+        );
+    }
+
+    #[test]
+    fn formats_hits_escapes_quotes_and_newlines_in_title() {
+        use chroma_types::MetadataValue;
+        let mut record = slugged("onboarding-0", "onboarding");
+        record.metadata.as_mut().expect("metadata").insert(
+            "title".to_string(),
+            MetadataValue::Str("A \"quoted\"\ntitle".to_string()),
+        );
+
+        let text = format_hits(&[record], None, "t-1");
+        assert!(
+            text.contains(" title=\"A \\\"quoted\\\" title\""),
+            "got: {text}"
+        );
+    }
+
+    #[test]
+    fn formats_hits_derives_slug_from_chunk_id_without_metadata() {
+        // No metadata at all, but the id is a canonical chunk id — the slug
+        // (and url) still resolve, matching the subagent_search path.
+        let text = format_hits(
+            &[hit("getting-started-3", Some("body"), None)],
+            Some("https://wiki.example.com"),
+            "t-1",
+        );
+        assert!(text.contains("slug=getting-started"), "got: {text}");
+        assert!(
+            text.contains(
+                " url=https://wiki.example.com/~/page-redirect?tenant_uuid=t-1&slug=getting-started"
+            ),
+            "got: {text}"
+        );
     }
 
     #[test]
     fn formats_empty_hits_as_no_results() {
-        assert_eq!(format_hits(&[]), "No results found.");
+        assert_eq!(format_hits(&[], None, "t-1"), "No results found.");
     }
 }

--- a/rust/foundation-api/src/agent_tools/subagent_search_tool.rs
+++ b/rust/foundation-api/src/agent_tools/subagent_search_tool.rs
@@ -21,16 +21,28 @@ pub(crate) struct SubagentSearchToolParams {
     pub query: String,
 }
 
-/// A deep-research tool bound to one request's endpoint and Chroma creds.
+/// A deep-research tool bound to one request's endpoint, Chroma creds, and UI
+/// origin (used to stamp page links on ranked documents).
 pub(crate) struct SubagentSearchTool {
     http: reqwest::Client,
     url: String,
     creds: SubagentSearchCreds,
+    ui_origin: Option<String>,
 }
 
 impl SubagentSearchTool {
-    pub(crate) fn new(http: reqwest::Client, url: String, creds: SubagentSearchCreds) -> Self {
-        Self { http, url, creds }
+    pub(crate) fn new(
+        http: reqwest::Client,
+        url: String,
+        creds: SubagentSearchCreds,
+        ui_origin: Option<String>,
+    ) -> Self {
+        Self {
+            http,
+            url,
+            creds,
+            ui_origin,
+        }
     }
 }
 
@@ -60,6 +72,7 @@ impl Tool for SubagentSearchTool {
             self.url.clone(),
             self.creds.clone(),
             params.query,
+            self.ui_origin.as_deref(),
         )
         .await
         .map_err(|err| AgentError::Tool(err.to_string()))?;

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -51,8 +51,10 @@ knowledge base. Use the `search` tool for targeted lookups and the \
 `subagent_search` tool for broad, multi-part research questions. When a search \
 hit looks relevant, use the `read_page` tool with its `slug` to read the full \
 page before relying on it. Ground every claim in retrieved documents and cite \
-the document ids you relied on. If the tools surface nothing relevant, say so \
-plainly rather than guessing.";
+each source page inline where you use it — as a Markdown link (titled by the \
+page, targeting the result's `url=`/`URL:` when reported, otherwise its slug) \
+— rather than appending a list of sources at the end. If the tools surface \
+nothing relevant, say so plainly rather than guessing.";
 
 /// Request body for `POST /api/agent`.
 #[derive(Debug, Deserialize, Validate)]
@@ -160,7 +162,9 @@ pub async fn foundation_agent(
 /// `subagent_search` tool, which is registered only when the dependency is
 /// configured. The Anthropic model reuses the shared HTTP pool, and the system
 /// prompt is taken from the request (which defaults to [`DEFAULT_SYSTEM_PROMPT`]
-/// when the caller omits it).
+/// when the caller omits it). The configured `foundation_ui_origin` is handed
+/// to each tool so retrieved documents carry resolvable page URLs the agent
+/// can cite (mirroring the MCP tools' deterministic link stamping).
 async fn build_agent(
     server: &FoundationApiServer,
     headers: &HeaderMap,
@@ -177,16 +181,20 @@ async fn build_agent(
         .to_string();
     let collection = wiki_client.wiki_collection(tenant, &token).await?;
 
+    let ui_origin = server.config.foundation.foundation_ui_origin.clone();
+
     let mut toolset = ToolSet::new();
     toolset.add(SearchTool::new(
         collection.clone(),
         WikiEmbedder::new(None),
         token.clone(),
+        tenant.to_string(),
+        ui_origin.clone(),
     ));
     toolset.add(ReadPageTool::new(
         collection,
         tenant.to_string(),
-        server.config.foundation.foundation_ui_origin.clone(),
+        ui_origin.clone(),
     ));
 
     // The deep-research tool is optional: register it only when the dependency
@@ -197,6 +205,7 @@ async fn build_agent(
             server.shared_http_client.clone(),
             url,
             creds,
+            ui_origin,
         ));
     }
 

--- a/rust/foundation-api/src/routes/subagent_search/mod.rs
+++ b/rust/foundation-api/src/routes/subagent_search/mod.rs
@@ -25,7 +25,9 @@
 //! database/collection come from foundation config.
 
 mod events;
+use crate::routes::links::page_url;
 use crate::routes::{caller_token, to_sse_event, whoami::whoami_and_authorize};
+use crate::wiki::chunking::ChunkRecordId;
 use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::{extract::State, http::HeaderMap, Json};
@@ -352,18 +354,43 @@ pub(crate) async fn subagent_search_text(
     url: String,
     creds: SubagentSearchCreds,
     query: String,
+    ui_origin: Option<&str>,
 ) -> Result<String, SubagentResultError> {
+    let tenant = creds.chroma_tenant.clone();
     let documents = collect_subagent_search_final(http, url, creds, query).await?;
-    Ok(format_ranked_documents(&documents))
+    Ok(format_ranked_documents(&documents, ui_origin, &tenant))
 }
 
-/// Renders ranked documents (most-relevant first) into a numbered text block of
-/// `id` + justification lines for the model to read.
-fn format_ranked_documents(documents: &[events::RankedDocument]) -> String {
+/// Renders ranked documents (most-relevant first) into a numbered text block
+/// for the model to read. Each entry carries the record `id`, the page `slug=`
+/// it resolves to, and a `url=` page link when a UI origin is configured —
+/// matching the `search` tool's output so the agent cites results from both
+/// tools the same way. A document whose id is not a chunk id gets neither
+/// slug nor url.
+fn format_ranked_documents(
+    documents: &[events::RankedDocument],
+    ui_origin: Option<&str>,
+    tenant: &str,
+) -> String {
     documents
         .iter()
         .enumerate()
-        .map(|(i, doc)| format!("{}. {}\n   {}", i + 1, doc.id, doc.justification))
+        .map(|(i, doc)| {
+            let slug = ChunkRecordId::slug_from_id(&doc.id);
+            let url = slug
+                .and_then(|slug| page_url(ui_origin, tenant, slug))
+                .map(|url| format!(" url={url}"))
+                .unwrap_or_default();
+            let slug = slug.map(|slug| format!(" slug={slug}")).unwrap_or_default();
+            format!(
+                "{}. {}{}{}\n   {}",
+                i + 1,
+                doc.id,
+                slug,
+                url,
+                doc.justification
+            )
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/rust/foundation-api/src/routes/subagent_search/tests/00_unit.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/00_unit.rs
@@ -4,7 +4,9 @@
 use super::super::events::{
     parse_ranked_documents, ActionData, AgentEvent, ErrorData, RankedDocument, SubagentSearchEvent,
 };
-use super::super::{parse_sse_data_line, subagent_search_payload, SubagentSearchCreds};
+use super::super::{
+    format_ranked_documents, parse_sse_data_line, subagent_search_payload, SubagentSearchCreds,
+};
 use serde_json::{json, Value};
 
 fn test_creds() -> SubagentSearchCreds {
@@ -141,6 +143,42 @@ into the index.
             },
         ]
     );
+}
+
+#[test]
+fn format_ranked_documents_stamps_slug_and_url() {
+    let doc = |id: &str, justification: &str| RankedDocument {
+        id: id.to_string(),
+        justification: justification.to_string(),
+    };
+    let docs = vec![
+        // A hyphenated slug keeps everything before the numeric chunk suffix.
+        doc("getting-started-12", "Covers the setup flow."),
+        // A non-chunk id has no page to link, so it gets neither slug nor url.
+        doc("plainid", "Odd one out."),
+    ];
+
+    let text = format_ranked_documents(&docs, Some("https://wiki.example.com"), "t-1");
+    assert!(
+        text.contains(
+            "1. getting-started-12 slug=getting-started \
+             url=https://wiki.example.com/~/page-redirect?tenant_uuid=t-1&slug=getting-started"
+        ),
+        "got: {text}"
+    );
+    assert!(text.contains("Covers the setup flow."));
+    assert!(text.contains("2. plainid\n   Odd one out."), "got: {text}");
+}
+
+#[test]
+fn format_ranked_documents_omits_url_without_origin() {
+    let docs = vec![RankedDocument {
+        id: "onboarding-0".to_string(),
+        justification: "J.".to_string(),
+    }];
+    let text = format_ranked_documents(&docs, None, "t-1");
+    assert!(text.contains("slug=onboarding"), "got: {text}");
+    assert!(!text.contains("url="), "got: {text}");
 }
 
 #[test]


### PR DESCRIPTION
## What

When `foundation_ui_origin` is configured, the `/api/agent` loop's tool results now carry a ready-made page link per document: `search` hits and `subagent_search` ranked documents get `slug=` / `url=` stamped via the shared `page_url` helper, matching what `read_page` already reports. The default system prompt now tells the agent to cite source pages inline as Markdown links using those urls, instead of appending a list of document ids.

## Why

Without link data the agent either cites opaque chunk ids or invents plausible-looking wiki URLs that 404. #7373 moved the MCP tools to deterministic link stamping (`page_url`) — the model copies links rather than constructing them — and this applies the same pattern to `/api/agent`, which powers the Foundation Slack bot and the foundation CLI's `ask`/`agent` commands. Both gain working citation links with no client-side changes.

## Notes

- Links resolve through foundation-ui's `/~/page-redirect` route (chroma-core/hosted-chroma#7890), which maps `tenant_uuid` + `slug` to the viewer's team page.
- Degrades cleanly when `foundation_ui_origin` is unset: results carry `slug=` only, no urls. Staging/prod don't set `foundation_ui_origin` yet, so this is inert in deployed envs until that config lands.
- The search hit's slug comes from chunk metadata, falling back to deriving it from the chunk record id — same resolution the subagent path uses. Hits also surface the page `title=` from metadata so inline citations use the stored title rather than a guessed one.

## Test

`cargo test -p foundation-api --lib` — 141 pass (new coverage for the `slug=`/`url=`/`title=` stamping); `cargo fmt` and `cargo clippy` clean.
