### PR TITLE
[ENH]: Add trace under poll_and_dispatch fanout

### DIFF
--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -11,7 +11,7 @@ use futures::future::join_all;
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 use thiserror::Error;
-use tracing::span;
+use tracing::{instrument, span};
 
 use crate::execution::orchestration::compact::CompactionContext;
 use crate::execution::orchestration::function_execution::FunctionExecutionContext;
@@ -149,6 +149,7 @@ impl FnConsumerManager {
     }
 
     /// Runs the attached function workflow for the given function across a batch of input collections.
+    #[instrument(name = "FnConsumerManager::dispatch_batch", skip(self), err)]
     async fn dispatch_batch(
         &self,
         fn_id: AttachedFunctionUuid,


### PR DESCRIPTION
## Description of changes

Adds a trace to `dispatch_batch`. The caller above this, `poll_and_dispatch`, fans out into futures that break the span connection.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_