### PR TITLE
Use UTF-8 for telemetry user id file

### DIFF
--- a/chromadb/telemetry/product/__init__.py
+++ b/chromadb/telemetry/product/__init__.py
@@ -85,12 +85,12 @@ class ProductTelemetryClient(Component):
         try:
             if not os.path.exists(self.USER_ID_PATH):
                 os.makedirs(os.path.dirname(self.USER_ID_PATH), exist_ok=True)
-                with open(self.USER_ID_PATH, "w") as f:
+                with open(self.USER_ID_PATH, "w", encoding="utf-8") as f:
                     new_user_id = str(uuid.uuid4())
                     f.write(new_user_id)
                 self._curr_user_id = new_user_id
             else:
-                with open(self.USER_ID_PATH, "r") as f:
+                with open(self.USER_ID_PATH, "r", encoding="utf-8") as f:
                     self._curr_user_id = f.read()
         except Exception:
             self._curr_user_id = self.UNKNOWN_USER_ID


### PR DESCRIPTION
## Problem
The product telemetry client persists its anonymous telemetry user id with plain `open(..., "w")` / `open(..., "r")`. That means the file uses the platform default text encoding, which can vary across environments.

The value written today is a UUID string, but using an explicit encoding keeps this small persistence path deterministic and matches the rest of the project style where text files commonly specify UTF-8.

## Before
The telemetry user id file was read and written with the process/platform default text encoding.

## After
The telemetry user id file is read and written with `encoding="utf-8"`.

## Verification
```bash
python -m py_compile chromadb/telemetry/product/__init__.py
```

I also attempted a tiny import-based read/write smoke check, but this local checkout is missing the `overrides` dependency, so importing `chromadb` failed before reaching this code path.