### PR TITLE
[CHORE]  Set version numbers for rust 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "chroma"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "backon",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-api-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "serde",
  "utoipa",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-error"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "http 1.4.0",
  "sqlx",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,15 +93,15 @@ google-cloud-spanner = { git = "https://github.com/yoshidan/google-cloud-rust", 
 google-cloud-gax = { git = "https://github.com/yoshidan/google-cloud-rust", tag = "v20260319", package = "gcloud-gax" }
 google-cloud-googleapis = { git = "https://github.com/yoshidan/google-cloud-rust", tag = "v20260319", package = "gcloud-googleapis", features = ["spanner"] }
 
-chroma = { path = "rust/chroma", version = "0.14.0" }
+chroma = { path = "rust/chroma", version = "0.15.0" }
 chroma-agent = { path = "rust/agent" }
-chroma-api-types = { path = "rust/api-types", version = "0.14.0" }
+chroma-api-types = { path = "rust/api-types", version = "0.15.0" }
 chroma-benchmark = { path = "rust/benchmark" }
 chroma-blockstore = { path = "rust/blockstore" }
 chroma-cache = { path = "rust/cache" }
 chroma-config = { path = "rust/config" }
 chroma-distance = { path = "rust/distance" }
-chroma-error = { path = "rust/error", version = "0.14.0" }
+chroma-error = { path = "rust/error", version = "0.15.0" }
 chroma-faults = { path = "rust/faults" }
 chroma-frontend = { path = "rust/frontend" }
 foundation-api = { path = "rust/foundation-api" }
@@ -116,7 +116,7 @@ chroma-storage = { path = "rust/storage" }
 chroma-system = { path = "rust/system" }
 chroma-sysdb = { path = "rust/sysdb" }
 chroma-tracing = { path = "rust/tracing" }
-chroma-types = { path = "rust/types", version = "0.14.0" }
+chroma-types = { path = "rust/types", version = "0.15.0" }
 chroma-sqlite = { path = "rust/sqlite" }
 chroma-cli = { path = "rust/cli" }
 chroma-jemalloc-pprof-server = { path = "rust/jemalloc-pprof-server" }

--- a/rust/api-types/Cargo.toml
+++ b/rust/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma-api-types"
-version = { workspace = true }
+version = "0.15.0"
 edition = "2021"
 description = "Chroma-provided crate for api-types used in the Chroma API."
 license = "Apache-2.0"

--- a/rust/api-types/Cargo.toml
+++ b/rust/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma-api-types"
-version = "0.14.0"
+version = { workspace = true }
 edition = "2021"
 description = "Chroma-provided crate for api-types used in the Chroma API."
 license = "Apache-2.0"

--- a/rust/chroma/Cargo.toml
+++ b/rust/chroma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma"
-version = { workspace = true }
+version = "0.15.0"
 edition = "2021"
 description = "Client for Chroma, the AI-native cloud database."
 license = "Apache-2.0"

--- a/rust/chroma/Cargo.toml
+++ b/rust/chroma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma"
-version = "0.14.0"
+version = { workspace = true }
 edition = "2021"
 description = "Client for Chroma, the AI-native cloud database."
 license = "Apache-2.0"

--- a/rust/error/Cargo.toml
+++ b/rust/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma-error"
-version = { workspace = true }
+version = "0.15.0"
 edition = "2021"
 description = "Chroma-provided crate for errors returned from Chroma."
 license = "Apache-2.0"

--- a/rust/error/Cargo.toml
+++ b/rust/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma-error"
-version = "0.14.0"
+version = { workspace = true }
 edition = "2021"
 description = "Chroma-provided crate for errors returned from Chroma."
 license = "Apache-2.0"

--- a/rust/types/Cargo.toml
+++ b/rust/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma-types"
-version = { workspace = true }
+version = "0.15.0"
 edition = "2021"
 description = "Chroma-provided crate for internal types used in the Chroma API."
 license = "Apache-2.0"

--- a/rust/types/Cargo.toml
+++ b/rust/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma-types"
-version = "0.14.0"
+version = { workspace = true }
 edition = "2021"
 description = "Chroma-provided crate for internal types used in the Chroma API."
 license = "Apache-2.0"


### PR DESCRIPTION
## Description of changes

This is a version number bump so I can publish the Rust client.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
