### PR TITLE
[BUG](worker): queue pulled async frontier

### DIFF
--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -245,6 +245,10 @@ pub enum AttachedFunctionOrchestratorResponse {
 }
 
 impl AttachedFunctionOrchestrator {
+    fn queued_compaction_offset(collection_info: &CollectionCompactInfo) -> Option<i64> {
+        (collection_info.pulled_log_offset >= 0).then_some(collection_info.pulled_log_offset)
+    }
+
     pub fn new(
         input_collection_data: Vec<FunctionInputCollectionData>,
         output_context: CompactionContext,
@@ -352,8 +356,8 @@ impl AttachedFunctionOrchestrator {
     ) -> bool {
         if let Some(work_queue_client) = &self.output_context.work_queue_client {
             let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
-            let compaction_offset = (self.get_input_collection_info().pulled_log_offset >= 0)
-                .then_some(self.get_input_collection_info().pulled_log_offset);
+            let compaction_offset =
+                Self::queued_compaction_offset(self.get_input_collection_info());
             let input = QueueFunctionInput::new(
                 attached_function.id,
                 self.get_input_collection_info().collection_id,
@@ -1095,6 +1099,7 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
 
 #[cfg(test)]
 mod tests {
+    use super::AttachedFunctionOrchestrator;
     use crate::execution::orchestration::compact::CollectionCompactInfo;
     use chroma_types::{Collection, CollectionUuid};
 
@@ -1117,19 +1122,19 @@ mod tests {
     fn async_queue_frontier_uses_pulled_log_offset() {
         let collection_info = compact_info(550, 250);
 
-        let compaction_offset = (collection_info.pulled_log_offset >= 0)
-            .then_some(collection_info.pulled_log_offset);
-
-        assert_eq!(compaction_offset, Some(550));
+        assert_eq!(
+            AttachedFunctionOrchestrator::queued_compaction_offset(&collection_info),
+            Some(550)
+        );
     }
 
     #[test]
     fn async_queue_frontier_ignores_uninitialized_offsets() {
         let collection_info = compact_info(-1, 250);
 
-        let compaction_offset = (collection_info.pulled_log_offset >= 0)
-            .then_some(collection_info.pulled_log_offset);
-
-        assert_eq!(compaction_offset, None);
+        assert_eq!(
+            AttachedFunctionOrchestrator::queued_compaction_offset(&collection_info),
+            None
+        );
     }
 }

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -1129,6 +1129,16 @@ mod tests {
     }
 
     #[test]
+    fn async_queue_frontier_uses_pulled_log_offset_even_when_it_regresses() {
+        let collection_info = compact_info(200, 250);
+
+        assert_eq!(
+            AttachedFunctionOrchestrator::queued_compaction_offset(&collection_info),
+            Some(200)
+        );
+    }
+
+    #[test]
     fn async_queue_frontier_ignores_uninitialized_offsets() {
         let collection_info = compact_info(-1, 250);
 

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -245,6 +245,10 @@ pub enum AttachedFunctionOrchestratorResponse {
 }
 
 impl AttachedFunctionOrchestrator {
+    fn queued_compaction_offset(collection_info: &CollectionCompactInfo) -> Option<i64> {
+        (collection_info.pulled_log_offset >= 0).then_some(collection_info.pulled_log_offset)
+    }
+
     pub fn new(
         input_collection_data: Vec<FunctionInputCollectionData>,
         output_context: CompactionContext,
@@ -352,8 +356,8 @@ impl AttachedFunctionOrchestrator {
     ) -> bool {
         if let Some(work_queue_client) = &self.output_context.work_queue_client {
             let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
-            let compaction_offset = (self.get_input_collection_info().collection.log_position >= 0)
-                .then_some(self.get_input_collection_info().collection.log_position);
+            let compaction_offset =
+                Self::queued_compaction_offset(self.get_input_collection_info());
             let input = QueueFunctionInput::new(
                 attached_function.id,
                 self.get_input_collection_info().collection_id,
@@ -1090,5 +1094,47 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
         // For async-only functions, we don't have any output records to apply.
         // The function will be processed asynchronously by an external consumer.
         self.finish_no_attached_function(ctx).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AttachedFunctionOrchestrator;
+    use crate::execution::orchestration::compact::CollectionCompactInfo;
+    use chroma_types::{Collection, CollectionUuid};
+
+    fn compact_info(pulled_log_offset: i64, persisted_log_position: i64) -> CollectionCompactInfo {
+        CollectionCompactInfo {
+            collection_id: CollectionUuid::new(),
+            collection: Collection {
+                log_position: persisted_log_position,
+                ..Default::default()
+            },
+            writers: None,
+            pulled_log_offset,
+            hnsw_index_uuid: None,
+            schema: None,
+            original_segment_flush_infos: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn queued_compaction_offset_uses_pulled_log_offset() {
+        let collection_info = compact_info(550, 250);
+
+        assert_eq!(
+            AttachedFunctionOrchestrator::queued_compaction_offset(&collection_info),
+            Some(550)
+        );
+    }
+
+    #[test]
+    fn queued_compaction_offset_ignores_uninitialized_frontier() {
+        let collection_info = compact_info(-1, 250);
+
+        assert_eq!(
+            AttachedFunctionOrchestrator::queued_compaction_offset(&collection_info),
+            None
+        );
     }
 }

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -356,13 +356,13 @@ impl AttachedFunctionOrchestrator {
     ) -> bool {
         if let Some(work_queue_client) = &self.output_context.work_queue_client {
             let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
-            let compaction_offset =
+            let queued_compaction_offset =
                 Self::queued_compaction_offset(self.get_input_collection_info());
             let input = QueueFunctionInput::new(
                 attached_function.id,
                 self.get_input_collection_info().collection_id,
                 attached_function.completion_offset as i64,
-                compaction_offset,
+                queued_compaction_offset,
             );
             let task = wrap(
                 operator,

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -1092,3 +1092,44 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
         self.finish_no_attached_function(ctx).await;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::execution::orchestration::compact::CollectionCompactInfo;
+    use chroma_types::{Collection, CollectionUuid};
+
+    fn compact_info(pulled_log_offset: i64, persisted_log_position: i64) -> CollectionCompactInfo {
+        CollectionCompactInfo {
+            collection_id: CollectionUuid::new(),
+            collection: Collection {
+                log_position: persisted_log_position,
+                ..Default::default()
+            },
+            writers: None,
+            pulled_log_offset,
+            hnsw_index_uuid: None,
+            schema: None,
+            original_segment_flush_infos: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn async_queue_frontier_uses_pulled_log_offset() {
+        let collection_info = compact_info(550, 250);
+
+        let compaction_offset = (collection_info.pulled_log_offset >= 0)
+            .then_some(collection_info.pulled_log_offset);
+
+        assert_eq!(compaction_offset, Some(550));
+    }
+
+    #[test]
+    fn async_queue_frontier_ignores_uninitialized_offsets() {
+        let collection_info = compact_info(-1, 250);
+
+        let compaction_offset = (collection_info.pulled_log_offset >= 0)
+            .then_some(collection_info.pulled_log_offset);
+
+        assert_eq!(compaction_offset, None);
+    }
+}

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -245,10 +245,6 @@ pub enum AttachedFunctionOrchestratorResponse {
 }
 
 impl AttachedFunctionOrchestrator {
-    fn queued_compaction_offset(collection_info: &CollectionCompactInfo) -> Option<i64> {
-        (collection_info.pulled_log_offset >= 0).then_some(collection_info.pulled_log_offset)
-    }
-
     pub fn new(
         input_collection_data: Vec<FunctionInputCollectionData>,
         output_context: CompactionContext,
@@ -356,8 +352,8 @@ impl AttachedFunctionOrchestrator {
     ) -> bool {
         if let Some(work_queue_client) = &self.output_context.work_queue_client {
             let operator = Box::new(QueueFunctionOperator::new(work_queue_client.clone()));
-            let compaction_offset =
-                Self::queued_compaction_offset(self.get_input_collection_info());
+            let compaction_offset = (self.get_input_collection_info().pulled_log_offset >= 0)
+                .then_some(self.get_input_collection_info().pulled_log_offset);
             let input = QueueFunctionInput::new(
                 attached_function.id,
                 self.get_input_collection_info().collection_id,
@@ -1094,47 +1090,5 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
         // For async-only functions, we don't have any output records to apply.
         // The function will be processed asynchronously by an external consumer.
         self.finish_no_attached_function(ctx).await;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::AttachedFunctionOrchestrator;
-    use crate::execution::orchestration::compact::CollectionCompactInfo;
-    use chroma_types::{Collection, CollectionUuid};
-
-    fn compact_info(pulled_log_offset: i64, persisted_log_position: i64) -> CollectionCompactInfo {
-        CollectionCompactInfo {
-            collection_id: CollectionUuid::new(),
-            collection: Collection {
-                log_position: persisted_log_position,
-                ..Default::default()
-            },
-            writers: None,
-            pulled_log_offset,
-            hnsw_index_uuid: None,
-            schema: None,
-            original_segment_flush_infos: Vec::new(),
-        }
-    }
-
-    #[test]
-    fn queued_compaction_offset_uses_pulled_log_offset() {
-        let collection_info = compact_info(550, 250);
-
-        assert_eq!(
-            AttachedFunctionOrchestrator::queued_compaction_offset(&collection_info),
-            Some(550)
-        );
-    }
-
-    #[test]
-    fn queued_compaction_offset_ignores_uninitialized_frontier() {
-        let collection_info = compact_info(-1, 250);
-
-        assert_eq!(
-            AttachedFunctionOrchestrator::queued_compaction_offset(&collection_info),
-            None
-        );
     }
 }


### PR DESCRIPTION
## Description of changes

Before this diff, `compaction_offset` was passed into `push_work` even though this call should mark all records up to `pulled_log_offset` ready for async function processing. This diff fixes that.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
