### PR TITLE
[BUG](work-queue): expose compaction frontier to consumer

### DIFF
--- a/idl/chromadb/proto/workqueue.proto
+++ b/idl/chromadb/proto/workqueue.proto
@@ -33,6 +33,7 @@ message WorkItemResult {
     string fn_id = 1;
     string input_coll_id = 2;
     int64 completion_offset = 3;
+    optional int64 compaction_offset = 4;
 }
 
 message GetWorkResponse {

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::OnceCell,
+    collections::HashSet,
     sync::{atomic::AtomicU32, Arc},
 };
 
@@ -97,6 +98,8 @@ pub struct AttachedFunctionOrchestrator {
     is_fn_consumer: bool,
 
     attached_function_id_filter: Option<AttachedFunctionUuid>,
+
+    resolved_attached_functions: Vec<AttachedFunction>,
 }
 
 #[derive(Error, Debug)]
@@ -257,6 +260,23 @@ pub enum AttachedFunctionOrchestratorResponse {
 }
 
 impl AttachedFunctionOrchestrator {
+    fn collect_resolved_attached_functions(
+        input_collection_data: &[FunctionInputCollectionData],
+    ) -> Vec<AttachedFunction> {
+        let mut seen_ids = HashSet::new();
+        let mut attached_functions = Vec::new();
+
+        for input in input_collection_data {
+            for attached_function in &input.resolved_attached_functions {
+                if seen_ids.insert(attached_function.id) {
+                    attached_functions.push(attached_function.clone());
+                }
+            }
+        }
+
+        attached_functions
+    }
+
     pub fn new(
         input_collection_data: Vec<FunctionInputCollectionData>,
         output_context: CompactionContext,
@@ -266,6 +286,8 @@ impl AttachedFunctionOrchestrator {
         is_fn_consumer: bool,
     ) -> Self {
         let orchestrator_context = OrchestratorContext::new(dispatcher.clone());
+        let resolved_attached_functions =
+            Self::collect_resolved_attached_functions(&input_collection_data);
 
         AttachedFunctionOrchestrator {
             input_collection_data,
@@ -279,7 +301,161 @@ impl AttachedFunctionOrchestrator {
             is_for_backfill,
             is_fn_consumer,
             attached_function_id_filter,
+            resolved_attached_functions,
         }
+    }
+
+    fn make_async_queue_task(
+        &self,
+        attached_function: &AttachedFunction,
+        ctx: &ComponentContext<Self>,
+    ) -> Result<TaskMessage, AttachedFunctionOrchestratorError> {
+        let work_queue_client = self
+            .output_context
+            .work_queue_client
+            .clone()
+            .ok_or_else(|| {
+                AttachedFunctionOrchestratorError::InvariantViolation(
+                    "Async function requires WorkQueue configuration".to_string(),
+                )
+            })?;
+        let operator = Box::new(QueueFunctionOperator::new(work_queue_client));
+        let compaction_offset = self.get_input_collection_info().collection.log_position;
+        let input = QueueFunctionInput::new(
+            attached_function.id,
+            self.get_input_collection_info().collection_id,
+            attached_function.completion_offset as i64,
+            compaction_offset,
+        );
+
+        Ok(wrap(
+            operator,
+            input,
+            ctx.receiver(),
+            self.context().task_cancellation_token.clone(),
+        ))
+    }
+
+    fn make_function_execution_task(
+        &self,
+        attached_function: &AttachedFunction,
+        ctx: &ComponentContext<Self>,
+    ) -> Result<TaskMessage, AttachedFunctionOrchestratorError> {
+        let output_collection_id = attached_function
+            .output_collection_id
+            .ok_or(AttachedFunctionOrchestratorError::OutputCollectionIdNotSet)?;
+
+        let database_name = chroma_types::DatabaseName::new(
+            self.get_input_collection_info().collection.database.clone(),
+        )
+        .ok_or_else(|| {
+            AttachedFunctionOrchestratorError::InvariantViolation(
+                "Invalid database name".to_string(),
+            )
+        })?;
+
+        Ok(wrap(
+            Box::new(GetCollectionAndSegmentsOperator::new(
+                self.output_context.sysdb.clone(),
+                output_collection_id,
+                database_name,
+            )),
+            (),
+            ctx.receiver(),
+            self.context().task_cancellation_token.clone(),
+        ))
+    }
+
+    fn plan_attached_function_tasks(
+        &mut self,
+        attached_functions: Vec<AttachedFunction>,
+        ctx: &ComponentContext<Self>,
+    ) -> Result<Vec<(TaskMessage, Option<Span>)>, AttachedFunctionOrchestratorError> {
+        let mut tasks = Vec::new();
+
+        let mut sync_attached_functions = Vec::new();
+        let mut async_attached_functions = Vec::new();
+        for attached_function in attached_functions {
+            if attached_function.is_async {
+                async_attached_functions.push(attached_function);
+            } else {
+                sync_attached_functions.push(attached_function);
+            }
+        }
+
+        if self.output_context.is_fn_consumer
+            && (sync_attached_functions.len() + async_attached_functions.len() != 1)
+        {
+            return Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                "Function consumer execution expects exactly one attached function".to_string(),
+            ));
+        }
+
+        if sync_attached_functions.len() > 1 || async_attached_functions.len() > 1 {
+            return Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                "At most one sync and one async attached function are supported per collection"
+                    .to_string(),
+            ));
+        }
+
+        let sync_attached_function = sync_attached_functions.pop();
+        let mut async_attached_function = async_attached_functions.pop();
+
+        if let Some(sync_attached_function) = sync_attached_function {
+            tracing::info!(
+                "[AttachedFunctionOrchestrator]: Prepared sync attached function '{}' for collection",
+                sync_attached_function.name
+            );
+
+            if self
+                .set_function_context(self.make_function_context(&sync_attached_function))
+                .is_err()
+            {
+                return Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                    "Failed to set function context for attached function".to_string(),
+                ));
+            }
+
+            self.pending_sync_attached_function = Some(sync_attached_function);
+        }
+
+        if let Some(async_attached_function) = async_attached_function.as_ref() {
+            tracing::info!(
+                "[AttachedFunctionOrchestrator]: Queueing async attached function '{}' for collection",
+                async_attached_function.name
+            );
+
+            if !self.output_context.is_fn_consumer {
+                tasks.push((
+                    self.make_async_queue_task(async_attached_function, ctx)?,
+                    Some(Span::current()),
+                ));
+                return Ok(tasks);
+            }
+        }
+
+        if let Some(sync_attached_function) = self.pending_sync_attached_function.take() {
+            tasks.push((
+                self.make_function_execution_task(&sync_attached_function, ctx)?,
+                Some(Span::current()),
+            ));
+        } else if let Some(async_attached_function) = async_attached_function.take() {
+            if self
+                .set_function_context(self.make_function_context(&async_attached_function))
+                .is_err()
+            {
+                return Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                    "Failed to set function context for attached function".to_string(),
+                ));
+            }
+
+            tasks.push((
+                self.make_function_execution_task(&async_attached_function, ctx)?,
+                Some(Span::current()),
+            ));
+        }
+
+        Ok(tasks)
     }
 
     /// Get the input collection info, following the same pattern as CompactionContext
@@ -357,93 +533,28 @@ impl AttachedFunctionOrchestrator {
         }
     }
 
-    async fn dispatch_async_function_queue(
-        &mut self,
-        attached_function: &AttachedFunction,
-        ctx: &ComponentContext<Self>,
-    ) -> bool {
-        if let Some(work_queue_client) = &self.output_context.work_queue_client {
-            let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
-            let input = QueueFunctionInput::new(
-                attached_function.id,
-                self.get_input_collection_info().collection_id,
-                attached_function.completion_offset as i64,
-                self.get_input_collection_info().pulled_log_offset,
-            );
-            let task = wrap(
-                operator,
-                input,
-                ctx.receiver(),
-                self.context().task_cancellation_token.clone(),
-            );
-            let res = self.dispatcher().send(task, Some(Span::current())).await;
-            self.ok_or_terminate(res, ctx).await.is_some()
-        } else {
-            tracing::error!("Async attached function found but no WorkQueue client configured");
-            self.terminate_with_result(
-                Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                    "Async function requires WorkQueue configuration".to_string(),
-                )),
-                ctx,
-            )
-            .await;
-            false
-        }
-    }
-
     async fn dispatch_function_execution(
         &mut self,
         attached_function: AttachedFunction,
         ctx: &ComponentContext<Self>,
     ) {
-        let output_collection_id = match attached_function.output_collection_id {
-            Some(id) => id,
-            None => {
-                tracing::error!(
-                    "[AttachedFunctionOrchestrator]: Output collection ID not set for attached function '{}'",
-                    attached_function.name
-                );
-                self.terminate_with_result(
-                    Err(AttachedFunctionOrchestratorError::OutputCollectionIdNotSet),
-                    ctx,
-                )
-                .await;
+        let task = match self.make_function_execution_task(&attached_function, ctx) {
+            Ok(task) => task,
+            Err(err) => {
+                if matches!(
+                    err,
+                    AttachedFunctionOrchestratorError::OutputCollectionIdNotSet
+                ) {
+                    tracing::error!(
+                        "[AttachedFunctionOrchestrator]: Output collection ID not set for attached function '{}'",
+                        attached_function.name
+                    );
+                }
+                self.terminate_with_result(Err(err), ctx).await;
                 return;
             }
         };
-
-        let database_name = match chroma_types::DatabaseName::new(
-            self.get_input_collection_info().collection.database.clone(),
-        ) {
-            Some(name) => name,
-            None => {
-                tracing::error!(
-                    "Invalid database name in input collection: {}",
-                    self.get_input_collection_info().collection.database
-                );
-                self.terminate_with_result(
-                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                        "Invalid database name".to_string(),
-                    )),
-                    ctx,
-                )
-                .await;
-                return;
-            }
-        };
-
-        let operator = Box::new(GetCollectionAndSegmentsOperator::new(
-            self.output_context.sysdb.clone(),
-            output_collection_id,
-            database_name,
-        ));
-        let task = wrap(
-            operator,
-            (),
-            ctx.receiver(),
-            self.context().task_cancellation_token.clone(),
-        );
-        let res = self.dispatcher().send(task, Some(Span::current())).await;
+        let res = self.dispatcher().send(task, None).await;
         self.ok_or_terminate(res, ctx).await;
     }
 
