### PR TITLE
[ENH]: AttachedFunctionOrchestrator sends spans to dispatcher

### DIFF
--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -363,7 +363,7 @@ impl AttachedFunctionOrchestrator {
                 ctx.receiver(),
                 self.context().task_cancellation_token.clone(),
             );
-            let res = self.dispatcher().send(task, None).await;
+            let res = self.dispatcher().send(task, Some(Span::current())).await;
             self.ok_or_terminate(res, ctx).await.is_some()
         } else {
             tracing::error!("Async attached function found but no WorkQueue client configured");
@@ -430,7 +430,7 @@ impl AttachedFunctionOrchestrator {
             ctx.receiver(),
             self.context().task_cancellation_token.clone(),
         );
-        let res = self.dispatcher().send(task, None).await;
+        let res = self.dispatcher().send(task, Some(Span::current())).await;
         self.ok_or_terminate(res, ctx).await;
     }
 
@@ -1030,7 +1030,7 @@ impl Handler<TaskResult<CollectionAndSegments, GetCollectionAndSegmentsError>>
             ctx.receiver(),
             self.context().task_cancellation_token.clone(),
         );
-        let res = self.dispatcher().send(task, None).await;
+        let res = self.dispatcher().send(task, Some(Span::current())).await;
         self.ok_or_terminate(res, ctx).await;
     }
 }


### PR DESCRIPTION
## Description of changes

AttachedFunctionOrchestrator was not passing parent spans into its dispatched operators. This change fixes that.

- Improvements & Bug fixes
    - 
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_