### PR TITLE
TST: use idiomatic Jest assertions in get.collection.test.ts

### DIFF
--- a/clients/js/packages/chromadb-core/test/get.collection.test.ts
+++ b/clients/js/packages/chromadb-core/test/get.collection.test.ts
@@ -44,18 +44,14 @@ describe("get collections", () => {
       embeddings: EMBEDDINGS,
       metadatas: METADATAS,
     });
-    try {
-      await collection.get({
+    await expect(
+      collection.get({
         where: {
           //@ts-ignore supposed to fail
           test: { $contains: "hello" },
         },
-      });
-    } catch (error: any) {
-      expect(error).toBeDefined();
-      expect(error).toBeInstanceOf(InvalidArgumentError);
-      expect(error.message).toMatchInlineSnapshot(`"Invalid where clause"`);
-    }
+      }),
+    ).rejects.toThrow(InvalidArgumentError);
   });
 
   test("it should get embedding with matching documents", async () => {


### PR DESCRIPTION
## Description of changes
Converted non-idiomatic try/catch block to idiomatic Jest assertions in `get.collection.test.ts`.

- Improvements & Bug fixes
  - Replaced manual try/catch block with `expect().rejects.toThrow(InvalidArgumentError)` in the "wrong code returns an error" test

## Test plan
- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

This change is test-only and does not affect correctness — only improves readability and idiomaticity of Jest tests as requested in #2801.

## Migration plan
No migrations needed. This is a test-only change.

## Observability plan
No observability changes needed. This is a test-only change.

## Documentation Changes
No documentation changes needed. This is a test-only change.