### PR TITLE
[BLD] ban relative imports via flake8-tidy-imports (#2334)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,11 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-tidy-imports]
         args:
-          - "--extend-ignore=E203,E501,E503"
+          - "--extend-ignore=E203,E501,E503,I250"
           - "--max-line-length=88"
+          - "--ban-relative-imports=true"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -8,7 +8,7 @@ It can be used to get information about available schemas and their versions.
 from typing import Dict, List, Set
 import os
 import json
-from .schema_utils import SCHEMAS_DIR
+from chromadb.utils.embedding_functions.schemas.schema_utils import SCHEMAS_DIR
 
 
 def get_available_schemas() -> List[str]:


### PR DESCRIPTION
## Description of changes

Fixes #2334.

- Fixed the last relative import in the codebase, in chromadb/utils/embedding_functions/schemas/registry.py
- Added flake8-tidy-imports to the flake8 pre-commit hook with --ban-relative-imports=true, so this doesn't creep back in
- Also ignored I250 (import aliasing) since that's a separate style rule, not what this issue is about

## Test plan

- Ran pre-commit run flake8 --files chromadb/utils/embedding_functions/schemas/registry.py, passes
- Grepped the repo for other `from .` / `from ..` imports, this was the only one left

## Migration plan

None, lint only, no behavior change.

## Observability plan

N/A

## Documentation Changes

N/A, no public API changed.