### PR TITLE
[CHORE] Limit GC proptest to 16 cases

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -6295,7 +6295,13 @@ mod tests {
             .join()
             .expect("Spawned thread should not fail to join");
         }
+    }
 
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            cases: 16,
+            .. ProptestConfig::default()
+        })]
         #[test]
         fn test_k8s_integration_rust_log_service_garbage_collect_unused_logs(
             operations in proptest::collection::vec(any::<OperationRecord>(), 1..=36),


### PR DESCRIPTION
## Description of changes

The garbage_collect_unused_logs proptest ran the default 256 cases
against vectors of up to 36 operations, for a worst case of 9,216
cycles of setup and execution.  Cap the case count at 16 via an
explicit ProptestConfig, reducing the worst case to 1,152 cycles
while retaining meaningful randomized coverage.

I worked on this test originally with Sicheng.  I'm comfortable with
the reduction in coverage if it means faster success rate or reduced
error rate on this test.  The intg tests have hung for me twice today
and I suspect it's this.

## Test plan

It still runs, just in 1/8th the time.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
