### PR TITLE
[CHORE](sysdb): simplify finishwork API, get rid of repair mechanism

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -291,7 +291,7 @@ def test_functions_allow_one_sync_and_one_async_per_collection(
     # A second sync function should fail because the sync slot is already occupied.
     with pytest.raises(
         ChromaError,
-        match="collection already has an attached function with the same execution mode: name=task_1, function=record_counter, output_collection=output_1",
+        match="collection already has a sync attached function: name=task_1, function=record_counter, output_collection=output_1",
     ):
         collection.attach_function(
             function=RECORD_COUNTER_FUNCTION,

--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -291,7 +291,7 @@ def test_functions_allow_one_sync_and_one_async_per_collection(
     # A second sync function should fail because the sync slot is already occupied.
     with pytest.raises(
         ChromaError,
-        match="collection already has a sync attached function: name=task_1, function=record_counter, output_collection=output_1",
+        match="collection already has an attached function with the same execution mode: name=task_1, function=record_counter, output_collection=output_1",
     ):
         collection.attach_function(
             function=RECORD_COUNTER_FUNCTION,

--- a/go/pkg/sysdb/coordinator/async_attached_function_simple_test.go
+++ b/go/pkg/sysdb/coordinator/async_attached_function_simple_test.go
@@ -24,7 +24,6 @@ func TestAsyncFunctionRepairFlowSimple(t *testing.T) {
 	functionID := uuid.New()
 	collectionID := uuid.New().String()
 	newCompletionOffset := uint64(50)
-	witnessedLogOffset := int64(100) // Higher than new offset - needs repair
 
 	attachedFunction := &dbmodel.AttachedFunction{
 		ID:                attachedFunctionID,
@@ -38,18 +37,10 @@ func TestAsyncFunctionRepairFlowSimple(t *testing.T) {
 		IsAsync: true,
 	}
 
-	collection := &dbmodel.CollectionAndMetadata{
-		Collection: &dbmodel.Collection{
-			ID:          collectionID,
-			LogPosition: witnessedLogOffset,
-		},
-	}
-
 	// Setup mocks
 	mockTxImpl := &dbmodel_mocks.ITransaction{}
 	mockMetaDomain := &dbmodel_mocks.IMetaDomain{}
 	mockAttachedFunctionDb := &dbmodel_mocks.IAttachedFunctionDb{}
-	mockCollectionDb := &dbmodel_mocks.ICollectionDb{}
 	mockFunctionDb := &dbmodel_mocks.IFunctionDb{}
 
 	coordinator := &Coordinator{
@@ -60,7 +51,6 @@ func TestAsyncFunctionRepairFlowSimple(t *testing.T) {
 		},
 	}
 
-	// First call - should return needs repair
 	// Transaction executes the function immediately
 	mockTxImpl.On("Transaction", mock.Anything, mock.AnythingOfType("func(context.Context) error")).
 		Return(func(ctx context.Context, fn func(context.Context) error) error {
@@ -75,12 +65,7 @@ func TestAsyncFunctionRepairFlowSimple(t *testing.T) {
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)
 	mockFunctionDb.On("GetByID", functionID).Return(function, nil)
 
-	mockMetaDomain.On("CollectionDb", mock.Anything).Return(mockCollectionDb)
-	mockCollectionDb.On("GetCollections", []string{collectionID}, (*string)(nil), "", "", (*int32)(nil), (*int32)(nil), false).
-		Return([]*dbmodel.CollectionAndMetadata{collection}, nil)
-
-	// Should update - heap_entry_pending is computed atomically within the update
-	mockAttachedFunctionDb.On("UpdateCompletionOffsetAndHeapEntry", attachedFunctionID, collectionID, int64(newCompletionOffset)).
+	mockAttachedFunctionDb.On("UpdateCompletionOffset", attachedFunctionID, collectionID, int64(newCompletionOffset)).
 		Return(nil)
 
 	req := &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationRequest{
@@ -91,16 +76,9 @@ func TestAsyncFunctionRepairFlowSimple(t *testing.T) {
 
 	resp, err := coordinator.TryFinishAsyncAttachedFunctionInvocation(ctx, req)
 
-	// Verify needs repair response
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-	assert.NotNil(t, resp.Result)
-
-	repairResp, ok := resp.Result.(*coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse_NeedsRepair)
-	assert.True(t, ok, "Expected NeedsRepair response, got %T", resp.Result)
-	if ok {
-		assert.Equal(t, uint64(witnessedLogOffset), repairResp.NeedsRepair.CurrentCollectionLogOffset)
-	}
+	assert.Equal(t, newCompletionOffset, resp.UpdatedCompletionOffset)
 
 	// Step 2: Finalize repair
 	mockAttachedFunctionDb.On("UpdateHeapEntryPending", attachedFunctionID, collectionID, false).Return(nil)
@@ -113,26 +91,6 @@ func TestAsyncFunctionRepairFlowSimple(t *testing.T) {
 	finishResp, err := coordinator.FinalizeAsyncAttachedFunctionRepair(ctx, finishReq)
 	assert.NoError(t, err)
 	assert.NotNil(t, finishResp)
-
-	// Step 3: Try again with updated log position - should succeed
-	collection.Collection.LogPosition = int64(newCompletionOffset)
-
-	// Now should update - heap_entry_pending is computed atomically within the update
-	mockAttachedFunctionDb.On("UpdateCompletionOffsetAndHeapEntry", attachedFunctionID, collectionID, int64(newCompletionOffset)).
-		Return(nil)
-
-	resp2, err := coordinator.TryFinishAsyncAttachedFunctionInvocation(ctx, req)
-
-	// Verify success response
-	assert.NoError(t, err)
-	assert.NotNil(t, resp2)
-	assert.NotNil(t, resp2.Result)
-
-	successResp, ok := resp2.Result.(*coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse_Success)
-	assert.True(t, ok, "Expected Success response, got %T", resp2.Result)
-	if ok {
-		assert.Equal(t, newCompletionOffset, successResp.Success.UpdatedCompletionOffset)
-	}
 }
 
 // Test no repair needed case
@@ -144,7 +102,6 @@ func TestAsyncFunctionNoRepairSimple(t *testing.T) {
 	functionID := uuid.New()
 	collectionID := uuid.New().String()
 	newCompletionOffset := uint64(100)
-	witnessedLogOffset := int64(80) // Lower than new offset - no repair needed
 
 	attachedFunction := &dbmodel.AttachedFunction{
 		ID:                attachedFunctionID,
@@ -158,18 +115,10 @@ func TestAsyncFunctionNoRepairSimple(t *testing.T) {
 		IsAsync: true,
 	}
 
-	collection := &dbmodel.CollectionAndMetadata{
-		Collection: &dbmodel.Collection{
-			ID:          collectionID,
-			LogPosition: witnessedLogOffset,
-		},
-	}
-
 	// Setup mocks
 	mockTxImpl := &dbmodel_mocks.ITransaction{}
 	mockMetaDomain := &dbmodel_mocks.IMetaDomain{}
 	mockAttachedFunctionDb := &dbmodel_mocks.IAttachedFunctionDb{}
-	mockCollectionDb := &dbmodel_mocks.ICollectionDb{}
 	mockFunctionDb := &dbmodel_mocks.IFunctionDb{}
 
 	coordinator := &Coordinator{
@@ -194,12 +143,7 @@ func TestAsyncFunctionNoRepairSimple(t *testing.T) {
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)
 	mockFunctionDb.On("GetByID", functionID).Return(function, nil)
 
-	mockMetaDomain.On("CollectionDb", mock.Anything).Return(mockCollectionDb)
-	mockCollectionDb.On("GetCollections", []string{collectionID}, (*string)(nil), "", "", (*int32)(nil), (*int32)(nil), false).
-		Return([]*dbmodel.CollectionAndMetadata{collection}, nil)
-
-	// Should update - heap_entry_pending is computed atomically within the update
-	mockAttachedFunctionDb.On("UpdateCompletionOffsetAndHeapEntry", attachedFunctionID, collectionID, int64(newCompletionOffset)).
+	mockAttachedFunctionDb.On("UpdateCompletionOffset", attachedFunctionID, collectionID, int64(newCompletionOffset)).
 		Return(nil)
 
 	req := &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationRequest{
@@ -213,13 +157,7 @@ func TestAsyncFunctionNoRepairSimple(t *testing.T) {
 	// Verify success response
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-	assert.NotNil(t, resp.Result)
-
-	successResp, ok := resp.Result.(*coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse_Success)
-	assert.True(t, ok, "Expected Success response, got %T", resp.Result)
-	if ok {
-		assert.Equal(t, newCompletionOffset, successResp.Success.UpdatedCompletionOffset)
-	}
+	assert.Equal(t, newCompletionOffset, resp.UpdatedCompletionOffset)
 }
 
 // Test idempotency of TryFinishAsyncAttachedFunctionInvocation
@@ -231,7 +169,6 @@ func TestAsyncFunctionTryFinishIdempotent(t *testing.T) {
 	functionID := uuid.New()
 	collectionID := uuid.New().String()
 	newCompletionOffset := uint64(50)
-	witnessedLogOffset := int64(100) // Higher than new offset - needs repair
 
 	attachedFunction := &dbmodel.AttachedFunction{
 		ID:                attachedFunctionID,
@@ -245,18 +182,10 @@ func TestAsyncFunctionTryFinishIdempotent(t *testing.T) {
 		IsAsync: true,
 	}
 
-	collection := &dbmodel.CollectionAndMetadata{
-		Collection: &dbmodel.Collection{
-			ID:          collectionID,
-			LogPosition: witnessedLogOffset,
-		},
-	}
-
 	// Setup mocks
 	mockTxImpl := &dbmodel_mocks.ITransaction{}
 	mockMetaDomain := &dbmodel_mocks.IMetaDomain{}
 	mockAttachedFunctionDb := &dbmodel_mocks.IAttachedFunctionDb{}
-	mockCollectionDb := &dbmodel_mocks.ICollectionDb{}
 	mockFunctionDb := &dbmodel_mocks.IFunctionDb{}
 
 	coordinator := &Coordinator{
@@ -281,13 +210,7 @@ func TestAsyncFunctionTryFinishIdempotent(t *testing.T) {
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)
 	mockFunctionDb.On("GetByID", functionID).Return(function, nil)
 
-	mockMetaDomain.On("CollectionDb", mock.Anything).Return(mockCollectionDb)
-	mockCollectionDb.On("GetCollections", []string{collectionID}, (*string)(nil), "", "", (*int32)(nil), (*int32)(nil), false).
-		Return([]*dbmodel.CollectionAndMetadata{collection}, nil)
-
-	// Should update with heap_entry_pending=true since repair is needed
-	// The operation is idempotent (same final state) but performs the update each time
-	mockAttachedFunctionDb.On("UpdateCompletionOffsetAndHeapEntry", attachedFunctionID, collectionID, int64(newCompletionOffset)).
+	mockAttachedFunctionDb.On("UpdateCompletionOffset", attachedFunctionID, collectionID, int64(newCompletionOffset)).
 		Return(nil).Times(3)
 
 	req := &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationRequest{
@@ -303,17 +226,10 @@ func TestAsyncFunctionTryFinishIdempotent(t *testing.T) {
 		// Verify same response each time
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
-		assert.NotNil(t, resp.Result)
-
-		repairResp, ok := resp.Result.(*coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse_NeedsRepair)
-		assert.True(t, ok, "Expected NeedsRepair response on call %d", i+1)
-		if ok {
-			assert.Equal(t, uint64(witnessedLogOffset), repairResp.NeedsRepair.CurrentCollectionLogOffset)
-		}
+		assert.Equal(t, newCompletionOffset, resp.UpdatedCompletionOffset)
 	}
 
-	// Verify UpdateCompletionOffsetAndHeapEntry was called 3 times (idempotent in result, not in execution)
-	mockAttachedFunctionDb.AssertNumberOfCalls(t, "UpdateCompletionOffsetAndHeapEntry", 3)
+	mockAttachedFunctionDb.AssertNumberOfCalls(t, "UpdateCompletionOffset", 3)
 }
 
 // Test idempotency of FinalizeAsyncAttachedFunctionRepair
@@ -370,7 +286,6 @@ func TestAsyncFunctionOffsetOnlyMovesForward(t *testing.T) {
 
 	// Test case 1: Try to move offset backwards (should fail)
 	backwardOffset := uint64(50)
-	witnessedLogOffset := int64(40) // No repair needed
 
 	attachedFunction := &dbmodel.AttachedFunction{
 		ID:                attachedFunctionID,
@@ -384,18 +299,10 @@ func TestAsyncFunctionOffsetOnlyMovesForward(t *testing.T) {
 		IsAsync: true,
 	}
 
-	collection := &dbmodel.CollectionAndMetadata{
-		Collection: &dbmodel.Collection{
-			ID:          collectionID,
-			LogPosition: witnessedLogOffset,
-		},
-	}
-
 	// Setup mocks
 	mockTxImpl := &dbmodel_mocks.ITransaction{}
 	mockMetaDomain := &dbmodel_mocks.IMetaDomain{}
 	mockAttachedFunctionDb := &dbmodel_mocks.IAttachedFunctionDb{}
-	mockCollectionDb := &dbmodel_mocks.ICollectionDb{}
 	mockFunctionDb := &dbmodel_mocks.IFunctionDb{}
 
 	coordinator := &Coordinator{
@@ -420,13 +327,9 @@ func TestAsyncFunctionOffsetOnlyMovesForward(t *testing.T) {
 	mockMetaDomain.On("FunctionDb", mock.Anything).Return(mockFunctionDb)
 	mockFunctionDb.On("GetByID", functionID).Return(function, nil)
 
-	mockMetaDomain.On("CollectionDb", mock.Anything).Return(mockCollectionDb)
-	mockCollectionDb.On("GetCollections", []string{collectionID}, (*string)(nil), "", "", (*int32)(nil), (*int32)(nil), false).
-		Return([]*dbmodel.CollectionAndMetadata{collection}, nil)
-
 	// The update should be called but due to WHERE clause protection, it won't actually update
 	// We simulate this by returning ErrAttachedFunctionOffsetWouldRegress (no rows affected)
-	mockAttachedFunctionDb.On("UpdateCompletionOffsetAndHeapEntry", attachedFunctionID, collectionID, int64(backwardOffset)).
+	mockAttachedFunctionDb.On("UpdateCompletionOffset", attachedFunctionID, collectionID, int64(backwardOffset)).
 		Return(common.ErrAttachedFunctionOffsetWouldRegress)
 
 	req := &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationRequest{
@@ -444,7 +347,7 @@ func TestAsyncFunctionOffsetOnlyMovesForward(t *testing.T) {
 	forwardOffset := uint64(150)
 
 	// Update mock for forward movement
-	mockAttachedFunctionDb.On("UpdateCompletionOffsetAndHeapEntry", attachedFunctionID, collectionID, int64(forwardOffset)).
+	mockAttachedFunctionDb.On("UpdateCompletionOffset", attachedFunctionID, collectionID, int64(forwardOffset)).
 		Return(nil).Once()
 
 	req2 := &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationRequest{
@@ -456,10 +359,5 @@ func TestAsyncFunctionOffsetOnlyMovesForward(t *testing.T) {
 	resp, err := coordinator.TryFinishAsyncAttachedFunctionInvocation(ctx, req2)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-
-	successResp, ok := resp.Result.(*coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse_Success)
-	assert.True(t, ok, "Expected Success response")
-	if ok {
-		assert.Equal(t, forwardOffset, successResp.Success.UpdatedCompletionOffset)
-	}
+	assert.Equal(t, forwardOffset, resp.UpdatedCompletionOffset)
 }

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -1447,8 +1447,6 @@ func (s *Coordinator) TryFinishAsyncAttachedFunctionInvocation(ctx context.Conte
 		return nil, status.Errorf(codes.InvalidArgument, "invalid collection_id: %v", err)
 	}
 
-	var witnessedLogOffset int64
-
 	err = s.catalog.txImpl.Transaction(ctx, func(txCtx context.Context) error {
 		attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, nil, true)
 		if err != nil {
@@ -1486,17 +1484,6 @@ func (s *Coordinator) TryFinishAsyncAttachedFunctionInvocation(ctx context.Conte
 			return status.Errorf(codes.InvalidArgument, "attached function is not async")
 		}
 
-		collectionIDs := []string{collectionID.String()}
-		collections, err := s.catalog.metaDomain.CollectionDb(txCtx).GetCollections(collectionIDs, nil, "", "", nil, nil, false)
-		if err != nil {
-			log.Error("Failed to get collection", zap.Error(err))
-			return err
-		}
-		if len(collections) == 0 {
-			log.Error("Collection not found", zap.String("collection_id", collectionID.String()))
-			return status.Errorf(codes.NotFound, "collection not found")
-		}
-
 		if attachedFunction.InputCollectionID != req.CollectionId {
 			log.Error("Collection ID mismatch",
 				zap.String("expected", attachedFunction.InputCollectionID),
@@ -1504,14 +1491,10 @@ func (s *Coordinator) TryFinishAsyncAttachedFunctionInvocation(ctx context.Conte
 			return status.Errorf(codes.InvalidArgument, "collection_id does not match attached function's input_collection_id")
 		}
 
-		witnessedLogOffset = collections[0].Collection.LogPosition
-
-		// UpdateCompletionOffsetAndHeapEntry now atomically computes heap_entry_pending based on the
-		// collection's log position at update time, avoiding TOCTOU race condition
-		err = s.catalog.metaDomain.AttachedFunctionDb(txCtx).UpdateCompletionOffsetAndHeapEntry(
+		err = s.catalog.metaDomain.AttachedFunctionDb(txCtx).UpdateCompletionOffset(
 			attachedFunctionID, collectionID.String(), int64(req.NewCompletionOffset))
 		if err != nil {
-			log.Error("Failed to update completion offset and heap_entry_pending", zap.Error(err))
+			log.Error("Failed to update completion offset", zap.Error(err))
 			return err
 		}
 
@@ -1522,25 +1505,8 @@ func (s *Coordinator) TryFinishAsyncAttachedFunctionInvocation(ctx context.Conte
 		return nil, err
 	}
 
-	if int64(req.NewCompletionOffset) < witnessedLogOffset {
-		log.Warn("Completion offset is behind collection log position - repair needed",
-			zap.Uint64("new_completion_offset", req.NewCompletionOffset),
-			zap.Int64("collection_log_position", witnessedLogOffset))
-		return &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse{
-			Result: &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse_NeedsRepair{
-				NeedsRepair: &coordinatorpb.FinishAsyncNeedsRepair{
-					CurrentCollectionLogOffset: uint64(witnessedLogOffset),
-				},
-			},
-		}, nil
-	}
-
 	return &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse{
-		Result: &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse_Success{
-			Success: &coordinatorpb.FinishAsyncSuccess{
-				UpdatedCompletionOffset: req.NewCompletionOffset,
-			},
-		},
+		UpdatedCompletionOffset: req.NewCompletionOffset,
 	}, nil
 }
 

--- a/go/pkg/sysdb/metastore/db/dao/task.go
+++ b/go/pkg/sysdb/metastore/db/dao/task.go
@@ -62,42 +62,26 @@ func (s *attachedFunctionDb) Update(attachedFunction *dbmodel.AttachedFunction) 
 	return nil
 }
 
-// UpdateCompletionOffsetAndHeapEntry updates both completion offset and heap_entry_pending flag atomically
-// Only updates if the new offset is greater than or equal to the current offset (prevents moving backwards)
-// The heap_entry_pending flag is computed atomically based on the collection's log_position at update time
-func (s *attachedFunctionDb) UpdateCompletionOffsetAndHeapEntry(id uuid.UUID, collectionID string, newOffset int64) error {
-	result := s.db.Exec(`
-		UPDATE attached_functions af
-		SET
-			completion_offset = ?,
-			heap_entry_pending = (CASE WHEN ? >= c.log_position THEN false ELSE true END),
-			updated_at = ?
-		FROM collections c
-		WHERE
-			af.id = ?
-			AND af.is_deleted = false
-			AND af.completion_offset <= ?
-			AND af.input_collection_id = c.id
-			AND c.id = ?`,
-		newOffset,
-		newOffset,
-		time.Now(),
-		id,
-		newOffset,
-		collectionID,
-	)
+// UpdateCompletionOffset updates only the completion offset.
+// Only updates if the new offset is greater than or equal to the current offset.
+func (s *attachedFunctionDb) UpdateCompletionOffset(id uuid.UUID, collectionID string, newOffset int64) error {
+	result := s.db.Model(&dbmodel.AttachedFunction{}).
+		Where("id = ?", id).
+		Where("input_collection_id = ?", collectionID).
+		Where("is_deleted = ?", false).
+		Where("completion_offset <= ?", newOffset).
+		Updates(map[string]interface{}{
+			"completion_offset": newOffset,
+			"updated_at":        time.Now(),
+		})
 
 	if result.Error != nil {
-		log.Error("update completion offset and heap_entry_pending failed", zap.Error(result.Error))
+		log.Error("update completion offset failed", zap.Error(result.Error))
 		return result.Error
 	}
 
 	if result.RowsAffected == 0 {
-		// Could be due to:
-		// 1. Attached function not found or deleted
-		// 2. Collection not found
-		// 3. Offset would move backwards
-		log.Warn("update completion offset and heap_entry_pending: no rows affected",
+		log.Warn("update completion offset: no rows affected",
 			zap.String("id", id.String()),
 			zap.String("collection_id", collectionID),
 			zap.Int64("new_offset", newOffset))

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
@@ -292,12 +292,12 @@ func (_m *IAttachedFunctionDb) Update(attachedFunction *dbmodel.AttachedFunction
 	return r0
 }
 
-// UpdateCompletionOffsetAndHeapEntry provides a mock function with given fields: id, collectionID, newOffset
-func (_m *IAttachedFunctionDb) UpdateCompletionOffsetAndHeapEntry(id uuid.UUID, collectionID string, newOffset int64) error {
+// UpdateCompletionOffset provides a mock function with given fields: id, collectionID, newOffset
+func (_m *IAttachedFunctionDb) UpdateCompletionOffset(id uuid.UUID, collectionID string, newOffset int64) error {
 	ret := _m.Called(id, collectionID, newOffset)
 
 	if len(ret) == 0 {
-		panic("no return value specified for UpdateCompletionOffsetAndHeapEntry")
+		panic("no return value specified for UpdateCompletionOffset")
 	}
 
 	var r0 error

--- a/go/pkg/sysdb/metastore/db/dbmodel/task.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/task.go
@@ -47,7 +47,7 @@ type IAttachedFunctionDb interface {
 	// - onlyReady: If true, only returns attached functions where is_ready = true
 	GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, ids []uuid.UUID, onlyReady bool) ([]*AttachedFunction, error)
 	Update(attachedFunction *AttachedFunction) error
-	UpdateCompletionOffsetAndHeapEntry(id uuid.UUID, collectionID string, newOffset int64) error
+	UpdateCompletionOffset(id uuid.UUID, collectionID string, newOffset int64) error
 	UpdateHeapEntryPending(id uuid.UUID, collectionID string, heapEntryPending bool) error
 	Finish(id uuid.UUID) error
 	SoftDelete(inputCollectionID string, name string) error

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -651,18 +651,7 @@ message TryFinishAsyncAttachedFunctionInvocationRequest {
 }
 
 message TryFinishAsyncAttachedFunctionInvocationResponse {
-  oneof result {
-    FinishAsyncSuccess success = 1;
-    FinishAsyncNeedsRepair needs_repair = 2;
-  }
-}
-
-message FinishAsyncSuccess {
   uint64 updated_completion_offset = 1;
-}
-
-message FinishAsyncNeedsRepair {
-  uint64 current_collection_log_offset = 1;
 }
 
 message FinalizeAsyncAttachedFunctionRepairRequest {

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -2896,24 +2896,19 @@ impl SysDb {
     pub async fn try_finish_async_attached_function_invocation(
         &mut self,
         request: chroma_types::chroma_proto::TryFinishAsyncAttachedFunctionInvocationRequest,
-    ) -> Result<
-        tonic::Response<
-            chroma_types::chroma_proto::TryFinishAsyncAttachedFunctionInvocationResponse,
-        >,
-        tonic::Status,
-    > {
+    ) -> Result<(), tonic::Status> {
         match self {
-            SysDb::Grpc(grpc) => {
-                grpc.client
-                    .clone()
-                    .try_finish_async_attached_function_invocation(request)
-                    .await
-            }
+            SysDb::Grpc(grpc) => grpc
+                .client
+                .clone()
+                .try_finish_async_attached_function_invocation(request)
+                .await
+                .map(|_| ()),
             SysDb::Sqlite(_) => unimplemented!(),
-            SysDb::Test(test) => {
-                test.try_finish_async_attached_function_invocation(request)
-                    .await
-            }
+            SysDb::Test(test) => test
+                .try_finish_async_attached_function_invocation(request)
+                .await
+                .map(|_| ()),
         }
     }
 

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -780,10 +780,7 @@ impl TestSysDb {
         >,
         tonic::Status,
     > {
-        use chroma_types::chroma_proto::{
-            FinishAsyncNeedsRepair, FinishAsyncSuccess,
-            TryFinishAsyncAttachedFunctionInvocationResponse,
-        };
+        use chroma_types::chroma_proto::TryFinishAsyncAttachedFunctionInvocationResponse;
         use chroma_types::AttachedFunctionUuid;
         use uuid::Uuid;
 
@@ -801,33 +798,11 @@ impl TestSysDb {
             .get_mut(&attached_function_uuid)
             .ok_or_else(|| tonic::Status::not_found("Attached function not found"))?;
 
-        // For test purposes, we'll simulate success if the new offset is greater than the current
-        // and needs repair if it's less than or equal
-        let response = if request.new_completion_offset > attached_function.completion_offset {
-            // Update the completion offset
+        if request.new_completion_offset > attached_function.completion_offset {
             attached_function.completion_offset = request.new_completion_offset;
-
-            TryFinishAsyncAttachedFunctionInvocationResponse {
-                result: Some(
-                    chroma_types::chroma_proto::try_finish_async_attached_function_invocation_response::Result::Success(
-                        FinishAsyncSuccess {
-                            updated_completion_offset: request.new_completion_offset,
-                        },
-                    ),
-                ),
-            }
-        } else {
-            // Simulate needs repair - return a mock current collection log offset
-            TryFinishAsyncAttachedFunctionInvocationResponse {
-                result: Some(
-                    chroma_types::chroma_proto::try_finish_async_attached_function_invocation_response::Result::NeedsRepair(
-                        FinishAsyncNeedsRepair {
-                            // For testing, we'll just return the current completion offset + 100
-                            current_collection_log_offset: attached_function.completion_offset + 100,
-                        },
-                    ),
-                ),
-            }
+        }
+        let response = TryFinishAsyncAttachedFunctionInvocationResponse {
+            updated_completion_offset: attached_function.completion_offset,
         };
 
         Ok(tonic::Response::new(response))

--- a/rust/worker/src/work_queue/server.rs
+++ b/rust/worker/src/work_queue/server.rs
@@ -59,7 +59,7 @@ pub async fn service_entrypoint() {
     let work_queue_handle = system.start_component(work_queue_manager);
 
     // Create and start gRPC server
-    let work_queue_server = WorkQueueServer::new(work_queue_handle.clone(), sysdb);
+    let work_queue_server = WorkQueueServer::new(work_queue_handle.clone());
     let server = work_queue_server.into_service();
     let port = service_config.my_port;
 

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -452,16 +452,16 @@ mod tests {
                 status_response.results[1].status
             );
 
-            // The original queue offset should be marked as needing repair because sysdb's
-            // completion has advanced while the collection frontier is still ahead.
+            // The original queue offset is now done because try_finish only updates sysdb's
+            // completion offset on this branch.
             assert_eq!(
                 status_response.results[0].status,
-                InvocationStatus::NeedsRepair as i32,
-                "Initial offset should still require repair"
+                InvocationStatus::Done as i32,
+                "Initial offset should be marked as done after sysdb advances completion"
             );
             assert_eq!(
                 status_response.results[0].current_completion_offset, new_offset,
-                "Repair status should report the latest sysdb completion offset"
+                "Done status should report the latest sysdb completion offset"
             );
 
             // The latest completion offset is not yet done because the collection frontier is ahead.

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -407,7 +407,8 @@ mod tests {
                 work_items.items.len()
             );
 
-            // The queue still exposes a repaired item for this function on this branch.
+            // The queued entry is removed because completion advanced beyond the
+            // stored queue frontier on this branch.
             let our_items: Vec<_> = work_items
                 .items
                 .iter()
@@ -416,8 +417,8 @@ mod tests {
 
             assert_eq!(
                 our_items.len(),
-                1,
-                "Expected repair to keep a visible work item on this branch"
+                0,
+                "Expected no visible work item once finish_work advances past the queued frontier"
             );
 
             // Check invocation status via sysdb

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -407,8 +407,8 @@ mod tests {
                 work_items.items.len()
             );
 
-            // The queued entry is removed because completion advanced beyond the
-            // stored queue frontier on this branch.
+            // The queued entry stays alive because completion has not yet advanced
+            // beyond the stored queue frontier.
             let our_items: Vec<_> = work_items
                 .items
                 .iter()
@@ -417,8 +417,13 @@ mod tests {
 
             assert_eq!(
                 our_items.len(),
-                0,
-                "Expected no visible work item once finish_work advances past the queued frontier"
+                1,
+                "Expected the queue item to remain visible until completion passes the queued frontier"
+            );
+            assert_eq!(our_items[0].completion_offset, new_offset);
+            assert_eq!(
+                our_items[0].compaction_offset,
+                Some(advanced_log_position)
             );
 
             // Check invocation status via sysdb

--- a/rust/worker/src/work_queue/types.rs
+++ b/rust/worker/src/work_queue/types.rs
@@ -35,9 +35,6 @@ pub enum WorkQueueError {
 
     #[error("Failed to check invocations: {0}")]
     CheckInvocationsFailed(String),
-
-    #[error("Failed to repair attached function: {0}")]
-    RepairFailed(String),
 }
 
 impl ChromaError for WorkQueueError {
@@ -50,7 +47,6 @@ impl ChromaError for WorkQueueError {
             WorkQueueError::SysDb(_) => ErrorCodes::Internal,
             WorkQueueError::TryFinishFailed(_) => ErrorCodes::Internal,
             WorkQueueError::CheckInvocationsFailed(_) => ErrorCodes::Internal,
-            WorkQueueError::RepairFailed(_) => ErrorCodes::Internal,
         }
     }
 
@@ -62,20 +58,4 @@ impl ChromaError for WorkQueueError {
             _ => true,
         }
     }
-}
-
-// Stub types for future sysdb integration
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub enum FinishResult {
-    Success,
-    NeedsRepair,
-}
-
-// Response type for FinishWork operations
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub enum FinishWorkResponse {
-    Success,
-    NeedsRepair { fn_id: AttachedFunctionUuid },
 }

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -1,8 +1,7 @@
 // V1: WorkDistributor import commented out
 // use crate::work_queue::distribution::WorkDistributor;
 use crate::work_queue::state::QueueState;
-use crate::work_queue::types::{FinishResult, WorkQueueError, WorkQueueRecord};
-
+use crate::work_queue::types::{WorkQueueError, WorkQueueRecord};
 use async_trait::async_trait;
 use chroma_error::ChromaError;
 use chroma_storage::{GetOptions, PutMode, PutOptions, Storage};
@@ -30,7 +29,7 @@ pub struct FinishWorkMessage {
     pub fn_id: AttachedFunctionUuid,
     pub input_coll_id: CollectionUuid,
     pub new_completion_offset: i64,
-    pub response_tx: oneshot::Sender<Result<FinishResult, WorkQueueError>>,
+    pub response_tx: oneshot::Sender<Result<(), WorkQueueError>>,
 }
 
 #[derive(Debug)]
@@ -59,11 +58,6 @@ pub(crate) struct WorkQueueManager {
     config: crate::work_queue::config::WorkQueueConfig,
     // Pending responses waiting for persistence (push work responses)
     pending_push_responses: Vec<oneshot::Sender<Result<(), WorkQueueError>>>,
-    // Pending responses for finish work
-    pending_finish_responses: Vec<(
-        FinishResult,
-        oneshot::Sender<Result<FinishResult, WorkQueueError>>,
-    )>,
 }
 
 impl WorkQueueManager {
@@ -79,7 +73,6 @@ impl WorkQueueManager {
             sysdb,
             config,
             pending_push_responses: Vec::new(),
-            pending_finish_responses: Vec::new(),
         }
     }
 
@@ -147,8 +140,7 @@ impl WorkQueueManager {
                 self.state.dirty = false;
 
                 let etag_msg = if has_etag { "" } else { " (no ETag)" };
-                let total_pending =
-                    self.pending_push_responses.len() + self.pending_finish_responses.len();
+                let total_pending = self.pending_push_responses.len();
                 tracing::debug!(
                     "Persisted work queue state{}, responding to {} pending requests",
                     etag_msg,
@@ -178,24 +170,12 @@ impl WorkQueueManager {
                 tracing::error!("Failed to send push work response - receiver dropped");
             }
         }
-
-        for (result, tx) in self.pending_finish_responses.drain(..) {
-            if tx.send(Ok(result)).is_err() {
-                tracing::error!("Failed to send finish work response - receiver dropped");
-            }
-        }
     }
 
     fn notify_pending_responses_error(&mut self, error: &WorkQueueError) {
         for tx in self.pending_push_responses.drain(..) {
             if tx.send(Err(error.clone())).is_err() {
                 tracing::error!("Failed to send push work error response - receiver dropped");
-            }
-        }
-
-        for (_, tx) in self.pending_finish_responses.drain(..) {
-            if tx.send(Err(error.clone())).is_err() {
-                tracing::error!("Failed to send finish work error response - receiver dropped");
             }
         }
     }
@@ -205,8 +185,7 @@ impl WorkQueueManager {
             return false;
         }
 
-        let total_pending_responses =
-            self.pending_push_responses.len() + self.pending_finish_responses.len();
+        let total_pending_responses = self.pending_push_responses.len();
 
         total_pending_responses >= self.config.persistence.pending_threshold
     }
@@ -297,10 +276,7 @@ impl Component for WorkQueueManager {
         tracing::info!("Stopping WorkQueueManager");
 
         // Final persist if dirty or if we have pending responses
-        if self.state.dirty
-            || !self.pending_push_responses.is_empty()
-            || !self.pending_finish_responses.is_empty()
-        {
+        if self.state.dirty || !self.pending_push_responses.is_empty() {
             self.persist()
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?;
@@ -347,7 +323,7 @@ impl Handler<FinishWorkMessage> for WorkQueueManager {
             .finish_work_success(&msg.fn_id, &msg.input_coll_id, msg.new_completion_offset);
 
         // Send immediate success response
-        if msg.response_tx.send(Ok(FinishResult::Success)).is_err() {
+        if msg.response_tx.send(Ok(())).is_err() {
             tracing::error!("Failed to send finish work success response - receiver dropped");
         }
 
@@ -570,23 +546,16 @@ mod tests {
 
         // Add pending responses
         let (tx1, rx1) = oneshot::channel();
-        let (tx2, rx2) = oneshot::channel();
         manager.pending_push_responses.push(tx1);
-        manager
-            .pending_finish_responses
-            .push((FinishResult::NeedsRepair, tx2));
 
         // Notify success
         manager.notify_pending_responses();
 
         // Check responses
         assert!(rx1.await.unwrap().is_ok());
-        let finish_result = rx2.await.unwrap().unwrap();
-        assert!(matches!(finish_result, FinishResult::NeedsRepair));
 
         // Queues should be empty
         assert!(manager.pending_push_responses.is_empty());
-        assert!(manager.pending_finish_responses.is_empty());
     }
 
     #[tokio::test]
@@ -595,11 +564,7 @@ mod tests {
 
         // Add pending responses
         let (tx1, rx1) = oneshot::channel();
-        let (tx2, rx2) = oneshot::channel();
         manager.pending_push_responses.push(tx1);
-        manager
-            .pending_finish_responses
-            .push((FinishResult::NeedsRepair, tx2));
 
         // Notify error
         let error = WorkQueueError::Storage("test error".to_string());
@@ -610,14 +575,9 @@ mod tests {
             rx1.await.unwrap(),
             Err(WorkQueueError::Storage(_))
         ));
-        assert!(matches!(
-            rx2.await.unwrap(),
-            Err(WorkQueueError::Storage(_))
-        ));
 
         // Queues should be empty
         assert!(manager.pending_push_responses.is_empty());
-        assert!(manager.pending_finish_responses.is_empty());
     }
 
     // Note: ETag mismatch testing requires storage that supports conditional puts

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -1,13 +1,11 @@
-use crate::work_queue::types::{FinishResult, WorkQueueError};
+use crate::work_queue::types::WorkQueueError;
 use crate::work_queue::work_queue_manager::{
     FinishWorkMessage, GetWorkMessage, PushWorkMessage, WorkQueueManager,
 };
-use chroma_sysdb::SysDb;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     work_queue_service_server::{WorkQueueService, WorkQueueServiceServer},
-    FinalizeAsyncAttachedFunctionRepairRequest, FinishWorkRequest, GetWorkRequest, GetWorkResponse,
-    PushWorkRequest, WorkItemResult,
+    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest, WorkItemResult,
 };
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use std::str::FromStr;
@@ -15,44 +13,15 @@ use tonic::{Request, Response, Status};
 
 pub struct WorkQueueServer {
     manager: ComponentHandle<WorkQueueManager>,
-    sysdb: SysDb,
 }
 
 impl WorkQueueServer {
-    pub fn new(manager: ComponentHandle<WorkQueueManager>, sysdb: SysDb) -> Self {
-        Self { manager, sysdb }
+    pub fn new(manager: ComponentHandle<WorkQueueManager>) -> Self {
+        Self { manager }
     }
 
     pub fn into_service(self) -> WorkQueueServiceServer<Self> {
         WorkQueueServiceServer::new(self)
-    }
-
-    // Handle repair by finalizing the repair in sysdb
-    async fn handle_repair(
-        &self,
-        fn_id: &AttachedFunctionUuid,
-        input_coll_id: &CollectionUuid,
-    ) -> Result<(), WorkQueueError> {
-        // The work has already been re-pushed by WorkQueueManager
-        // We just need to finalize the repair
-        let repair_request = FinalizeAsyncAttachedFunctionRepairRequest {
-            attached_function_id: fn_id.to_string(),
-            collection_id: input_coll_id.to_string(),
-        };
-
-        let mut sysdb = self.sysdb.clone();
-        sysdb
-            .finalize_async_attached_function_repair(repair_request)
-            .await
-            .map_err(|e| WorkQueueError::RepairFailed(e.to_string()))?;
-
-        tracing::info!(
-            "Repair finalized for function {} and collection {}",
-            fn_id,
-            input_coll_id
-        );
-
-        Ok(())
     }
 }
 
@@ -96,14 +65,11 @@ impl WorkQueueService for WorkQueueServer {
         let req = request.into_inner();
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
 
-        let fn_id = AttachedFunctionUuid::from_str(&req.fn_id)
-            .map_err(|e| Status::invalid_argument(format!("Invalid fn_id: {}", e)))?;
-        let input_coll_id = CollectionUuid::from_str(&req.input_coll_id)
-            .map_err(|e| Status::invalid_argument(format!("Invalid collection_id: {}", e)))?;
-
         let msg = FinishWorkMessage {
-            fn_id,
-            input_coll_id,
+            fn_id: AttachedFunctionUuid::from_str(&req.fn_id)
+                .map_err(|e| Status::invalid_argument(format!("Invalid fn_id: {}", e)))?,
+            input_coll_id: CollectionUuid::from_str(&req.input_coll_id)
+                .map_err(|e| Status::invalid_argument(format!("Invalid collection_id: {}", e)))?,
             new_completion_offset: req.completion_offset,
             response_tx,
         };
@@ -114,25 +80,11 @@ impl WorkQueueService for WorkQueueServer {
             .await
             .map_err(|e| Status::internal(format!("Failed to send message: {}", e)))?;
 
-        let result = response_rx
+        response_rx
             .await
             .map_err(|e| Status::internal(format!("Failed to receive response: {}", e)))?
             .map_err(|e: WorkQueueError| Status::internal(e.to_string()))?;
-
-        // Handle the result
-        match result {
-            FinishResult::Success => {
-                // Success case - just return ok
-                Ok(Response::new(()))
-            }
-            FinishResult::NeedsRepair => {
-                // NeedsRepair case - handle repair
-                self.handle_repair(&fn_id, &input_coll_id)
-                    .await
-                    .map_err(|e| Status::internal(e.to_string()))?;
-                Ok(Response::new(()))
-            }
-        }
+        Ok(Response::new(()))
     }
 
     async fn get_work(


### PR DESCRIPTION
## Description of changes

This PR removes the "repair mechanic" from the `finishwork` API. Previously, when a compaction's `new_completion_offset` was behind the collection's `log_position`, sysdb would return a `NeedsRepair` response and the work queue server would call `FinalizeAsyncAttachedFunctionRepair` to re-push the work item. Now that the compaction frontier is tracked in-memory (from the prior PR in the stack), this comparison is no longer needed — `TryFinishAsyncAttachedFunctionInvocation` simply updates the offset and always returns success.

The changes cascade through four layers: the protobuf definition, the Go sysdb coordinator + DAO, the Rust sysdb client, and the Rust work queue server.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_