### PR TITLE
[BUG](test): Fix default pytest fixtures

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -387,19 +387,22 @@ def _fastapi_fixture(
         yield from run(args)
 
 
+@pytest.fixture()
 def fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=False)
+    yield from _fastapi_fixture(is_persistent=False)
 
 
+@pytest.fixture()
 def async_fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(
+    yield from _fastapi_fixture(
         is_persistent=False,
         chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
     )
 
 
+@pytest.fixture()
 def fastapi_persistent() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=True)
+    yield from _fastapi_fixture(is_persistent=True)
 
 
 def fastapi_ssl() -> Generator[System, None, None]:
@@ -753,8 +756,8 @@ def filtered_fixture_names() -> List[str]:
         "fastapi",
         "async_fastapi",
         "fastapi_persistent",
-        "sqlite_fixture",
-        "sqlite_persistent",
+        "python_sqlite_ephemeral",
+        "python_sqlite_persistent",
     ]
 
     if "CHROMA_INTEGRATION_TEST" in os.environ:


### PR DESCRIPTION
## Description of changes


Fixes the default pytest fixture setup in `chromadb/test/conftest.py`.

Changes:
- Added `@pytest.fixture()` to `fastapi`, `async_fastapi`, and `fastapi_persistent`.
- Changed those fixtures to use `yield from _fastapi_fixture(...)`.
- Replaced invalid fixture names with `python_sqlite_ephemeral` and `python_sqlite_persistent`.

Fixes #7395

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python

```text
python -m pytest chromadb\test\test_api.py --collect-only -q
531 tests collected

python -m pytest "chromadb\test\test_api.py::test_heartbeat[fastapi-classic]" -q -vv
1 passed

## Migration plan

None

## Observability plan

None

## Documentation Changes

None