### PR TITLE
[BUG](python): Fix async heartbeat endpoint

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -171,7 +171,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @trace_method("AsyncFastAPI.heartbeat", OpenTelemetryGranularity.OPERATION)
     @override
     async def heartbeat(self) -> int:
-        response = await self._make_request("get", "")
+        response = await self._make_request("get", "/heartbeat")
         return int(response["nanosecond heartbeat"])
 
     @trace_method("AsyncFastAPI.create_database", OpenTelemetryGranularity.OPERATION)

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -5,6 +5,7 @@ import chromadb
 from chromadb.config import Settings, System
 from chromadb.api import ClientAPI
 import chromadb.server.fastapi
+from chromadb.api.async_fastapi import AsyncFastAPI
 from chromadb.api.fastapi import FastAPI
 import pytest
 import tempfile
@@ -151,6 +152,25 @@ def test_fastapi_uses_http_limits_from_settings() -> None:
     assert limits.max_keepalive_connections == 16
     assert captured["timeout"] is None
     assert captured["verify"] is True
+
+
+@pytest.mark.asyncio
+async def test_async_fastapi_heartbeat_uses_heartbeat_endpoint() -> None:
+    settings = Settings(
+        chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=8000,
+    )
+    system = System(settings)
+    client = AsyncFastAPI(system)
+
+    async def mock_make_request(method: str, path: str) -> Dict[str, int]:
+        assert method == "get"
+        assert path == "/heartbeat"
+        return {"nanosecond heartbeat": 1234567890}
+
+    with patch.object(client, "_make_request", mock_make_request):
+        assert await client.heartbeat() == 1234567890
 
 
 def test_persistent_client_close() -> None:


### PR DESCRIPTION
﻿## Description of changes

### What Problem This Solves

`AsyncFastAPI.heartbeat()` exposes the same public health-check method as the sync `FastAPI.heartbeat()` client, but it was delegating to `_make_request("get", "")`.

`_make_request()` appends the provided path to the already-resolved API base URL. Passing an empty string therefore keeps the async heartbeat request at the API root for the configured API prefix:

```text
GET <api_base_url>
```

The server heartbeat contract is a dedicated route, and the sync client already targets that route:

```python
resp_json = self._make_request("get", "/heartbeat")
```

That left the two Python HTTP clients with the same public method and the same expected response shape, but different request targets:

```text
sync heartbeat : GET <api_base_url>/heartbeat
async heartbeat: GET <api_base_url>
```

This matters because `heartbeat()` is an API contract check: callers use it to confirm that the server is reachable and returning the `"nanosecond heartbeat"` payload. The async implementation still parsed `response["nanosecond heartbeat"]` and returned it as an `int`, but it was asking the API root for that endpoint-specific payload.

This PR aligns the async client with the sync client and server route contract by changing only the delegated request path from `""` to `"/heartbeat"`. The public API remains unchanged, and the fix does not alter response parsing, authentication, server routes, collection APIs, persisted data, or sync client behavior.
### Changes

- Updates `AsyncFastAPI.heartbeat()` to call `_make_request("get", "/heartbeat")`.
- Preserves the existing response parsing behavior by continuing to return `int(response["nanosecond heartbeat"])`.
- Adds `test_async_fastapi_heartbeat_uses_heartbeat_endpoint` to verify that the async heartbeat method:
  - uses HTTP `get`;
  - delegates to `/heartbeat`;
  - returns the `nanosecond heartbeat` value from the response.
- Links the fix to the existing issue with `Fixes #6870`.

### Evidence

The production change is intentionally narrow: one request path in `chromadb/api/async_fastapi.py` changes from the empty path to the dedicated heartbeat endpoint.

```text
before: _make_request("get", "")
after : _make_request("get", "/heartbeat")
```

The added async unit test patches `_make_request`, asserts the delegated method and path, and verifies that `heartbeat()` returns the integer value from the mocked heartbeat response.

Focused validation run locally:

```powershell
D:\ZXY\Dev\Miniforge3\condabin\mamba.bat run -n prw-chroma-py312 python -m pytest chromadb\test\test_client.py::test_async_fastapi_heartbeat_uses_heartbeat_endpoint -q
```

Result:

```text
1 passed in 0.03s
```

Sibling HTTP client test run locally:

```powershell
D:\ZXY\Dev\Miniforge3\condabin\mamba.bat run -n prw-chroma-py312 python -m pytest chromadb\test\test_client.py::test_fastapi_uses_http_limits_from_settings -q
```

Result:

```text
1 passed in 0.02s
```

Also run:

```powershell
git diff --check
```

Result: passed.

### Possible call chain / impact

```text
AsyncHttpClient(...).heartbeat()
-> AsyncClient.heartbeat()
-> AsyncFastAPI.heartbeat()
-> _make_request("get", "/heartbeat")
-> returns response["nanosecond heartbeat"] as int
```

The impact is limited to the async Python heartbeat request path. This PR does not change persisted data, server schemas, authentication, collection APIs, response parsing, or sync client behavior.
## Test plan

_How are these changes tested?_

- [x] Focused Python tests pass locally
- [x] `git diff --check`
- [x] Full `yarn test` / package Jest suite not run locally

Focused validation run locally:

```powershell
D:\ZXY\Dev\Miniforge3\condabin\mamba.bat run -n prw-chroma-py312 python -m pytest chromadb\test\test_client.py::test_async_fastapi_heartbeat_uses_heartbeat_endpoint -q
```

Result:

```text
1 passed in 0.03s
```

Sibling HTTP client test run locally:

```powershell
D:\ZXY\Dev\Miniforge3\condabin\mamba.bat run -n prw-chroma-py312 python -m pytest chromadb\test\test_client.py::test_fastapi_uses_http_limits_from_settings -q
```

Result:

```text
1 passed in 0.02s
```

Also run:

```powershell
git diff --check
```

Result: passed.

The full `yarn test` / package Jest suite was not run locally. This PR changes only the Python async heartbeat endpoint path; the local validation above covers the touched Python client behavior and a sibling HTTP client test.
## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

No migration is required.

This is a client-side endpoint correction for the async heartbeat method. It does not change persisted data, server schemas, auth behavior, collection APIs, or sync client behavior.

## Observability plan

_What is the plan to instrument and monitor this change?_

No new instrumentation is required.

The affected behavior is directly observable through `AsyncHttpClient(...).heartbeat()`: it now requests the dedicated `/heartbeat` endpoint and returns the server heartbeat value from that response.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

No documentation changes are required.

The public heartbeat API remains the same; this PR only fixes the async client's internal endpoint path.




