### PR TITLE
[BLD](ci): per-arch Docker cache keys via builder v2

### DIFF
--- a/.github/actions/build_service_images/action.yaml
+++ b/.github/actions/build_service_images/action.yaml
@@ -61,7 +61,11 @@ runs:
   using: "composite"
   steps:
     - name: Setup Blacksmith Docker cache
-      uses: useblacksmith/setup-docker-builder@v1
+      uses: useblacksmith/setup-docker-builder@v2
+      with:
+        # Release service-images bake runs single-arch; its own key keeps it
+        # from contending with the PR/CI warm cache or the release-cli builds.
+        cache-key: chroma-service-images-amd64
 
     - name: Resolve commit SHA
       shell: bash

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -13,6 +13,13 @@ inputs:
   dockerhub-password:
     description: "DockerHub password"
     required: false
+  cache-key:
+    description: >-
+      Unique identifier for this build's Docker layer cache (sticky disk).
+      Builds with the same cache-key share cached layers; builds that should
+      not contend for the same warm cache (e.g. different architectures or
+      different Dockerfiles) must use different keys.
+    required: true
 
 runs:
   using: "composite"
@@ -31,4 +38,6 @@ runs:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-password }}
     - name: Set up Blacksmith builder
-      uses: useblacksmith/setup-docker-builder@v1
+      uses: useblacksmith/setup-docker-builder@v2
+      with:
+        cache-key: ${{ inputs.cache-key }}

--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -73,6 +73,10 @@ jobs:
           ghcr-password: ${{ secrets.GITHUB_TOKEN }}
           dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          # Per-arch cache key: amd64 and arm64 each get their own sticky-disk
+          # lineage so the two architectures never overwrite or discard each
+          # other's (architecture-specific) compile cache.
+          cache-key: chroma-release-cli-${{ matrix.platform }}
 
       - name: Compute arch-specific tags
         id: tags
@@ -99,8 +103,12 @@ jobs:
           docker pull --platform ${{ matrix.docker_platform }} rust:1.92.0
           docker pull --platform ${{ matrix.docker_platform }} debian:stable-slim
 
+      # Uses the per-arch-keyed Blacksmith builder configured (and set as the
+      # default buildx builder) by the "Set up Docker" step above. The
+      # cache-key is owned by setup-docker-builder@v2, so we use the standard
+      # build-push action here rather than one that re-derives its own key.
       - name: Build and push image
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: rust/Dockerfile
@@ -132,6 +140,9 @@ jobs:
           ghcr-password: ${{ secrets.GITHUB_TOKEN }}
           dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          # This job only assembles a multi-arch manifest (no image build), so
+          # it gets its own key and never contends with the per-arch builds.
+          cache-key: chroma-release-cli-manifest
 
       - name: Create and push manifest
         shell: bash

--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          # Shared warm CI cache: the build-images job in pr.yml populates this
+          # key and the downstream single-arch test jobs clone it.
+          cache-key: chroma-ci-amd64
       - name: Start Tilt services
         uses: ./.github/actions/tilt
       - run: bin/cluster-test.sh bash -c 'cd go && make test'

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -501,6 +501,9 @@ jobs:
         with:
           dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          # Shared warm CI cache: the build-images job in pr.yml populates this
+          # key and the downstream single-arch test jobs clone it.
+          cache-key: chroma-ci-amd64
       - name: Preload default ONNX model
         uses: ./.github/actions/preload-default-onnx-model
       - name: Start Tilt services

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -117,6 +117,9 @@ jobs:
         with:
           dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          # Shared warm CI cache: the build-images job in pr.yml populates this
+          # key and the downstream single-arch test jobs clone it.
+          cache-key: chroma-ci-amd64
       - name: Start services in Tilt
         uses: ./.github/actions/tilt
       - name: Build CLI

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -26,7 +26,10 @@ jobs:
       - uses: ./.github/actions/python
         with:
           python-version: "3.12"
-      - uses: useblacksmith/setup-docker-builder@v1
+      - uses: useblacksmith/setup-docker-builder@v2
+        with:
+          # Shares the warm single-arch CI cache used by the PR test jobs.
+          cache-key: chroma-ci-amd64
       - uses: ./.github/actions/preload-default-onnx-model
       - uses: ./.github/actions/tilt
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -179,7 +179,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Blacksmith builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          # This job warms the single-arch CI cache; the downstream test jobs
+          # (_rust-tests, _go-tests, _python-tests) clone it via the same key.
+          cache-key: chroma-ci-amd64
       - name: Build all CI images (warms BuildKit cache on sticky disk)
         run: docker buildx bake -f .github/actions/tilt-setup-prebuild/docker-bake.hcl
 
@@ -226,8 +230,11 @@ jobs:
 
   go-tests:
     name: Go tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'go')
+    needs: [change-detection, build-images]
+    if: |
+      always() &&
+      !failure() && !cancelled() &&
+      contains(fromJson(needs.change-detection.outputs.tests-to-run), 'go')
     uses: ./.github/workflows/_go-tests.yml
     secrets: inherit
 


### PR DESCRIPTION
Upgrade setup-docker-builder v1 -> v2 and thread an explicit cache-key through the docker composite action and all build/test jobs. The multi-arch release-cli build keys on the platform so amd64 and arm64 no longer share one sticky-disk lineage and stop discarding each other's arch-specific compile cache. CI/test jobs share one warm key; release service-images and the manifest-merge job get their own.