### PR TITLE
[ENH](js): Add conditional transactions to chromadb client

### DIFF
--- a/clients/new-js/packages/chromadb/examples/conditional-transactions.ts
+++ b/clients/new-js/packages/chromadb/examples/conditional-transactions.ts
@@ -1,0 +1,107 @@
+/**
+ * Collection-scoped conditional transaction example.
+ *
+ * Run against a Chroma server that supports conditional transactions:
+ *
+ *   cd clients/new-js
+ *   npx tsx packages/chromadb/examples/conditional-transactions.ts
+ *
+ * Optional environment:
+ *
+ *   CHROMA_ENDPOINT=http://localhost:8000
+ *   CHROMA_TENANT=default_tenant
+ *   CHROMA_DATABASE=default_database
+ *   CHROMA_API_KEY=...
+ */
+
+import { ChromaClient } from "../src/index.ts";
+
+const COLLECTION_NAME = "transactional_chroma_js_example";
+const RECORD_ID = "txn-doc";
+
+const endpoint = new URL(
+  process.env.CHROMA_ENDPOINT ?? "http://localhost:8000",
+);
+const apiKey = process.env.CHROMA_API_KEY;
+
+const client = new ChromaClient({
+  ssl: endpoint.protocol === "https:",
+  host: endpoint.hostname,
+  port:
+    endpoint.port !== ""
+      ? Number(endpoint.port)
+      : endpoint.protocol === "https:"
+      ? 443
+      : 80,
+  tenant: process.env.CHROMA_TENANT ?? "default_tenant",
+  database: process.env.CHROMA_DATABASE ?? "default_database",
+  headers: apiKey ? { "x-chroma-token": apiKey } : undefined,
+});
+
+const metadata = (status: string, version: number) => ({
+  status,
+  version,
+});
+
+const main = async () => {
+  try {
+    await client.deleteCollection({ name: COLLECTION_NAME });
+  } catch {
+    // Ignore missing collections so the example is repeatable.
+  }
+
+  const collection = await client.getOrCreateCollection({
+    name: COLLECTION_NAME,
+    embeddingFunction: null,
+  });
+
+  const outcome = await collection.conditional().run(
+    async (txn) => {
+      const existing = await txn.get({
+        ids: [RECORD_ID],
+        include: ["documents", "metadatas"],
+      });
+
+      if (existing.ids.length === 0) {
+        await txn.add({
+          ids: [RECORD_ID],
+          embeddings: [[1.0, 0.0, 0.0]],
+          metadatas: [metadata("created-by-run", 1)],
+        });
+        return "created";
+      }
+
+      await txn.update({
+        ids: [RECORD_ID],
+        metadatas: [metadata("updated-by-run", 1)],
+      });
+      return "updated";
+    },
+    { maxRetries: 3 },
+  );
+  console.log(`run() transaction ${outcome} "${RECORD_ID}"`);
+
+  const txn = collection.conditional();
+  const before = await txn.get({
+    ids: [RECORD_ID],
+    include: ["documents", "metadatas"],
+  });
+  if (before.ids.length === 0) {
+    throw new Error(`"${RECORD_ID}" disappeared before manual commit`);
+  }
+
+  await txn.update({
+    ids: [RECORD_ID],
+    metadatas: [metadata("updated-by-manual-commit", 2)],
+  });
+  const committed = await txn.commit();
+  console.log(`manual commit wrote ${committed.record_count} record(s)`);
+
+  const after = await collection.get({
+    ids: [RECORD_ID],
+    include: ["metadatas"],
+  });
+  console.log("final metadata:", after.metadatas);
+};
+
+await main();

--- a/clients/new-js/packages/chromadb/src/chroma-fetch.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-fetch.ts
@@ -1,15 +1,23 @@
 import {
+  ChromaBackoffError,
   ChromaClientError,
   ChromaConnectionError,
+  ChromaConditionalWriteConflictError,
   ChromaError,
   ChromaForbiddenError,
   ChromaNotFoundError,
   ChromaQuotaExceededError,
   ChromaRateLimitError,
   ChromaServerError,
+  ChromaStaleReadError,
   ChromaUnauthorizedError,
   ChromaUniqueError,
 } from "./errors";
