### PR TITLE
[BUG](worker): Scope BackfillFn by function

### DIFF
--- a/rust/frontend-core/src/attached_function_ops.rs
+++ b/rust/frontend-core/src/attached_function_ops.rs
@@ -11,6 +11,7 @@ use chroma_sysdb::SysDb;
 use chroma_types::{
     AttachFunctionError, AttachedFunction, AttachedFunctionUuid, Cmek, Collection, CollectionUuid,
     DatabaseName, FinishCreateAttachedFunctionError, Operation, OperationRecord, Schema,
+    UpdateMetadataValue, CHROMA_BACKFILL_ATTACHED_FUNCTION_ID_KEY,
 };
 
 use crate::retry::retry_transient;
@@ -49,6 +50,39 @@ pub struct AddAttachedFunctionInputResult {
     pub attached_function_id: AttachedFunctionUuid,
     pub created: bool,
     pub output_schema_str: String,
+}
+
+pub async fn push_backfill_records(
+    log: &mut Log,
+    tenant: &str,
+    database_name: DatabaseName,
+    input_collection_id: CollectionUuid,
+    input_collection: &Collection,
+    attached_function_id: AttachedFunctionUuid,
+    num_backfill_records: usize,
+) -> Result<(), PushLogsError> {
+    let dim = input_collection.dimension.unwrap_or(1) as usize;
+    let fake_embedding = vec![0.0; dim];
+    let cmek: Option<Cmek> = input_collection
+        .schema
+        .as_ref()
+        .and_then(|s| s.cmek.clone());
+    let records = vec![
+        OperationRecord {
+            id: "backfill_id".to_string(),
+            embedding: Some(fake_embedding),
+            encoding: None,
+            metadata: Some(std::collections::HashMap::from([(
+                CHROMA_BACKFILL_ATTACHED_FUNCTION_ID_KEY.to_string(),
+                UpdateMetadataValue::Str(attached_function_id.to_string()),
+            )])),
+            document: None,
+            operation: Operation::BackfillFn,
+        };
+        num_backfill_records
+    ];
+    log.push_logs(tenant, database_name, input_collection_id, records, cmek)
+        .await
 }
 
 /// Create an attached function and mark it ready in one shot.
@@ -289,25 +323,16 @@ pub async fn create_attached_function_with_backfill(
     }
 
     // Backfill: push dummy records to force a compaction cycle.
-    let dim = input_collection.dimension.unwrap_or(1) as usize;
-    let fake_embedding = vec![0.0; dim];
-    let cmek: Option<Cmek> = input_collection
-        .schema
-        .as_ref()
-        .and_then(|s| s.cmek.clone());
-    let records = vec![
-        OperationRecord {
-            id: "backfill_id".to_string(),
-            embedding: Some(fake_embedding),
-            encoding: None,
-            metadata: None,
-            document: None,
-            operation: Operation::BackfillFn,
-        };
-        num_backfill_records
-    ];
-    log.push_logs(&tenant, database_name, input_collection_id, records, cmek)
-        .await?;
+    push_backfill_records(
+        log,
+        &tenant,
+        database_name,
+        input_collection_id,
+        input_collection,
+        id,
+        num_backfill_records,
+    )
+    .await?;
 
     let schema_str = serde_json::to_string(&output_schema)?;
     sysdb

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -2670,44 +2670,24 @@ impl ServiceBasedFrontend {
         tenant_name: String,
         database_name: DatabaseName,
         input_collection_id: CollectionUuid,
-        _attached_function_id: chroma_types::AttachedFunctionUuid,
+        attached_function_id: chroma_types::AttachedFunctionUuid,
     ) -> Result<(), chroma_types::AttachFunctionError> {
         let input_collection = self
             .get_cached_collection(database_name.clone(), input_collection_id)
             .await
             .map_err(|e| chroma_types::AttachFunctionError::Internal(Box::new(e)))?;
 
-        let dim = input_collection.dimension.unwrap_or(1) as usize;
-        let fake_embedding = vec![0.0; dim];
-        let cmek: Option<Cmek> = input_collection
-            .schema
-            .as_ref()
-            .and_then(|schema| schema.cmek.clone());
-
-        // Match the existing attach flow and push enough dummy records to
-        // trigger compaction for the newly added input collection.
-        let records = vec![
-            OperationRecord {
-                id: "backfill_id".to_string(),
-                embedding: Some(fake_embedding),
-                encoding: None,
-                metadata: None,
-                document: None,
-                operation: Operation::BackfillFn,
-            };
-            250
-        ];
-
-        self.log_client
-            .push_logs(
-                &tenant_name,
-                database_name,
-                input_collection_id,
-                records,
-                cmek,
-            )
-            .await
-            .map_err(|e| chroma_types::AttachFunctionError::Internal(Box::new(e)))?;
+        frontend_core::attached_function_ops::push_backfill_records(
+            &mut self.log_client,
+            &tenant_name,
+            database_name,
+            input_collection_id,
+            &input_collection,
+            attached_function_id,
+            250,
+        )
+        .await
+        .map_err(|e| chroma_types::AttachFunctionError::Internal(Box::new(e)))?;
 
         Ok(())
     }

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -1,10 +1,12 @@
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::{
-    logical_size_of_metadata, Chunk, DataRecord, DeletedMetadata, LogRecord,
+    logical_size_of_metadata, AttachedFunctionUuid, Chunk, DataRecord, DeletedMetadata, LogRecord,
     MaterializedLogOperation, Metadata, MetadataDelta, MetadataValue, MetadataValueConversionError,
     Operation, Schema, SegmentType, SegmentUuid, UpdateMetadata, UpdateMetadataValue,
+    CHROMA_BACKFILL_ATTACHED_FUNCTION_ID_KEY,
 };
 use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use thiserror::Error;
