### PR TITLE
[BUG](work-queue): finish against compaction frontier

### DIFF
--- a/bin/windows_upgrade_sqlite.py
+++ b/bin/windows_upgrade_sqlite.py
@@ -4,15 +4,41 @@ import io
 import os
 import sys
 import shutil
+import time
+from typing import Optional
 
 # Used by Github Action runners to upgrade sqlite version to 3.42.0
 DLL_URL = "https://www.sqlite.org/2023/sqlite-dll-win64-x64-3420000.zip"
+DOWNLOAD_TIMEOUT_SECONDS = 30
+DOWNLOAD_RETRIES = 5
+
+
+def download_sqlite_dll_zip() -> bytes:
+    last_error: Optional[httpx.HTTPError] = None
+    for attempt in range(1, DOWNLOAD_RETRIES + 1):
+        try:
+            response = httpx.get(
+                DLL_URL,
+                follow_redirects=True,
+                timeout=DOWNLOAD_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            return bytes(response.content)
+        except httpx.HTTPError as exc:
+            last_error = exc
+            if attempt == DOWNLOAD_RETRIES:
+                raise
+            print(
+                f"Download attempt {attempt} failed: {exc}. Retrying...",
+                flush=True,
+            )
+            time.sleep(attempt)
+    raise RuntimeError("failed to download sqlite DLL") from last_error
+
 
 if __name__ == "__main__":
     # Download and extract the DLL
-    r = httpx.get(DLL_URL, follow_redirects=True)
-    r.raise_for_status()
-    z = zipfile.ZipFile(io.BytesIO(r.content))
+    z = zipfile.ZipFile(io.BytesIO(download_sqlite_dll_zip()))
     z.extractall(".")
     # Print current Python path
     exec_path = os.path.dirname(sys.executable)

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -308,7 +308,7 @@ impl QueueState {
         fn_id: &AttachedFunctionUuid,
         input_coll_id: &CollectionUuid,
         completion_offset: i64,
-    ) -> bool {
+    ) {
         let key = (*fn_id, *input_coll_id);
 
         if let Some(existing_offsets) = self.dedup_index.get_mut(&key) {
@@ -320,11 +320,9 @@ impl QueueState {
                 // Remove from dedup index
                 self.dedup_index.remove(&key);
                 self.dirty = true;
-                return true;
+                return;
             }
         }
-
-        false
     }
 }
 

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -322,7 +322,6 @@ impl QueueState {
                 self.dirty = true;
                 return true;
             }
-
         }
 
         false

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -320,7 +320,6 @@ impl QueueState {
                 // Remove from dedup index
                 self.dedup_index.remove(&key);
                 self.dirty = true;
-                return;
             }
         }
     }

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -300,8 +300,9 @@ impl QueueState {
         true
     }
 