+
+type ErrorBody = {
+  error?: string;
+  message?: string;
+};
 
 const offlineError = (error: any): boolean => {
   return Boolean(
@@ -20,15 +28,19 @@ const offlineError = (error: any): boolean => {
   );
 };
 
-const getErrorMessage = async (response: Response): Promise<string> => {
+const getErrorBody = async (response: Response): Promise<ErrorBody> => {
   try {
-    const body = await response.clone().json();
-    return (
-      body.message || body.error || `${response.status}: ${response.statusText}`
-    );
+    return await response.clone().json();
   } catch {
-    return `${response.status}: ${response.statusText}`;
+    return {};
   }
+};
+
+const getErrorMessage = async (response: Response): Promise<string> => {
+  const body = await getErrorBody(response);
+  return (
+    body.message || body.error || `${response.status}: ${response.statusText}`
+  );
 };
 
 export const chromaFetch: typeof fetch = async (input, init) => {
@@ -71,7 +83,28 @@ export const chromaFetch: typeof fetch = async (input, init) => {
         `The requested resource could not be found`,
       );
     case 409:
-      throw new ChromaUniqueError("The resource already exists");
+      const conflictBody = await getErrorBody(response);
+      if (
+        conflictBody.error === "ConditionalWriteConflictError" ||
+        conflictBody.message === "conditional write conflict"
+      ) {
+        throw new ChromaConditionalWriteConflictError(
+          conflictBody.message || "conditional write conflict",
+        );
+      }
+      throw new ChromaUniqueError(
+        conflictBody.message || "The resource already exists",
+      );
+    case 412:
+      const preconditionBody = await getErrorBody(response);
+      if (preconditionBody.error === "StaleReadError") {
+        throw new ChromaStaleReadError(
+          preconditionBody.message || "stale read",
+        );
+      }
+      throw new ChromaClientError(
+        preconditionBody.message || "Precondition Failed",
+      );
     case 422:
       try {
         const body = await response.json();
@@ -96,6 +129,12 @@ export const chromaFetch: typeof fetch = async (input, init) => {
         );
       }
     case 429:
+      const rateLimitBody = await getErrorBody(response);
+      if (rateLimitBody.error === "Backoff") {
+        throw new ChromaBackoffError(
+          rateLimitBody.message || "Backoff and retry",
+        );
+      }
       throw new ChromaRateLimitError("Rate limit exceeded");
   }
 

--- a/clients/new-js/packages/chromadb/src/collection.ts
+++ b/clients/new-js/packages/chromadb/src/collection.ts
@@ -19,7 +19,20 @@ import {
   Where,
   WhereDocument,
 } from "./types";
-import { Include, SparseVector, SearchPayload } from "./api";
+import {
+  AddCollectionRecordsPayload,
+  ConditionalCommitPayload,
+  ConditionalCommitResult as ApiConditionalCommitResult,
+  ConditionalGetRequestPayload,
+  ConditionalGetResponse,
+  ConditionalTransactionOperationPayload,
+  DeleteCollectionRecordsPayload,
+  Include,
+  SparseVector,
+  SearchPayload,
+  UpdateCollectionRecordsPayload,
+  UpsertCollectionRecordsPayload,
+} from "./api";
 import { CollectionService, RecordService } from "./api";
 import {
   validateRecordSetLengthConsistency,
@@ -39,7 +52,12 @@ import {
   deserializeMetadata,
 } from "./utils";
 import { createClient } from "@hey-api/client-fetch";
-import { ChromaValueError } from "./errors";
+import {
+  ChromaBackoffError,
+  ChromaConditionalWriteConflictError,
+  ChromaStaleReadError,
+  ChromaValueError,
+} from "./errors";
 import {
   CollectionConfiguration,
   processUpdateCollectionConfig,
@@ -49,6 +67,71 @@ import { SearchLike, SearchResult, toSearch } from "./execution";
 import { isPlainObject } from "./execution/expression/common";
 import { Schema, EMBEDDING_KEY, DOCUMENT_KEY } from "./schema";
 import type { SparseVectorIndexConfig } from "./schema";
+
+export type ConditionalCommitResult = ApiConditionalCommitResult;
+
+export type ConditionalTransactionRunOptions = {
+  /** Maximum number of retries for retryable OCC conflicts and stale reads. */
+  maxRetries?: number;
+};
+
+type CollectionGetArgs = Partial<{
+  ids?: string[];
+  where?: Where;
+  limit?: number;
+  offset?: number;
+  whereDocument?: WhereDocument;
+  include?: Include[];
+}>;
+
+type CollectionWriteArgs = {
+  /** Unique identifiers for the records */
+  ids: string[];
+  /** Optional pre-computed embeddings */
+  embeddings?: number[][];
+  /** Optional metadata for each record */
+  metadatas?: Metadata[];
+  /** Optional document text (will be embedded if embeddings not provided) */
+  documents?: string[];
+  /** Optional URIs for the records */
+  uris?: string[];
+};
+
+export interface ConditionalCollectionTransaction {
+  /**
+   * Reads records inside the transaction and captures the OCC snapshot.
+   */
+  get<TMeta extends Metadata = Metadata>(
+    args?: CollectionGetArgs,
+  ): Promise<GetResult<TMeta>>;
+  /**
+   * Buffers an add operation. Each ID must have been read as absent first.
+   */
+  add(args: CollectionWriteArgs): Promise<void>;
+  /**
+   * Buffers an update operation. Each ID must have been read as present first.
+   */
+  update(args: CollectionWriteArgs): Promise<void>;
+  /**
+   * Buffers an upsert operation.
+   */
+  upsert(args: CollectionWriteArgs): Promise<void>;
+  /**
+   * Buffers a delete operation. Each ID must have been read as present first.
+   */
+  delete(args: { ids: string[] }): Promise<void>;
+  /**
+   * Commits buffered writes.
+   */
+  commit(): Promise<ConditionalCommitResult>;
+  /**
+   * Runs a callback and commits if it succeeds, retrying retryable conflicts.
+   */
+  run<T>(
+    callback: (transaction: ConditionalCollectionTransaction) => T | Promise<T>,
+    options?: ConditionalTransactionRunOptions | number,
+  ): Promise<T>;
+}
 
 /**
  * Interface for collection operations using collection ID.
@@ -219,6 +302,10 @@ export interface Collection {
     /** Maximum number of records to delete. Can only be used with where or whereDocument filters. */
     limit?: number;
   }): Promise<DeleteResult>;
+  /**
+   * Starts a collection-scoped optimistic transaction.
+   */
+  conditional(): ConditionalCollectionTransaction;
   /**
    * Performs hybrid search on the collection using expression builders.
    * @param searches - Single search payload or array of payloads
@@ -671,7 +758,8 @@ export class CollectionImpl implements Collection {
     return defaultFunction ?? undefined;
   }
 
-  private async prepareRecords<T extends boolean = false>({
+  /** @internal */
+  public async prepareRecords<T extends boolean = false>({
     recordSet,
     update = false as T,
   }: {
@@ -711,7 +799,8 @@ export class CollectionImpl implements Collection {
       : PreparedInsertRecordSet;
   }
 
-  private validateGet(
+  /** @internal */
+  public validateGetRequest(
     include: Include[],
     ids?: string[],
     where?: Where,
@@ -841,7 +930,7 @@ export class CollectionImpl implements Collection {
       include = ["documents", "metadatas"],
     } = args;
 
-    this.validateGet(include, ids, where, whereDocument);
+    this.validateGetRequest(include, ids, where, whereDocument);
 
     const { data } = await RecordService.collectionGet({
       client: this.apiClient,
@@ -1148,6 +1237,36 @@ export class CollectionImpl implements Collection {
     return { deleted: data?.deleted ?? 0 };
   }
 
+  /** @internal */
+  public async conditionalGetRaw(
+    body: ConditionalGetRequestPayload,
+  ): Promise<ConditionalGetResponse> {
+    const { data } = await RecordService.collectionConditionalGet({
+      client: this.apiClient,
+      path: await this.path(),
+      body,
+    });
+
+    return data;
+  }
+
+  /** @internal */
+  public async conditionalCommitRaw(
+    body: ConditionalCommitPayload,
+  ): Promise<ConditionalCommitResult> {
+    const { data } = await RecordService.collectionConditionalCommit({
+      client: this.apiClient,
+      path: await this.path(),
+      body,
+    });
+
+    return data;
+  }
+
+  public conditional(): ConditionalCollectionTransaction {
+    return new ConditionalCollectionTransactionImpl(this);
+  }
+
   public async getIndexingStatus(): Promise<IndexingStatus> {
     const { data } = await RecordService.indexingStatus({
       client: this.apiClient,
@@ -1155,6 +1274,474 @@ export class CollectionImpl implements Collection {
     });
 
     return data;
+  }
+}
+
+const DEFAULT_CONDITIONAL_MAX_RETRIES = 3;
+
+const isRetryableConditionalError = (error: unknown): boolean => {
+  if (
+    error instanceof ChromaConditionalWriteConflictError ||
+    error instanceof ChromaStaleReadError ||
+    error instanceof ChromaBackoffError
+  ) {
+    return true;
+  }
+
+  const name = (error as { name?: unknown })?.name;
+  return (
+    name === "ConditionalWriteConflictError" ||
+    name === "StaleReadError" ||
+    name === "Backoff"
+  );
+};
+
+const conditionalMaxRetries = (
+  options?: ConditionalTransactionRunOptions | number,
+): number => {
+  const maxRetries =
+    typeof options === "number"
+      ? options
+      : options?.maxRetries ?? DEFAULT_CONDITIONAL_MAX_RETRIES;
+
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new ChromaValueError("maxRetries must be a non-negative integer");
+  }
+
+  return maxRetries;
+};
+
+class ConditionalCollectionTransactionImpl
+  implements ConditionalCollectionTransaction
+{
+  private readIds = new Set<string>();
+  private readToken: number | null = null;
+  private knownPresent = new Set<string>();
+  private knownAbsent = new Set<string>();
+  private bufferedWriteIds = new Set<string>();
+  private operations: ConditionalTransactionOperationPayload[] = [];
+  private closed = false;
+  private commitBlockedByRun = false;
+  private retryableOperationError: unknown;
+
+  constructor(private readonly collection: CollectionImpl) {}
+
+  public async get<TMeta extends Metadata = Metadata>(
+    args: CollectionGetArgs = {},
+  ): Promise<GetResult<TMeta>> {
+    const {
+      ids,
+      where,
+      limit,
+      offset,
+      whereDocument,
+      include = ["documents", "metadatas"],
+    } = args;
+
+    this.collection.validateGetRequest(include, ids, where, whereDocument);
+
+    const data = await this.runTransactionOperation(async () => {
+      const request = this.prepareGet({
+        ids,
+        where,
+        limit,
+        offset,
+        where_document: whereDocument,
+        include,
+      });
+      const response = await this.collection.conditionalGetRaw(request);
+      this.recordGet(request, response.ids, response.read_token);
+      return response;
+    });
+
+    const deserializedMetadatas = deserializeMetadatas(data.metadatas) ?? [];
+
+    return new GetResult<TMeta>({
+      documents: data.documents ?? [],
+      embeddings: data.embeddings ?? [],
+      ids: data.ids,
+      include: data.include,
+      metadatas: deserializedMetadatas as (TMeta | null)[],
+      uris: data.uris ?? [],
+    });
+  }
+
+  public async add({
+    ids,
+    embeddings,
+    metadatas,
+    documents,
+    uris,
+  }: CollectionWriteArgs): Promise<void> {
+    const preparedRecordSet = await this.collection.prepareRecords({
+      recordSet: {
+        ids,
+        embeddings,
+        documents,
+        metadatas,
+        uris,
+      },
+    });
+
+    this.bufferWrite("add", preparedRecordSet.ids, {
+      ids: preparedRecordSet.ids,
+      embeddings: preparedRecordSet.embeddings,
+      metadatas: serializeMetadatas(preparedRecordSet.metadatas),
+      documents: preparedRecordSet.documents,
+      uris: preparedRecordSet.uris,
+    });
+  }
+
+  public async update({
+    ids,
+    embeddings,
+    metadatas,
+    documents,
+    uris,
+  }: CollectionWriteArgs): Promise<void> {
+    const preparedRecordSet = await this.collection.prepareRecords({
+      recordSet: {
+        ids,
+        embeddings,
+        documents,
+        metadatas,
+        uris,
+      },
+      update: true,
+    });
+
+    this.bufferWrite("update", preparedRecordSet.ids, {
+      ids: preparedRecordSet.ids,
+      embeddings: preparedRecordSet.embeddings,
+      metadatas: serializeMetadatas(preparedRecordSet.metadatas),
+      documents: preparedRecordSet.documents,
+      uris: preparedRecordSet.uris,
+    });
+  }
+
+  public async upsert({
+    ids,
+    embeddings,
+    metadatas,
+    documents,
+    uris,
+  }: CollectionWriteArgs): Promise<void> {
+    const preparedRecordSet = await this.collection.prepareRecords({
+      recordSet: {
+        ids,
+        embeddings,
+        documents,
+        metadatas,
+        uris,
+      },
+    });
+
+    this.bufferWrite("upsert", preparedRecordSet.ids, {
+      ids: preparedRecordSet.ids,
+      embeddings: preparedRecordSet.embeddings,
+      metadatas: serializeMetadatas(preparedRecordSet.metadatas),
+      documents: preparedRecordSet.documents,
+      uris: preparedRecordSet.uris,
+    });
+  }
+
+  public async delete({ ids }: { ids: string[] }): Promise<void> {
+    this.ensureOpen();
+    validateIDs(ids);
+
+    this.bufferWrite("delete", ids, {
+      ids,
+      where: null,
+      where_document: null,
+      limit: null,
+    });
+  }
+
+  public async commit(): Promise<ConditionalCommitResult> {
+    if (this.commitBlockedByRun) {
+      throw new ChromaValueError("txn.commit() cannot be called inside run()");
+    }
+    return this.commitAfterRun();
+  }
+
+  public async run<T>(
+    callback: (transaction: ConditionalCollectionTransaction) => T | Promise<T>,
+    options?: ConditionalTransactionRunOptions | number,
+  ): Promise<T> {
+    const maxRetries = conditionalMaxRetries(options);
+
+    let attempt = 0;
+    while (true) {
+      const transaction = this.newAttempt(attempt);
+      transaction.commitBlockedByRun = true;
+
+      let value: T;
+      try {
+        value = await callback(transaction);
+      } catch (error) {
+        if (
+          transaction.retryableOperationError === error &&
+          attempt < maxRetries
+        ) {
+          attempt += 1;
+          continue;
+        }
+        throw error;
+      } finally {
+        transaction.commitBlockedByRun = false;
+      }
+
+      try {
+        await transaction.commitAfterRun();
+      } catch (error) {
+        if (isRetryableConditionalError(error) && attempt < maxRetries) {
+          attempt += 1;
+          continue;
+        }
+        throw error;
+      }
+
+      return value;
+    }
+  }
+
+  private async runTransactionOperation<T>(
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (isRetryableConditionalError(error)) {
+        this.retryableOperationError = error;
+      }
+      throw error;
+    }
+  }
+
+  private newAttempt(attempt: number): ConditionalCollectionTransactionImpl {
+    if (attempt === 0) {
+      return this;
+    }
+    return new ConditionalCollectionTransactionImpl(this.collection);
+  }
+
+  private async commitAfterRun(): Promise<ConditionalCommitResult> {
+    this.ensureOpen();
+
+    if (this.operations.length === 0) {
+      this.closed = true;
+      return {
+        first_inserted_record_offset: null,
+        record_count: 0,
+      };
+    }
+
+    const result = await this.runTransactionOperation(() =>
+      this.collection.conditionalCommitRaw({
+        read_token: this.readToken,
+        read_ids: [...this.readIds].sort(),
+        operations: [...this.operations],
+      }),
+    );
+    this.closed = true;
+    return result;
+  }
+
+  private prepareGet(
+    payload: Omit<ConditionalGetRequestPayload, "read_token">,
+  ): ConditionalGetRequestPayload {
+    this.ensureOpen();
+    const request = { ...payload, read_token: this.readToken };
+    this.validateGetRequest(request);
+    return request;
+  }
+
+  private recordGet(
+    request: ConditionalGetRequestPayload,
+    returnedIds: string[],
+    readToken: number,
+  ): void {
+    this.ensureOpen();
+    this.validateGetRequest(request);
+    this.validateReadToken(request.read_token ?? null, readToken);
+
+    const returnedIdSet = new Set(returnedIds);
+    for (const id of returnedIds) {
+      if (this.bufferedWriteIds.has(id)) {
+        throw this.invalidReadAfterWrite(id);
+      }
+    }
+
+    const requestIds = request.ids ?? undefined;
+    if (requestIds) {
+      for (const id of requestIds) {
+        this.readIds.add(id);
+      }
+      for (const id of returnedIds) {
+        this.readIds.add(id);
+        this.knownPresent.add(id);
+        this.knownAbsent.delete(id);
+      }
+      if (!request.where && !request.where_document) {
+        for (const id of requestIds) {
+          if (!returnedIdSet.has(id)) {
+            this.knownAbsent.add(id);
+            this.knownPresent.delete(id);
+          }
+        }
+      }
+    } else {
+      for (const id of returnedIds) {
+        this.readIds.add(id);
+        this.knownPresent.add(id);
+        this.knownAbsent.delete(id);
+      }
+    }
+
+    if (this.readToken === null) {
+      this.readToken = readToken;
+    }
+  }
+
+  private validateGetRequest(request: ConditionalGetRequestPayload): void {
+    const ids = request.ids ?? undefined;
+    if (ids) {
+      for (const id of ids) {
+        if (this.bufferedWriteIds.has(id)) {
+          throw this.invalidReadAfterWrite(id);
+        }
+      }
+      return;
+    }
+
+    const limit = request.limit ?? undefined;
+    if (!Number.isInteger(limit) || (limit as number) <= 0) {
+      throw new ChromaValueError(
+        "transactional filter reads require a positive limit",
+      );
+    }
+  }
+
+  private validateReadToken(
+    expectedReadToken: number | null,
+    actualReadToken: number | null | undefined,
+  ): void {
+    if (actualReadToken === null || actualReadToken === undefined) {
+      throw new ChromaValueError(
+        "transactional get response did not include an OCC read token",
+      );
+    }
+    if (!Number.isSafeInteger(actualReadToken) || actualReadToken < 0) {
+      throw new ChromaValueError(
+        `transactional read token offset ${actualReadToken} is not a safe integer`,
+      );
+    }
+    if (expectedReadToken !== null && expectedReadToken !== actualReadToken) {
+      throw new ChromaValueError(
+        "transactional read token changed from log upper bound offset " +
+          `${expectedReadToken} to ${actualReadToken}`,
+      );
+    }
+    if (this.readToken !== null && this.readToken !== actualReadToken) {
+      throw new ChromaValueError(
+        "transactional read token changed from log upper bound offset " +
+          `${this.readToken} to ${actualReadToken}`,
+      );
+    }
+  }
+
+  private bufferWrite(
+    operation: "add",
+    ids: string[],
+    payload: AddCollectionRecordsPayload,
+  ): void;
+  private bufferWrite(
+    operation: "update",
+    ids: string[],
+    payload: UpdateCollectionRecordsPayload,
+  ): void;
+  private bufferWrite(
+    operation: "upsert",
+    ids: string[],
+    payload: UpsertCollectionRecordsPayload,
+  ): void;
+  private bufferWrite(
+    operation: "delete",
+    ids: string[],
+    payload: DeleteCollectionRecordsPayload,
+  ): void;
+  private bufferWrite(
+    operation: ConditionalTransactionOperationPayload["operation"],
+    ids: string[],
+    payload:
+      | AddCollectionRecordsPayload
+      | UpdateCollectionRecordsPayload
+      | UpsertCollectionRecordsPayload
+      | DeleteCollectionRecordsPayload,
+  ): void {
+    this.ensureOpen();
+    this.validateBufferedWrite(operation, ids);
+    for (const id of ids) {
+      this.bufferedWriteIds.add(id);
+    }
+    this.operations.push({
+      operation,
+      payload,
+    } as ConditionalTransactionOperationPayload);
+  }
+
+  private validateBufferedWrite(
+    operation: ConditionalTransactionOperationPayload["operation"],
+    ids: string[],
+  ): void {
+    const callIds = new Set<string>();
+    for (const id of ids) {
+      if (callIds.has(id)) {
+        throw new ChromaValueError(
+          `transactional write request contains duplicate id "${id}"`,
+        );
+      }
+      callIds.add(id);
+      if (this.bufferedWriteIds.has(id)) {
+        throw new ChromaValueError(
+          `transaction already has a buffered write for id "${id}"`,
+        );
+      }
+      this.validateWritePrecondition(operation, id);
+    }
+  }
+
+  private validateWritePrecondition(
+    operation: ConditionalTransactionOperationPayload["operation"],
+    id: string,
+  ): void {
+    if (operation === "add" && !this.knownAbsent.has(id)) {
+      throw new ChromaValueError(
+        `transactional add for id "${id}" requires a prior read proving the id is absent`,
+      );
+    }
+    if (operation === "update" && !this.knownPresent.has(id)) {
+      throw new ChromaValueError(
+        `transactional update for id "${id}" requires a prior read proving the id is present`,
+      );
+    }
+    if (operation === "delete" && !this.knownPresent.has(id)) {
+      throw new ChromaValueError(
+        `transactional delete for id "${id}" requires a prior read proving the id is present`,
+      );
+    }
+  }
+
+  private ensureOpen(): void {
+    if (this.closed) {
+      throw new ChromaValueError("conditional transaction is closed");
+    }
+  }
+
+  private invalidReadAfterWrite(id: string): ChromaValueError {
+    return new ChromaValueError(
+      `cannot transactionally read id "${id}" after buffering a write for it`,
+    );
   }
 }
 
@@ -1190,7 +1777,13 @@ const HANDLE_NOT_SUPPORTED_ERROR =
  * function or schema. Obtained via {@link ChromaClient.collection}.
  */
 export class CollectionHandle extends CollectionImpl {
-  constructor({ chromaClient, apiClient, id, tenant, database }: CollectionHandleArgs) {
+  constructor({
+    chromaClient,
+    apiClient,
+    id,
+    tenant,
+    database,
+  }: CollectionHandleArgs) {
     super({
       chromaClient,
       apiClient,
@@ -1293,8 +1886,6 @@ export class CollectionHandle extends CollectionImpl {
       const knn = record.$knn as Record<string, unknown>;
       if (typeof knn.query === "string") return true;
     }
-    return Object.values(record).some((value) =>
-      this.hasStringKnnQuery(value),
-    );
+    return Object.values(record).some((value) => this.hasStringKnnQuery(value));
   }
 }

--- a/clients/new-js/packages/chromadb/src/errors.ts
+++ b/clients/new-js/packages/chromadb/src/errors.ts
@@ -99,12 +99,39 @@ export class ChromaRateLimitError extends Error {
   }
 }
 
+export class ChromaConditionalWriteConflictError extends Error {
+  name = "ConditionalWriteConflictError";
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+  }
+}
+
+export class ChromaStaleReadError extends Error {
+  name = "StaleReadError";
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+  }
+}
+
+export class ChromaBackoffError extends Error {
+  name = "Backoff";
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+  }
+}
+
 export function createErrorByType(type: string, message: string) {
   switch (type) {
     case "InvalidCollection":
       return new InvalidCollectionError(message);
     case "InvalidArgumentError":
       return new InvalidArgumentError(message);
+    case "ConditionalWriteConflictError":
+      return new ChromaConditionalWriteConflictError(message);
+    case "StaleReadError":
+      return new ChromaStaleReadError(message);
+    case "Backoff":
+      return new ChromaBackoffError(message);
     default:
       return undefined;
   }

--- a/clients/new-js/packages/chromadb/src/index.ts
+++ b/clients/new-js/packages/chromadb/src/index.ts
@@ -6,7 +6,13 @@
 // Apply Deno compatibility patch
 import "./deno";
 
-export { Collection, CollectionHandle } from "./collection";
+export { CollectionHandle } from "./collection";
+export type {
+  Collection,
+  ConditionalCollectionTransaction,
+  ConditionalCommitResult,
+  ConditionalTransactionRunOptions,
+} from "./collection";
 export { withChroma } from "./next";
 export * from "./types";
 export * from "./admin-client";

--- a/clients/new-js/packages/chromadb/test/conditional-transaction.test.ts
+++ b/clients/new-js/packages/chromadb/test/conditional-transaction.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { chromaFetch } from "../src/chroma-fetch";
+import { CollectionImpl } from "../src/collection";
+import { RecordService } from "../src/api";
+import {
+  ChromaBackoffError,
+  ChromaConditionalWriteConflictError,
+  ChromaStaleReadError,
+} from "../src/errors";
+
+const collection = () =>
+  new CollectionImpl({
+    chromaClient: {
+      getMaxBatchSize: jest.fn(async () => 100),
+      supportsBase64Encoding: jest.fn(async () => false),
+    } as any,
+    apiClient: {} as any,
+    id: "00000000-0000-0000-0000-000000000001",
+    tenant: "tenant",
+    database: "database",
+    name: "test",
+    configuration: {},
+  });
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("conditional collection transactions", () => {
+  test("tracks point reads and commits buffered adds", async () => {
+    const getSpy = jest
+      .spyOn(RecordService, "collectionConditionalGet")
+      .mockResolvedValue({
+        data: {
+          ids: ["present"],
+          documents: ["present document"],
+          include: ["documents"],
+          read_token: 42,
+        },
+      } as any);
+    const commitSpy = jest
+      .spyOn(RecordService, "collectionConditionalCommit")
+      .mockResolvedValue({
+        data: {
+          first_inserted_record_offset: 7,
+          record_count: 1,
+        },
+      } as any);
+
+    const transaction = collection().conditional();
+    const result = await transaction.get({
+      ids: ["present", "absent"],
+      include: ["documents"],
+    });
+    await transaction.add({ ids: ["absent"], embeddings: [[1, 2, 3]] });
+    const committed = await transaction.commit();
+
+    expect(result.ids).toEqual(["present"]);
+    expect(result.documents).toEqual(["present document"]);
+    expect(committed).toEqual({
+      first_inserted_record_offset: 7,
+      record_count: 1,
+    });
+    expect(getSpy.mock.calls[0][0]).toMatchObject({
+      path: {
+        tenant: "tenant",
+        database: "database",
+        collection_id: "00000000-0000-0000-0000-000000000001",
+      },
+      body: {
+        ids: ["present", "absent"],
+        include: ["documents"],
+        read_token: null,
+      },
+    });
+    expect(commitSpy.mock.calls[0][0]).toMatchObject({
+      body: {
+        read_token: 42,
+        read_ids: ["absent", "present"],
+        operations: [
+          {
+            operation: "add",
+            payload: {
+              ids: ["absent"],
+              embeddings: [[1, 2, 3]],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  test("commits write-only upserts without a read token", async () => {
+    const commitSpy = jest
+      .spyOn(RecordService, "collectionConditionalCommit")
+      .mockResolvedValue({
+        data: {
+          first_inserted_record_offset: 11,
+          record_count: 1,
+        },
+      } as any);
+
+    const transaction = collection().conditional();
+    await transaction.upsert({ ids: ["unknown"], embeddings: [[1]] });
+    await transaction.commit();
+
+    expect(commitSpy.mock.calls[0][0]).toMatchObject({
+      body: {
+        read_token: null,
+        read_ids: [],
+        operations: [
+          {
+            operation: "upsert",
+            payload: {
+              ids: ["unknown"],
+              embeddings: [[1]],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  test("rejects writes that do not satisfy transaction preconditions", async () => {
+    const transaction = collection().conditional();
+
+    await expect(
+      transaction.add({ ids: ["id"], embeddings: [[1]] }),
+    ).rejects.toThrow(
+      'transactional add for id "id" requires a prior read proving the id is absent',
+    );
+  });
+
+  test("rejects reads after a buffered write for the same id", async () => {
+    const getSpy = jest.spyOn(RecordService, "collectionConditionalGet");
+    const transaction = collection().conditional();
+
+    await transaction.upsert({ ids: ["id"], embeddings: [[1]] });
+
+    await expect(transaction.get({ ids: ["id"] })).rejects.toThrow(
+      'cannot transactionally read id "id" after buffering a write for it',
+    );
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  test("requires positive limits for transactional filter reads", async () => {
+    const transaction = collection().conditional();
+
+    await expect(transaction.get({ where: { tag: "value" } })).rejects.toThrow(
+      "transactional filter reads require a positive limit",
+    );
+  });
+
+  test("run retries commit conflicts with fresh transactions", async () => {
+    const commitSpy = jest
+      .spyOn(RecordService, "collectionConditionalCommit")
+      .mockRejectedValueOnce(
+        new ChromaConditionalWriteConflictError("conditional write conflict"),
+      )
+      .mockResolvedValueOnce({
+        data: {
+          first_inserted_record_offset: 12,
+          record_count: 1,
+        },
+      } as any);
+
+    let attempts = 0;
+    const result = await collection()
+      .conditional()
+      .run(
+        async (transaction) => {
+          attempts += 1;
+          await transaction.upsert({
+            ids: [`id-${attempts}`],
+            embeddings: [[attempts]],
+          });
+          return `attempt-${attempts}`;
+        },
+        { maxRetries: 1 },
+      );
+
+    expect(result).toBe("attempt-2");
+    expect(attempts).toBe(2);
+    expect(commitSpy).toHaveBeenCalledTimes(2);
+    expect(
+      (commitSpy.mock.calls[0][0] as any).body.operations[0].payload.ids,
+    ).toEqual(["id-1"]);
+    expect(
+      (commitSpy.mock.calls[1][0] as any).body.operations[0].payload.ids,
+    ).toEqual(["id-2"]);
+  });
+
+  test("run retries stale reads from transaction operations only", async () => {
+    const getSpy = jest
+      .spyOn(RecordService, "collectionConditionalGet")
+      .mockRejectedValueOnce(new ChromaStaleReadError("stale read"))
+      .mockResolvedValueOnce({
+        data: {
+          ids: ["id"],
+          documents: ["document"],
+          include: ["documents"],
+          read_token: 43,
+        },
+      } as any);
+    const commitSpy = jest.spyOn(RecordService, "collectionConditionalCommit");
+
+    const result = await collection()
+      .conditional()
+      .run(
+        async (transaction) => {
+          const got = await transaction.get({
+            ids: ["id"],
+            include: ["documents"],
+          });
+          return got.ids[0];
+        },
+        { maxRetries: 1 },
+      );
+
+    expect(result).toBe("id");
+    expect(getSpy).toHaveBeenCalledTimes(2);
+    expect(commitSpy).not.toHaveBeenCalled();
+  });
+
+  test("run does not retry user-raised retryable errors", async () => {
+    let attempts = 0;
+
+    await expect(
+      collection()
+        .conditional()
+        .run(
+          () => {
+            attempts += 1;
+            throw new ChromaConditionalWriteConflictError(
+              "user-raised conflict",
+            );
+          },
+          { maxRetries: 1 },
+        ),
+    ).rejects.toThrow("user-raised conflict");
+
+    expect(attempts).toBe(1);
+  });
+
+  test("run rejects explicit commits inside callbacks", async () => {
+    await expect(
+      collection()
+        .conditional()
+        .run(async (transaction) => {
+          await transaction.commit();
+        }),
+    ).rejects.toThrow("txn.commit() cannot be called inside run()");
+  });
+});
+
+describe("conditional transaction errors", () => {
+  test("maps conditional write conflict responses", async () => {
+    jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "ConditionalWriteConflictError",
+          message: "conditional write conflict",
+        }),
+        { status: 409 },
+      ),
+    );
+
+    await expect(chromaFetch("http://localhost")).rejects.toThrow(
+      ChromaConditionalWriteConflictError,
+    );
+  });
+
+  test("maps stale read responses", async () => {
+    jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "StaleReadError",
+          message: "read token is too old",
+        }),
+        { status: 412 },
+      ),
+    );
+
+    await expect(chromaFetch("http://localhost")).rejects.toThrow(
+      ChromaStaleReadError,
+    );
+  });
+
+  test("maps backoff responses", async () => {
+    jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "Backoff",
+          message: "Backoff and retry",
+        }),
+        { status: 429 },
+      ),
+    );
+
+    await expect(chromaFetch("http://localhost")).rejects.toThrow(
+      ChromaBackoffError,
+    );
+  });
+});


### PR DESCRIPTION
## Description of changes

Introduce collection-scoped optimistic concurrency (OCC) transactions
via `collection.conditional()`. A transaction reads records to capture
an OCC snapshot, buffers add/update/upsert/delete operations, and
commits them atomically against the captured read token.

Client-side preconditions are enforced before commit: adds require a
prior read proving the id absent, updates and deletes require a prior
read proving the id present, and reads after a buffered write for the
same id are rejected. `run()` executes a callback and commits, retrying
retryable conflicts up to a configurable limit.

Map the relevant HTTP responses to typed errors in chroma-fetch: 409
ConditionalWriteConflictError, 412 StaleReadError, and 429 Backoff, with
matching error classes exported from errors.ts and registered in
createErrorByType.

Export the Collection interface and conditional transaction types, and
add an example plus tests covering the new API.

## Test plan

I ran the included demo and rely on CI for (mocked) unit tests.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
