### PR TITLE
[BUG](js): Preserve default path port

### DIFF
--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -107,7 +107,7 @@ export class ChromaClient {
       const parsedPath = parseConnectionPath(args.path);
       ssl = parsedPath.ssl;
       host = parsedPath.host;
-      port = parsedPath.port;
+      port = parsedPath.port ?? port;
     }
 
     if (args.auth) {

--- a/clients/new-js/packages/chromadb/src/utils.ts
+++ b/clients/new-js/packages/chromadb/src/utils.ts
@@ -763,11 +763,18 @@ export const validateNResults = (nResults: number) => {
 
 export const parseConnectionPath = (path: string) => {
   try {
+    const explicitPort = path.match(
+      /^[a-z][a-z\d+.-]*:\/\/(?:[^@/?#]*@)?(?:\[[^\]]+\]|[^:/?#]+):(\d+)(?=[/?#]|$)/i,
+    )?.[1];
     const url = new URL(path);
 
     const ssl = url.protocol === "https:";
     const host = url.hostname;
-    const port = url.port ? Number(url.port) : undefined;
+    const port = explicitPort
+      ? Number(explicitPort)
+      : url.port
+      ? Number(url.port)
+      : undefined;
 
     return {
       ssl,

--- a/clients/new-js/packages/chromadb/src/utils.ts
+++ b/clients/new-js/packages/chromadb/src/utils.ts
@@ -767,12 +767,12 @@ export const parseConnectionPath = (path: string) => {
 
     const ssl = url.protocol === "https:";
     const host = url.hostname;
-    const port = url.port;
+    const port = url.port ? Number(url.port) : undefined;
 
     return {
       ssl,
       host,
-      port: Number(port),
+      port,
     };
   } catch {
     throw new ChromaValueError(`Invalid URL: ${path}`);

--- a/clients/new-js/packages/chromadb/test/offline.test.ts
+++ b/clients/new-js/packages/chromadb/test/offline.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@jest/globals";
 import { ChromaClient } from "../src";
+import { parseConnectionPath } from "../src/utils";
 
 test("it fails with a nice error when offline", async () => {
   const chroma = new ChromaClient({ host: "example.invalid" });
@@ -11,4 +12,26 @@ test("it fails with a nice error when offline", async () => {
       `"Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable."`,
     );
   }
+});
+
+test("deprecated path parsing preserves the default client port when no port is provided", () => {
+  expect(parseConnectionPath("http://localhost")).toEqual({
+    ssl: false,
+    host: "localhost",
+    port: undefined,
+  });
+
+  expect(parseConnectionPath("https://api.trychroma.com")).toEqual({
+    ssl: true,
+    host: "api.trychroma.com",
+    port: undefined,
+  });
+});
+
+test("deprecated path parsing keeps explicit custom ports", () => {
+  expect(parseConnectionPath("http://localhost:8001")).toEqual({
+    ssl: false,
+    host: "localhost",
+    port: 8001,
+  });
 });

--- a/clients/new-js/packages/chromadb/test/offline.test.ts
+++ b/clients/new-js/packages/chromadb/test/offline.test.ts
@@ -28,10 +28,44 @@ test("deprecated path parsing preserves the default client port when no port is 
   });
 });
 
-test("deprecated path parsing keeps explicit custom ports", () => {
+test("deprecated path parsing keeps explicit ports", () => {
+  expect(parseConnectionPath("http://localhost:80")).toEqual({
+    ssl: false,
+    host: "localhost",
+    port: 80,
+  });
+
+  expect(parseConnectionPath("https://api.trychroma.com:443")).toEqual({
+    ssl: true,
+    host: "api.trychroma.com",
+    port: 443,
+  });
+
   expect(parseConnectionPath("http://localhost:8001")).toEqual({
     ssl: false,
     host: "localhost",
     port: 8001,
   });
+});
+
+test("deprecated path client keeps the default port when the path omits a port", () => {
+  const chroma = new ChromaClient({ path: "http://localhost" });
+
+  expect((chroma as any).apiClient.getConfig().baseUrl).toBe(
+    "http://localhost:8000",
+  );
+});
+
+test("deprecated path client keeps explicit default ports", () => {
+  const httpClient = new ChromaClient({ path: "http://localhost:80" });
+  const httpsClient = new ChromaClient({
+    path: "https://api.trychroma.com:443",
+  });
+
+  expect((httpClient as any).apiClient.getConfig().baseUrl).toBe(
+    "http://localhost:80",
+  );
+  expect((httpsClient as any).apiClient.getConfig().baseUrl).toBe(
+    "https://api.trychroma.com:443",
+  );
 });


### PR DESCRIPTION
﻿## Description of changes

### What Problem This Solves

The deprecated JS client `path` compatibility path could turn URLs without an explicit port into port `0`, and a checklist pass also found that explicit scheme-default ports such as `:80` and `:443` needed direct coverage.

`ChromaClient({ path })` still maps the parsed `path` into `ssl`, `host`, and `port`:

```ts
const parsedPath = parseConnectionPath(args.path);
ssl = parsedPath.ssl;
host = parsedPath.host;
port = parsedPath.port;
```

Before this PR, `parseConnectionPath()` converted `url.port` with `Number(port)`. For URLs such as `http://localhost` or `https://api.trychroma.com`, JavaScript exposes `url.port` as an empty string when no explicit port is present:

```ts
new URL("http://localhost").port          // ""
new URL("https://api.trychroma.com").port // ""
```

`Number("")` becomes `0`, so the deprecated path flow could produce client configuration equivalent to `http://localhost:0` or `https://api.trychroma.com:0` instead of preserving the client default port.

A reviewer-checklist pass found a related compatibility edge: WHATWG `URL` also normalizes explicit scheme-default ports away:

```ts
new URL("http://localhost:80").port          // ""
new URL("https://api.trychroma.com:443").port // ""
```

So relying only on `url.port` would preserve omitted-port URLs, but would lose explicitly supplied default ports.

### Changes

- Updates `parseConnectionPath()` so URLs without an explicit port return `port: undefined` instead of `port: 0`.
- Preserves explicitly supplied ports before WHATWG `URL` normalization can erase scheme-default ports such as `:80` and `:443`.
- Updates `ChromaClient` so the deprecated `path` flow keeps the existing default client port when `parsedPath.port` is `undefined`.
- Keeps explicit custom ports working, for example `http://localhost:8001` still parses to `port: 8001`.
- Adds constructor-level no-network tests for the final `baseUrl`, not only the parser return value.
- Leaves the preferred `host`, `port`, and `ssl` constructor options unchanged.

### Evidence

The parser now captures an explicit port from the raw input before constructing `URL`, then falls back to `url.port` only when no raw explicit port was present:

```ts
const explicitPort = path.match(
  /^[a-z][a-z\d+.-]*:\/\/(?:[^@/?#]*@)?(?:\[[^\]]+\]|[^:/?#]+):(\d+)(?=[/?#]|$)/i,
)?.[1];
```

The deprecated `path` assignment still falls back to the existing client default when the parsed URL omitted a port:

```ts
port = parsedPath.port ?? port;
```

A focused local `tsx` validation covered parser output and final `ChromaClient` `baseUrl` construction:

```ts
parseConnectionPath("http://localhost")
// { ssl: false, host: "localhost", port: undefined }

parseConnectionPath("https://api.trychroma.com")
// { ssl: true, host: "api.trychroma.com", port: undefined }

parseConnectionPath("http://localhost:80")
// { ssl: false, host: "localhost", port: 80 }

parseConnectionPath("https://api.trychroma.com:443")
// { ssl: true, host: "api.trychroma.com", port: 443 }

parseConnectionPath("http://localhost:8001")
// { ssl: false, host: "localhost", port: 8001 }

new ChromaClient({ path: "http://localhost" })
// baseUrl: "http://localhost:8000"

new ChromaClient({ path: "http://localhost:80" })
// baseUrl: "http://localhost:80"

new ChromaClient({ path: "https://api.trychroma.com:443" })
// baseUrl: "https://api.trychroma.com:443"
```

Focused validation result:

```text
path parser and ChromaClient baseUrl focused verification passed
```

Additional validation:

```powershell
D:\ZXY\Github\chroma\clients\new-js\packages\chromadb\node_modules\.bin\tsx.cmd C:\Users\MiaoXing\AppData\Local\Temp\verify-chroma-client-path-baseurl.mts
D:\ZXY\Github\chroma\clients\new-js\packages\chromadb\node_modules\.bin\prettier.cmd --check src\utils.ts test\offline.test.ts
git diff --check
```

Results:

```text
path parser and ChromaClient baseUrl focused verification passed
All matched files use Prettier code style!
git diff --check passed
```

A focused Jest regression test was added in `clients/new-js/packages/chromadb/test/offline.test.ts` for no-port URLs, explicit default ports, explicit custom ports, and constructor `baseUrl` behavior. Running the Jest file directly in this local Windows checkout was not completed because the package `globalSetup` attempts to build the Rust binary and `cargo` is not available locally:

```text
?? Building Rust binary...
'cargo' is not recognized as an internal or external command,
operable program or batch file.
Error building Rust binary: Error: Command failed: cargo build --bin chroma
```

CI should run this Jest test in the repository's normal JS test environment.

### Possible call chain / impact

```text
new ChromaClient({ path: "http://localhost" })
-> ChromaClient constructor calls parseConnectionPath(args.path)
-> parseConnectionPath reads URL protocol, hostname, and optional port
-> omitted port returns undefined
-> ChromaClient keeps its existing default port via parsedPath.port ?? port
```

```text
new ChromaClient({ path: "http://localhost:80" })
-> ChromaClient constructor calls parseConnectionPath(args.path)
-> parseConnectionPath captures the raw explicit port before URL normalization
-> parsedPath.port is 80
-> ChromaClient uses the explicitly supplied port
```

This PR affects only the deprecated `path` compatibility path. Users configuring the client with the preferred `host`, `port`, and `ssl` options are not affected. Explicit ports supplied through `path` remain supported, including scheme-default ports such as `:80` and `:443`.
## Test plan

_How are these changes tested?_

- [x] Focused local validation for the JS path parsing and constructor `baseUrl` behavior
- [x] Focused Prettier check on modified JS files
- [x] `git diff --check`
- [x] Full `yarn test` / package Jest suite not run locally

Focused validation run locally with `tsx`:

```powershell
D:\ZXY\Github\chroma\clients\new-js\packages\chromadb\node_modules\.bin\tsx.cmd C:\Users\MiaoXing\AppData\Local\Temp\verify-chroma-client-path-baseurl.mts
```

The script covered these parser cases:

```ts
parseConnectionPath("http://localhost")
// { ssl: false, host: "localhost", port: undefined }

parseConnectionPath("https://api.trychroma.com")
// { ssl: true, host: "api.trychroma.com", port: undefined }

parseConnectionPath("http://localhost:80")
// { ssl: false, host: "localhost", port: 80 }

parseConnectionPath("https://api.trychroma.com:443")
// { ssl: true, host: "api.trychroma.com", port: 443 }

parseConnectionPath("http://localhost:8001")
// { ssl: false, host: "localhost", port: 8001 }
```

It also covered final client `baseUrl` behavior for omitted ports, explicit scheme-default ports, and explicit custom ports.

Result:

```text
path parser and ChromaClient baseUrl focused verification passed
```

Also run:

```powershell
D:\ZXY\Github\chroma\clients\new-js\packages\chromadb\node_modules\.bin\prettier.cmd --check src\utils.ts test\offline.test.ts
git diff --check
```

Results:

```text
All matched files use Prettier code style!
git diff --check passed
```

I also added focused Jest tests in `clients/new-js/packages/chromadb/test/offline.test.ts`. Running that Jest file directly in this local Windows checkout starts the package `globalSetup`, which attempts to build the Rust binary and fails because `cargo` is not available locally:

```text
?? Building Rust binary...
'cargo' is not recognized as an internal or external command,
operable program or batch file.
Error building Rust binary: Error: Command failed: cargo build --bin chroma
```

CI should run this in the repository's normal JS test environment.
## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

No migration is required.

This only affects the deprecated `path` compatibility path. Users configuring the client through the preferred `host`, `port`, and `ssl` options are unaffected. Explicit ports in `path` remain supported.

## Observability plan

_What is the plan to instrument and monitor this change?_

No new instrumentation is required.

The behavior is observable from the client base URL produced by deprecated `path` input: URLs without explicit ports no longer route through `:0`.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

No documentation changes are required.

The `path` argument is already marked deprecated. This PR preserves backward-compatible behavior for users still relying on it without changing the recommended constructor options.


