### PR TITLE
[ENH](tilt): Support custom foundation service config

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -204,6 +204,10 @@ k8s_yaml(
 
 rfe_config_file = os.environ.get('RFE_CONFIG_FILE') or ("rust/frontend/sample_configs/distributed_mcmr.yaml" if os.environ.get('MULTI_REGION') == 'true' else "rust/frontend/sample_configs/distributed.yaml")
 worker_config_file = 'rust/worker/chroma_mcmr.yaml' if os.environ.get('MULTI_REGION') == 'true' else 'rust/worker/chroma_config.yaml'
+foundation_config_file = os.environ.get('FOUNDATION_CONFIG_FILE')
+foundation_config_set_file = ''
+if foundation_config_file:
+  foundation_config_set_file = ',foundationService.configuration=' + foundation_config_file
 
 distributed_chroma_values = "k8s/distributed-chroma/values.yaml,k8s/distributed-chroma/values.dev.yaml"
 if os.environ.get('ADDITIONAL_DISTRIBUTED_CHROMA_VALUES'):
@@ -214,7 +218,7 @@ if os.path.exists('k8s/distributed-chroma/values.foundation.local.yaml'):
 # We manually call helm template so we can call set-file
 k8s_yaml(
   local(
-    'helm template --set-file rustFrontendService.configuration=' + rfe_config_file + ',rustLogService.configuration=' + worker_config_file + ',heapTenderService.configuration=' + worker_config_file + ',compactionService.configuration=' + worker_config_file + ',queryService.configuration=' + worker_config_file + ',garbageCollector.configuration=' + worker_config_file + ',rustSysdbService.configuration=' + worker_config_file + ',workQueueService.configuration=' + worker_config_file + ',fnConsumer.configuration=' + worker_config_file + ' --values ' + distributed_chroma_values + ' k8s/distributed-chroma'
+    'helm template --set-file rustFrontendService.configuration=' + rfe_config_file + ',rustLogService.configuration=' + worker_config_file + ',heapTenderService.configuration=' + worker_config_file + ',compactionService.configuration=' + worker_config_file + ',queryService.configuration=' + worker_config_file + ',garbageCollector.configuration=' + worker_config_file + ',rustSysdbService.configuration=' + worker_config_file + ',workQueueService.configuration=' + worker_config_file + ',fnConsumer.configuration=' + worker_config_file + foundation_config_set_file + ' --values ' + distributed_chroma_values + ' k8s/distributed-chroma'
   ),
 )
 
@@ -236,6 +240,8 @@ watch_file('rust/frontend/sample_configs/distributed2.yaml')
 watch_file('rust/worker/chroma_config.yaml')
 watch_file('rust/worker/chroma_config2.yaml')
 watch_file('rust/worker/chroma_mcmr.yaml')
+if foundation_config_file:
+  watch_file(foundation_config_file)
 watch_file('k8s/distributed-chroma/values.yaml')
 watch_file('k8s/distributed-chroma/values.dev.yaml')
 watch_file('k8s/distributed-chroma/values2.yaml')

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.90
+version: 0.1.91
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/foundation-service.yaml
+++ b/k8s/distributed-chroma/templates/foundation-service.yaml
@@ -59,6 +59,9 @@ spec:
             {{- with .Values.foundationService.env }}
 {{ toYaml . | indent 12 }}
             {{- end }}
+            {{ if .Values.foundationService.otherEnvConfig }}
+              {{ .Values.foundationService.otherEnvConfig | nindent 12 }}
+            {{ end }}
           volumeMounts:
             - name: foundation-server-config
               mountPath: /config/


### PR DESCRIPTION
## Description of changes

Allow overriding the foundation service configuration in local Tilt
development via the FOUNDATION_CONFIG_FILE environment variable. When
set, the file is passed to helm template with --set-file and registered
with watch_file so edits trigger a redeploy.

Also add an optional foundationService.otherEnvConfig block to the
foundation service template so extra environment configuration can be
injected into the container spec.

## Test plan

Local tilt up from hosted + CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
