### PR TITLE
[ENH] Read page tool

### DIFF
--- a/rust/foundation-api/src/agent_tools/mod.rs
+++ b/rust/foundation-api/src/agent_tools/mod.rs
@@ -2,13 +2,16 @@
 //! cores.
 //!
 //! Each tool reuses a route core ([`crate::routes::search`] /
-//! [`crate::routes::subagent_search`]) so the agent loop and the bare HTTP
-//! routes share one retrieval implementation. Per-request state (resolved
-//! collection, caller token, deep-research creds) is captured as struct fields
-//! when the `/api/agent` handler builds the toolset.
+//! [`crate::routes::read_page`] / [`crate::routes::subagent_search`]) so the
+//! agent loop and the bare HTTP routes share one retrieval implementation.
+//! Per-request state (resolved collection, caller token, deep-research creds)
+//! is captured as struct fields when the `/api/agent` handler builds the
+//! toolset.
 
+mod read_page_tool;
 mod search_tool;
 mod subagent_search_tool;
 
+pub(crate) use read_page_tool::ReadPageTool;
 pub(crate) use search_tool::SearchTool;
 pub(crate) use subagent_search_tool::SubagentSearchTool;

--- a/rust/foundation-api/src/agent_tools/read_page_tool.rs
+++ b/rust/foundation-api/src/agent_tools/read_page_tool.rs
@@ -1,0 +1,135 @@
+//! `read_page` agent tool: reconstruct a single wiki page in full by slug.
+//!
+//! Wraps the same [`read_page_from_collection`] core the `POST /api/read-page`
+//! route and the `read_page` MCP tool use, so every surface reassembles pages
+//! the same way. The per-request state (the resolved collection, the tenant,
+//! and the configured UI origin used to stamp page links) is captured as struct
+//! fields when the `/api/agent` handler builds the toolset; the model only
+//! supplies the slug it wants to read, typically one surfaced by a prior
+//! `search` result.
+
+use async_trait::async_trait;
+use chroma::ChromaCollection;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use chroma_agent::{AgentError, Tool, ToolCallMetadata};
+
+use crate::routes::read_page::{read_page_from_collection, FoundationPage};
+
+/// Model-supplied parameters for [`ReadPageTool`].
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct ReadPageToolParams {
+    /// Slug of the wiki page to read in full, as reported by a `search` hit
+    /// (`slug=...`).
+    pub slug: String,
+}
+
+/// A page-read tool bound to one request's collection, tenant, and UI origin.
+pub(crate) struct ReadPageTool {
+    collection: ChromaCollection,
+    tenant: String,
+    ui_origin: Option<String>,
+}
+
+impl ReadPageTool {
+    pub(crate) fn new(
+        collection: ChromaCollection,
+        tenant: String,
+        ui_origin: Option<String>,
+    ) -> Self {
+        Self {
+            collection,
+            tenant,
+            ui_origin,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ReadPageTool {
+    type ModelSuppliedParams = ReadPageToolParams;
+    type RuntimeParams = ();
+
+    fn name(&self) -> &str {
+        "read_page"
+    }
+
+    fn description(&self) -> &str {
+        "Read a single knowledge-base page in full by its slug (as reported by a \
+         `search` hit's `slug=`), returning its title, categories, link, and \
+         complete markdown content. Use this to pull the source material behind \
+         a search hit so you can read and cite it directly."
+    }
+
+    async fn call(
+        &self,
+        params: Self::ModelSuppliedParams,
+        _runtime: Self::RuntimeParams,
+    ) -> Result<(String, Option<ToolCallMetadata>), AgentError> {
+        let page = read_page_from_collection(
+            &self.collection,
+            &self.tenant,
+            self.ui_origin.as_deref(),
+            &params.slug,
+        )
+        .await
+        .map_err(|err| AgentError::Tool(err.to_string()))?;
+
+        match page {
+            Some(page) => Ok((format_page(&page), None)),
+            None => Ok((format!("No page found for slug '{}'.", params.slug), None)),
+        }
+    }
+}
+
+/// Renders a full page into a text block the model can read and cite: a header
+/// of title / slug / link / categories, followed by the complete markdown.
+fn format_page(page: &FoundationPage) -> String {
+    let mut header = format!("Title: {}\nSlug: {}", page.title, page.slug);
+    if let Some(url) = &page.url {
+        header.push_str(&format!("\nURL: {url}"));
+    }
+    if !page.categories.is_empty() {
+        header.push_str(&format!("\nCategories: {}", page.categories.join(", ")));
+    }
+    format!("{header}\n\n{}", page.content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn page(url: Option<&str>, categories: Vec<&str>) -> FoundationPage {
+        FoundationPage {
+            slug: "onboarding".to_string(),
+            title: "Onboarding".to_string(),
+            categories: categories.into_iter().map(str::to_string).collect(),
+            updated_at: Some(1700),
+            content: "# Welcome\nBody text.".to_string(),
+            url: url.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn formats_page_with_header_and_content() {
+        let text = format_page(&page(
+            Some("https://wiki.example.com/~/page-redirect?slug=onboarding"),
+            vec!["eng"],
+        ));
+        assert!(text.contains("Title: Onboarding"));
+        assert!(text.contains("Slug: onboarding"));
+        assert!(text.contains("URL: https://wiki.example.com/~/page-redirect?slug=onboarding"));
+        assert!(text.contains("Categories: eng"));
+        assert!(text.contains("# Welcome\nBody text."));
+    }
+
+    #[test]
+    fn formats_page_omits_url_and_categories_when_absent() {
+        let text = format_page(&page(None, vec![]));
+        assert!(!text.contains("URL:"));
+        assert!(!text.contains("Categories:"));
+        assert!(text.contains("Title: Onboarding"));
+        assert!(text.contains("Body text."));
+    }
+}

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -7,12 +7,13 @@
 //! `action`/`observation`/`done` schema. Inference is non-streaming
 //! (Anthropic), so events are step-level, not token-level.
 //!
-//! The two tools (`search`, `subagent_search`) reuse the same cores as the
-//! standalone `/api/search` and `/api/subagent_search` routes; per-request
-//! state (collection, token, deep-research creds) is resolved once in the
-//! handler and captured by the tools. The shared `reqwest::Client` is cloned
-//! into both the Anthropic model and the deep-research tool so connection pools
-//! are reused rather than rebuilt per request.
+//! The tools (`search`, `read_page`, `subagent_search`) reuse the same cores as
+//! the standalone `/api/search`, `/api/read-page`, and `/api/subagent_search`
+//! routes; per-request state (collection, token, deep-research creds) is
+//! resolved once in the handler and captured by the tools. The shared
+//! `reqwest::Client` is cloned into both the Anthropic model and the
+//! deep-research tool so connection pools are reused rather than rebuilt per
+//! request.
 //!
 //! Clients may seed the agent's system prompt via the request body (`system`);
 //! when omitted, a built-in default steers the agent to answer from the
@@ -36,7 +37,7 @@ use chroma_agent::{
 };
 use events::{action_event, action_text, observation_event, AgentSseEvent};
 
-use crate::agent_tools::{SearchTool, SubagentSearchTool};
+use crate::agent_tools::{ReadPageTool, SearchTool, SubagentSearchTool};
 use crate::routes::subagent_search::SubagentSearchCreds;
 use crate::routes::{caller_token, to_sse_event, whoami::whoami_and_authorize};
 use crate::wiki::embed::WikiEmbedder;
@@ -47,9 +48,11 @@ use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer}
 /// to ground its answer in the knowledge base via the available tools.
 const DEFAULT_SYSTEM_PROMPT: &str = "You are a research assistant for an internal \
 knowledge base. Use the `search` tool for targeted lookups and the \
-`subagent_search` tool for broad, multi-part research questions. Ground every \
-claim in retrieved documents and cite the document ids you relied on. If the \
-tools surface nothing relevant, say so plainly rather than guessing.";
+`subagent_search` tool for broad, multi-part research questions. When a search \
+hit looks relevant, use the `read_page` tool with its `slug` to read the full \
+page before relying on it. Ground every claim in retrieved documents and cite \
+the document ids you relied on. If the tools surface nothing relevant, say so \
+plainly rather than guessing.";
 
 /// Request body for `POST /api/agent`.
 #[derive(Debug, Deserialize, Validate)]
@@ -176,9 +179,14 @@ async fn build_agent(
 
     let mut toolset = ToolSet::new();
     toolset.add(SearchTool::new(
-        collection,
+        collection.clone(),
         WikiEmbedder::new(None),
         token.clone(),
+    ));
+    toolset.add(ReadPageTool::new(
+        collection,
+        tenant.to_string(),
+        server.config.foundation.foundation_ui_origin.clone(),
     ));
 
     // The deep-research tool is optional: register it only when the dependency

--- a/rust/foundation-api/src/routes/mcp/server.rs
+++ b/rust/foundation-api/src/routes/mcp/server.rs
@@ -49,7 +49,7 @@ impl FoundationMcpServer {
     /// resolved tenant, and the scorecard guard — which the caller must hold
     /// for the duration of the tool run. On failure the `Err` is the
     /// `CallToolResult` to return verbatim.
-    async fn authorize_and_meter(
+    async fn authorize_and_scorecard(
         &self,
         ctx: &RequestContext<RoleServer>,
         op: &str,
@@ -116,7 +116,7 @@ impl FoundationMcpServer {
         Parameters(params): Parameters<AskFoundationParams>,
     ) -> CallToolResult {
         let (headers, tenant, _guard) = match self
-            .authorize_and_meter(&ctx, "op:foundation_mcp_ask")
+            .authorize_and_scorecard(&ctx, "op:foundation_mcp_ask")
             .await
         {
             Ok(prelude) => prelude,
@@ -178,7 +178,7 @@ impl FoundationMcpServer {
         Parameters(params): Parameters<SearchParams>,
     ) -> CallToolResult {
         let (headers, tenant, _guard) = match self
-            .authorize_and_meter(&ctx, "op:foundation_mcp_search")
+            .authorize_and_scorecard(&ctx, "op:foundation_mcp_search")
             .await
         {
             Ok(prelude) => prelude,
@@ -234,7 +234,7 @@ impl FoundationMcpServer {
         Parameters(params): Parameters<ReadPageParams>,
     ) -> CallToolResult {
         let (headers, tenant, _guard) = match self
-            .authorize_and_meter(&ctx, "op:foundation_mcp_read_page")
+            .authorize_and_scorecard(&ctx, "op:foundation_mcp_read_page")
             .await
         {
             Ok(prelude) => prelude,

--- a/rust/foundation-api/src/routes/read_page.rs
+++ b/rust/foundation-api/src/routes/read_page.rs
@@ -120,9 +120,28 @@ pub(crate) async fn run_read_page(
     let token = caller_token(headers).ok_or(ReadPageError::MissingToken)?;
     let collection = wiki_client.wiki_collection(tenant, token).await?;
 
-    let mut page = read_full_page(&collection, slug).await?;
-    if let (Some(page), Some(origin)) = (&mut page, &server.config.foundation.foundation_ui_origin)
-    {
+    read_page_from_collection(
+        &collection,
+        tenant,
+        server.config.foundation.foundation_ui_origin.as_deref(),
+        slug,
+    )
+    .await
+}
+
+/// Reconstructs the full page for `slug` from an already-resolved wiki
+/// `collection`, stamping the page's `url` from `ui_origin` (left `None` when
+/// the origin is unset). Callers that resolve the collection once and reuse it
+/// across many reads (e.g. the agent's `read_page` tool) go through this;
+/// [`run_read_page`] resolves the collection per call and then delegates here.
+pub(crate) async fn read_page_from_collection(
+    collection: &ChromaCollection,
+    tenant: &str,
+    ui_origin: Option<&str>,
+    slug: &str,
+) -> Result<Option<FoundationPage>, ReadPageError> {
+    let mut page = read_full_page(collection, slug).await?;
+    if let (Some(page), Some(origin)) = (&mut page, ui_origin) {
         page.url = page_redirect_url(origin, tenant, &page.slug);
     }
     Ok(page)


### PR DESCRIPTION
## Description of changes

Adds a `read_page` tool to the Foundation agent (`POST /api/agent`) so the agent can pull a full wiki page by `slug` — the natural follow-up to a `search` hit — instead of reasoning over chunk-level snippets alone.

### New functionality
- New `read_page` agent tool: given a page `slug` (as surfaced by a `search` hit), it reconstructs the full page and returns the title, categories, link, and complete markdown for the agent to read and cite.
- Registered unconditionally alongside `search` in `build_agent`, so it is available on both `POST /api/agent` (SSE) and the MCP `ask_foundation` tool, which share the same agent assembly.
- Default system prompt now steers the agent to `read_page` a relevant hit's `slug` before relying on it.

### Improvements & Bug fixes
- Extracted a shared `read_page_from_collection` core in `read_page.rs`. The agent tool, the `POST /api/read-page` route, and the `read_page` MCP tool now all reassemble pages and stamp page links through one implementation — no duplicated logic. The HTTP/MCP surfaces resolve the collection per request; the agent tool reuses the collection it already resolved once (matching how `search` works).

## Test plan
- `cargo test -p foundation-api` passes, including new unit tests for the tool's page formatting (header + content, and omission of URL/categories when absent).
- Existing `read_page` route/MCP tests continue to pass, confirming the refactor into `read_page_from_collection` preserves behavior.

## Migration plan
None. No schema, API, or config changes — the tool reuses existing wiki retrieval and is additive to the agent's toolset.

## Observability plan
No new surface area. The tool runs inside the existing agent loop and emits the same action/observation SSE events as other tools; page reads go through the same wiki client (auth, quota, metering, billing) as `/api/read-page`.

## Documentation Changes
None required — internal agent tooling with no user-facing API change.