### PR TITLE
[ENH](foundation-api): add trajectory reasoning endpoint

### DIFF
--- a/rust/foundation-api/src/routes/mod.rs
+++ b/rust/foundation-api/src/routes/mod.rs
@@ -81,6 +81,10 @@ pub(crate) fn router() -> Router<FoundationApiServer> {
             post(trajectories::foundation_finalize_trajectory),
         )
         .route(
+            "/api/trajectories/{id}/reasoning",
+            get(trajectories::foundation_get_trajectory_reasoning),
+        )
+        .route(
             "/api/trajectories/{id}",
             get(trajectories::foundation_get_trajectory),
         )

--- a/rust/foundation-api/src/routes/trajectories.rs
+++ b/rust/foundation-api/src/routes/trajectories.rs
@@ -220,7 +220,7 @@ pub async fn foundation_get_trajectory_reasoning(
     State(server): State<FoundationApiServer>,
     Path(id): Path<Uuid>,
     Query(query): Query<ReadTrajectoryReasoningQuery>,
-) -> Result<Json<Vec<TrajectoryReasoningResponse>>, ServerError> {
+) -> Result<Json<Option<TrajectoryReasoningResponse>>, ServerError> {
     let identity =
         whoami_and_authorize(&*server.auth, &headers, AuthzAction::ViewFoundation).await?;
     let tenant = identity.tenant;
@@ -243,7 +243,7 @@ pub async fn foundation_get_trajectory_reasoning(
 fn reasoning_for_slug(
     file: &ReasoningTrajectoryFile,
     slug: &str,
-) -> Vec<TrajectoryReasoningResponse> {
+) -> Option<TrajectoryReasoningResponse> {
     let entries = &file.trajectory.entries;
     let mut reasoning_prefix = Vec::new();
     let mut last_match = None;
@@ -263,15 +263,15 @@ fn reasoning_for_slug(
     }
 
     let Some((entry_index, reasoning_len)) = last_match else {
-        return Vec::new();
+        return None;
     };
     let other_slugs = other_written_slugs(&entries[entry_index].writes, slug);
 
-    vec![TrajectoryReasoningResponse {
+    Some(TrajectoryReasoningResponse {
         slug: slug.to_string(),
         reasoning: reasoning_prefix.into_iter().take(reasoning_len).collect(),
         other_slugs,
-    }]
+    })
 }
 
 fn other_written_slugs(writes: &[crate::trajectories::ReasoningWrite], slug: &str) -> Vec<String> {
@@ -457,10 +457,10 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_for_slug_returns_empty_when_slug_was_not_written() {
+    fn reasoning_for_slug_returns_none_when_slug_was_not_written() {
         let file = minimal_file(vec![entry(Some("thinking"), &["other"])]);
 
-        assert_eq!(reasoning_for_slug(&file, "target"), Vec::new());
+        assert_eq!(reasoning_for_slug(&file, "target"), None);
     }
 
     #[test]
@@ -475,7 +475,7 @@ mod tests {
 
         assert_eq!(
             reasoning_for_slug(&file, "target"),
-            vec![TrajectoryReasoningResponse {
+            Some(TrajectoryReasoningResponse {
                 slug: "target".to_string(),
                 reasoning: vec![
                     "first target".to_string(),
@@ -483,7 +483,7 @@ mod tests {
                     "final target".to_string(),
                 ],
                 other_slugs: vec!["sibling".to_string()],
-            }]
+            })
         );
     }
 
@@ -497,11 +497,11 @@ mod tests {
 
         assert_eq!(
             reasoning_for_slug(&file, "target"),
-            vec![TrajectoryReasoningResponse {
+            Some(TrajectoryReasoningResponse {
                 slug: "target".to_string(),
                 reasoning: vec!["before".to_string()],
                 other_slugs: Vec::new(),
-            }]
+            })
         );
     }
 }

--- a/rust/foundation-api/src/routes/trajectories.rs
+++ b/rust/foundation-api/src/routes/trajectories.rs
@@ -259,9 +259,7 @@ fn reasoning_for_slug(
         }
     }
 
-    let Some((entry_index, reasoning_len)) = last_match else {
-        return None;
-    };
+    let (entry_index, reasoning_len) = last_match?;
     let other_slugs = entries[entry_index]
         .writes
         .iter()

--- a/rust/foundation-api/src/routes/trajectories.rs
+++ b/rust/foundation-api/src/routes/trajectories.rs
@@ -14,7 +14,7 @@ use axum::{
     Json,
 };
 use chroma_error::{ChromaError, ErrorCodes};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
@@ -40,6 +40,29 @@ pub struct ReadTrajectoryQuery {
     pub require_finalized: bool,
 }
 
+/// Query parameters for `GET /api/trajectories/{id}/reasoning`.
+#[derive(Debug, Default, PartialEq, Eq, Deserialize)]
+pub struct ReadTrajectoryReasoningQuery {
+    /// Wiki page slug to find in trajectory write calls. Present-but-empty is
+    /// valid and targets the wiki root page.
+    pub slug: Option<String>,
+    /// Reject open trajectories when true. Defaults false so callers can
+    /// inspect a partial trajectory while it executes.
+    #[serde(default)]
+    pub require_finalized: bool,
+}
+
+/// Reasoning traces associated with one page write.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct TrajectoryReasoningResponse {
+    /// The requested page slug.
+    pub slug: String,
+    /// Trimmed non-empty reasoning traces through the final write action.
+    pub reasoning: Vec<String>,
+    /// Other slugs written by the same final action, excluding `slug`.
+    pub other_slugs: Vec<String>,
+}
+
 /// Errors raised while running trajectory routes after request extraction.
 #[derive(Debug, thiserror::Error)]
 pub enum TrajectoryRouteError {
@@ -55,13 +78,18 @@ pub enum TrajectoryRouteError {
     /// The trajectory operation failed.
     #[error(transparent)]
     Trajectory(#[from] TrajectoryError),
+    /// The reasoning route requires a slug query parameter.
+    #[error("missing slug query parameter")]
+    MissingSlug,
 }
 
 impl ChromaError for TrajectoryRouteError {
     fn code(&self) -> ErrorCodes {
         match self {
             TrajectoryRouteError::RouteDisabled => ErrorCodes::Internal,
-            TrajectoryRouteError::MissingToken => ErrorCodes::InvalidArgument,
+            TrajectoryRouteError::MissingToken | TrajectoryRouteError::MissingSlug => {
+                ErrorCodes::InvalidArgument
+            }
             TrajectoryRouteError::Resolve(err) if err.is_not_found() => ErrorCodes::NotFound,
             TrajectoryRouteError::Resolve(err) => err.code(),
             TrajectoryRouteError::Trajectory(err) => err.code(),
@@ -186,6 +214,76 @@ pub async fn foundation_get_trajectory(
     Ok(Json(response))
 }
 
+/// `GET /api/trajectories/{id}/reasoning` returns reasoning for one page write.
+pub async fn foundation_get_trajectory_reasoning(
+    headers: HeaderMap,
+    State(server): State<FoundationApiServer>,
+    Path(id): Path<Uuid>,
+    Query(query): Query<ReadTrajectoryReasoningQuery>,
+) -> Result<Json<Vec<TrajectoryReasoningResponse>>, ServerError> {
+    let identity =
+        whoami_and_authorize(&*server.auth, &headers, AuthzAction::ViewFoundation).await?;
+    let tenant = identity.tenant;
+    let _guard = server.scorecard_request(&[
+        "op:foundation_get_trajectory_reasoning",
+        &format!("tenant:{tenant}"),
+    ])?;
+    let slug = query.slug.ok_or(TrajectoryRouteError::MissingSlug)?;
+
+    let (client, collection) = trajectory_collection(&server, &headers, &tenant).await?;
+    let file = trajectory_op(
+        client,
+        &tenant,
+        load_generate_trajectory(&collection, id, query.require_finalized),
+    )
+    .await?;
+    Ok(Json(reasoning_for_slug(&file, &slug)))
+}
+
+fn reasoning_for_slug(
+    file: &ReasoningTrajectoryFile,
+    slug: &str,
+) -> Vec<TrajectoryReasoningResponse> {
+    let entries = &file.trajectory.entries;
+    let mut reasoning_prefix = Vec::new();
+    let mut last_match = None;
+
+    for (index, entry) in entries.iter().enumerate() {
+        if let Some(reasoning) = entry.reasoning.as_ref() {
+            let trimmed = reasoning.trim();
+            if !trimmed.is_empty() {
+                reasoning_prefix.push(trimmed.to_string());
+            }
+        }
+        let reasoning_len_after_entry = reasoning_prefix.len();
+
+        if entry.writes.iter().any(|write| write.slug == slug) {
+            last_match = Some((index, reasoning_len_after_entry));
+        }
+    }
+
+    let Some((entry_index, reasoning_len)) = last_match else {
+        return Vec::new();
+    };
+    let other_slugs = other_written_slugs(&entries[entry_index].writes, slug);
+
+    vec![TrajectoryReasoningResponse {
+        slug: slug.to_string(),
+        reasoning: reasoning_prefix.into_iter().take(reasoning_len).collect(),
+        other_slugs,
+    }]
+}
+
+fn other_written_slugs(writes: &[crate::trajectories::ReasoningWrite], slug: &str) -> Vec<String> {
+    let mut slugs = Vec::new();
+    for write in writes {
+        if write.slug != slug && !slugs.contains(&write.slug) {
+            slugs.push(write.slug.clone());
+        }
+    }
+    slugs
+}
+
 async fn trajectory_collection<'a>(
     server: &'a FoundationApiServer,
     headers: &HeaderMap,
@@ -219,8 +317,33 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::trajectories::{
+        ReasoningEntry, ReasoningTrajectory, ReasoningTrajectoryFile, ReasoningWrite,
+    };
     use chroma::client::ChromaHttpClientError;
     use serde_json::json;
+
+    fn minimal_file(entries: Vec<ReasoningEntry>) -> ReasoningTrajectoryFile {
+        ReasoningTrajectoryFile {
+            citations: None,
+            trajectory: ReasoningTrajectory {
+                id: Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
+                entries,
+            },
+        }
+    }
+
+    fn entry(reasoning: Option<&str>, slugs: &[&str]) -> ReasoningEntry {
+        ReasoningEntry {
+            reasoning: reasoning.map(str::to_string),
+            writes: slugs
+                .iter()
+                .map(|slug| ReasoningWrite {
+                    slug: (*slug).to_string(),
+                })
+                .collect(),
+        }
+    }
 
     #[test]
     fn route_errors_map_complete_contract_codes() {
@@ -229,6 +352,7 @@ mod tests {
             vec![
                 TrajectoryRouteError::RouteDisabled.code(),
                 TrajectoryRouteError::MissingToken.code(),
+                TrajectoryRouteError::MissingSlug.code(),
                 TrajectoryRouteError::Resolve(FoundationChromaClientError::InvalidToken(
                     "bad token".to_string(),
                 ))
@@ -264,6 +388,7 @@ mod tests {
             ],
             vec![
                 ErrorCodes::Internal,
+                ErrorCodes::InvalidArgument,
                 ErrorCodes::InvalidArgument,
                 ErrorCodes::InvalidArgument,
                 ErrorCodes::NotFound,
@@ -304,6 +429,79 @@ mod tests {
             ReadTrajectoryQuery {
                 require_finalized: true,
             }
+        );
+    }
+
+    #[test]
+    fn reasoning_query_requires_slug_but_allows_root_slug() {
+        assert_eq!(
+            serde_json::from_value::<ReadTrajectoryReasoningQuery>(json!({
+                "require_finalized": true
+            }))
+            .unwrap(),
+            ReadTrajectoryReasoningQuery {
+                slug: None,
+                require_finalized: true,
+            }
+        );
+        assert_eq!(
+            serde_json::from_value::<ReadTrajectoryReasoningQuery>(json!({
+                "slug": "",
+            }))
+            .unwrap(),
+            ReadTrajectoryReasoningQuery {
+                slug: Some(String::new()),
+                require_finalized: false,
+            }
+        );
+    }
+
+    #[test]
+    fn reasoning_for_slug_returns_empty_when_slug_was_not_written() {
+        let file = minimal_file(vec![entry(Some("thinking"), &["other"])]);
+
+        assert_eq!(reasoning_for_slug(&file, "target"), Vec::new());
+    }
+
+    #[test]
+    fn reasoning_for_slug_uses_latest_write_and_prefix_reasoning() {
+        let file = minimal_file(vec![
+            entry(Some("  first target  "), &["target"]),
+            entry(Some("intermediate"), &["other"]),
+            entry(Some("  \n  "), &[]),
+            entry(Some("final target"), &["target", "sibling", "sibling"]),
+            entry(Some("after final target"), &["later"]),
+        ]);
+
+        assert_eq!(
+            reasoning_for_slug(&file, "target"),
+            vec![TrajectoryReasoningResponse {
+                slug: "target".to_string(),
+                reasoning: vec![
+                    "first target".to_string(),
+                    "intermediate".to_string(),
+                    "final target".to_string(),
+                ],
+                other_slugs: vec!["sibling".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn reasoning_for_slug_returns_written_slug_without_reasoning() {
+        let file = minimal_file(vec![
+            entry(Some("before"), &["other"]),
+            entry(None, &["target"]),
+            entry(Some("after target"), &["other"]),
+        ]);
+
+        assert_eq!(
+            reasoning_for_slug(&file, "target"),
+            vec![TrajectoryReasoningResponse {
+                slug: "target".to_string(),
+                reasoning: vec!["before".to_string()],
+                other_slugs: Vec::new(),
+            }]
         );
     }
 }

--- a/rust/foundation-api/src/routes/trajectories.rs
+++ b/rust/foundation-api/src/routes/trajectories.rs
@@ -250,10 +250,7 @@ fn reasoning_for_slug(
 
     for (index, entry) in entries.iter().enumerate() {
         if let Some(reasoning) = entry.reasoning.as_ref() {
-            let trimmed = reasoning.trim();
-            if !trimmed.is_empty() {
-                reasoning_prefix.push(trimmed.to_string());
-            }
+            reasoning_prefix.push(reasoning.clone());
         }
         let reasoning_len_after_entry = reasoning_prefix.len();
 
@@ -265,23 +262,18 @@ fn reasoning_for_slug(
     let Some((entry_index, reasoning_len)) = last_match else {
         return None;
     };
-    let other_slugs = other_written_slugs(&entries[entry_index].writes, slug);
+    let other_slugs = entries[entry_index]
+        .writes
+        .iter()
+        .filter(|write| write.slug != slug)
+        .map(|write| write.slug.clone())
+        .collect();
 
     Some(TrajectoryReasoningResponse {
         slug: slug.to_string(),
         reasoning: reasoning_prefix.into_iter().take(reasoning_len).collect(),
         other_slugs,
     })
-}
-
-fn other_written_slugs(writes: &[crate::trajectories::ReasoningWrite], slug: &str) -> Vec<String> {
-    let mut slugs = Vec::new();
-    for write in writes {
-        if write.slug != slug && !slugs.contains(&write.slug) {
-            slugs.push(write.slug.clone());
-        }
-    }
-    slugs
 }
 
 async fn trajectory_collection<'a>(
@@ -343,6 +335,8 @@ mod tests {
                 })
                 .collect(),
         }
+        .normalized()
+        .expect("test entry should have reasoning or writes after normalization")
     }
 
     #[test]
@@ -468,7 +462,6 @@ mod tests {
         let file = minimal_file(vec![
             entry(Some("  first target  "), &["target"]),
             entry(Some("intermediate"), &["other"]),
-            entry(Some("  \n  "), &[]),
             entry(Some("final target"), &["target", "sibling", "sibling"]),
             entry(Some("after final target"), &["later"]),
         ]);

--- a/rust/foundation-api/src/trajectories/model.rs
+++ b/rust/foundation-api/src/trajectories/model.rs
@@ -58,24 +58,31 @@ impl<'de> Deserialize<'de> for ReasoningEntry {
         D: Deserializer<'de>,
     {
         let raw = GeneratedReasoningEntry::deserialize(deserializer)?;
-        Ok(ReasoningEntry {
-            reasoning: normalize_reasoning(raw.reasoning.as_deref()),
-            writes: dedupe_writes(raw.writes),
-        })
+        Ok(ReasoningEntry::new_normalized(
+            raw.reasoning.as_deref(),
+            raw.writes,
+        ))
     }
 }
 
 impl ReasoningEntry {
-    pub(crate) fn normalized(&self) -> Option<Self> {
-        let entry = ReasoningEntry {
-            reasoning: normalize_reasoning(self.reasoning.as_deref()),
-            writes: dedupe_writes(self.writes.clone()),
-        };
-        if entry.reasoning.is_some() || !entry.writes.is_empty() {
-            Some(entry)
-        } else {
-            None
+    fn new_normalized<I>(reasoning: Option<&str>, writes: I) -> Self
+    where
+        I: IntoIterator<Item = ReasoningWrite>,
+    {
+        ReasoningEntry {
+            reasoning: normalize_reasoning(reasoning),
+            writes: dedupe_writes(writes),
         }
+    }
+
+    pub(crate) fn normalized(&self) -> Option<Self> {
+        ReasoningEntry::new_normalized(self.reasoning.as_deref(), self.writes.iter().cloned())
+            .into_non_empty()
+    }
+
+    fn into_non_empty(self) -> Option<Self> {
+        (self.reasoning.is_some() || !self.writes.is_empty()).then_some(self)
     }
 }
 
@@ -199,8 +206,8 @@ fn project_entries(entries: Vec<GeneratedEntry>) -> Vec<ReasoningEntry> {
     for (index, entry) in entries.iter().enumerate() {
         let GeneratedEntry::Action(action) = entry else {
             if let GeneratedEntry::Reasoning(entry) = entry {
-                if entry.reasoning.is_some() || !entry.writes.is_empty() {
-                    out.push(entry.clone());
+                if let Some(entry) = entry.normalized() {
+                    out.push(entry);
                 }
             }
             continue;
@@ -210,10 +217,13 @@ fn project_entries(entries: Vec<GeneratedEntry>) -> Vec<ReasoningEntry> {
             GeneratedEntry::Action(_) | GeneratedEntry::Reasoning(_) => None,
         });
 
-        let reasoning = normalize_reasoning(action.reasoning.as_deref());
-        let writes = action_writes(action, observation);
-        if reasoning.is_some() || !writes.is_empty() {
-            out.push(ReasoningEntry { reasoning, writes });
+        if let Some(entry) = ReasoningEntry::new_normalized(
+            action.reasoning.as_deref(),
+            action_writes(action, observation),
+        )
+        .into_non_empty()
+        {
+            out.push(entry);
         }
     }
 
@@ -246,12 +256,6 @@ fn action_writes(
         let Some(slug) = slug else {
             continue;
         };
-        if writes
-            .iter()
-            .any(|write: &ReasoningWrite| write.slug == slug)
-        {
-            continue;
-        }
         writes.push(ReasoningWrite {
             slug: slug.to_string(),
         });
@@ -270,7 +274,10 @@ fn normalize_reasoning(reasoning: Option<&str>) -> Option<String> {
         .map(str::to_string)
 }
 
-fn dedupe_writes(writes: Vec<ReasoningWrite>) -> Vec<ReasoningWrite> {
+fn dedupe_writes<I>(writes: I) -> Vec<ReasoningWrite>
+where
+    I: IntoIterator<Item = ReasoningWrite>,
+{
     let mut out = Vec::new();
     for write in writes {
         if out

--- a/rust/foundation-api/src/trajectories/record_format.rs
+++ b/rust/foundation-api/src/trajectories/record_format.rs
@@ -12,7 +12,7 @@ use super::error::TrajectoryError;
 use super::ids::{encode_index, uuid_to_tid};
 use super::limits::{ENTRY_INDEX_WIDTH, VALUE_MAX_BYTES};
 use super::model::{ReasoningEntry, ReasoningTrajectory, ReasoningTrajectoryFile, WriteState};
-use super::validate::validate_entry;
+use super::validate::normalize_entry;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ChromaRecord {
@@ -171,10 +171,7 @@ pub(crate) fn collect_entry_records(
     index: usize,
     entry: &ReasoningEntry,
 ) -> Result<(), TrajectoryError> {
-    validate_entry(entry)?;
-    let entry = entry.normalized().ok_or_else(|| {
-        TrajectoryError::InvalidValue("reasoning entry must have reasoning or writes".to_string())
-    })?;
+    let entry = normalize_entry(entry)?;
     let entry_component = encode_index(index, ENTRY_INDEX_WIDTH)?;
     push_chunkset(
         records,

--- a/rust/foundation-api/src/trajectories/validate.rs
+++ b/rust/foundation-api/src/trajectories/validate.rs
@@ -14,13 +14,18 @@ pub(crate) fn validate_file(file: &ReasoningTrajectoryFile) -> Result<(), Trajec
     Ok(())
 }
 
-/// Validate one pruned reasoning entry.
-pub(crate) fn validate_entry(entry: &ReasoningEntry) -> Result<(), TrajectoryError> {
+/// Return the canonical stored form of one pruned reasoning entry.
+pub(crate) fn normalize_entry(entry: &ReasoningEntry) -> Result<ReasoningEntry, TrajectoryError> {
     let Some(entry) = entry.normalized() else {
         return Err(TrajectoryError::InvalidValue(
             "reasoning entry must have reasoning or writes".to_string(),
         ));
     };
     encode_index(entry.writes.len(), CALL_INDEX_WIDTH)?;
-    Ok(())
+    Ok(entry)
+}
+
+/// Validate one pruned reasoning entry.
+pub(crate) fn validate_entry(entry: &ReasoningEntry) -> Result<(), TrajectoryError> {
+    normalize_entry(entry).map(drop)
 }


### PR DESCRIPTION
## Description of changes

Add GET /api/trajectories/{id}/reasoning to surface the reasoning
traces that led to a wiki page write. Given a page slug, walk the
trajectory's actions and observations to find the final write action
targeting that slug, then return the trimmed non-empty reasoning
accumulated through that action along with any sibling slugs written by
the same action.

Slug resolution reads the tool call params first and falls back to
observation metadata, skipping calls marked skipped_due_to_handoff. Only
wiki_apply_patch and wiki_upsert_file count as writes. A present-but-empty
slug is valid and targets the wiki root page; a missing slug is rejected
with InvalidArgument.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
