### PR TITLE
[CHORE](js-client): Bump chromadb to 3.5.0

### DIFF
--- a/clients/new-js/packages/chromadb/package.json
+++ b/clients/new-js/packages/chromadb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "3.4.5",
+  "version": "3.5.0",
   "description": "A JavaScript interface for chroma",
   "keywords": [
     "chroma",


### PR DESCRIPTION
## Summary

- Bump `clients/new-js/packages/chromadb` from `3.4.5` to `3.5.0`.
- This is a **release version bump** to ship the multiple-sparse-vector-index support that has already landed in `clients/new-js` but is unpublished (npm `latest` is `3.4.3`; `3.4.4`/`3.4.5` were never published).
- Minor bump per semver: the feature is additive and backward compatible.

## Test plan

- [ ] `cd clients/new-js && pnpm build` succeeds
- [ ] `npm publish --dry-run` shows version `3.5.0` and expected contents
- [ ] Smoke-test multiple sparse indices against the published package

Made with [Cursor](https://cursor.com)