@@ -632,6 +743,18 @@ impl Orchestrator for AttachedFunctionOrchestrator {
         &mut self,
         ctx: &ComponentContext<Self>,
     ) -> Vec<(TaskMessage, Option<Span>)> {
+        if !self.resolved_attached_functions.is_empty() {
+            return match self
+                .plan_attached_function_tasks(self.resolved_attached_functions.clone(), ctx)
+            {
+                Ok(tasks) => tasks,
+                Err(err) => {
+                    self.terminate_with_result(Err(err), ctx).await;
+                    Vec::new()
+                }
+            };
+        }
+
         // Start by getting the attached function for this collection
         let collection_info = self.get_input_collection_info();
         let operator = Box::new(GetAttachedFunctionOperator::new(
@@ -710,105 +833,16 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
             self.finish_no_attached_function(ctx).await;
             return;
         }
-
-        let mut sync_attached_functions = Vec::new();
-        let mut async_attached_functions = Vec::new();
-        for attached_function in message.attached_functions {
-            if attached_function.is_async {
-                async_attached_functions.push(attached_function);
-            } else {
-                sync_attached_functions.push(attached_function);
-            }
-        }
-
-        if self.output_context.is_fn_consumer
-            && (sync_attached_functions.len() + async_attached_functions.len() != 1)
-        {
-            self.terminate_with_result(
-                Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                    "Function consumer execution expects exactly one attached function".to_string(),
-                )),
-                ctx,
-            )
-            .await;
-            return;
-        }
-
-        if sync_attached_functions.len() > 1 || async_attached_functions.len() > 1 {
-            self.terminate_with_result(
-                Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                    "At most one sync and one async attached function are supported per collection"
-                        .to_string(),
-                )),
-                ctx,
-            )
-            .await;
-            return;
-        }
-
-        let sync_attached_function = sync_attached_functions.pop();
-        let mut async_attached_function = async_attached_functions.pop();
-
-        if let Some(sync_attached_function) = sync_attached_function {
-            tracing::info!(
-                "[AttachedFunctionOrchestrator]: Prepared sync attached function '{}' for collection",
-                sync_attached_function.name
-            );
-
-            if self
-                .set_function_context(self.make_function_context(&sync_attached_function))
-                .is_err()
-            {
-                self.terminate_with_result(
-                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                        "Failed to set function context for attached function".to_string(),
-                    )),
-                    ctx,
-                )
-                .await;
+        let tasks = match self.plan_attached_function_tasks(message.attached_functions, ctx) {
+            Ok(tasks) => tasks,
+            Err(err) => {
+                self.terminate_with_result(Err(err), ctx).await;
                 return;
             }
+        };
 
-            self.pending_sync_attached_function = Some(sync_attached_function);
-        }
-
-        if let Some(async_attached_function) = async_attached_function.as_ref() {
-            tracing::info!(
-                    "[AttachedFunctionOrchestrator]: Queueing async attached function '{}' for collection",
-                    async_attached_function.name
-                );
-
-            if !self.output_context.is_fn_consumer {
-                if !self
-                    .dispatch_async_function_queue(async_attached_function, ctx)
-                    .await
-                {
-                    return;
-                }
-                return;
-            }
-        }
-
-        if let Some(sync_attached_function) = self.pending_sync_attached_function.take() {
-            self.dispatch_function_execution(sync_attached_function, ctx)
-                .await;
-        } else if let Some(async_attached_function) = async_attached_function.take() {
-            if self
-                .set_function_context(self.make_function_context(&async_attached_function))
-                .is_err()
-            {
-                self.terminate_with_result(
-                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                        "Failed to set function context for attached function".to_string(),
-                    )),
-                    ctx,
-                )
-                .await;
-                return;
-            }
-
-            self.dispatch_function_execution(async_attached_function, ctx)
-                .await;
+        for (task, span) in tasks {
+            self.send(task, ctx, span).await;
         }
     }
 }

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -260,6 +260,10 @@ pub enum AttachedFunctionOrchestratorResponse {
 }
 
 impl AttachedFunctionOrchestrator {
+    fn queued_compaction_offset(collection_info: &CollectionCompactInfo) -> i64 {
+        collection_info.pulled_log_offset
+    }
+
     fn collect_resolved_attached_functions(
         input_collection_data: &[FunctionInputCollectionData],
     ) -> Vec<AttachedFunction> {
@@ -665,13 +669,14 @@ impl Orchestrator for AttachedFunctionOrchestrator {
             }
 
             let attached_function = self.resolved_attached_functions[0].clone();
-            if self
-                .set_function_context(self.make_function_context(&attached_function))
-                .is_err()
+            if let Err(function_context) =
+                self.set_function_context(self.make_function_context(&attached_function))
             {
                 self.terminate_with_result(
                     Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                        "Failed to set function context for attached function".to_string(),
+                        format!(
+                            "Failed to set function context for attached function: {function_context:?}"
+                        ),
                     )),
                     ctx,
                 )
@@ -846,13 +851,13 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
             if !self.output_context.is_fn_consumer {
                 if let Some(work_queue_client) = &self.output_context.work_queue_client {
                     let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
-                    let compaction_offset =
-                        self.get_input_collection_info().collection.log_position;
+                    let queued_compaction_offset =
+                        Self::queued_compaction_offset(self.get_input_collection_info());
                     let input = QueueFunctionInput::new(
                         async_attached_function.id,
                         self.get_input_collection_info().collection_id,
                         async_attached_function.completion_offset as i64,
-                        compaction_offset,
+                        queued_compaction_offset,
                     );
                     let task = wrap(
                         operator,
@@ -860,7 +865,7 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
                         ctx.receiver(),
                         self.context().task_cancellation_token.clone(),
                     );
-                    let res = self.dispatcher().send(task, None).await;
+                    let res = self.dispatcher().send(task, Some(Span::current())).await;
                     if self.ok_or_terminate(res, ctx).await.is_none() {
                         return;
                     }
@@ -1206,11 +1211,48 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_pulled_log_offset;
+    use super::{resolve_pulled_log_offset, AttachedFunctionOrchestrator};
+    use crate::execution::orchestration::compact::CollectionCompactInfo;
+    use chroma_types::{Collection, CollectionUuid};
 
     #[test]
     fn test_resolve_pulled_log_offset() {
         assert_eq!(resolve_pulled_log_offset(true, 199, 299), 299);
         assert_eq!(resolve_pulled_log_offset(false, 199, 299), 199);
+    }
+
+    fn compact_info(pulled_log_offset: i64, persisted_log_position: i64) -> CollectionCompactInfo {
+        CollectionCompactInfo {
+            collection_id: CollectionUuid::new(),
+            collection: Collection {
+                log_position: persisted_log_position,
+                ..Default::default()
+            },
+            writers: None,
+            pulled_log_offset,
+            hnsw_index_uuid: None,
+            schema: None,
+            original_segment_flush_infos: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn async_queue_frontier_uses_pulled_log_offset() {
+        let collection_info = compact_info(550, 250);
+
+        assert_eq!(
+            AttachedFunctionOrchestrator::queued_compaction_offset(&collection_info),
+            550
+        );
+    }
+
+    #[test]
+    fn async_queue_frontier_uses_pulled_log_offset_even_when_it_regresses() {
+        let collection_info = compact_info(200, 250);
+
+        assert_eq!(
+            AttachedFunctionOrchestrator::queued_compaction_offset(&collection_info),
+            200
+        );
     }
 }

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -305,37 +305,6 @@ impl AttachedFunctionOrchestrator {
         }
     }
 
-    fn make_async_queue_task(
-        &self,
-        attached_function: &AttachedFunction,
-        ctx: &ComponentContext<Self>,
-    ) -> Result<TaskMessage, AttachedFunctionOrchestratorError> {
-        let work_queue_client = self
-            .output_context
-            .work_queue_client
-            .clone()
-            .ok_or_else(|| {
-                AttachedFunctionOrchestratorError::InvariantViolation(
-                    "Async function requires WorkQueue configuration".to_string(),
-                )
-            })?;
-        let operator = Box::new(QueueFunctionOperator::new(work_queue_client));
-        let compaction_offset = self.get_input_collection_info().collection.log_position;
-        let input = QueueFunctionInput::new(
-            attached_function.id,
-            self.get_input_collection_info().collection_id,
-            attached_function.completion_offset as i64,
-            compaction_offset,
-        );
-
-        Ok(wrap(
-            operator,
-            input,
-            ctx.receiver(),
-            self.context().task_cancellation_token.clone(),
-        ))
-    }
-
     fn make_function_execution_task(
         &self,
         attached_function: &AttachedFunction,
@@ -364,98 +333,6 @@ impl AttachedFunctionOrchestrator {
             ctx.receiver(),
             self.context().task_cancellation_token.clone(),
         ))
-    }
-
-    fn plan_attached_function_tasks(
-        &mut self,
-        attached_functions: Vec<AttachedFunction>,
-        ctx: &ComponentContext<Self>,
-    ) -> Result<Vec<(TaskMessage, Option<Span>)>, AttachedFunctionOrchestratorError> {
-        let mut tasks = Vec::new();
-
-        let mut sync_attached_functions = Vec::new();
-        let mut async_attached_functions = Vec::new();
-        for attached_function in attached_functions {
-            if attached_function.is_async {
-                async_attached_functions.push(attached_function);
-            } else {
-                sync_attached_functions.push(attached_function);
-            }
-        }
-
-        if self.output_context.is_fn_consumer
-            && (sync_attached_functions.len() + async_attached_functions.len() != 1)
-        {
-            return Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                "Function consumer execution expects exactly one attached function".to_string(),
-            ));
-        }
-
-        if sync_attached_functions.len() > 1 || async_attached_functions.len() > 1 {
-            return Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                "At most one sync and one async attached function are supported per collection"
-                    .to_string(),
-            ));
-        }
-
-        let sync_attached_function = sync_attached_functions.pop();
-        let mut async_attached_function = async_attached_functions.pop();
-
-        if let Some(sync_attached_function) = sync_attached_function {
-            tracing::info!(
-                "[AttachedFunctionOrchestrator]: Prepared sync attached function '{}' for collection",
-                sync_attached_function.name
-            );
-
-            if self
-                .set_function_context(self.make_function_context(&sync_attached_function))
-                .is_err()
-            {
-                return Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                    "Failed to set function context for attached function".to_string(),
-                ));
-            }
-
-            self.pending_sync_attached_function = Some(sync_attached_function);
-        }
-
-        if let Some(async_attached_function) = async_attached_function.as_ref() {
-            tracing::info!(
-                "[AttachedFunctionOrchestrator]: Queueing async attached function '{}' for collection",
-                async_attached_function.name
-            );
-
-            if !self.output_context.is_fn_consumer {
-                tasks.push((
-                    self.make_async_queue_task(async_attached_function, ctx)?,
-                    Some(Span::current()),
-                ));
-                return Ok(tasks);
-            }
-        }
-
-        if let Some(sync_attached_function) = self.pending_sync_attached_function.take() {
-            tasks.push((
-                self.make_function_execution_task(&sync_attached_function, ctx)?,
-                Some(Span::current()),
-            ));
-        } else if let Some(async_attached_function) = async_attached_function.take() {
-            if self
-                .set_function_context(self.make_function_context(&async_attached_function))
-                .is_err()
-            {
-                return Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                    "Failed to set function context for attached function".to_string(),
-                ));
-            }
-
-            tasks.push((
-                self.make_function_execution_task(&async_attached_function, ctx)?,
-                Some(Span::current()),
-            ));
-        }
-
-        Ok(tasks)
     }
 
     /// Get the input collection info, following the same pattern as CompactionContext
