### PR TITLE
[ENH](foundation-api): Add granola collection

### DIFF
--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -124,7 +124,11 @@ impl FoundationConfig {
         // collection (metadata-indexed, text/vector deferred), which `/init`
         // creates and wires in as the attached-function base (see the field
         // docs above). The collections listed here stay fully indexed.
-        vec!["notion".to_string(), "gdrive".to_string()]
+        vec![
+            "notion".to_string(),
+            "gdrive".to_string(),
+            "granola".to_string(),
+        ]
     }
     fn default_function_name() -> String {
         "http_generate".to_string()


### PR DESCRIPTION
## Summary
Adds `"granola"` to `FoundationConfig`'s default source-collections list so that `/init` enables chunk-sibling grouping and attaches `http_generate` on the tenant's `FOUNDATION/granola` collection — the same one-line treatment the other Foundation sources get.

**ADR:** [Granola Source ADR](https://app.notion.com/p/38958a6d8191818fb2c9fb1e8f4eef35) (§D6, Sync status integration).

Checklist:
- [x] Architecture change → ADR linked above.
- [ ] Security-sensitive — n/a.
- [ ] New monitoring/alerting — n/a.
- [ ] User-facing docs — n/a.
- [ ] Manual deploy steps — n/a.
