### PR TITLE
[ENH](work-queue): add optional compaction offset

### DIFF
--- a/idl/chromadb/proto/workqueue.proto
+++ b/idl/chromadb/proto/workqueue.proto
@@ -8,12 +8,14 @@ message WorkQueueRecord {
     string fn_id = 1;
     string input_coll_id = 2;
     int64 completion_offset = 3;
+    optional int64 compaction_offset = 4;
 }
 
 message PushWorkRequest {
     string fn_id = 1;
     string input_coll_id = 2;
     int64 completion_offset = 3;
+    optional int64 compaction_offset = 4;
 }
 
 message FinishWorkRequest {

--- a/rust/worker/src/bin/work_queue_cli.rs
+++ b/rust/worker/src/bin/work_queue_cli.rs
@@ -28,6 +28,10 @@ enum Commands {
         /// Completion offset
         #[arg(short, long)]
         offset: i64,
+
+        /// Compaction offset
+        #[arg(long)]
+        compaction_offset: Option<i64>,
     },
 
     /// Get work from the queue
@@ -68,8 +72,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             function_id,
             collection_id,
             offset,
+            compaction_offset,
         } => {
-            client.push_work(function_id, collection_id, offset).await?;
+            client
+                .push_work(function_id, collection_id, offset, compaction_offset)
+                .await?;
             println!("✓ Work pushed successfully");
         }
 

--- a/rust/worker/src/execution/operators/queue_function.rs
+++ b/rust/worker/src/execution/operators/queue_function.rs
@@ -24,6 +24,7 @@ pub struct QueueFunctionInput {
     pub attached_function_id: AttachedFunctionUuid,
     pub input_collection_id: CollectionUuid,
     pub completion_offset: i64,
+    pub compaction_offset: Option<i64>,
 }
 
 impl QueueFunctionInput {
@@ -31,11 +32,13 @@ impl QueueFunctionInput {
         attached_function_id: AttachedFunctionUuid,
         input_collection_id: CollectionUuid,
         completion_offset: i64,
+        compaction_offset: Option<i64>,
     ) -> Self {
         Self {
             attached_function_id,
             input_collection_id,
             completion_offset,
+            compaction_offset,
         }
     }
 }