@@ -538,22 +415,53 @@ impl AttachedFunctionOrchestrator {
         attached_function: AttachedFunction,
         ctx: &ComponentContext<Self>,
     ) {
-        let task = match self.make_function_execution_task(&attached_function, ctx) {
-            Ok(task) => task,
-            Err(err) => {
-                if matches!(
-                    err,
-                    AttachedFunctionOrchestratorError::OutputCollectionIdNotSet
-                ) {
-                    tracing::error!(
-                        "[AttachedFunctionOrchestrator]: Output collection ID not set for attached function '{}'",
-                        attached_function.name
-                    );
-                }
-                self.terminate_with_result(Err(err), ctx).await;
+        let output_collection_id = match attached_function.output_collection_id {
+            Some(id) => id,
+            None => {
+                tracing::error!(
+                    "[AttachedFunctionOrchestrator]: Output collection ID not set for attached function '{}'",
+                    attached_function.name
+                );
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::OutputCollectionIdNotSet),
+                    ctx,
+                )
+                .await;
                 return;
             }
         };
+
+        let database_name = match chroma_types::DatabaseName::new(
+            self.get_input_collection_info().collection.database.clone(),
+        ) {
+            Some(name) => name,
+            None => {
+                tracing::error!(
+                    "Invalid database name in input collection: {}",
+                    self.get_input_collection_info().collection.database
+                );
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Invalid database name".to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
+                return;
+            }
+        };
+
+        let operator = Box::new(GetCollectionAndSegmentsOperator::new(
+            self.output_context.sysdb.clone(),
+            output_collection_id,
+            database_name,
+        ));
+        let task = wrap(
+            operator,
+            (),
+            ctx.receiver(),
+            self.context().task_cancellation_token.clone(),
+        );
         let res = self.dispatcher().send(task, None).await;
         self.ok_or_terminate(res, ctx).await;
     }
@@ -744,11 +652,45 @@ impl Orchestrator for AttachedFunctionOrchestrator {
         ctx: &ComponentContext<Self>,
     ) -> Vec<(TaskMessage, Option<Span>)> {
         if !self.resolved_attached_functions.is_empty() {
-            return match self
-                .plan_attached_function_tasks(self.resolved_attached_functions.clone(), ctx)
+            if self.resolved_attached_functions.len() != 1 {
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Function consumer execution expects exactly one attached function"
+                            .to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
+                return Vec::new();
+            }
+
+            let attached_function = self.resolved_attached_functions[0].clone();
+            if self
+                .set_function_context(self.make_function_context(&attached_function))
+                .is_err()
             {
-                Ok(tasks) => tasks,
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Failed to set function context for attached function".to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
+                return Vec::new();
+            }
+
+            return match self.make_function_execution_task(&attached_function, ctx) {
+                Ok(task) => vec![(task, Some(Span::current()))],
                 Err(err) => {
+                    if matches!(
+                        err,
+                        AttachedFunctionOrchestratorError::OutputCollectionIdNotSet
+                    ) {
+                        tracing::error!(
+                            "[AttachedFunctionOrchestrator]: Output collection ID not set for attached function '{}'",
+                            attached_function.name
+                        );
+                    }
                     self.terminate_with_result(Err(err), ctx).await;
                     Vec::new()
                 }
@@ -833,16 +775,129 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
             self.finish_no_attached_function(ctx).await;
             return;
         }
-        let tasks = match self.plan_attached_function_tasks(message.attached_functions, ctx) {
-            Ok(tasks) => tasks,
-            Err(err) => {
-                self.terminate_with_result(Err(err), ctx).await;
+
+        let mut sync_attached_functions = Vec::new();
+        let mut async_attached_functions = Vec::new();
+        for attached_function in message.attached_functions {
+            if attached_function.is_async {
+                async_attached_functions.push(attached_function);
+            } else {
+                sync_attached_functions.push(attached_function);
+            }
+        }
+
+        if self.output_context.is_fn_consumer
+            && (sync_attached_functions.len() + async_attached_functions.len() != 1)
+        {
+            self.terminate_with_result(
+                Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                    "Function consumer execution expects exactly one attached function".to_string(),
+                )),
+                ctx,
+            )
+            .await;
+            return;
+        }
+
+        if sync_attached_functions.len() > 1 || async_attached_functions.len() > 1 {
+            self.terminate_with_result(
+                Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                    "At most one sync and one async attached function are supported per collection"
+                        .to_string(),
+                )),
+                ctx,
+            )
+            .await;
+            return;
+        }
+
+        let sync_attached_function = sync_attached_functions.pop();
+        let mut async_attached_function = async_attached_functions.pop();
+
+        if let Some(sync_attached_function) = sync_attached_function {
+            tracing::info!(
+                "[AttachedFunctionOrchestrator]: Prepared sync attached function '{}' for collection",
+                sync_attached_function.name
+            );
+
+            if self
+                .set_function_context(self.make_function_context(&sync_attached_function))
+                .is_err()
+            {
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Failed to set function context for attached function".to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
                 return;
             }
-        };
 
