### PR TITLE
[BUG](fn-consumer): Add function execution span

### DIFF
--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -2,6 +2,7 @@ use std::cell::OnceCell;
 
 use chroma_system::System;
 use chroma_types::{AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName};
+use tracing::info_span;
 use uuid::Uuid;
 
 use crate::execution::operators::materialize_logs::MaterializeLogOutput;
@@ -160,6 +161,13 @@ impl FunctionExecutionContext {
         fn_inputs: Vec<(CollectionUuid, i64)>,
         system: System,
     ) -> Result<CompactionResponse, CompactionError> {
+        let span = info_span!(
+            "FunctionExecutionContext::run",
+            attached_function_id = %attached_function_id,
+            batch_size = fn_inputs.len()
+        );
+        let _guard = span.enter();
+
         if fn_inputs.is_empty() {
             return Err(CompactionError::InvariantViolation(
                 "Function execution requires at least one input collection",

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -154,7 +154,7 @@ impl FunctionExecutionContext {
         )
     }
 
-    #[tracing::instrument(skip(system))]
+    #[tracing::instrument(skip(self, system))]
     pub async fn run(
         self,
         attached_function_id: AttachedFunctionUuid,

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -2,7 +2,6 @@ use std::cell::OnceCell;
 
 use chroma_system::System;
 use chroma_types::{AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName};
-use tracing::info_span;
 use uuid::Uuid;
 
 use crate::execution::operators::materialize_logs::MaterializeLogOutput;
@@ -155,19 +154,13 @@ impl FunctionExecutionContext {
         )
     }
 
+    #[tracing::instrument(skip(system))]
     pub async fn run(
         self,
         attached_function_id: AttachedFunctionUuid,
         fn_inputs: Vec<(CollectionUuid, i64)>,
         system: System,
     ) -> Result<CompactionResponse, CompactionError> {
-        let span = info_span!(
-            "FunctionExecutionContext::run",
-            attached_function_id = %attached_function_id,
-            batch_size = fn_inputs.len()
-        );
-        let _guard = span.enter();
-
         if fn_inputs.is_empty() {
             return Err(CompactionError::InvariantViolation(
                 "Function execution requires at least one input collection",


### PR DESCRIPTION
## Summary
Adds a local root span inside FunctionExecutionContext::run so dequeued fn-consumer executions show up under a clear function-execution span in Honeycomb.

## Test plan
- Verified the diff only adds the span in function_execution.rs
- Did not run tests (tracing-only change)