-    /// Mark work as successfully completed
-    /// Returns true if any work was actually removed
+    /// Mark work as successfully completed.
+    /// Removes the queue entry once completion reaches the queued frontier;
+    /// otherwise leaves the queued entry unchanged.
     pub fn finish_work_success(
         &mut self,
         fn_id: &AttachedFunctionUuid,
@@ -310,9 +311,8 @@ impl QueueState {
     ) -> bool {
         let key = (*fn_id, *input_coll_id);
 
-        // Check if there's an entry to remove
-        if let Some(&existing_offsets) = self.dedup_index.get(&key) {
-            if existing_offsets.completion_offset <= completion_offset {
+        if let Some(existing_offsets) = self.dedup_index.get_mut(&key) {
+            if existing_offsets.dedup_frontier() <= completion_offset {
                 // Remove the single entry for this key
                 self.pending_work
                     .retain(|r| !(r.fn_id == *fn_id && r.input_coll_id == *input_coll_id));
@@ -322,6 +322,7 @@ impl QueueState {
                 self.dirty = true;
                 return true;
             }
+
         }
 
         false
@@ -453,5 +454,24 @@ mod tests {
         assert_eq!(state.pending_work.len(), 1);
         assert_eq!(state.pending_work[0].completion_offset, 20);
         assert_eq!(state.pending_work[0].compaction_offset, Some(60));
+    }
+
+    #[test]
+    fn test_finish_work_waits_for_compaction_offset() {
+        let mut state = QueueState::new();
+
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+
+        state.push_work(fn_id, coll_id, 20, Some(60));
+        assert_eq!(state.pending_work.len(), 1);
+
+        state.finish_work_success(&fn_id, &coll_id, 40);
+        assert_eq!(state.pending_work.len(), 1);
+        assert_eq!(state.pending_work[0].completion_offset, 20);
+        assert_eq!(state.pending_work[0].compaction_offset, Some(60));
+
+        state.finish_work_success(&fn_id, &coll_id, 60);
+        assert_eq!(state.pending_work.len(), 0);
     }
 }

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -389,7 +389,8 @@ mod tests {
                 .await
                 .expect("Failed to finish work");
 
-            // Get work - should contain the requeued repair work at the new offset
+            // Get work - the queued entry is removed because completion advanced beyond the
+            // stored queue frontier on this branch.
             let work_items = ctx
                 .work_queue_client
                 .get_work("test_shard".to_string(), 10)
@@ -401,7 +402,7 @@ mod tests {
                 work_items.items.len()
             );
 
-            // Filter to check our function is in the queue with the repaired offset
+            // The queue no longer exposes an item for this function after finish_work succeeds.
             let our_items: Vec<_> = work_items
                 .items
                 .iter()
@@ -410,12 +411,8 @@ mod tests {
 
             assert_eq!(
                 our_items.len(),
-                1,
-                "Expected 1 work item for our function after finish_work requeued repair"
-            );
-            assert_eq!(
-                our_items[0].completion_offset, new_offset,
-                "Expected repaired work item to use the new completion offset"
+                0,
+                "Expected no visible work item once finish_work advances past the queued frontier"
             );
 
             // Check invocation status via sysdb

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -447,11 +447,16 @@ mod tests {
                 status_response.results[1].status
             );
 
-            // The initial offset (100) should be marked as done since we finished at 150
+            // The initial offset still reports NeedsRepair on this branch because sysdb
+            // has advanced completion but still exposes the repair state.
             assert_eq!(
                 status_response.results[0].status,
-                InvocationStatus::Done as i32,
-                "Initial offset should be done"
+                InvocationStatus::NeedsRepair as i32,
+                "Initial offset should still require repair until sysdb is simplified"
+            );
+            assert_eq!(
+                status_response.results[0].current_completion_offset, new_offset,
+                "Repair status should report the latest sysdb completion offset"
             );
 
             // The server finalizes repair before responding, so the new offset is back to a normal queued state.

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -550,11 +550,8 @@ impl Handler<FinishWorkMessage> for WorkQueueManager {
         }
 
         // Use the queued compaction frontier to decide whether to remove or advance the entry.
-        self.state.finish_work_success(
-            &msg.fn_id,
-            &msg.input_coll_id,
-            msg.new_completion_offset,
-        );
+        self.state
+            .finish_work_success(&msg.fn_id, &msg.input_coll_id, msg.new_completion_offset);
 
         // Send immediate success response
         if msg.response_tx.send(Ok(FinishResult::Success)).is_err() {

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -14,7 +14,6 @@ use chroma_storage::{GetOptions, PutMode, PutOptions, Storage};
 use chroma_sysdb::SysDb;
 use chroma_system::{Component, ComponentContext, ComponentRuntime, Handler};
 use chroma_types::chroma_proto::{
-    try_finish_async_attached_function_invocation_response::Result as TryFinishResult,
     CheckInvocationStatusRequest, InvocationCheckItem, InvocationStatus, InvocationStatusResult,
     TryFinishAsyncAttachedFunctionInvocationRequest,
 };
@@ -282,36 +281,25 @@ impl WorkQueueManager {
         }
     }
 
-    // Call sysdb's TryFinishAsyncAttachedFunctionInvocation
+    // Update sysdb's completion offset for an async attached function invocation.
     #[tracing::instrument(name = "WorkQueueManager::try_finish_invocation", skip(self))]
     async fn try_finish_invocation(
         &mut self,
         fn_id: &AttachedFunctionUuid,
         input_coll_id: &CollectionUuid,
         completion_offset: i64,
-    ) -> Result<FinishResult, WorkQueueError> {
+    ) -> Result<(), WorkQueueError> {
         let request = TryFinishAsyncAttachedFunctionInvocationRequest {
             attached_function_id: fn_id.to_string(),
             collection_id: input_coll_id.to_string(),
             new_completion_offset: completion_offset as u64,
         };
 
-        let response = self
-            .sysdb
+        self.sysdb
             .try_finish_async_attached_function_invocation(request)
             .await
             .map_err(|e| WorkQueueError::TryFinishFailed(e.message().to_string()))?;
-
-        let inner = response.into_inner();
-        match inner.result {
-            Some(result) => match result {
-                TryFinishResult::Success(_) => Ok(FinishResult::Success),
-                TryFinishResult::NeedsRepair(_) => Ok(FinishResult::NeedsRepair),
-            },
-            None => Err(WorkQueueError::TryFinishFailed(
-                "Empty response".to_string(),
-            )),
-        }
+        Ok(())
     }
 
     // Check invocation completion status (boolean version for compatibility)
@@ -551,47 +539,26 @@ impl Handler<FinishWorkMessage> for WorkQueueManager {
 
     async fn handle(&mut self, msg: FinishWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
         // Call sysdb
-        let finish_result = match self
+        if let Err(e) = self
             .try_finish_invocation(&msg.fn_id, &msg.input_coll_id, msg.new_completion_offset)
             .await
         {
-            Ok(result) => result,
-            Err(e) => {
-                if msg.response_tx.send(Err(e)).is_err() {
-                    tracing::error!("Failed to send error response");
-                }
-                return;
+            if msg.response_tx.send(Err(e)).is_err() {
+                tracing::error!("Failed to send error response");
             }
-        };
+            return;
+        }
 
-        match finish_result {
-            FinishResult::Success => {
-                // Use encapsulated finish_work_success method
-                self.state.finish_work_success(
-                    &msg.fn_id,
-                    &msg.input_coll_id,
-                    msg.new_completion_offset,
-                );
+        // Use the queued compaction frontier to decide whether to remove or advance the entry.
+        self.state.finish_work_success(
+            &msg.fn_id,
+            &msg.input_coll_id,
+            msg.new_completion_offset,
+        );
 
-                // Send immediate success response
-                if msg.response_tx.send(Ok(FinishResult::Success)).is_err() {
-                    tracing::error!(
-                        "Failed to send finish work success response - receiver dropped"
-                    );
-                }
-                return;
-            }
-            FinishResult::NeedsRepair => {
-                // Re-push work and queue response atomically
-                self.push_work_and_queue_response(
-                    msg.fn_id,
-                    msg.input_coll_id,
-                    msg.new_completion_offset,
-                    None,
-                    WorkResponse::Repair(msg.response_tx),
-                )
-                .await;
-            }
+        // Send immediate success response
+        if msg.response_tx.send(Ok(FinishResult::Success)).is_err() {
+            tracing::error!("Failed to send finish work success response - receiver dropped");
         }
 
         // Check if persist needed


### PR DESCRIPTION
## Description of changes

Part 3 of a stack of changes to persist the input collection compaction offset instead of the function completion offset in the WQS file.

This change adjusts the FinishWork handler to ignore NeedsRepair from sysdb and just compare the recieved progress offset against the persisted compaction_offset to decide if it should requeue work.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_