-        for (task, span) in tasks {
-            self.send(task, ctx, span).await;
+            self.pending_sync_attached_function = Some(sync_attached_function);
+        }
+
+        if let Some(async_attached_function) = async_attached_function.as_ref() {
+            tracing::info!(
+                    "[AttachedFunctionOrchestrator]: Queueing async attached function '{}' for collection",
+                    async_attached_function.name
+                );
+
+            if !self.output_context.is_fn_consumer {
+                if let Some(work_queue_client) = &self.output_context.work_queue_client {
+                    let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
+                    let compaction_offset = self.get_input_collection_info().collection.log_position;
+                    let input = QueueFunctionInput::new(
+                        async_attached_function.id,
+                        self.get_input_collection_info().collection_id,
+                        async_attached_function.completion_offset as i64,
+                        compaction_offset,
+                    );
+                    let task = wrap(
+                        operator,
+                        input,
+                        ctx.receiver(),
+                        self.context().task_cancellation_token.clone(),
+                    );
+                    let res = self.dispatcher().send(task, None).await;
+                    if self.ok_or_terminate(res, ctx).await.is_none() {
+                        return;
+                    }
+                } else {
+                    tracing::error!("Async attached function found but no WorkQueue client configured");
+                    self.terminate_with_result(
+                        Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                            "Async function requires WorkQueue configuration".to_string(),
+                        )),
+                        ctx,
+                    )
+                    .await;
+                    return;
+                }
+                return;
+            }
+        }
+
+        if let Some(sync_attached_function) = self.pending_sync_attached_function.take() {
+            self.dispatch_function_execution(sync_attached_function, ctx)
+                .await;
+        } else if let Some(async_attached_function) = async_attached_function.take() {
+            if self
+                .set_function_context(self.make_function_context(&async_attached_function))
+                .is_err()
+            {
+                self.terminate_with_result(
+                    Err(AttachedFunctionOrchestratorError::InvariantViolation(
+                        "Failed to set function context for attached function".to_string(),
+                    )),
+                    ctx,
+                )
+                .await;
+                return;
+            }
+
+            self.dispatch_function_execution(async_attached_function, ctx)
+                .await;
         }
     }
 }

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -846,7 +846,8 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
             if !self.output_context.is_fn_consumer {
                 if let Some(work_queue_client) = &self.output_context.work_queue_client {
                     let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
-                    let compaction_offset = self.get_input_collection_info().collection.log_position;
+                    let compaction_offset =
+                        self.get_input_collection_info().collection.log_position;
                     let input = QueueFunctionInput::new(
                         async_attached_function.id,
                         self.get_input_collection_info().collection_id,
@@ -864,7 +865,9 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
                         return;
                     }
                 } else {
-                    tracing::error!("Async attached function found but no WorkQueue client configured");
+                    tracing::error!(
+                        "Async attached function found but no WorkQueue client configured"
+                    );
                     self.terminate_with_result(
                         Err(AttachedFunctionOrchestratorError::InvariantViolation(
                             "Async function requires WorkQueue configuration".to_string(),

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -517,6 +517,42 @@ impl CompactionContext {
         system: System,
         is_getting_compacted_logs: bool,
     ) -> Result<LogFetchOrchestratorResponse, LogFetchOrchestratorError> {
+        self.run_get_logs_with_attached_function(
+            collection_id,
+            database_name,
+            system,
+            is_getting_compacted_logs,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn run_get_logs_for_attached_function(
+        &mut self,
+        collection_id: CollectionUuid,
+        database_name: chroma_types::DatabaseName,
+        system: System,
+        is_getting_compacted_logs: bool,
+        attached_function_id: chroma_types::AttachedFunctionUuid,
+    ) -> Result<LogFetchOrchestratorResponse, LogFetchOrchestratorError> {
+        self.run_get_logs_with_attached_function(
+            collection_id,
+            database_name,
+            system,
+            is_getting_compacted_logs,
+            Some(attached_function_id),
+        )
+        .await
+    }
+
+    async fn run_get_logs_with_attached_function(
+        &mut self,
+        collection_id: CollectionUuid,
+        database_name: chroma_types::DatabaseName,
+        system: System,
+        is_getting_compacted_logs: bool,
+        attached_function_id_filter: Option<chroma_types::AttachedFunctionUuid>,
+    ) -> Result<LogFetchOrchestratorResponse, LogFetchOrchestratorError> {
         // TODO(tanujnay112): This is awful, we need to find a better way to pass
         // the active collection info around.
         self.collection_info = OnceCell::new();
@@ -547,6 +583,7 @@ impl CompactionContext {
             self.work_queue_client.clone(),
             self.is_fn_consumer,
             self.log_start_offset,
+            attached_function_id_filter,
         );
 
         let log_fetch_response = match log_fetch_orchestrator.run(system.clone()).await {
@@ -563,6 +600,7 @@ impl CompactionContext {
             LogFetchOrchestratorResponse::Success(success) => {
                 let materialized = success.materialized;
                 let collection_info = success.collection_info;
+                let resolved_attached_functions = success.resolved_attached_functions;
 
                 self.collection_info
                     .set(collection_info.clone())
@@ -570,7 +608,12 @@ impl CompactionContext {
                         CompactionContextError::InvariantViolation("Collection info already set")
                     })?;
 
-                Ok(Success::new(materialized, collection_info.clone()).into())
+                Ok(Success::new(
+                    materialized,
+                    collection_info.clone(),
+                    resolved_attached_functions,
+                )
+                .into())
             }
             LogFetchOrchestratorResponse::RequireCompactionOffsetRepair(repair) => {
                 Ok(RequireCompactionOffsetRepair::new(
@@ -819,6 +862,7 @@ impl CompactionContext {
                 .map_err(CompactionError::CompactionContextError)?
                 .clone(),
             materialized_log_data: log_fetch_records,
+            resolved_attached_functions: Vec::new(),
         };
 
         let mut ran_backfill = false;
@@ -987,6 +1031,7 @@ impl CompactionContext {
         let function_input_collection_data = FunctionInputCollectionData {
             collection_info: collection_info.clone(),
             materialized_log_data: log_fetch_records.clone(),
+            resolved_attached_functions: Vec::new(),
         };
 
         let mut self_clone_fn = self.clone();

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -517,7 +517,7 @@ impl CompactionContext {
         system: System,
         is_getting_compacted_logs: bool,
     ) -> Result<LogFetchOrchestratorResponse, LogFetchOrchestratorError> {
-        self.run_get_logs_with_attached_function(
+        self.run_get_logs_inner(
             collection_id,
             database_name,
             system,
@@ -535,7 +535,7 @@ impl CompactionContext {
         is_getting_compacted_logs: bool,
         attached_function_id: chroma_types::AttachedFunctionUuid,
     ) -> Result<LogFetchOrchestratorResponse, LogFetchOrchestratorError> {
-        self.run_get_logs_with_attached_function(
+        self.run_get_logs_inner(
             collection_id,
             database_name,
             system,
@@ -545,7 +545,7 @@ impl CompactionContext {
         .await
     }
 
-    async fn run_get_logs_with_attached_function(
+    async fn run_get_logs_inner(
         &mut self,
         collection_id: CollectionUuid,
         database_name: chroma_types::DatabaseName,

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -516,41 +516,6 @@ impl CompactionContext {
         database_name: chroma_types::DatabaseName,
         system: System,
         is_getting_compacted_logs: bool,
-    ) -> Result<LogFetchOrchestratorResponse, LogFetchOrchestratorError> {
-        self.run_get_logs_inner(
-            collection_id,
-            database_name,
-            system,
-            is_getting_compacted_logs,
-            None,
-        )
-        .await
-    }
-
-    pub(crate) async fn run_get_logs_for_attached_function(
-        &mut self,
-        collection_id: CollectionUuid,
-        database_name: chroma_types::DatabaseName,
-        system: System,
-        is_getting_compacted_logs: bool,
-        attached_function_id: chroma_types::AttachedFunctionUuid,
-    ) -> Result<LogFetchOrchestratorResponse, LogFetchOrchestratorError> {
-        self.run_get_logs_inner(
-            collection_id,
-            database_name,
-            system,
-            is_getting_compacted_logs,
-            Some(attached_function_id),
-        )
-        .await
-    }
-
-    async fn run_get_logs_inner(
-        &mut self,
-        collection_id: CollectionUuid,
-        database_name: chroma_types::DatabaseName,
-        system: System,
-        is_getting_compacted_logs: bool,
         attached_function_id_filter: Option<chroma_types::AttachedFunctionUuid>,
     ) -> Result<LogFetchOrchestratorResponse, LogFetchOrchestratorError> {
         // TODO(tanujnay112): This is awful, we need to find a better way to pass
@@ -844,6 +809,7 @@ impl CompactionContext {
                 database_name,
                 system.clone(),
                 true,
+                None,
             )
             .await?
         {
@@ -980,7 +946,13 @@ impl CompactionContext {
         system: System,
     ) -> Result<CompactionResponse, CompactionError> {
         let result = self
-            .run_get_logs(collection_id, database_name.clone(), system.clone(), false)
+            .run_get_logs(
+                collection_id,
+                database_name.clone(),
+                system.clone(),
+                false,
+                None,
+            )
             .await?;
 
         let (log_fetch_records, collection_info) = match result {
@@ -3640,6 +3612,7 @@ mod tests {
                     .expect("database name should be valid"),
                 system.clone(),
                 false,
+                None,
             )
             .await;
 
@@ -5182,7 +5155,13 @@ mod tests {
         );
 
         let fetch_response = fn_consumer_context
-            .run_get_logs(collection_id, database_name.clone(), system.clone(), false)
+            .run_get_logs(
+                collection_id,
+                database_name.clone(),
+                system.clone(),
+                false,
+                None,
+            )
             .await
             .expect("fn-consumer log fetch should succeed");
 
@@ -5244,7 +5223,13 @@ mod tests {
         );
 
         let second_fetch_response = second_window_context
-            .run_get_logs(collection_id, database_name.clone(), system.clone(), false)
+            .run_get_logs(
+                collection_id,
+                database_name.clone(),
+                system.clone(),
+                false,
+                None,
+            )
             .await
             .expect("second fn-consumer log fetch should succeed");
 

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -5,8 +5,7 @@ use chroma_types::{AttachedFunction, AttachedFunctionUuid, CollectionUuid, Datab
 use uuid::Uuid;
 
 use crate::execution::operators::{
-    fetch_log::FetchLogError,
-    materialize_logs::MaterializeLogOutput,
+    fetch_log::FetchLogError, materialize_logs::MaterializeLogOutput,
 };
 
 use super::{

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -17,6 +17,7 @@ use super::{
 #[derive(Debug, Clone)]
 pub struct FunctionExecutionInput {
     pub collection_id: CollectionUuid,
+    pub queue_completion_offset: i64,
     pub queue_compaction_offset: i64,
 }
 
@@ -109,12 +110,17 @@ impl FunctionExecutionContext {
     }
 
     async fn fetch_function_input_collection_data(
-        compaction_context: CompactionContext,
+        mut compaction_context: CompactionContext,
         collection_id: CollectionUuid,
+        queue_completion_offset: i64,
         attached_function_id: AttachedFunctionUuid,
         database_name: DatabaseName,
         system: System,
     ) -> Result<FunctionInputCollectionData, CompactionError> {
+        // The queue tracks progress per (function, input collection). For
+        // multi-input async functions this is more precise than the shared
+        // attached-function completion watermark.
+        compaction_context.log_start_offset = Some(queue_completion_offset);
         let log_fetch_context = compaction_context;
         let result = match Self::fetch_function_input_logs(
             log_fetch_context.clone(),
@@ -224,33 +230,28 @@ impl FunctionExecutionContext {
             Self::resolve_shared_input_database_name(base_context.clone(), &fn_inputs).await?;
         let mut input_collection_data = Vec::with_capacity(fn_inputs.len());
         for input in fn_inputs {
+            if has_reached_queue_frontier(
+                input.queue_completion_offset,
+                input.queue_compaction_offset,
+            ) {
+                tracing::info!(
+                    collection_id = %input.collection_id,
+                    completion_offset = input.queue_completion_offset,
+                    queue_compaction_offset = input.queue_compaction_offset,
+                    "Skipping stale fn-consumer work item because queue progress is already at or beyond the queued frontier"
+                );
+                continue;
+            }
+
             let collection_data = Box::pin(Self::fetch_function_input_collection_data(
                 base_context.clone(),
                 input.collection_id,
+                input.queue_completion_offset,
                 attached_function_id,
                 shared_database_name.clone(),
                 system.clone(),
             ))
             .await?;
-
-            let completion_offset = collection_data
-                .resolved_attached_functions
-                .iter()
-                .find(|attached_function| attached_function.id == attached_function_id)
-                .map(|attached_function| attached_function.completion_offset as i64)
-                .ok_or(CompactionError::InvariantViolation(
-                    "Missing resolved attached function state for fn-consumer input collection",
-                ))?;
-
-            if has_reached_queue_frontier(completion_offset, input.queue_compaction_offset) {
-                tracing::info!(
-                    collection_id = %input.collection_id,
-                    completion_offset,
-                    queue_compaction_offset = input.queue_compaction_offset,
-                    "Skipping stale fn-consumer work item because attached function is already at or beyond the queued frontier"
-                );
-                continue;
-            }
 
             input_collection_data.push(collection_data);
         }
@@ -289,7 +290,6 @@ impl FunctionExecutionContext {
 
 #[cfg(test)]
 mod tests {
-<<<<<<< HEAD
     use super::FunctionExecutionContext;
     use crate::execution::{
         operators::fetch_log::FetchLogError,
@@ -322,17 +322,5 @@ mod tests {
         assert!(!FunctionExecutionContext::should_backfill_on_fetch_error(
             &err
         ));
-=======
-    use super::has_reached_queue_frontier;
-
-    #[test]
-    fn zero_queue_frontier_is_not_treated_as_completed_work() {
-        assert!(!has_reached_queue_frontier(0, 0));
-    }
-
-    #[test]
-    fn positive_queue_frontier_still_treats_equality_as_complete() {
-        assert!(has_reached_queue_frontier(40, 40));
->>>>>>> 2f78f7180 ([BUG](fn-consumer): handle zero queue frontier)
     }
 }

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -48,7 +48,7 @@ pub struct FunctionExecutionContext {
 }
 
 fn has_reached_queue_frontier(completion_offset: i64, queue_compaction_offset: i64) -> bool {
-    queue_compaction_offset > 0 && completion_offset >= queue_compaction_offset
+    completion_offset >= queue_compaction_offset
 }
 
 impl FunctionExecutionContext {
@@ -67,12 +67,12 @@ impl FunctionExecutionContext {
         attached_function_id: AttachedFunctionUuid,
     ) -> Result<LogFetchOrchestratorResponse, CompactionError> {
         Ok(log_fetch_context
-            .run_get_logs_for_attached_function(
+            .run_get_logs(
                 collection_id,
                 database_name.clone(),
                 system.clone(),
                 use_compacted_logs,
-                attached_function_id,
+                Some(attached_function_id),
             )
             .await?)
     }
@@ -289,7 +289,7 @@ impl FunctionExecutionContext {
 
 #[cfg(test)]
 mod tests {
-    use super::FunctionExecutionContext;
+    use super::{has_reached_queue_frontier, FunctionExecutionContext};
     use crate::execution::{
         operators::fetch_log::FetchLogError,
         orchestration::{
@@ -308,6 +308,11 @@ mod tests {
         assert!(FunctionExecutionContext::should_backfill_on_fetch_error(
             &err
         ));
+    }
+
+    #[test]
+    fn zero_queue_frontier_treats_equality_as_complete() {
+        assert!(has_reached_queue_frontier(0, 0));
     }
 
     #[test]

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -17,7 +17,6 @@ use super::{
 #[derive(Debug, Clone)]
 pub struct FunctionExecutionInput {
     pub collection_id: CollectionUuid,
-    pub queue_completion_offset: i64,
     pub queue_compaction_offset: i64,
 }
 
@@ -110,17 +109,12 @@ impl FunctionExecutionContext {
     }
 
     async fn fetch_function_input_collection_data(
-        mut compaction_context: CompactionContext,
+        compaction_context: CompactionContext,
         collection_id: CollectionUuid,
-        queue_completion_offset: i64,
         attached_function_id: AttachedFunctionUuid,
         database_name: DatabaseName,
         system: System,
     ) -> Result<FunctionInputCollectionData, CompactionError> {
-        // The queue tracks progress per (function, input collection). For
-        // multi-input async functions this is more precise than the shared
-        // attached-function completion watermark.
-        compaction_context.log_start_offset = Some(queue_completion_offset);
         let log_fetch_context = compaction_context;
         let result = match Self::fetch_function_input_logs(
             log_fetch_context.clone(),
@@ -230,28 +224,33 @@ impl FunctionExecutionContext {
             Self::resolve_shared_input_database_name(base_context.clone(), &fn_inputs).await?;
         let mut input_collection_data = Vec::with_capacity(fn_inputs.len());
         for input in fn_inputs {
-            if has_reached_queue_frontier(
-                input.queue_completion_offset,
-                input.queue_compaction_offset,
-            ) {
-                tracing::info!(
-                    collection_id = %input.collection_id,
-                    completion_offset = input.queue_completion_offset,
-                    queue_compaction_offset = input.queue_compaction_offset,
-                    "Skipping stale fn-consumer work item because queue progress is already at or beyond the queued frontier"
-                );
-                continue;
-            }
-
             let collection_data = Box::pin(Self::fetch_function_input_collection_data(
                 base_context.clone(),
                 input.collection_id,
-                input.queue_completion_offset,
                 attached_function_id,
                 shared_database_name.clone(),
                 system.clone(),
             ))
             .await?;
+
+            let completion_offset = collection_data
+                .resolved_attached_functions
+                .iter()
+                .find(|attached_function| attached_function.id == attached_function_id)
+                .map(|attached_function| attached_function.completion_offset as i64)
+                .ok_or(CompactionError::InvariantViolation(
+                    "Missing resolved attached function state for fn-consumer input collection",
+                ))?;
+
+            if has_reached_queue_frontier(completion_offset, input.queue_compaction_offset) {
+                tracing::info!(
+                    collection_id = %input.collection_id,
+                    completion_offset,
+                    queue_compaction_offset = input.queue_compaction_offset,
+                    "Skipping stale fn-consumer work item because attached function is already at or beyond the queued frontier"
+                );
+                continue;
+            }
 
             input_collection_data.push(collection_data);
         }

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -174,39 +174,6 @@ impl FunctionExecutionContext {
         }
     }
 
-    async fn finish_stale_work_items(
-        work_queue_client: Option<crate::work_queue::work_queue_client::WorkQueueClient>,
-        attached_function_id: AttachedFunctionUuid,
-        stale_work_items: &[(CollectionUuid, i64)],
-    ) -> Result<(), CompactionError> {
-        if stale_work_items.is_empty() {
-            return Ok(());
-        }
-
-        let Some(mut work_queue_client) = work_queue_client else {
-            return Err(CompactionError::InvariantViolation(
-                "fn-consumer stale work cleanup requires a work queue client",
-            ));
-        };
-
-        for (collection_id, completion_offset) in stale_work_items {
-            work_queue_client
-                .finish_work(
-                    attached_function_id.to_string(),
-                    collection_id.to_string(),
-                    *completion_offset,
-                )
-                .await
-                .map_err(|_| {
-                    CompactionError::InvariantViolation(
-                        "Failed to clear stale fn-consumer work queue entry",
-                    )
-                })?;
-        }
-
-        Ok(())
-    }
-
     async fn resolve_shared_input_database_name(
         compaction_context: CompactionContext,
         fn_inputs: &[FunctionExecutionInput],
@@ -252,7 +219,6 @@ impl FunctionExecutionContext {
         let shared_database_name =
             Self::resolve_shared_input_database_name(base_context.clone(), &fn_inputs).await?;
         let mut input_collection_data = Vec::with_capacity(fn_inputs.len());
-        let mut stale_work_items = Vec::new();
         for input in fn_inputs {
             let collection_data = Box::pin(Self::fetch_function_input_collection_data(
                 base_context.clone(),
@@ -279,19 +245,11 @@ impl FunctionExecutionContext {
                     queue_compaction_offset = input.queue_compaction_offset,
                     "Skipping stale fn-consumer work item because attached function is already at or beyond the queued frontier"
                 );
-                stale_work_items.push((input.collection_id, completion_offset));
                 continue;
             }
 
             input_collection_data.push(collection_data);
         }
-
-        Self::finish_stale_work_items(
-            base_context.work_queue_client.clone(),
-            attached_function_id,
-            &stale_work_items,
-        )
-        .await?;
 
         if input_collection_data.is_empty() {
             return Ok(CompactionResponse::Success {

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -127,13 +127,13 @@ impl FunctionExecutionContext {
         {
             Ok(result) => result,
             Err(err) if Self::should_backfill_on_fetch_error(&err) => {
-                return Self::fetch_backfilled_function_input_collection_data(
+                return Box::pin(Self::fetch_backfilled_function_input_collection_data(
                     log_fetch_context,
                     collection_id,
                     attached_function_id,
                     database_name,
                     system,
-                )
+                ))
                 .await;
             }
             Err(err) => return Err(err),
@@ -146,13 +146,13 @@ impl FunctionExecutionContext {
                 resolved_attached_functions: success.resolved_attached_functions,
             }),
             LogFetchOrchestratorResponse::RequireFunctionBackfill(_) => {
-                Self::fetch_backfilled_function_input_collection_data(
+                Box::pin(Self::fetch_backfilled_function_input_collection_data(
                     log_fetch_context,
                     collection_id,
                     attached_function_id,
                     database_name,
                     system,
-                )
+                ))
                 .await
             }
             LogFetchOrchestratorResponse::RequireCompactionOffsetRepair(_) => {

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -1,23 +1,30 @@
-use std::cell::OnceCell;
-
 use chroma_error::source_chain_contains;
 use chroma_log::grpc_log::GrpcPullLogsError;
 use chroma_system::System;
 use chroma_types::{AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName};
 use uuid::Uuid;
 
-use crate::execution::operators::materialize_logs::MaterializeLogOutput;
+use crate::execution::operators::{
+    fetch_log::FetchLogError,
+    materialize_logs::MaterializeLogOutput,
+};
 
 use super::{
     compact::{CollectionCompactInfo, CompactionContext, CompactionError, CompactionResponse},
     log_fetch_orchestrator::{LogFetchOrchestratorError, LogFetchOrchestratorResponse},
 };
-use crate::execution::operators::fetch_log::FetchLogError;
+
+#[derive(Debug, Clone)]
+pub struct FunctionExecutionInput {
+    pub collection_id: CollectionUuid,
+    pub queue_compaction_offset: i64,
+}
 
 #[derive(Debug, Clone)]
 pub struct FunctionInputCollectionData {
     pub collection_info: CollectionCompactInfo,
     pub materialized_log_data: Vec<MaterializeLogOutput>,
+    pub resolved_attached_functions: Vec<AttachedFunction>,
 }
 
 #[derive(Debug, Clone)]
@@ -47,98 +54,110 @@ impl FunctionExecutionContext {
         }
     }
 
-    fn build_log_fetch_context(
-        mut compaction_context: CompactionContext,
-        log_start_offset: i64,
-    ) -> CompactionContext {
-        compaction_context.collection_info = OnceCell::new();
-        compaction_context.log_start_offset = Some(log_start_offset);
-        compaction_context
-    }
-
     async fn fetch_function_input_logs(
         mut log_fetch_context: CompactionContext,
         collection_id: CollectionUuid,
         database_name: chroma_types::DatabaseName,
         system: System,
         use_compacted_logs: bool,
+        attached_function_id: AttachedFunctionUuid,
     ) -> Result<LogFetchOrchestratorResponse, CompactionError> {
         Ok(log_fetch_context
-            .run_get_logs(
+            .run_get_logs_for_attached_function(
                 collection_id,
                 database_name.clone(),
                 system.clone(),
                 use_compacted_logs,
+                attached_function_id,
             )
             .await?)
+    }
+
+    async fn fetch_backfilled_function_input_collection_data(
+        log_fetch_context: CompactionContext,
+        collection_id: CollectionUuid,
+        attached_function_id: AttachedFunctionUuid,
+        database_name: DatabaseName,
+        system: System,
+    ) -> Result<FunctionInputCollectionData, CompactionError> {
+        match Self::fetch_function_input_logs(
+            log_fetch_context,
+            collection_id,
+            database_name,
+            system,
+            true,
+            attached_function_id,
+        )
+        .await?
+        {
+            LogFetchOrchestratorResponse::Success(success) => Ok(FunctionInputCollectionData {
+                collection_info: success.collection_info,
+                materialized_log_data: success.materialized,
+                resolved_attached_functions: success.resolved_attached_functions,
+            }),
+            LogFetchOrchestratorResponse::RequireCompactionOffsetRepair(_)
+            | LogFetchOrchestratorResponse::RequireFunctionBackfill(_) => {
+                Err(CompactionError::InvariantViolation(
+                    "Function execution backfill fetch should only return success",
+                ))
+            }
+        }
     }
 
     async fn fetch_function_input_collection_data(
         compaction_context: CompactionContext,
         collection_id: CollectionUuid,
-        completion_offset: i64,
+        attached_function_id: AttachedFunctionUuid,
         database_name: DatabaseName,
         system: System,
     ) -> Result<FunctionInputCollectionData, CompactionError> {
-        let log_fetch_context =
-            Self::build_log_fetch_context(compaction_context, completion_offset);
+        let log_fetch_context = compaction_context;
         let result = match Self::fetch_function_input_logs(
             log_fetch_context.clone(),
             collection_id,
             database_name.clone(),
             system.clone(),
             false,
+            attached_function_id,
         )
         .await
         {
             Ok(result) => result,
             Err(err) if Self::should_backfill_on_fetch_error(&err) => {
-                match Self::fetch_function_input_logs(
+                return Self::fetch_backfilled_function_input_collection_data(
                     log_fetch_context,
                     collection_id,
+                    attached_function_id,
                     database_name,
                     system,
-                    true,
                 )
-                .await?
-                {
-                    LogFetchOrchestratorResponse::Success(success) => {
-                        return Ok(FunctionInputCollectionData {
-                            collection_info: success.collection_info,
-                            materialized_log_data: success.materialized,
-                        });
-                    }
-                    LogFetchOrchestratorResponse::RequireCompactionOffsetRepair(_)
-                    | LogFetchOrchestratorResponse::RequireFunctionBackfill(_) => {
-                        return Err(CompactionError::InvariantViolation(
-                            "Function execution backfill fetch should only return success",
-                        ));
-                    }
-                }
+                .await;
             }
             Err(err) => return Err(err),
         };
 
-        let (materialized_log_data, collection_info) = match result {
-            LogFetchOrchestratorResponse::Success(success) => {
-                (success.materialized, success.collection_info)
-            }
-            LogFetchOrchestratorResponse::RequireFunctionBackfill(backfill) => {
-                // BackfillFn forces compaction and schedules async work. Fn-consumers
-                // only backfill when their incremental log offset has been purged.
-                (backfill.materialized, backfill.collection_info)
+        match result {
+            LogFetchOrchestratorResponse::Success(success) => Ok(FunctionInputCollectionData {
+                collection_info: success.collection_info,
+                materialized_log_data: success.materialized,
+                resolved_attached_functions: success.resolved_attached_functions,
+            }),
+            LogFetchOrchestratorResponse::RequireFunctionBackfill(_) => {
+                Self::fetch_backfilled_function_input_collection_data(
+                    log_fetch_context,
+                    collection_id,
+                    attached_function_id,
+                    database_name,
+                    system,
+                )
+                .await
             }
             LogFetchOrchestratorResponse::RequireCompactionOffsetRepair(_) => {
-                return Err(CompactionError::InvariantViolation(
+                Err(CompactionError::InvariantViolation(
                     "Function execution does not support compaction offset repair",
-                ));
+                ))
             }
-        };
-
-        Ok(FunctionInputCollectionData {
-            collection_info,
-            materialized_log_data,
-        })
+        }
     }
 
     fn should_backfill_on_fetch_error(error: &CompactionError) -> bool {
@@ -155,11 +174,44 @@ impl FunctionExecutionContext {
         }
     }
 
+    async fn finish_stale_work_items(
+        work_queue_client: Option<crate::work_queue::work_queue_client::WorkQueueClient>,
+        attached_function_id: AttachedFunctionUuid,
+        stale_work_items: &[(CollectionUuid, i64)],
+    ) -> Result<(), CompactionError> {
+        if stale_work_items.is_empty() {
+            return Ok(());
+        }
+
+        let Some(mut work_queue_client) = work_queue_client else {
+            return Err(CompactionError::InvariantViolation(
+                "fn-consumer stale work cleanup requires a work queue client",
+            ));
+        };
+
+        for (collection_id, completion_offset) in stale_work_items {
+            work_queue_client
+                .finish_work(
+                    attached_function_id.to_string(),
+                    collection_id.to_string(),
+                    *completion_offset,
+                )
+                .await
+                .map_err(|_| {
+                    CompactionError::InvariantViolation(
+                        "Failed to clear stale fn-consumer work queue entry",
+                    )
+                })?;
+        }
+
+        Ok(())
+    }
+
     async fn resolve_shared_input_database_name(
         compaction_context: CompactionContext,
-        fn_inputs: &[(CollectionUuid, i64)],
+        fn_inputs: &[FunctionExecutionInput],
     ) -> Result<DatabaseName, CompactionError> {
-        let Some((first_input_collection_id, _)) = fn_inputs.first() else {
+        let Some(first_input) = fn_inputs.first() else {
             return Err(CompactionError::InvariantViolation(
                 "Function execution requires at least one input collection",
             ));
@@ -170,7 +222,7 @@ impl FunctionExecutionContext {
         // do not carry the database name. Pass the database name from the work queue
         // service and remove this unscoped lookup once that metadata is available.
         let collection_info = sysdb
-            .get_collection_with_segments(None, *first_input_collection_id)
+            .get_collection_with_segments(None, first_input.collection_id)
             .await
             .map_err(|_| {
                 CompactionError::InvariantViolation(
@@ -187,7 +239,7 @@ impl FunctionExecutionContext {
     pub async fn run(
         self,
         attached_function_id: AttachedFunctionUuid,
-        fn_inputs: Vec<(CollectionUuid, i64)>,
+        fn_inputs: Vec<FunctionExecutionInput>,
         system: System,
     ) -> Result<CompactionResponse, CompactionError> {
         if fn_inputs.is_empty() {
@@ -200,17 +252,51 @@ impl FunctionExecutionContext {
         let shared_database_name =
             Self::resolve_shared_input_database_name(base_context.clone(), &fn_inputs).await?;
         let mut input_collection_data = Vec::with_capacity(fn_inputs.len());
-        for (collection_id, completion_offset) in fn_inputs {
-            input_collection_data.push(
-                Box::pin(Self::fetch_function_input_collection_data(
-                    base_context.clone(),
-                    collection_id,
+        let mut stale_work_items = Vec::new();
+        for input in fn_inputs {
+            let collection_data = Box::pin(Self::fetch_function_input_collection_data(
+                base_context.clone(),
+                input.collection_id,
+                attached_function_id,
+                shared_database_name.clone(),
+                system.clone(),
+            ))
+            .await?;
+
+            let completion_offset = collection_data
+                .resolved_attached_functions
+                .iter()
+                .find(|attached_function| attached_function.id == attached_function_id)
+                .map(|attached_function| attached_function.completion_offset as i64)
+                .ok_or(CompactionError::InvariantViolation(
+                    "Missing resolved attached function state for fn-consumer input collection",
+                ))?;
+
+            if completion_offset >= input.queue_compaction_offset {
+                tracing::info!(
+                    collection_id = %input.collection_id,
                     completion_offset,
-                    shared_database_name.clone(),
-                    system.clone(),
-                ))
-                .await?,
-            );
+                    queue_compaction_offset = input.queue_compaction_offset,
+                    "Skipping stale fn-consumer work item because attached function is already at or beyond the queued frontier"
+                );
+                stale_work_items.push((input.collection_id, completion_offset));
+                continue;
+            }
+
+            input_collection_data.push(collection_data);
+        }
+
+        Self::finish_stale_work_items(
+            base_context.work_queue_client.clone(),
+            attached_function_id,
+            &stale_work_items,
+        )
+        .await?;
+
+        if input_collection_data.is_empty() {
+            return Ok(CompactionResponse::Success {
+                job_id: attached_function_id.into(),
+            });
         }
 
         let mut compaction_context = base_context;

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -47,6 +47,10 @@ pub struct FunctionExecutionContext {
     compaction_context: CompactionContext,
 }
 
+fn has_reached_queue_frontier(completion_offset: i64, queue_compaction_offset: i64) -> bool {
+    queue_compaction_offset > 0 && completion_offset >= queue_compaction_offset
+}
+
 impl FunctionExecutionContext {
     pub fn new(compaction_context: &CompactionContext) -> Self {
         Self {
@@ -238,7 +242,7 @@ impl FunctionExecutionContext {
                     "Missing resolved attached function state for fn-consumer input collection",
                 ))?;
 
-            if completion_offset >= input.queue_compaction_offset {
+            if has_reached_queue_frontier(completion_offset, input.queue_compaction_offset) {
                 tracing::info!(
                     collection_id = %input.collection_id,
                     completion_offset,
@@ -285,6 +289,7 @@ impl FunctionExecutionContext {
 
 #[cfg(test)]
 mod tests {
+<<<<<<< HEAD
     use super::FunctionExecutionContext;
     use crate::execution::{
         operators::fetch_log::FetchLogError,
@@ -317,5 +322,17 @@ mod tests {
         assert!(!FunctionExecutionContext::should_backfill_on_fetch_error(
             &err
         ));
+=======
+    use super::has_reached_queue_frontier;
+
+    #[test]
+    fn zero_queue_frontier_is_not_treated_as_completed_work() {
+        assert!(!has_reached_queue_frontier(0, 0));
+    }
+
+    #[test]
+    fn positive_queue_frontier_still_treats_equality_as_complete() {
+        assert!(has_reached_queue_frontier(40, 40));
+>>>>>>> 2f78f7180 ([BUG](fn-consumer): handle zero queue frontier)
     }
 }

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -627,23 +627,20 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
             self.context.is_rebuild(),
         ) {
             let completion_offset = match self.attached_function_id_filter {
-                Some(_) => match self.context.log_start_offset {
-                    Some(offset) => offset,
-                    None => match self.resolved_attached_functions.as_ref() {
-                        Some(attached_functions) if attached_functions.len() == 1 => {
-                            attached_functions[0].completion_offset as i64
-                        }
-                        _ => {
-                            self.terminate_with_result(
-                                Err(LogFetchOrchestratorError::InvariantViolation(
-                                    "fn-consumer log fetch requires resolved attached function state",
-                                )),
-                                ctx,
-                            )
-                            .await;
-                            return;
-                        }
-                    },
+                Some(_) => match self.resolved_attached_functions.as_ref() {
+                    Some(attached_functions) if attached_functions.len() == 1 => {
+                        attached_functions[0].completion_offset as i64
+                    }
+                    _ => {
+                        self.terminate_with_result(
+                            Err(LogFetchOrchestratorError::InvariantViolation(
+                                "fn-consumer log fetch requires resolved attached function state",
+                            )),
+                            ctx,
+                        )
+                        .await;
+                        return;
+                    }
                 },
                 None => match self.context.log_start_offset {
                     Some(offset) => offset,

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -331,7 +331,7 @@ impl Orchestrator for LogFetchOrchestrator {
         &mut self,
         ctx: &ComponentContext<Self>,
     ) -> Vec<(TaskMessage, Option<Span>)> {
-        if self.context.is_fn_consumer {
+        if self.context.is_fn_consumer && self.attached_function_id_filter.is_some() {
             vec![(
                 wrap(
                     Box::new(GetAttachedFunctionOperator::new(
@@ -620,6 +620,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
         let mut pulled_log_offset = collection.log_position;
         let mut log_upper_bound_offset = None;
 
+<<<<<<< HEAD
         // Compacted-state backfill reads the whole live segment and is not
         // constrained by the incremental max_compaction_size window.
         if Self::should_resolve_async_fn_boundary(
@@ -629,10 +630,16 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
             let completion_offset = match self.context.log_start_offset {
                 Some(offset) => offset,
                 None => match self.resolved_attached_functions.as_ref() {
+=======
+        if self.context.is_fn_consumer {
+            let completion_offset = match self.attached_function_id_filter {
+                Some(_) => match self.resolved_attached_functions.as_ref() {
+>>>>>>> 19cc0f428 ([BUG](fn-consumer): restore log fetch fallback)
                     Some(attached_functions) if attached_functions.len() == 1 => {
                         attached_functions[0].completion_offset as i64
                     }
                     _ => {
+<<<<<<< HEAD
                     self.terminate_with_result(
                         Err(LogFetchOrchestratorError::InvariantViolation(
                             "fn-consumer log fetch requires resolved attached function state",
@@ -641,6 +648,29 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                     )
                     .await;
                     return;
+=======
+                        self.terminate_with_result(
+                            Err(LogFetchOrchestratorError::InvariantViolation(
+                                "fn-consumer log fetch requires resolved attached function state",
+                            )),
+                            ctx,
+                        )
+                        .await;
+                        return;
+                    }
+                },
+                None => match self.context.log_start_offset {
+                    Some(offset) => offset,
+                    None => {
+                        self.terminate_with_result(
+                            Err(LogFetchOrchestratorError::InvariantViolation(
+                                "fn-consumer log fetch requires log_start_offset",
+                            )),
+                            ctx,
+                        )
+                        .await;
+                        return;
+>>>>>>> 19cc0f428 ([BUG](fn-consumer): restore log fetch fallback)
                     }
                 },
             };

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -332,9 +332,6 @@ impl Orchestrator for LogFetchOrchestrator {
         ctx: &ComponentContext<Self>,
     ) -> Vec<(TaskMessage, Option<Span>)> {
         if self.context.is_fn_consumer {
-            let attached_function_id = self
-                .attached_function_id_filter
-                .expect("fn-consumer log fetch requires an attached function id filter");
             vec![(
                 wrap(
                     Box::new(GetAttachedFunctionOperator::new(
@@ -343,7 +340,7 @@ impl Orchestrator for LogFetchOrchestrator {
                     )),
                     GetAttachedFunctionInput {
                         collection_id: self.collection_id,
-                        attached_function_id: Some(attached_function_id),
+                        attached_function_id: self.attached_function_id_filter,
                     },
                     ctx.receiver(),
                     self.context

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -620,44 +620,30 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
         let mut pulled_log_offset = collection.log_position;
         let mut log_upper_bound_offset = None;
 
-<<<<<<< HEAD
         // Compacted-state backfill reads the whole live segment and is not
         // constrained by the incremental max_compaction_size window.
         if Self::should_resolve_async_fn_boundary(
             self.context.is_fn_consumer,
             self.context.is_rebuild(),
         ) {
-            let completion_offset = match self.context.log_start_offset {
-                Some(offset) => offset,
-                None => match self.resolved_attached_functions.as_ref() {
-=======
-        if self.context.is_fn_consumer {
             let completion_offset = match self.attached_function_id_filter {
-                Some(_) => match self.resolved_attached_functions.as_ref() {
->>>>>>> 19cc0f428 ([BUG](fn-consumer): restore log fetch fallback)
-                    Some(attached_functions) if attached_functions.len() == 1 => {
-                        attached_functions[0].completion_offset as i64
-                    }
-                    _ => {
-<<<<<<< HEAD
-                    self.terminate_with_result(
-                        Err(LogFetchOrchestratorError::InvariantViolation(
-                            "fn-consumer log fetch requires resolved attached function state",
-                        )),
-                        ctx,
-                    )
-                    .await;
-                    return;
-=======
-                        self.terminate_with_result(
-                            Err(LogFetchOrchestratorError::InvariantViolation(
-                                "fn-consumer log fetch requires resolved attached function state",
-                            )),
-                            ctx,
-                        )
-                        .await;
-                        return;
-                    }
+                Some(_) => match self.context.log_start_offset {
+                    Some(offset) => offset,
+                    None => match self.resolved_attached_functions.as_ref() {
+                        Some(attached_functions) if attached_functions.len() == 1 => {
+                            attached_functions[0].completion_offset as i64
+                        }
+                        _ => {
+                            self.terminate_with_result(
+                                Err(LogFetchOrchestratorError::InvariantViolation(
+                                    "fn-consumer log fetch requires resolved attached function state",
+                                )),
+                                ctx,
+                            )
+                            .await;
+                            return;
+                        }
+                    },
                 },
                 None => match self.context.log_start_offset {
                     Some(offset) => offset,
@@ -670,7 +656,6 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                         )
                         .await;
                         return;
->>>>>>> 19cc0f428 ([BUG](fn-consumer): restore log fetch fallback)
                     }
                 },
             };

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -22,8 +22,8 @@ use chroma_system::{
     Orchestrator, OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
-    Chunk, CollectionUuid, JobId, LogRecord, MetadataValue, SchemaMismatchError, SegmentFlushInfo,
-    SegmentScope, SegmentShard, SegmentShardError,
+    AttachedFunction, AttachedFunctionUuid, Chunk, CollectionUuid, JobId, LogRecord, MetadataValue,
+    SchemaMismatchError, SegmentFlushInfo, SegmentScope, SegmentShard, SegmentShardError,
 };
 use opentelemetry::trace::TraceContextExt;
 use std::sync::{atomic::AtomicU32, Arc};
@@ -41,6 +41,10 @@ use crate::{
             get_async_fn_fetch_boundaries::{
                 GetAsyncFnFetchBoundariesError, GetAsyncFnFetchBoundariesInput,
                 GetAsyncFnFetchBoundariesOperator,
+            },
+            get_attached_function::{
+                GetAttachedFunctionInput, GetAttachedFunctionOperator,
+                GetAttachedFunctionOperatorError, GetAttachedFunctionOutput,
             },
             get_collection_and_segments::{
                 GetCollectionAndSegmentsError, GetCollectionAndSegmentsOperator,
@@ -87,6 +91,8 @@ pub enum LogFetchOrchestratorError {
     FetchLog(#[from] FetchLogError),
     #[error("Error getting collection and segments: {0}")]
     GetCollectionAndSegments(#[from] GetCollectionAndSegmentsError),
+    #[error("Error getting attached function: {0}")]
+    GetAttachedFunction(#[from] GetAttachedFunctionOperatorError),
     #[error("Error creating hnsw writer: {0}")]
     HnswSegment(#[from] DistributedHNSWSegmentFromSegmentError),
     #[error("Invalid database name")]
@@ -157,6 +163,7 @@ impl ChromaError for LogFetchOrchestratorError {
                 Self::CompactionContext(e) => e.should_trace_error(),
                 Self::FetchLog(e) => e.should_trace_error(),
                 Self::GetCollectionAndSegments(e) => e.should_trace_error(),
+                Self::GetAttachedFunction(e) => e.should_trace_error(),
                 Self::HnswSegment(e) => e.should_trace_error(),
                 Self::InvalidDatabaseName => true,
                 Self::InvariantViolation(_) => true,
@@ -202,6 +209,7 @@ where
 pub(crate) struct Success {
     pub materialized: Vec<MaterializeLogOutput>,
     pub collection_info: CollectionCompactInfo,
+    pub resolved_attached_functions: Vec<AttachedFunction>,
 }
 
 #[derive(Debug)]
@@ -241,10 +249,12 @@ impl Success {
     pub fn new(
         materialized: Vec<MaterializeLogOutput>,
         collection_info: CollectionCompactInfo,
+        resolved_attached_functions: Vec<AttachedFunction>,
     ) -> Self {
         Self {
             materialized,
             collection_info,
+            resolved_attached_functions,
         }
     }
 }
@@ -292,6 +302,8 @@ pub(crate) struct LogFetchOrchestrator {
     num_uncompleted_materialization_tasks: usize,
     materialized_outputs: Vec<MaterializeLogOutput>,
     has_backfill: bool,
+    resolved_attached_functions: Option<Vec<AttachedFunction>>,
+    attached_function_id_filter: Option<AttachedFunctionUuid>,
 }
 
 #[async_trait]
@@ -319,22 +331,34 @@ impl Orchestrator for LogFetchOrchestrator {
         &mut self,
         ctx: &ComponentContext<Self>,
     ) -> Vec<(TaskMessage, Option<Span>)> {
-        vec![(
-            wrap(
-                Box::new(GetCollectionAndSegmentsOperator {
-                    sysdb: self.context.sysdb.clone(),
-                    collection_id: self.collection_id,
-                    database_name: self.database_name.clone(),
-                }),
-                (),
-                ctx.receiver(),
-                self.context
-                    .orchestrator_context
-                    .task_cancellation_token
-                    .clone(),
-            ),
-            Some(Span::current()),
-        )]
+        if self.context.is_fn_consumer {
+            let attached_function_id = self
+                .attached_function_id_filter
+                .expect("fn-consumer log fetch requires an attached function id filter");
+            vec![(
+                wrap(
+                    Box::new(GetAttachedFunctionOperator::new(
+                        self.context.sysdb.clone(),
+                        self.collection_id,
+                    )),
+                    GetAttachedFunctionInput {
+                        collection_id: self.collection_id,
+                        attached_function_id: Some(attached_function_id),
+                    },
+                    ctx.receiver(),
+                    self.context
+                        .orchestrator_context
+                        .task_cancellation_token
+                        .clone(),
+                ),
+                Some(Span::current()),
+            )]
+        } else {
+            vec![(
+                self.make_get_collection_and_segments_task(ctx),
+                Some(Span::current()),
+            )]
+        }
     }
 }
 
@@ -382,6 +406,7 @@ impl LogFetchOrchestrator {
         work_queue_client: Option<WorkQueueClient>,
         is_fn_consumer: bool,
         log_start_offset: Option<i64>,
+        attached_function_id_filter: Option<AttachedFunctionUuid>,
     ) -> Self {
         let mut context = CompactionContext::new(
             rebuild_info,
@@ -413,7 +438,25 @@ impl LogFetchOrchestrator {
             num_uncompleted_materialization_tasks: 0,
             materialized_outputs: Vec::new(),
             has_backfill: false,
+            resolved_attached_functions: None,
+            attached_function_id_filter,
         }
+    }
+
+    fn make_get_collection_and_segments_task(&self, ctx: &ComponentContext<Self>) -> TaskMessage {
+        wrap(
+            Box::new(GetCollectionAndSegmentsOperator {
+                sysdb: self.context.sysdb.clone(),
+                collection_id: self.collection_id,
+                database_name: self.database_name.clone(),
+            }),
+            (),
+            ctx.receiver(),
+            self.context
+                .orchestrator_context
+                .task_cancellation_token
+                .clone(),
+        )
     }
 
     async fn partition(&mut self, records: Chunk<LogRecord>, ctx: &ComponentContext<Self>) {
@@ -523,6 +566,43 @@ impl LogFetchOrchestrator {
 }
 
 #[async_trait]
+impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorError>>
+    for LogFetchOrchestrator
+{
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        message: TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorError>,
+        ctx: &ComponentContext<Self>,
+    ) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
+            Some(output) => output,
+            None => return,
+        };
+
+        if output.attached_functions.len() != 1 {
+            self.terminate_with_result(
+                Err(LogFetchOrchestratorError::InvariantViolation(
+                    "fn-consumer log fetch requires exactly one attached function",
+                )),
+                ctx,
+            )
+            .await;
+            return;
+        }
+
+        self.resolved_attached_functions = Some(output.attached_functions);
+        self.send(
+            self.make_get_collection_and_segments_task(ctx),
+            ctx,
+            Some(Span::current()),
+        )
+        .await;
+    }
+}
+
+#[async_trait]
 impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegmentsError>>
     for LogFetchOrchestrator
 {
@@ -551,17 +631,23 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
         ) {
             let completion_offset = match self.context.log_start_offset {
                 Some(offset) => offset,
-                None => {
+                None => match self.resolved_attached_functions.as_ref() {
+                    Some(attached_functions) if attached_functions.len() == 1 => {
+                        attached_functions[0].completion_offset as i64
+                    }
+                    _ => {
                     self.terminate_with_result(
                         Err(LogFetchOrchestratorError::InvariantViolation(
-                            "fn-consumer log fetch requires log_start_offset",
+                            "fn-consumer log fetch requires resolved attached function state",
                         )),
                         ctx,
                     )
                     .await;
                     return;
-                }
+                    }
+                },
             };
+            self.context.log_start_offset = Some(completion_offset);
 
             let max_compaction_size = self.context.max_compaction_size;
             let blockfile_provider = self.context.blockfile_provider.clone();
@@ -1096,7 +1182,12 @@ impl Handler<TaskResult<SourceRecordSegmentOutput, SourceRecordSegmentError>>
         };
         if output.is_empty() {
             self.terminate_with_result(
-                Ok(Success::new(vec![], collection_info.clone()).into()),
+                Ok(Success::new(
+                    vec![],
+                    collection_info.clone(),
+                    self.resolved_attached_functions.clone().unwrap_or_default(),
+                )
+                .into()),
                 ctx,
             )
             .await;
@@ -1139,7 +1230,12 @@ impl Handler<TaskResult<SourceRecordSegmentV2Output, SourceRecordSegmentV2Error>
                 }
             };
             self.terminate_with_result(
-                Ok(Success::new(vec![], collection_info.clone()).into()),
+                Ok(Success::new(
+                    vec![],
+                    collection_info.clone(),
+                    self.resolved_attached_functions.clone().unwrap_or_default(),
+                )
+                .into()),
                 ctx,
             )
             .await;
@@ -1182,8 +1278,16 @@ impl Handler<TaskResult<SourceRecordSegmentV2Output, SourceRecordSegmentV2Error>
             .await;
             return;
         }
-        self.terminate_with_result(Ok(Success::new(materialized, collection_info).into()), ctx)
-            .await;
+        self.terminate_with_result(
+            Ok(Success::new(
+                materialized,
+                collection_info,
+                self.resolved_attached_functions.clone().unwrap_or_default(),
+            )
+            .into()),
+            ctx,
+        )
+        .await;
     }
 }
 
@@ -1252,8 +1356,16 @@ impl Handler<TaskResult<MaterializeLogOutput, MaterializeLogOperatorError>>
                 .await;
                 return;
             }
-            self.terminate_with_result(Ok(Success::new(materialized, collection_info).into()), ctx)
-                .await;
+            self.terminate_with_result(
+                Ok(Success::new(
+                    materialized,
+                    collection_info,
+                    self.resolved_attached_functions.clone().unwrap_or_default(),
+                )
+                .into()),
+                ctx,
+            )
+            .await;
         }
     }
 }

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -271,18 +271,20 @@ impl FnConsumerManager {
             work_items.push((
                 fn_id,
                 input_coll_id,
+                item.completion_offset,
                 item.compaction_offset.unwrap_or(item.completion_offset),
             ));
         }
 
         let mut grouped_work_items: HashMap<AttachedFunctionUuid, Vec<FunctionExecutionInput>> =
             HashMap::new();
-        for (fn_id, input_coll_id, compaction_offset) in work_items {
+        for (fn_id, input_coll_id, completion_offset, compaction_offset) in work_items {
             grouped_work_items
                 .entry(fn_id)
                 .or_default()
                 .push(FunctionExecutionInput {
                     collection_id: input_coll_id,
+                    queue_completion_offset: completion_offset,
                     queue_compaction_offset: compaction_offset,
                 });
         }

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -271,20 +271,18 @@ impl FnConsumerManager {
             work_items.push((
                 fn_id,
                 input_coll_id,
-                item.completion_offset,
                 item.compaction_offset.unwrap_or(item.completion_offset),
             ));
         }
 
         let mut grouped_work_items: HashMap<AttachedFunctionUuid, Vec<FunctionExecutionInput>> =
             HashMap::new();
-        for (fn_id, input_coll_id, completion_offset, compaction_offset) in work_items {
+        for (fn_id, input_coll_id, compaction_offset) in work_items {
             grouped_work_items
                 .entry(fn_id)
                 .or_default()
                 .push(FunctionExecutionInput {
                     collection_id: input_coll_id,
-                    queue_completion_offset: completion_offset,
                     queue_compaction_offset: compaction_offset,
                 });
         }

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -15,7 +15,9 @@ use tracing::{instrument, span};
 
 use crate::compactor::config::CompactorConfig;
 use crate::execution::orchestration::compact::CompactionContext;
-use crate::execution::orchestration::function_execution::FunctionExecutionContext;
+use crate::execution::orchestration::function_execution::{
+    FunctionExecutionContext, FunctionExecutionInput,
+};
 use crate::fn_consumer::config::FnConsumerConfig;
 use crate::work_queue::work_queue_client::WorkQueueClient;
 
@@ -163,7 +165,7 @@ impl FnConsumerManager {
     async fn dispatch_batch(
         &self,
         fn_id: AttachedFunctionUuid,
-        batch: Vec<(CollectionUuid, i64)>,
+        batch: Vec<FunctionExecutionInput>,
     ) -> Result<(), DispatchError> {
         let Some(dispatcher) = self.context.dispatcher.clone() else {
             tracing::error!("Dispatcher not set on FnConsumerManager");
@@ -266,16 +268,23 @@ impl FnConsumerManager {
                 );
                 continue;
             };
-            work_items.push((fn_id, input_coll_id, item.completion_offset));
+            work_items.push((
+                fn_id,
+                input_coll_id,
+                item.compaction_offset.unwrap_or(item.completion_offset),
+            ));
         }
 
-        let mut grouped_work_items: HashMap<AttachedFunctionUuid, Vec<(CollectionUuid, i64)>> =
+        let mut grouped_work_items: HashMap<AttachedFunctionUuid, Vec<FunctionExecutionInput>> =
             HashMap::new();
-        for (fn_id, input_coll_id, completion_offset) in work_items {
+        for (fn_id, input_coll_id, compaction_offset) in work_items {
             grouped_work_items
                 .entry(fn_id)
                 .or_default()
-                .push((input_coll_id, completion_offset));
+                .push(FunctionExecutionInput {
+                    collection_id: input_coll_id,
+                    queue_compaction_offset: compaction_offset,
+                });
         }
 
         let mut batches_to_process = Vec::new();
@@ -292,15 +301,10 @@ impl FnConsumerManager {
             // TODO(tanujnay112): Cap how many input collections a single function
             // execution can process at once instead of only relying on
             // get_work_batch_size to indirectly bound this batch.
-            let mut batch = Vec::new();
-            for (input_coll_id, completion_offset) in items {
-                batch.push((input_coll_id, completion_offset));
-            }
-
-            if !batch.is_empty() {
+            if !items.is_empty() {
                 self.in_progress
                     .insert(fn_id, InProgressFn::new(self.context.job_expiry_seconds));
-                batches_to_process.push((fn_id, batch));
+                batches_to_process.push((fn_id, items));
                 remaining_capacity -= 1;
             }
         }

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -268,11 +268,16 @@ impl FnConsumerManager {
                 );
                 continue;
             };
-            work_items.push((
-                fn_id,
-                input_coll_id,
-                item.compaction_offset.unwrap_or(item.completion_offset),
-            ));
+            let Some(compaction_offset) = item.compaction_offset else {
+                tracing::error!(
+                    fn_id = %fn_id,
+                    input_coll_id = %input_coll_id,
+                    completion_offset = item.completion_offset,
+                    "skipping work item: missing required compaction_offset"
+                );
+                continue;
+            };
+            work_items.push((fn_id, input_coll_id, compaction_offset));
         }
 
         let mut grouped_work_items: HashMap<AttachedFunctionUuid, Vec<FunctionExecutionInput>> =

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -165,6 +165,7 @@ impl WorkQueueService for WorkQueueServer {
                 fn_id: record.fn_id.to_string(),
                 input_coll_id: record.input_coll_id.to_string(),
                 completion_offset: record.completion_offset,
+                compaction_offset: Some(record.compaction_offset),
             })
             .collect();
 


### PR DESCRIPTION
## Description of changes

This PR fixes a bug where the fn-consumer work queue was not exposing the **compaction frontier** — the offset up to which the input collection has been compacted. Without this, the fn-consumer couldn't tell whether a queued work item was stale (i.e., the attached function had already processed past the queued offset), leading to redundant or incorrect re-execution.

The fix threads `compaction_offset` through the entire pipeline:

1. Proto: add `compaction_offset` to `WorkItemResult`
2. Work queue server: populate it when serving work items
3. Fn-consumer manager: use it to build `FunctionExecutionInput` (replacing the raw `(CollectionUuid, i64)` tuple)
4. Log fetch orchestrator: fetch attached function state first (when in fn-consumer mode), then use the resolved `completion_offset` from sysdb instead of the stale value from the work queue
5. Function execution context: after fetching, skip work items where the attached function has already reached or passed the queued frontier

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_