@@ -68,10 +71,11 @@ impl Operator<QueueFunctionInput, QueueFunctionOutput> for QueueFunctionOperator
 
     async fn run(&self, input: &QueueFunctionInput) -> Result<QueueFunctionOutput, Self::Error> {
         tracing::info!(
-            "Queuing async attached function - function_id: {}, collection_id: {}, offset: {}",
+            "Queuing async attached function - function_id: {}, collection_id: {}, offset: {}, compaction_offset: {:?}",
             input.attached_function_id,
             input.input_collection_id,
-            input.completion_offset
+            input.completion_offset,
+            input.compaction_offset
         );
 
         let mut client = self.work_queue_client.clone();
@@ -80,6 +84,7 @@ impl Operator<QueueFunctionInput, QueueFunctionOutput> for QueueFunctionOperator
                 input.attached_function_id.to_string(),
                 input.input_collection_id.to_string(),
                 input.completion_offset,
+                input.compaction_offset,
             )
             .await
             .map_err(QueueFunctionError::QueueError)?;

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -352,10 +352,13 @@ impl AttachedFunctionOrchestrator {
     ) -> bool {
         if let Some(work_queue_client) = &self.output_context.work_queue_client {
             let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
+            let compaction_offset = (self.get_input_collection_info().collection.log_position >= 0)
+                .then_some(self.get_input_collection_info().collection.log_position);
             let input = QueueFunctionInput::new(
                 attached_function.id,
                 self.get_input_collection_info().collection_id,
                 attached_function.completion_offset as i64,
+                compaction_offset,
             );
             let task = wrap(
                 operator,

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -186,6 +186,7 @@ impl QueueState {
                     fn_id,
                     input_coll_id,
                     completion_offset: offsets.value(i),
+                    compaction_offset: None,
                     insertion_order: orders.value(i),
                 };
 
@@ -222,6 +223,7 @@ impl QueueState {
         fn_id: AttachedFunctionUuid,
         input_coll_id: CollectionUuid,
         completion_offset: i64,
+        compaction_offset: Option<i64>,
     ) -> bool {
         let key = (fn_id, input_coll_id);
 
@@ -238,6 +240,7 @@ impl QueueState {
             fn_id,
             input_coll_id,
             completion_offset,
+            compaction_offset,
             insertion_order: self.next_insertion_order,
         };
 
@@ -290,6 +293,7 @@ mod tests {
             fn_id: AttachedFunctionUuid(Uuid::new_v4()),
             input_coll_id: CollectionUuid(Uuid::new_v4()),
             completion_offset: 100,
+            compaction_offset: None,
             insertion_order: 0,
         };
 
@@ -297,6 +301,7 @@ mod tests {
             fn_id: AttachedFunctionUuid(Uuid::new_v4()),
             input_coll_id: CollectionUuid(Uuid::new_v4()),
             completion_offset: 200,
+            compaction_offset: None,
             insertion_order: 1,
         };
 
@@ -304,6 +309,7 @@ mod tests {
             fn_id: AttachedFunctionUuid(Uuid::new_v4()),
             input_coll_id: CollectionUuid(Uuid::new_v4()),
             completion_offset: 300,
+            compaction_offset: None,
             insertion_order: 2,
         };
 

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -169,7 +169,7 @@ mod tests {
 
             // Push work
             ctx.work_queue_client
-                .push_work(fn_id.to_string(), coll_id.to_string(), offset)
+                .push_work(fn_id.to_string(), coll_id.to_string(), offset, None)
                 .await
                 .expect("Failed to push work");
 
@@ -244,7 +244,7 @@ mod tests {
                     .expect("Failed to create async attached function");
 
                 ctx.work_queue_client
-                    .push_work(fn_id.to_string(), coll_id.to_string(), i * 100)
+                    .push_work(fn_id.to_string(), coll_id.to_string(), i * 100, None)
                     .await
                     .expect("Failed to push work");
 
@@ -379,7 +379,7 @@ mod tests {
 
             // Push work
             ctx.work_queue_client
-                .push_work(fn_id.to_string(), coll_id.to_string(), initial_offset)
+                .push_work(fn_id.to_string(), coll_id.to_string(), initial_offset, None)
                 .await
                 .expect("Failed to push work");
 

--- a/rust/worker/src/work_queue/types.rs
+++ b/rust/worker/src/work_queue/types.rs
@@ -8,6 +8,7 @@ pub struct WorkQueueRecord {
     pub fn_id: AttachedFunctionUuid,
     pub input_coll_id: CollectionUuid,
     pub completion_offset: i64,
+    pub compaction_offset: Option<i64>,
     pub insertion_order: u64,
 }
 

--- a/rust/worker/src/work_queue/work_queue_client.rs
+++ b/rust/worker/src/work_queue/work_queue_client.rs
@@ -70,11 +70,13 @@ impl WorkQueueClient {
         fn_id: String,
         input_coll_id: String,
         completion_offset: i64,
+        compaction_offset: Option<i64>,
     ) -> Result<(), Box<dyn ChromaError>> {
         let request = Request::new(PushWorkRequest {
             fn_id,
             input_coll_id,
             completion_offset,
+            compaction_offset,
         });
 
         self.client

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -29,6 +29,7 @@ pub struct PushWorkMessage {
     pub fn_id: AttachedFunctionUuid,
     pub input_coll_id: CollectionUuid,
     pub completion_offset: i64,
+    pub compaction_offset: Option<i64>,
     pub response_tx: oneshot::Sender<Result<(), WorkQueueError>>,
 }
 
@@ -254,11 +255,12 @@ impl WorkQueueManager {
         fn_id: AttachedFunctionUuid,
         input_coll_id: CollectionUuid,
         completion_offset: i64,
+        compaction_offset: Option<i64>,
         response: WorkResponse,
     ) {
         let _ = self
             .state
-            .push_work(fn_id, input_coll_id, completion_offset);
+            .push_work(fn_id, input_coll_id, completion_offset, compaction_offset);
 
         // TODO(tanujnay112): Can optimize the case where we push work
         // that gets deduplicated. That would require epoch tracking
@@ -423,7 +425,7 @@ impl WorkQueueManager {
             );
 
             self.state
-                .push_work(item.fn_id, item.input_coll_id, *current_completion_offset);
+                .push_work(item.fn_id, item.input_coll_id, *current_completion_offset, None);
         }
 
         if let Err(e) = self.persist().await {
@@ -522,15 +524,17 @@ impl Handler<PushWorkMessage> for WorkQueueManager {
 
     async fn handle(&mut self, msg: PushWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
         tracing::info!(
-            "Received PushWorkMessage for fn_id: {}, input_coll_id: {}, completion_offset: {}",
+            "Received PushWorkMessage for fn_id: {}, input_coll_id: {}, completion_offset: {}, compaction_offset: {:?}",
             msg.fn_id,
             msg.input_coll_id,
-            msg.completion_offset
+            msg.completion_offset,
+            msg.compaction_offset
         );
         self.push_work_and_queue_response(
             msg.fn_id,
             msg.input_coll_id,
             msg.completion_offset,
+            msg.compaction_offset,
             WorkResponse::Push(msg.response_tx),
         )
         .await;
@@ -579,6 +583,7 @@ impl Handler<FinishWorkMessage> for WorkQueueManager {
                     msg.fn_id,
                     msg.input_coll_id,
                     msg.new_completion_offset,
+                    None,
                     WorkResponse::Repair(msg.response_tx),
                 )
                 .await;
@@ -714,17 +719,17 @@ mod tests {
         let coll_id = CollectionUuid(Uuid::new_v4());
 
         // Test direct state manipulation to verify deduplication logic
-        state.push_work(fn_id, coll_id, 100);
+        state.push_work(fn_id, coll_id, 100, None);
         assert_eq!(state.pending_work.len(), 1);
         assert_eq!(state.pending_work[0].completion_offset, 100);
 
         // Push with lower offset should be ignored
-        state.push_work(fn_id, coll_id, 50);
+        state.push_work(fn_id, coll_id, 50, None);
         assert_eq!(state.pending_work.len(), 1);
         assert_eq!(state.pending_work[0].completion_offset, 100);
 
         // Push with higher offset should replace
-        state.push_work(fn_id, coll_id, 200);
+        state.push_work(fn_id, coll_id, 200, None);
         assert_eq!(state.pending_work.len(), 1);
         assert_eq!(state.pending_work[0].completion_offset, 200);
 
@@ -739,7 +744,7 @@ mod tests {
         let coll_id = CollectionUuid(Uuid::new_v4());
 
         // Push work
-        state.push_work(fn_id, coll_id, 100);
+        state.push_work(fn_id, coll_id, 100, None);
         assert_eq!(state.pending_work.len(), 1);
 
         // Finish work
@@ -758,6 +763,7 @@ mod tests {
                 AttachedFunctionUuid(Uuid::new_v4()),
                 CollectionUuid(Uuid::new_v4()),
                 i * 100,
+                None,
             );
         }
 
@@ -789,11 +795,13 @@ mod tests {
                 AttachedFunctionUuid(Uuid::new_v4()),
                 CollectionUuid(Uuid::new_v4()),
                 100,
+                None,
             );
             manager.state.push_work(
                 AttachedFunctionUuid(Uuid::new_v4()),
                 CollectionUuid(Uuid::new_v4()),
                 200,
+                None,
             );
             manager.persist().await.unwrap();
         }
@@ -883,9 +891,9 @@ mod tests {
         let coll_id = CollectionUuid(Uuid::new_v4());
 
         // Push multiple work items with different offsets
-        state.push_work(fn_id, coll_id, 100);
-        state.push_work(fn_id, coll_id, 200);
-        state.push_work(fn_id, coll_id, 300);
+        state.push_work(fn_id, coll_id, 100, None);
+        state.push_work(fn_id, coll_id, 200, None);
+        state.push_work(fn_id, coll_id, 300, None);
         assert_eq!(state.pending_work.len(), 1);
         assert_eq!(state.pending_work[0].completion_offset, 300);
 

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -424,8 +424,12 @@ impl WorkQueueManager {
                 current_completion_offset
             );
 
-            self.state
-                .push_work(item.fn_id, item.input_coll_id, *current_completion_offset, None);
+            self.state.push_work(
+                item.fn_id,
+                item.input_coll_id,
+                *current_completion_offset,
+                None,
+            );
         }
 
         if let Err(e) = self.persist().await {

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -71,6 +71,7 @@ impl WorkQueueService for WorkQueueServer {
             fn_id,
             input_coll_id,
             completion_offset: req.completion_offset,
+            compaction_offset: req.compaction_offset,
             response_tx,
         };
 


### PR DESCRIPTION
## Description of changes

Part 1 of a stack of changes to persist the input collection compaction offset instead of the function completion offset in the WQS file.

This diff starts off by requiring this compaction offset to be sent in the PushWork API.

- Improvements & Bug fixes
    - 
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_