### PR TITLE
[BUG] Reject NUL bytes in documents to protect the FTS5 index

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1448,6 +1448,13 @@ def validate_documents(documents: Documents, nullable: bool = False) -> None:
             continue
         if not is_document(document):
             raise ValueError(f"Expected document to be a str, got {document}")
+        if "\x00" in document:
+            # Embedded NUL bytes corrupt the SQLite FTS5 inverted index used for
+            # full-text search, breaking queries for the whole collection.
+            raise ValueError(
+                "Expected document to not contain NUL (0x00) bytes, "
+                f"got a document with a NUL byte at index {document.index(chr(0))}"
+            )
 
 
 def validate_images(images: Images) -> None:

--- a/chromadb/test/api/test_document_validation.py
+++ b/chromadb/test/api/test_document_validation.py
@@ -1,0 +1,23 @@
+import pytest
+
+from chromadb.api.types import validate_documents
+
+
+def test_validate_documents_accepts_plain_strings() -> None:
+    validate_documents(["hello", "world"])
+
+
+def test_validate_documents_rejects_non_string() -> None:
+    with pytest.raises(ValueError, match="Expected document to be a str"):
+        validate_documents(["ok", 42])  # type: ignore[list-item]
+
+
+def test_validate_documents_rejects_nul_bytes() -> None:
+    # Embedded NUL bytes corrupt the SQLite FTS5 inverted index for the whole
+    # collection (see #7388), so they must be rejected up front.
+    with pytest.raises(ValueError, match="NUL"):
+        validate_documents(["before\x00after"])
+
+
+def test_validate_documents_nullable_allows_none() -> None:
+    validate_documents(["ok", None], nullable=True)  # type: ignore[list-item]


### PR DESCRIPTION
A document containing an embedded NUL (0x00) byte passes validation but corrupts the SQLite FTS5 inverted index for the whole collection — after a single such `upsert`, `PRAGMA quick_check` reports a malformed inverted index and full-text queries break.

This rejects NUL bytes in `validate_documents`, alongside the existing type check, so the write fails fast with a clear `ValueError` instead of silently corrupting the index. Adds unit tests covering the NUL rejection plus the existing accept/reject paths (the NUL test fails on main, passes with this change).

Fixes #7388