### PR TITLE
[DOC] Fix parameter names in AdminAPI docstrings

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -582,7 +582,7 @@ class AdminAPI(ABC):
         """Create a new database. Raises an error if the database already exists.
 
         Args:
-            database: The name of the database to create.
+            name: The name of the database to create.
 
         """
         pass
@@ -592,7 +592,7 @@ class AdminAPI(ABC):
         """Get a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to get.
+            name: The name of the database to get.
             tenant: The tenant of the database to get.
 
         """
@@ -603,7 +603,7 @@ class AdminAPI(ABC):
         """Delete a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to delete.
+            name: The name of the database to delete.
             tenant: The tenant of the database to delete.
 
         """
@@ -629,7 +629,7 @@ class AdminAPI(ABC):
         """Create a new tenant. Raises an error if the tenant already exists.
 
         Args:
-            tenant: The name of the tenant to create.
+            name: The name of the tenant to create.
 
         """
         pass
@@ -639,7 +639,7 @@ class AdminAPI(ABC):
         """Get a tenant. Raises an error if the tenant does not exist.
 
         Args:
-            tenant: The name of the tenant to get.
+            name: The name of the tenant to get.
 
         """
         pass

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -534,7 +534,7 @@ class AsyncAdminAPI(ABC):
         """Create a new database. Raises an error if the database already exists.
 
         Args:
-            database: The name of the database to create.
+            name: The name of the database to create.
 
         """
         pass
@@ -544,7 +544,7 @@ class AsyncAdminAPI(ABC):
         """Get a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to get.
+            name: The name of the database to get.
             tenant: The tenant of the database to get.
 
         """
@@ -555,7 +555,7 @@ class AsyncAdminAPI(ABC):
         """Delete a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to delete.
+            name: The name of the database to delete.
             tenant: The tenant of the database to delete.
 
         """
@@ -581,7 +581,7 @@ class AsyncAdminAPI(ABC):
         """Create a new tenant. Raises an error if the tenant already exists.
 
         Args:
-            tenant: The name of the tenant to create.
+            name: The name of the tenant to create.
 
         """
         pass
@@ -591,7 +591,7 @@ class AsyncAdminAPI(ABC):
         """Get a tenant. Raises an error if the tenant does not exist.
 
         Args:
-            tenant: The name of the tenant to get.
+            name: The name of the tenant to get.
 
         """
         pass


### PR DESCRIPTION
## Description of changes

The `AdminAPI` methods `create_database`, `get_database`, `delete_database`, `create_tenant`, and `get_tenant` all take a `name` parameter, but their docstrings document it as `database` or `tenant`. This fixes the parameter names in both the sync (`chromadb/api/__init__.py`) and async (`chromadb/api/async_api.py`) interfaces. The correct `tenant:` entries (where `tenant` is a real parameter) are left unchanged.

Doc-only change; no behavior modified.

## Test plan

N/A - docstring-only edits, verified against the method signatures.

## Documentation Changes

These docstrings are the API documentation; no separate docs changes required.