### PR TITLE
[BLD] Share rust builder stage across tilt bake targets

### DIFF
--- a/.github/actions/tilt-setup-prebuild/docker-bake.hcl
+++ b/.github/actions/tilt-setup-prebuild/docker-bake.hcl
@@ -1,3 +1,12 @@
+// All rust/Dockerfile targets must pass identical args so they share a
+// single builder stage in the buildkit cache. A differing arg (even one
+// that only affects the log_service binary) forks the builder into two
+// cache keys and compiles the entire workspace twice.
+//
+// NOTE: action.yaml discovers targets by grepping '^target' in this file,
+// so a shared inheritance block would itself get built — hence the args
+// are repeated on each target instead.
+
 target "rust-log-service" {
   dockerfile = "rust/Dockerfile"
   target = "log_service"
@@ -10,6 +19,9 @@ target "rust-log-service" {
 target "rust-sysdb-service" {
   dockerfile = "rust/Dockerfile"
   target = "sysdb_service"
+  args = {
+    LOG_SERVICE_CARGO_FEATURES = "faults"
+  }
   tags = [ "rust-sysdb-service:ci" ]
 }
 
@@ -28,48 +40,72 @@ target "sysdb-migration" {
 target "rust-sysdb-migration" {
   dockerfile = "rust/Dockerfile"
   target = "rust-sysdb-migration"
+  args = {
+    LOG_SERVICE_CARGO_FEATURES = "faults"
+  }
   tags = [ "rust-sysdb-migration:ci" ]
 }
 
 target "rust-frontend-service" {
   dockerfile = "rust/Dockerfile"
   target = "cli"
+  args = {
+    LOG_SERVICE_CARGO_FEATURES = "faults"
+  }
   tags = [ "rust-frontend-service:ci" ]
 }
 
 target "query-service" {
   dockerfile = "rust/Dockerfile"
   target = "query_service"
+  args = {
+    LOG_SERVICE_CARGO_FEATURES = "faults"
+  }
   tags = [ "query-service:ci" ]
 }
 
 target "compactor-service" {
   dockerfile = "rust/Dockerfile"
   target = "compaction_service"
+  args = {
+    LOG_SERVICE_CARGO_FEATURES = "faults"
+  }
   tags = [ "compactor-service:ci" ]
 }
 
 target "garbage-collector" {
   dockerfile = "rust/Dockerfile"
   target = "garbage_collector"
+  args = {
+    LOG_SERVICE_CARGO_FEATURES = "faults"
+  }
   tags = [ "garbage-collector:ci" ]
 }
 
 target "load-service" {
   dockerfile = "rust/Dockerfile"
   target = "load_service"
+  args = {
+    LOG_SERVICE_CARGO_FEATURES = "faults"
+  }
   tags = [ "load-service:ci" ]
 }
 
 target "work-queue-service" {
   dockerfile = "rust/Dockerfile"
   target = "work_queue_service"
+  args = {
+    LOG_SERVICE_CARGO_FEATURES = "faults"
+  }
   tags = [ "work-queue-service:ci" ]
 }
 
 target "fn-consumer" {
   dockerfile = "rust/Dockerfile"
   target = "fn_consumer"
+  args = {
+    LOG_SERVICE_CARGO_FEATURES = "faults"
+  }
   tags = [ "fn-consumer:ci" ]
 }
 


### PR DESCRIPTION
## Problem

CI tilt image prebuilds compile the entire rust workspace **twice** on every docker layer-cache miss, adding ~5-6 minutes to every cold "Start Tilt stack" run in both chroma and hosted-chroma CI. hosted-chroma's Rust (K8s Integration) job recently hit its 30-min timeout partly because of this ([example run](https://github.com/chroma-core/hosted-chroma/actions/runs/28958303861)).

In `.github/actions/tilt-setup-prebuild/docker-bake.hcl`, only the `rust-log-service` target set `LOG_SERVICE_CARGO_FEATURES = "faults"`. All rust targets build from `rust/Dockerfile`, which has a single shared `builder` stage fed by that ARG — so the differing build arg gave the builder stage **two distinct buildkit cache keys**, and the full workspace compiled once per key. Worse, the builder's cargo cache mounts use `sharing=locked`, so the two builder variants serialized instead of running concurrently: observed 5m23s + ~5m more blocked on the lock, ~11 min wall-clock for what should be one ~5-min compile.

## Fix

Set `LOG_SERVICE_CARGO_FEATURES = "faults"` identically on **all ten** rust targets, so they all resolve one builder stage / one cache key / one workspace compile.

**Why this is safe:** in `rust/Dockerfile`, the ARG only gates one extra step in the builder — `cargo build -p chroma-log-service --bin log_service --features "$LOG_SERVICE_CARGO_FEATURES"` — which runs *after* the main `cargo build --workspace` and only overwrites the `log_service` binary. Every runtime stage just `COPY`s its own binary out of the builder, and only the `log_service` stage copies `log_service`. So the other nine images ship byte-identical binaries to before; only the log-service image gets the faults build, exactly as it does today.

**Why repetition instead of a shared `inherits` block:** `action.yaml` discovers buildable targets by grepping `^target` in the bake file, so a shared `target "_rust-common"` block would itself get picked up and built as a bogus batch entry. A comment in the bake file documents both constraints.

## Verification

`docker buildx bake -f .github/actions/tilt-setup-prebuild/docker-bake.hcl --print` — all 10 `rust/Dockerfile` targets now resolve `args = { LOG_SERVICE_CARGO_FEATURES = "faults" }`:

```
compactor-service         args={'LOG_SERVICE_CARGO_FEATURES': 'faults'}
fn-consumer               args={'LOG_SERVICE_CARGO_FEATURES': 'faults'}
garbage-collector         args={'LOG_SERVICE_CARGO_FEATURES': 'faults'}
load-service              args={'LOG_SERVICE_CARGO_FEATURES': 'faults'}
query-service             args={'LOG_SERVICE_CARGO_FEATURES': 'faults'}
rust-frontend-service     args={'LOG_SERVICE_CARGO_FEATURES': 'faults'}
rust-log-service          args={'LOG_SERVICE_CARGO_FEATURES': 'faults'}
rust-sysdb-migration      args={'LOG_SERVICE_CARGO_FEATURES': 'faults'}
rust-sysdb-service        args={'LOG_SERVICE_CARGO_FEATURES': 'faults'}
work-queue-service        args={'LOG_SERVICE_CARGO_FEATURES': 'faults'}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)