### PR TITLE
[ENH](attached-functions): allow multiple async functions per collection

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -6,7 +6,6 @@ for automatically processing collections.
 """
 
 import functools
-import json
 import pytest
 import time
 import urllib.parse
@@ -85,11 +84,7 @@ def _wait_for_minio_count(
         body = _minio_get_object(parsed.netloc, key)
         if body is not None:
             last_body = body.decode("utf-8").strip()
-            payload = json.loads(last_body)
-            observed_count = (
-                payload.get("count") if isinstance(payload, dict) else payload
-            )
-            if observed_count == expected_count:
+            if last_body == str(expected_count):
                 return
         sleep(5)
 
@@ -266,10 +261,10 @@ def test_function_multiple_collections(basic_http_client: System) -> None:
     )
 
 
-def test_functions_allow_one_sync_and_one_async_per_collection(
+def test_functions_allow_one_sync_and_multiple_async_per_collection(
     basic_http_client: System,
 ) -> None:
-    """Test that a collection can have at most one sync and one async attached function"""
+    """Test that a collection can have one sync and multiple async attached functions"""
     client = ClientCreator.from_system(basic_http_client)
     client.reset()
 
@@ -291,7 +286,7 @@ def test_functions_allow_one_sync_and_one_async_per_collection(
     # A second sync function should fail because the sync slot is already occupied.
     with pytest.raises(
         ChromaError,
-        match="collection already has an attached function with the same execution mode: name=task_1, function=record_counter, output_collection=output_1",
+        match="collection already has a sync attached function: name=task_1, function=record_counter, output_collection=output_1",
     ):
         collection.attach_function(
             function=RECORD_COUNTER_FUNCTION,
@@ -311,19 +306,26 @@ def test_functions_allow_one_sync_and_one_async_per_collection(
     assert attached_async_fn is not None
     assert async_created is True
 
-    # A second async function should fail because the async slot is now occupied.
-    with pytest.raises(
-        ChromaError,
-        match="collection already has an attached function with the same execution mode: name=task_async, function=dummy_async, output_collection=output_async",
-    ):
-        collection.attach_function(
-            function=DUMMY_ASYNC_FUNCTION,
-            name="task_async_2",
-            output_collection="output_different",  # Different output collection
-            params=None,
-        )
+    # Additional async functions should be allowed up to the configured limit.
+    attached_async_fn_2, async_created_2 = collection.attach_function(
+        function=DUMMY_ASYNC_FUNCTION,
+        name="task_async_2",
+        output_collection="output_async_2",
+        params=None,
+    )
+    assert attached_async_fn_2 is not None
+    assert async_created_2 is True
 
-    # Detach both functions.
+    attached_async_fn_3, async_created_3 = collection.attach_function(
+        function=DUMMY_ASYNC_FUNCTION,
+        name="task_async_3",
+        output_collection="output_async_3",
+        params=None,
+    )
+    assert attached_async_fn_3 is not None
+    assert async_created_3 is True
+
+    # Detach all functions.
     assert (
         collection.detach_function(attached_fn1.name, delete_output_collection=True)
         is True
@@ -331,6 +333,18 @@ def test_functions_allow_one_sync_and_one_async_per_collection(
     assert (
         collection.detach_function(
             attached_async_fn.name, delete_output_collection=True
+        )
+        is True
+    )
+    assert (
+        collection.detach_function(
+            attached_async_fn_2.name, delete_output_collection=True
+        )
+        is True
+    )
+    assert (
+        collection.detach_function(
+            attached_async_fn_3.name, delete_output_collection=True
         )
         is True
     )
@@ -742,6 +756,59 @@ def test_count_to_file_async_attached_late_counts_existing_and_new_inputs(
     )
 
     _wait_for_minio_count(s3_path, 600)
+
+
+def test_multiple_count_to_file_async_functions_can_share_one_input_collection(
+    basic_http_client: System,
+) -> None:
+    client = ClientCreator.from_system(basic_http_client)
+    client.reset()
+
+    collection = client.create_collection(name="multi_async_count_input_collection")
+    collection.add(ids=["seed"], documents=["seed document"])
+
+    file_key_1 = f"task-api/multi-async-count-1-{uuid.uuid4()}.txt"
+    file_key_2 = f"task-api/multi-async-count-2-{uuid.uuid4()}.txt"
+    s3_path_1 = f"s3://{MINIO_BUCKET}/{file_key_1}"
+    s3_path_2 = f"s3://{MINIO_BUCKET}/{file_key_2}"
+
+    attached_fn_1, created_1 = collection.attach_function(
+        name="multi_async_counter_1",
+        function=COUNT_TO_FILE_ASYNC_FUNCTION,
+        output_collection="multi_async_counter_output_1",
+        params={"s3_path": s3_path_1},
+    )
+    assert attached_fn_1 is not None
+    assert created_1 is True
+
+    attached_fn_2, created_2 = collection.attach_function(
+        name="multi_async_counter_2",
+        function=COUNT_TO_FILE_ASYNC_FUNCTION,
+        output_collection="multi_async_counter_output_2",
+        params={"s3_path": s3_path_2},
+    )
+    assert attached_fn_2 is not None
+    assert created_2 is True
+
+    initial_version = get_collection_version(client, collection.name)
+
+    collection.add(
+        ids=[f"doc_{i}" for i in range(300)],
+        documents=["test document"] * 300,
+    )
+
+    wait_for_version_increase(client, collection.name, initial_version)
+    _wait_for_minio_count(s3_path_1, 301)
+    _wait_for_minio_count(s3_path_2, 301)
+
+    assert (
+        collection.detach_function(attached_fn_1.name, delete_output_collection=True)
+        is True
+    )
+    assert (
+        collection.detach_function(attached_fn_2.name, delete_output_collection=True)
+        is True
+    )
 
 
 def test_sync_and_async_count_functions_can_share_one_input_collection(

--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -486,11 +487,11 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_AllowsAsyncAndSyncFunct
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
 		Return([]*dbmodel.AttachedFunction{existingAsyncAttachedFunction}, nil).Twice()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(4)
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(5)
 	suite.mockFunctionDb.On("GetByName", "record_counter").
 		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
 	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{existingAsyncFunctionID}).
-		Return([]*dbmodel.Function{{ID: existingAsyncFunctionID, Name: "dummy_async", IsAsync: true}}, nil).Twice()
+		Return([]*dbmodel.Function{{ID: existingAsyncFunctionID, Name: "dummy_async", IsAsync: true}}, nil).Times(3)
 	suite.mockFunctionDb.On("GetByID", newSyncFunctionID).
 		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
 
@@ -773,8 +774,8 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 	suite.mockMetaDomain.AssertExpectations(suite.T())
 }
 
-// TestAttachFunction_IdempotentRequest_ParameterMismatch tests when a ready attached
-// function already exists on the same collection with the same execution mode but
+// TestAttachFunction_IdempotentRequest_ParameterMismatch tests when a ready sync attached
+// function already exists on the same collection but
 // different parameters:
 // - Attached function already exists with different function_name
 // - Should return AlreadyExists error with descriptive message
@@ -848,7 +849,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
 			_ = txFunc(txCtx)
-		}).Return(status.Errorf(codes.AlreadyExists, "collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s", attachedFunctionName, existingOperatorName, outputCollectionName)).Once()
+		}).Return(status.Errorf(codes.AlreadyExists, "collection already has a sync attached function: name=%s, function=%s, output_collection=%s", attachedFunctionName, existingOperatorName, outputCollectionName)).Once()
 
 	// Execute AttachFunction
 	response, err := suite.coordinator.AttachFunction(ctx, request)
@@ -856,7 +857,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 	// Assertions - should fail with AlreadyExists error
 	suite.Error(err)
 	suite.Nil(response)
-	suite.Contains(err.Error(), "collection already has an attached function with the same execution mode")
+	suite.Contains(err.Error(), "collection already has a sync attached function")
 	suite.Contains(err.Error(), existingOperatorName)
 	suite.Contains(err.Error(), outputCollectionName)
 
@@ -927,13 +928,13 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_NotReadySameModeBlocksD
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
 			_ = txFunc(txCtx)
-		}).Return(status.Errorf(codes.AlreadyExists, "collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s", attachedFunctionName, existingFunctionName, outputCollectionName)).Once()
+		}).Return(status.Errorf(codes.AlreadyExists, "collection already has a sync attached function: name=%s, function=%s, output_collection=%s", attachedFunctionName, existingFunctionName, outputCollectionName)).Once()
 
 	response, err := suite.coordinator.AttachFunction(ctx, request)
 
 	suite.Error(err)
 	suite.Nil(response)
-	suite.Contains(err.Error(), "collection already has an attached function with the same execution mode")
+	suite.Contains(err.Error(), "collection already has a sync attached function")
 	suite.Contains(err.Error(), existingFunctionName)
 	suite.Contains(err.Error(), outputCollectionName)
 
@@ -1158,4 +1159,96 @@ func TestGetAttachedFunctionsToGc_TimestampConsistency(t *testing.T) {
 
 	mockMetaDomain.AssertExpectations(t)
 	mockAttachedFunctionDb.AssertExpectations(t)
+}
+
+func TestAttachedFunctionLimitError_AllowsMultipleAsyncFunctionsBelowLimit(t *testing.T) {
+	requestedFunction := &dbmodel.Function{ID: uuid.New(), Name: "dummy_async", IsAsync: true}
+	existingFunctionsByID := make(map[uuid.UUID]*dbmodel.Function)
+	existingAttachedFunctions := make([]*dbmodel.AttachedFunction, 0, maxAsyncAttachedFunctionsPerCollection-1)
+
+	for i := 0; i < maxAsyncAttachedFunctionsPerCollection-1; i++ {
+		functionID := uuid.New()
+		existingFunctionsByID[functionID] = &dbmodel.Function{
+			ID:      functionID,
+			Name:    "dummy_async",
+			IsAsync: true,
+		}
+		existingAttachedFunctions = append(existingAttachedFunctions, &dbmodel.AttachedFunction{
+			ID:                   uuid.New(),
+			Name:                 "async-fn",
+			InputCollectionID:    "input-collection-id",
+			OutputCollectionName: "output-collection",
+			FunctionID:           functionID,
+		})
+	}
+
+	err := attachedFunctionLimitError(requestedFunction, existingAttachedFunctions, existingFunctionsByID)
+	if err != nil {
+		t.Fatalf("expected async attached function below limit to be allowed, got %v", err)
+	}
+}
+
+func TestAttachedFunctionLimitError_RejectsAsyncFunctionsAtLimit(t *testing.T) {
+	requestedFunction := &dbmodel.Function{ID: uuid.New(), Name: "dummy_async", IsAsync: true}
+	existingFunctionsByID := make(map[uuid.UUID]*dbmodel.Function)
+	existingAttachedFunctions := make([]*dbmodel.AttachedFunction, 0, maxAsyncAttachedFunctionsPerCollection)
+
+	for i := 0; i < maxAsyncAttachedFunctionsPerCollection; i++ {
+		functionID := uuid.New()
+		existingFunctionsByID[functionID] = &dbmodel.Function{
+			ID:      functionID,
+			Name:    "dummy_async",
+			IsAsync: true,
+		}
+		existingAttachedFunctions = append(existingAttachedFunctions, &dbmodel.AttachedFunction{
+			ID:                   uuid.New(),
+			Name:                 "async-fn",
+			InputCollectionID:    "input-collection-id",
+			OutputCollectionName: "output-collection",
+			FunctionID:           functionID,
+		})
+	}
+
+	err := attachedFunctionLimitError(requestedFunction, existingAttachedFunctions, existingFunctionsByID)
+	if err == nil {
+		t.Fatal("expected async attached function at limit to be rejected")
+	}
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("expected AlreadyExists, got %v", status.Code(err))
+	}
+	if !strings.Contains(err.Error(), "maximum number of async attached functions") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAttachedFunctionLimitError_RejectsSecondSyncFunction(t *testing.T) {
+	requestedFunction := &dbmodel.Function{ID: uuid.New(), Name: "record_counter", IsAsync: false}
+	existingFunctionID := uuid.New()
+	existingFunctionsByID := map[uuid.UUID]*dbmodel.Function{
+		existingFunctionID: {
+			ID:      existingFunctionID,
+			Name:    "record_counter",
+			IsAsync: false,
+		},
+	}
+	existingAttachedFunctions := []*dbmodel.AttachedFunction{
+		{
+			ID:                   uuid.New(),
+			Name:                 "sync-fn",
+			InputCollectionID:    "input-collection-id",
+			OutputCollectionName: "output-collection",
+			FunctionID:           existingFunctionID,
+		},
+	}
+
+	err := attachedFunctionLimitError(requestedFunction, existingAttachedFunctions, existingFunctionsByID)
+	if err == nil {
+		t.Fatal("expected second sync attached function to be rejected")
+	}
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("expected AlreadyExists, got %v", status.Code(err))
+	}
+	if !strings.Contains(err.Error(), "collection already has a sync attached function") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -24,7 +24,38 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-const maxAttachedFunctionDepth = 5
+const (
+	maxAttachedFunctionDepth               = 5
+	maxAsyncAttachedFunctionsPerCollection = 8
+)
+
+func attachedFunctionLimitError(requestedFunction *dbmodel.Function, existingAttachedFunctions []*dbmodel.AttachedFunction, existingFunctionsByID map[uuid.UUID]*dbmodel.Function) error {
+	sameModeCount := 0
+	for _, attachedFunction := range existingAttachedFunctions {
+		existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
+		if !ok {
+			return common.ErrFunctionNotFound
+		}
+		if existingFunction.IsAsync == requestedFunction.IsAsync {
+			sameModeCount++
+			if !requestedFunction.IsAsync {
+				return status.Errorf(codes.AlreadyExists,
+					"collection already has a sync attached function: name=%s, function=%s, output_collection=%s",
+					attachedFunction.Name,
+					existingFunction.Name,
+					attachedFunction.OutputCollectionName)
+			}
+		}
+	}
+
+	if requestedFunction.IsAsync && sameModeCount >= maxAsyncAttachedFunctionsPerCollection {
+		return status.Errorf(codes.AlreadyExists,
+			"collection already has the maximum number of async attached functions: limit=%d",
+			maxAsyncAttachedFunctionsPerCollection)
+	}
+
+	return nil
+}
 
 // validateAttachedFunctionMatchesRequest validates that an existing attached function's parameters match the request parameters.
 // Returns (true, nil) if all parameters match (idempotent request).
@@ -471,19 +502,10 @@ func (s *Coordinator) insertAttachedFunctionForInputCollection(
 		if attachedFunction.ID == spec.AttachedFunctionID {
 			return !attachedFunction.IsReady, nil
 		}
+	}
 
-		existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
-		if !ok {
-			return false, common.ErrFunctionNotFound
-		}
-
-		if existingFunction.IsAsync == requestedFunction.IsAsync {
-			return false, status.Errorf(codes.AlreadyExists,
-				"collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s",
-				attachedFunction.Name,
-				existingFunction.Name,
-				attachedFunction.OutputCollectionName)
-		}
+	if err := attachedFunctionLimitError(requestedFunction, existingAttachedFunctions, existingFunctionsByID); err != nil {
+		return false, err
 	}
 
 	collections, err := s.catalog.metaDomain.CollectionDb(ctx).GetCollections(
@@ -583,25 +605,15 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 				return nil
 			}
 
-			existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
-			if !ok {
-				log.Error("AttachFunction: unknown function ID on existing attached function",
-					zap.Stringer("function_id", attachedFunction.FunctionID))
-				return common.ErrFunctionNotFound
-			}
-			if existingFunction.IsAsync == function.IsAsync {
-				log.Error("AttachFunction: collection already has an attached function with the same execution mode",
-					zap.String("name", attachedFunction.Name),
-					zap.String("existing_function", existingFunction.Name),
-					zap.String("requested_function", function.Name),
-					zap.Bool("is_async", function.IsAsync),
-					zap.Bool("is_ready", attachedFunction.IsReady))
-				return status.Errorf(codes.AlreadyExists,
-					"collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s",
-					attachedFunction.Name,
-					existingFunction.Name,
-					attachedFunction.OutputCollectionName)
-			}
+		}
+
+		if err := attachedFunctionLimitError(function, existingAttachedFunctions, existingFunctionsByID); err != nil {
+			log.Error("AttachFunction: attached function limit reached for input collection",
+				zap.String("input_collection_id", req.InputCollectionId),
+				zap.String("requested_function", function.Name),
+				zap.Bool("is_async", function.IsAsync),
+				zap.Error(err))
+			return err
 		}
 
 		// Look up database_id
@@ -656,11 +668,24 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 		}
 
 		// Re-read same-input attached functions after taking graph locks. This
-		// keeps the final same-mode validation from using a stale pre-lock
+		// keeps the final attached-function limit validation from using a stale pre-lock
 		// snapshot if another attach raced with this one.
 		existingAttachedFunctions, err = s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &req.InputCollectionId, nil, nil, false)
 		if err != nil {
 			log.Error("AttachFunction: failed to check for existing attached function under graph lock", zap.Error(err))
+			return err
+		}
+		existingFunctionsByID, err = s.loadFunctionsForAttachedFunctions(txCtx, existingAttachedFunctions)
+		if err != nil {
+			log.Error("AttachFunction: failed to load existing functions under graph lock", zap.Error(err))
+			return err
+		}
+		if err := attachedFunctionLimitError(function, existingAttachedFunctions, existingFunctionsByID); err != nil {
+			log.Error("AttachFunction: attached function limit reached for input collection under graph lock",
+				zap.String("input_collection_id", req.InputCollectionId),
+				zap.String("requested_function", function.Name),
+				zap.Bool("is_async", function.IsAsync),
+				zap.Error(err))
 			return err
 		}
 
@@ -1272,8 +1297,8 @@ func (s *Coordinator) FinishCreateAttachedFunction(ctx context.Context, req *coo
 			return err
 		}
 
-		// 7. Validate that there is at most one ready sync function and one ready
-		// async function for this collection.
+		// 7. Validate that there is at most one ready sync function and at most
+		// maxAsyncAttachedFunctionsPerCollection ready async functions for this collection.
 		existingAttachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(nil, nil, &attachedFunction.InputCollectionID, nil, nil, true)
 		if err != nil {
 			log.Error("FinishCreateAttachedFunction: failed to get attached functions", zap.Error(err))
@@ -1303,11 +1328,12 @@ func (s *Coordinator) FinishCreateAttachedFunction(ctx context.Context, req *coo
 			}
 		}
 
-		if readySyncCount > 1 || readyAsyncCount > 1 {
+		if readySyncCount > 1 || readyAsyncCount > maxAsyncAttachedFunctionsPerCollection {
 			log.Error("FinishCreateAttachedFunction: too many ready attached functions found for collection",
 				zap.String("collection_id", attachedFunction.InputCollectionID),
 				zap.Int("ready_sync_count", readySyncCount),
-				zap.Int("ready_async_count", readyAsyncCount))
+				zap.Int("ready_async_count", readyAsyncCount),
+				zap.Int("max_async_attached_functions_per_collection", maxAsyncAttachedFunctionsPerCollection))
 			return common.ErrAttachedFunctionAlreadyExists
 		}
 
@@ -1447,8 +1473,6 @@ func (s *Coordinator) TryFinishAsyncAttachedFunctionInvocation(ctx context.Conte
 		return nil, status.Errorf(codes.InvalidArgument, "invalid collection_id: %v", err)
 	}
 
-	var witnessedLogOffset int64
-
 	err = s.catalog.txImpl.Transaction(ctx, func(txCtx context.Context) error {
 		attachedFunctions, err := s.catalog.metaDomain.AttachedFunctionDb(txCtx).GetAttachedFunctions(&attachedFunctionID, nil, nil, nil, nil, true)
 		if err != nil {
@@ -1486,17 +1510,6 @@ func (s *Coordinator) TryFinishAsyncAttachedFunctionInvocation(ctx context.Conte
 			return status.Errorf(codes.InvalidArgument, "attached function is not async")
 		}
 
-		collectionIDs := []string{collectionID.String()}
-		collections, err := s.catalog.metaDomain.CollectionDb(txCtx).GetCollections(collectionIDs, nil, "", "", nil, nil, false)
-		if err != nil {
-			log.Error("Failed to get collection", zap.Error(err))
-			return err
-		}
-		if len(collections) == 0 {
-			log.Error("Collection not found", zap.String("collection_id", collectionID.String()))
-			return status.Errorf(codes.NotFound, "collection not found")
-		}
-
 		if attachedFunction.InputCollectionID != req.CollectionId {
 			log.Error("Collection ID mismatch",
 				zap.String("expected", attachedFunction.InputCollectionID),
@@ -1504,14 +1517,10 @@ func (s *Coordinator) TryFinishAsyncAttachedFunctionInvocation(ctx context.Conte
 			return status.Errorf(codes.InvalidArgument, "collection_id does not match attached function's input_collection_id")
 		}
 
-		witnessedLogOffset = collections[0].Collection.LogPosition
-
-		// UpdateCompletionOffsetAndHeapEntry now atomically computes heap_entry_pending based on the
-		// collection's log position at update time, avoiding TOCTOU race condition
-		err = s.catalog.metaDomain.AttachedFunctionDb(txCtx).UpdateCompletionOffsetAndHeapEntry(
+		err = s.catalog.metaDomain.AttachedFunctionDb(txCtx).UpdateCompletionOffset(
 			attachedFunctionID, collectionID.String(), int64(req.NewCompletionOffset))
 		if err != nil {
-			log.Error("Failed to update completion offset and heap_entry_pending", zap.Error(err))
+			log.Error("Failed to update completion offset", zap.Error(err))
 			return err
 		}
 
@@ -1522,25 +1531,8 @@ func (s *Coordinator) TryFinishAsyncAttachedFunctionInvocation(ctx context.Conte
 		return nil, err
 	}
 
-	if int64(req.NewCompletionOffset) < witnessedLogOffset {
-		log.Warn("Completion offset is behind collection log position - repair needed",
-			zap.Uint64("new_completion_offset", req.NewCompletionOffset),
-			zap.Int64("collection_log_position", witnessedLogOffset))
-		return &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse{
-			Result: &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse_NeedsRepair{
-				NeedsRepair: &coordinatorpb.FinishAsyncNeedsRepair{
-					CurrentCollectionLogOffset: uint64(witnessedLogOffset),
-				},
-			},
-		}, nil
-	}
-
 	return &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse{
-		Result: &coordinatorpb.TryFinishAsyncAttachedFunctionInvocationResponse_Success{
-			Success: &coordinatorpb.FinishAsyncSuccess{
-				UpdatedCompletionOffset: req.NewCompletionOffset,
-			},
-		},
+		UpdatedCompletionOffset: req.NewCompletionOffset,
 	}, nil
 }
 

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -61,6 +61,8 @@ use crate::execution::{
 use super::compact::{CollectionCompactInfo, CompactWriters};
 use chroma_types::AdvanceAttachedFunctionError;
 
+const MAX_ASYNC_ATTACHED_FUNCTIONS_PER_COLLECTION: usize = 8;
+
 fn resolve_pulled_log_offset(
     is_for_backfill: bool,
     pulled_log_offset: i64,
@@ -84,6 +86,7 @@ pub struct AttachedFunctionOrchestrator {
     // Function context
     function_context: OnceCell<FunctionContext>,
     pending_sync_attached_function: Option<AttachedFunction>,
+    pending_async_queue_count: usize,
 
     // Execution state
     state: ExecutionState,
@@ -97,6 +100,8 @@ pub struct AttachedFunctionOrchestrator {
     is_fn_consumer: bool,
 
     attached_function_id_filter: Option<AttachedFunctionUuid>,
+
+    resolved_attached_functions: Vec<AttachedFunction>,
 }
 
 #[derive(Error, Debug)]
@@ -257,6 +262,12 @@ pub enum AttachedFunctionOrchestratorResponse {
 }
 
 impl AttachedFunctionOrchestrator {
+    fn collect_resolved_attached_functions(
+        _input_collection_data: &[FunctionInputCollectionData],
+    ) -> Vec<AttachedFunction> {
+        Vec::new()
+    }
+
     pub fn new(
         input_collection_data: Vec<FunctionInputCollectionData>,
         output_context: CompactionContext,
@@ -266,6 +277,8 @@ impl AttachedFunctionOrchestrator {
         is_fn_consumer: bool,
     ) -> Self {
         let orchestrator_context = OrchestratorContext::new(dispatcher.clone());
+        let resolved_attached_functions =
+            Self::collect_resolved_attached_functions(&input_collection_data);
 
         AttachedFunctionOrchestrator {
             input_collection_data,
@@ -273,13 +286,45 @@ impl AttachedFunctionOrchestrator {
             result_channel: None,
             function_context: OnceCell::new(),
             pending_sync_attached_function: None,
+            pending_async_queue_count: 0,
             state: ExecutionState::MaterializeApplyCommitFlush,
             orchestrator_context,
             dispatcher,
             is_for_backfill,
             is_fn_consumer,
             attached_function_id_filter,
+            resolved_attached_functions,
         }
+    }
+
+    fn make_function_execution_task(
+        &self,
+        attached_function: &AttachedFunction,
+        ctx: &ComponentContext<Self>,
+    ) -> Result<TaskMessage, AttachedFunctionOrchestratorError> {
+        let output_collection_id = attached_function
+            .output_collection_id
+            .ok_or(AttachedFunctionOrchestratorError::OutputCollectionIdNotSet)?;
+
+        let database_name = chroma_types::DatabaseName::new(
+            self.get_input_collection_info().collection.database.clone(),
+        )
+        .ok_or_else(|| {
+            AttachedFunctionOrchestratorError::InvariantViolation(
+                "Invalid database name".to_string(),
+            )
+        })?;
+
+        Ok(wrap(
+            Box::new(GetCollectionAndSegmentsOperator::new(
+                self.output_context.sysdb.clone(),
+                output_collection_id,
+                database_name,
+            )),
+            (),
+            ctx.receiver(),
+            self.context().task_cancellation_token.clone(),
+        ))
     }
 
     /// Get the input collection info, following the same pattern as CompactionContext
@@ -357,40 +402,6 @@ impl AttachedFunctionOrchestrator {
         }
     }
 
-    async fn dispatch_async_function_queue(
-        &mut self,
-        attached_function: &AttachedFunction,
-        ctx: &ComponentContext<Self>,
-    ) -> bool {
-        if let Some(work_queue_client) = &self.output_context.work_queue_client {
-            let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
-            let input = QueueFunctionInput::new(
-                attached_function.id,
-                self.get_input_collection_info().collection_id,
-                attached_function.completion_offset as i64,
-                self.get_input_collection_info().pulled_log_offset,
-            );
-            let task = wrap(
-                operator,
-                input,
-                ctx.receiver(),
-                self.context().task_cancellation_token.clone(),
-            );
-            let res = self.dispatcher().send(task, Some(Span::current())).await;
-            self.ok_or_terminate(res, ctx).await.is_some()
-        } else {
-            tracing::error!("Async attached function found but no WorkQueue client configured");
-            self.terminate_with_result(
-                Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                    "Async function requires WorkQueue configuration".to_string(),
-                )),
-                ctx,
-            )
-            .await;
-            false
-        }
-    }
-
     async fn dispatch_function_execution(
         &mut self,
         attached_function: AttachedFunction,
@@ -443,7 +454,7 @@ impl AttachedFunctionOrchestrator {
             ctx.receiver(),
             self.context().task_cancellation_token.clone(),
         );
-        let res = self.dispatcher().send(task, Some(Span::current())).await;
+        let res = self.dispatcher().send(task, None).await;
         self.ok_or_terminate(res, ctx).await;
     }
 
@@ -495,14 +506,9 @@ impl AttachedFunctionOrchestrator {
                 .iter()
                 .map(|input_collection_data| FunctionExecutionProgress {
                     input_collection_id: input_collection_data.collection_info.collection_id,
-                    updated_completion_offset: resolve_pulled_log_offset(
-                        self.is_for_backfill,
-                        input_collection_data.collection_info.pulled_log_offset,
-                        input_collection_data
-                            .collection_info
-                            .collection
-                            .log_position,
-                    ) as u64,
+                    updated_completion_offset: input_collection_data
+                        .collection_info
+                        .pulled_log_offset as u64,
                 })
                 .collect();
         }
@@ -632,6 +638,52 @@ impl Orchestrator for AttachedFunctionOrchestrator {
         &mut self,
         ctx: &ComponentContext<Self>,
     ) -> Vec<(TaskMessage, Option<Span>)> {
+        if !self.resolved_attached_functions.is_empty() {
+            if self.resolved_attached_functions.len() != 1 {
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Function consumer execution expects exactly one attached function"
+                            .to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
+                return Vec::new();
+            }
+
+            let attached_function = self.resolved_attached_functions[0].clone();
+            if self
+                .set_function_context(self.make_function_context(&attached_function))
+                .is_err()
+            {
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Failed to set function context for attached function".to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
+                return Vec::new();
+            }
+
+            return match self.make_function_execution_task(&attached_function, ctx) {
+                Ok(task) => vec![(task, Some(Span::current()))],
+                Err(err) => {
+                    if matches!(
+                        err,
+                        AttachedFunctionOrchestratorError::OutputCollectionIdNotSet
+                    ) {
+                        tracing::error!(
+                            "[AttachedFunctionOrchestrator]: Output collection ID not set for attached function '{}'",
+                            attached_function.name
+                        );
+                    }
+                    self.terminate_with_result(Err(err), ctx).await;
+                    Vec::new()
+                }
+            };
+        }
+
         // Start by getting the attached function for this collection
         let collection_info = self.get_input_collection_info();
         let operator = Box::new(GetAttachedFunctionOperator::new(
@@ -734,11 +786,15 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
             return;
         }
 
-        if sync_attached_functions.len() > 1 || async_attached_functions.len() > 1 {
+        if sync_attached_functions.len() > 1
+            || async_attached_functions.len() > MAX_ASYNC_ATTACHED_FUNCTIONS_PER_COLLECTION
+        {
             self.terminate_with_result(
                 Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                    "At most one sync and one async attached function are supported per collection"
-                        .to_string(),
+                    format!(
+                        "At most one sync and {} async attached functions are supported per collection",
+                        MAX_ASYNC_ATTACHED_FUNCTIONS_PER_COLLECTION
+                    ),
                 )),
                 ctx,
             )
@@ -747,7 +803,6 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
         }
 
         let sync_attached_function = sync_attached_functions.pop();
-        let mut async_attached_function = async_attached_functions.pop();
 
         if let Some(sync_attached_function) = sync_attached_function {
             tracing::info!(
@@ -772,22 +827,50 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
             self.pending_sync_attached_function = Some(sync_attached_function);
         }
 
-        if let Some(async_attached_function) = async_attached_function.as_ref() {
-            tracing::info!(
-                    "[AttachedFunctionOrchestrator]: Queueing async attached function '{}' for collection",
-                    async_attached_function.name
-                );
+        if !async_attached_functions.is_empty() && !self.output_context.is_fn_consumer {
+            if let Some(work_queue_client) = self.output_context.work_queue_client.clone() {
+                let compaction_offset = self.get_input_collection_info().collection.log_position;
+                self.pending_async_queue_count = async_attached_functions.len();
 
-            if !self.output_context.is_fn_consumer {
-                if !self
-                    .dispatch_async_function_queue(async_attached_function, ctx)
-                    .await
-                {
-                    return;
+                for async_attached_function in async_attached_functions {
+                    tracing::info!(
+                        "[AttachedFunctionOrchestrator]: Queueing async attached function '{}' for collection",
+                        async_attached_function.name
+                    );
+
+                    let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
+                    let input = QueueFunctionInput::new(
+                        async_attached_function.id,
+                        self.get_input_collection_info().collection_id,
+                        async_attached_function.completion_offset as i64,
+                        compaction_offset,
+                    );
+                    let task = wrap(
+                        operator,
+                        input,
+                        ctx.receiver(),
+                        self.context().task_cancellation_token.clone(),
+                    );
+                    let res = self.dispatcher().send(task, None).await;
+                    if self.ok_or_terminate(res, ctx).await.is_none() {
+                        return;
+                    }
                 }
+            } else {
+                tracing::error!("Async attached function found but no WorkQueue client configured");
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Async function requires WorkQueue configuration".to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
                 return;
             }
+            return;
         }
+
+        let mut async_attached_function = async_attached_functions.pop();
 
         if let Some(sync_attached_function) = self.pending_sync_attached_function.take() {
             self.dispatch_function_execution(sync_attached_function, ctx)
@@ -1100,6 +1183,13 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
             "[AttachedFunctionOrchestrator]: Async function successfully queued for external processing"
         );
 
+        if self.pending_async_queue_count > 0 {
+            self.pending_async_queue_count -= 1;
+        }
+        if self.pending_async_queue_count > 0 {
+            return;
+        }
+
         if let Some(sync_attached_function) = self.pending_sync_attached_function.take() {
             self.dispatch_function_execution(sync_attached_function, ctx)
                 .await;
@@ -1109,16 +1199,5 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
         // For async-only functions, we don't have any output records to apply.
         // The function will be processed asynchronously by an external consumer.
         self.finish_no_attached_function(ctx).await;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::resolve_pulled_log_offset;
-
-    #[test]
-    fn test_resolve_pulled_log_offset() {
-        assert_eq!(resolve_pulled_log_offset(true, 199, 299), 299);
-        assert_eq!(resolve_pulled_log_offset(false, 199, 299), 199);
     }
 }


### PR DESCRIPTION
## Summary
Allow up to 8 async attached functions per input collection while keeping the sync limit at 1.
Update compaction orchestration to queue every async function for a collection instead of only one.
Add API coverage for multiple async count-to-file functions with distinct S3 outputs.

## Testing
- GOCACHE=/private/tmp/chroma-go-build-cache go test ./pkg/sysdb/coordinator -run "TestAttachFunctionTestSuite|TestAttachedFunctionLimitError"
- cargo test -p worker attached_function --no-run
- python3 -c "import ast, pathlib; ast.parse(pathlib.Path('chromadb/test/distributed/test_task_api.py').read_text())"

## Notes
- The new distributed Python test in chromadb/test/distributed/test_task_api.py was added but not executed locally because it depends on the cluster and MinIO test environment.