@@ -572,6 +574,17 @@ impl PartitionedMaterializeLogsResult {
         self.shards.iter().any(|s| s.has_backfill())
     }
 
+    pub fn backfill_attached_function_ids(&self) -> HashSet<AttachedFunctionUuid> {
+        self.shards
+            .iter()
+            .flat_map(|s| s.backfill_attached_function_ids().iter().copied())
+            .collect()
+    }
+
+    pub fn has_legacy_backfill_signal(&self) -> bool {
+        self.shards.iter().any(|s| s.has_legacy_backfill_signal())
+    }
+
     pub fn split(
         &self,
         pivot_offset_id: u32,
@@ -609,7 +622,8 @@ impl PartitionedMaterializeLogsResult {
 pub struct MaterializeLogsResult {
     pub logs: Chunk<LogRecord>,
     pub materialized: Chunk<MaterializedLogRecord>,
-    pub has_backfill: bool,
+    pub backfill_attached_function_ids: HashSet<AttachedFunctionUuid>,
+    pub has_legacy_backfill_signal: bool,
 }
 
 impl MaterializeLogsResult {
@@ -626,7 +640,15 @@ impl MaterializeLogsResult {
     }
 
     pub fn has_backfill(&self) -> bool {
-        self.has_backfill
+        self.has_legacy_backfill_signal || !self.backfill_attached_function_ids.is_empty()
+    }
+
+    pub fn backfill_attached_function_ids(&self) -> &HashSet<AttachedFunctionUuid> {
+        &self.backfill_attached_function_ids
+    }
+
+    pub fn has_legacy_backfill_signal(&self) -> bool {
+        self.has_legacy_backfill_signal
     }
 
     pub fn iter(&'_ self) -> MaterializeLogsResultIter<'_> {
@@ -804,14 +826,29 @@ pub async fn materialize_logs(
         .await?;
     }
 
-    let mut has_backfill = false;
+    let mut backfill_attached_function_ids = HashSet::new();
+    let mut has_legacy_backfill_signal = false;
     // Populate updates to these and fresh records that are being
     // inserted for the first time.
     async {
         for (log_record, log_index) in logs.iter() {
             match log_record.record.operation {
                 Operation::BackfillFn => {
-                    has_backfill = true;
+                    if let Some(metadata) = &log_record.record.metadata {
+                        if let Some(UpdateMetadataValue::Str(attached_function_id)) =
+                            metadata.get(CHROMA_BACKFILL_ATTACHED_FUNCTION_ID_KEY)
+                        {
+                            if let Ok(attached_function_id) =
+                                AttachedFunctionUuid::from_str(attached_function_id)
+                            {
+                                backfill_attached_function_ids.insert(attached_function_id);
+                            }
+                        } else {
+                            has_legacy_backfill_signal = true;
+                        }
+                    } else {
+                        has_legacy_backfill_signal = true;
+                    }
                     continue;
                 }
                 Operation::Add => {
@@ -1103,7 +1140,8 @@ pub async fn materialize_logs(
     Ok(MaterializeLogsResult {
         logs,
         materialized: Chunk::new(res.into()),
-        has_backfill,
+        backfill_attached_function_ids,
+        has_legacy_backfill_signal,
     })
 }
 
@@ -1135,7 +1173,8 @@ pub async fn materialize_logs_for_rebuild(
     Ok(MaterializeLogsResult {
         logs,
         materialized: Chunk::new(res.into()),
-        has_backfill: false, // Rebuild path never has backfill
+        backfill_attached_function_ids: HashSet::new(), // Rebuild path never has backfill
+        has_legacy_backfill_signal: false,              // Rebuild path never has backfill
     })
 }
 

--- a/rust/types/src/lib.rs
+++ b/rust/types/src/lib.rs
@@ -58,6 +58,7 @@ pub use operation::*;
 pub use operators::*;
 pub use quantized_cluster::*;
 pub use record::*;
+pub const CHROMA_BACKFILL_ATTACHED_FUNCTION_ID_KEY: &str = "chroma:backfill_attached_function_id";
 pub use scalar_encoding::*;
 pub use segment::*;
 pub use segment_scope::*;

--- a/rust/worker/src/execution/operators/source_record_segment_v2.rs
+++ b/rust/worker/src/execution/operators/source_record_segment_v2.rs
@@ -85,7 +85,8 @@ impl Operator<SourceRecordSegmentV2Input, SourceRecordSegmentV2Output>
         let empty_shard = || MaterializeLogsResult {
             logs: Chunk::new(Vec::new().into()),
             materialized: Chunk::new(Vec::new().into()),
-            has_backfill: false,
+            backfill_attached_function_ids: std::collections::HashSet::new(),
+            has_legacy_backfill_signal: false,
         };
         let build_partition = |materialized: MaterializeLogsResult| {
             let shards = (0..self.shard_count)

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -92,7 +92,13 @@ impl FunctionExecutionContext {
             LogFetchOrchestratorResponse::Success(success) => {
                 (success.materialized, success.collection_info)
             }
-            LogFetchOrchestratorResponse::RequireFunctionBackfill(_) => {
+            LogFetchOrchestratorResponse::RequireFunctionBackfill(backfill) => {
+                tracing::info!(
+                    collection_id = %collection_id,
+                    backfill_function_count = backfill.attached_function_ids.len(),
+                    has_legacy_backfill_signal = backfill.has_legacy_backfill_signal,
+                    "Refetching compacted logs after attached-function backfill signal"
+                );
                 match Self::fetch_function_input_logs(
                     log_fetch_context,
                     collection_id,

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -22,10 +22,11 @@ use chroma_system::{
     Orchestrator, OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
-    Chunk, CollectionUuid, JobId, LogRecord, MetadataValue, SchemaMismatchError, SegmentFlushInfo,
-    SegmentScope, SegmentShard, SegmentShardError,
+    AttachedFunctionUuid, Chunk, CollectionUuid, JobId, LogRecord, MetadataValue,
+    SchemaMismatchError, SegmentFlushInfo, SegmentScope, SegmentShard, SegmentShardError,
 };
 use opentelemetry::trace::TraceContextExt;
+use std::collections::HashSet;
 use std::sync::{atomic::AtomicU32, Arc};
 use thiserror::Error;
 use tokio::sync::oneshot::{error::RecvError, Sender};
@@ -215,16 +216,22 @@ pub(crate) struct RequireCompactionOffsetRepair {
 pub(crate) struct RequireFunctionBackfill {
     pub materialized: Vec<MaterializeLogOutput>,
     pub collection_info: CollectionCompactInfo,
+    pub attached_function_ids: HashSet<AttachedFunctionUuid>,
+    pub has_legacy_backfill_signal: bool,
 }
 
 impl RequireFunctionBackfill {
     pub fn new(
         materialized: Vec<MaterializeLogOutput>,
         collection_info: CollectionCompactInfo,
+        attached_function_ids: HashSet<AttachedFunctionUuid>,
+        has_legacy_backfill_signal: bool,
     ) -> Self {
         Self {
             materialized,
             collection_info,
+            attached_function_ids,
+            has_legacy_backfill_signal,
         }
     }
 }
@@ -291,7 +298,8 @@ pub(crate) struct LogFetchOrchestrator {
     state: ExecutionState,
     num_uncompleted_materialization_tasks: usize,
     materialized_outputs: Vec<MaterializeLogOutput>,
-    has_backfill: bool,
+    backfill_attached_function_ids: HashSet<AttachedFunctionUuid>,
+    has_legacy_backfill_signal: bool,
 }
 
 #[async_trait]
@@ -408,7 +416,8 @@ impl LogFetchOrchestrator {
             state: ExecutionState::Pending,
             num_uncompleted_materialization_tasks: 0,
             materialized_outputs: Vec::new(),
-            has_backfill: false,
+            backfill_attached_function_ids: HashSet::new(),
+            has_legacy_backfill_signal: false,
         }
     }
 
@@ -1141,7 +1150,9 @@ impl Handler<TaskResult<SourceRecordSegmentV2Output, SourceRecordSegmentV2Error>
         self.num_uncompleted_materialization_tasks = 0;
         for partition in output.partitions {
             if partition.result.has_backfill() {
-                self.has_backfill = true;
+                self.backfill_attached_function_ids
+                    .extend(partition.result.backfill_attached_function_ids());
+                self.has_legacy_backfill_signal |= partition.result.has_legacy_backfill_signal();
             }
 
             if !partition.result.is_empty() {
@@ -1165,9 +1176,18 @@ impl Handler<TaskResult<SourceRecordSegmentV2Output, SourceRecordSegmentV2Error>
         };
 
         let materialized = std::mem::take(&mut self.materialized_outputs);
-        if self.has_backfill {
+        if self.has_legacy_backfill_signal || !self.backfill_attached_function_ids.is_empty() {
+            let backfill_attached_function_ids =
+                std::mem::take(&mut self.backfill_attached_function_ids);
+            let has_legacy_backfill_signal = std::mem::take(&mut self.has_legacy_backfill_signal);
             self.terminate_with_result(
-                Ok(RequireFunctionBackfill::new(materialized, collection_info).into()),
+                Ok(RequireFunctionBackfill::new(
+                    materialized,
+                    collection_info,
+                    backfill_attached_function_ids,
+                    has_legacy_backfill_signal,
+                )
+                .into()),
                 ctx,
             )
             .await;
@@ -1212,7 +1232,9 @@ impl Handler<TaskResult<MaterializeLogOutput, MaterializeLogOperatorError>>
         };
 
         if output.result.has_backfill() {
-            self.has_backfill = true;
+            self.backfill_attached_function_ids
+                .extend(output.result.backfill_attached_function_ids());
+            self.has_legacy_backfill_signal |= output.result.has_legacy_backfill_signal();
         }
 
         if !output.result.is_empty() {
@@ -1235,9 +1257,19 @@ impl Handler<TaskResult<MaterializeLogOutput, MaterializeLogOperatorError>>
             };
 
             let materialized = std::mem::take(&mut self.materialized_outputs);
-            if self.has_backfill {
+            if self.has_legacy_backfill_signal || !self.backfill_attached_function_ids.is_empty() {
+                let backfill_attached_function_ids =
+                    std::mem::take(&mut self.backfill_attached_function_ids);
+                let has_legacy_backfill_signal =
+                    std::mem::take(&mut self.has_legacy_backfill_signal);
                 self.terminate_with_result(
-                    Ok(RequireFunctionBackfill::new(materialized, collection_info).into()),
+                    Ok(RequireFunctionBackfill::new(
+                        materialized,
+                        collection_info,
+                        backfill_attached_function_ids,
+                        has_legacy_backfill_signal,
+                    )
+                    .into()),
                     ctx,
                 )
                 .await;


### PR DESCRIPTION
## Summary
- scope BackfillFn records by attached function ID when attach paths enqueue backfill
- preserve legacy unscoped backfill signals during segment materialization
- carry scoped backfill IDs through log fetch so follow-up routing can key off function-specific signals

## Testing
- cargo fmt --all
- cargo check -p chroma-types -p frontend-core -p chroma-frontend -p chroma-segment -p worker