### PR TITLE
[BUG] Fix fn-consumer GC boundary handling

### DIFF
--- a/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
+++ b/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
@@ -115,7 +115,7 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
             };
 
             for (i, (version, created_at, mode)) in versions.iter_mut().rev().enumerate() {
-                // Fn-consumers need every surviving boundary after the protected version.
+                // Keep around every version that the fn-consumer has yet to process.
                 if fn_protected_version
                     .is_some_and(|protected_version| *version >= protected_version)
                 {

--- a/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
+++ b/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
@@ -114,8 +114,13 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
                 None
             };
 
+            // We have a lower bound on which versions we can delete via fn_protected_version.
+            // We must mark EVERY version above this to keep. We use the same logic to also
+            // keep versions that are too new (based on cutoff_time and min_versions_to_keep).
+            // Earlier, this code mistakenly assumed that only the lowest version in the protected
+            // chain needs to be marked as Keep and later logic will make sure to keep all versions
+            // above it. This was wrong.
             for (i, (version, created_at, mode)) in versions.iter_mut().rev().enumerate() {
-                // Keep around every version that the fn-consumer has yet to process.
                 if fn_protected_version
                     .is_some_and(|protected_version| *version >= protected_version)
                 {

--- a/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
+++ b/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
@@ -115,7 +115,8 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
             };
 
             for (i, (version, created_at, mode)) in versions.iter_mut().rev().enumerate() {
-                if fn_protected_version.is_some_and(|protected_version| *version >= protected_version)
+                if fn_protected_version
+                    .is_some_and(|protected_version| *version >= protected_version)
                 {
                     tracing::debug!(
                         collection_id = %collection_id,

--- a/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
+++ b/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
@@ -115,6 +115,7 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
             };
 
             for (i, (version, created_at, mode)) in versions.iter_mut().rev().enumerate() {
+                // Fn-consumers need every surviving boundary after the protected version.
                 if fn_protected_version
                     .is_some_and(|protected_version| *version >= protected_version)
                 {

--- a/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
+++ b/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
@@ -115,12 +115,14 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
             };
 
             for (i, (version, created_at, mode)) in versions.iter_mut().rev().enumerate() {
-                if fn_protected_version == Some(*version) {
+                if fn_protected_version.is_some_and(|protected_version| *version >= protected_version)
+                {
                     tracing::debug!(
                         collection_id = %collection_id,
-                        protected_version = *version,
+                        protected_version = fn_protected_version,
+                        version = *version,
                         min_completion_offset,
-                        "Keeping version <= attached function completion offset"
+                        "Keeping version in attached function protected chain"
                     );
                     *mode = CollectionVersionAction::Keep;
                 } else if i >= input.min_versions_to_keep as usize
@@ -673,5 +675,67 @@ mod tests {
         let b_versions = result.versions.remove(&collection_b).unwrap();
         assert_eq!(b_versions.get(&40), Some(&CollectionVersionAction::Keep));
         assert_eq!(b_versions.get(&50), Some(&CollectionVersionAction::Keep));
+    }
+
+    #[tokio::test]
+    async fn test_compute_versions_to_delete_keeps_full_chain_after_attached_function_floor() {
+        let now = Utc::now();
+        let collection_id = CollectionUuid::new();
+
+        let mut graph = VersionGraph::new();
+        let v30 = graph.add_node(VersionGraphNode {
+            collection_id,
+            version: 30,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(48),
+            },
+        });
+        let v409 = graph.add_node(VersionGraphNode {
+            collection_id,
+            version: 409,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(24),
+            },
+        });
+        let v410 = graph.add_node(VersionGraphNode {
+            collection_id,
+            version: 410,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(12),
+            },
+        });
+        let v411 = graph.add_node(VersionGraphNode {
+            collection_id,
+            version: 411,
+            status: VersionStatus::Alive {
+                created_at: now - Duration::hours(1),
+            },
+        });
+        graph.add_edge(v30, v409, ());
+        graph.add_edge(v409, v410, ());
+        graph.add_edge(v410, v411, ());
+
+        let input = ComputeVersionsToDeleteInput {
+            graph,
+            cutoff_time: now - Duration::hours(6),
+            min_versions_to_keep: 1,
+            soft_deleted_collections: HashSet::new(),
+            min_attached_function_completion_offsets: HashMap::from([(collection_id, 21433)]),
+            version_log_positions: HashMap::from([(
+                collection_id,
+                BTreeMap::from([(21433, 30), (314658, 409), (315490, 410), (315855, 411)]),
+            )]),
+        };
+
+        let mut result = ComputeVersionsToDeleteOperator {}
+            .run(&input)
+            .await
+            .unwrap();
+
+        let versions = result.versions.remove(&collection_id).unwrap();
+        assert_eq!(versions.get(&30), Some(&CollectionVersionAction::Keep));
+        assert_eq!(versions.get(&409), Some(&CollectionVersionAction::Keep));
+        assert_eq!(versions.get(&410), Some(&CollectionVersionAction::Keep));
+        assert_eq!(versions.get(&411), Some(&CollectionVersionAction::Keep));
     }
 }

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -363,7 +363,7 @@ impl AttachedFunctionOrchestrator {
                 ctx.receiver(),
                 self.context().task_cancellation_token.clone(),
             );
-            let res = self.dispatcher().send(task, None).await;
+            let res = self.dispatcher().send(task, Some(Span::current())).await;
             self.ok_or_terminate(res, ctx).await.is_some()
         } else {
             tracing::error!("Async attached function found but no WorkQueue client configured");
@@ -430,7 +430,7 @@ impl AttachedFunctionOrchestrator {
             ctx.receiver(),
             self.context().task_cancellation_token.clone(),
         );
-        let res = self.dispatcher().send(task, None).await;
+        let res = self.dispatcher().send(task, Some(Span::current())).await;
         self.ok_or_terminate(res, ctx).await;
     }
 
@@ -1030,7 +1030,7 @@ impl Handler<TaskResult<CollectionAndSegments, GetCollectionAndSegmentsError>>
             ctx.receiver(),
             self.context().task_cancellation_token.clone(),
         );
-        let res = self.dispatcher().send(task, None).await;
+        let res = self.dispatcher().send(task, Some(Span::current())).await;
         self.ok_or_terminate(res, ctx).await;
     }
 }

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, SystemTime};
 use thiserror::Error;
 use tracing::{instrument, span};
 
+use crate::compactor::config::CompactorConfig;
 use crate::execution::orchestration::compact::CompactionContext;
 use crate::execution::orchestration::function_execution::FunctionExecutionContext;
 use crate::fn_consumer::config::FnConsumerConfig;
@@ -67,6 +68,10 @@ pub struct FnConsumerContext {
     pub blockfile_provider: BlockfileProvider,
     pub hnsw_provider: HnswIndexProvider,
     pub spann_provider: SpannProvider,
+    pub fetch_log_batch_size: u32,
+    pub fetch_log_concurrency: usize,
+    pub max_compaction_size: usize,
+    pub max_partition_size: usize,
 }
 
 impl std::fmt::Debug for FnConsumerContext {
@@ -100,6 +105,7 @@ impl FnConsumerManager {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: FnConsumerConfig,
+        compactor_config: CompactorConfig,
         my_member_id: String,
         system: System,
         work_queue_client: WorkQueueClient,
@@ -122,6 +128,10 @@ impl FnConsumerManager {
             blockfile_provider,
             hnsw_provider,
             spann_provider,
+            fetch_log_batch_size: compactor_config.fetch_log_batch_size,
+            fetch_log_concurrency: compactor_config.fetch_log_concurrency,
+            max_compaction_size: compactor_config.max_compaction_size,
+            max_partition_size: compactor_config.max_partition_size,
         };
         Self {
             context,
@@ -172,11 +182,11 @@ impl FnConsumerManager {
         // execution flow applies each input collection's completion offset when
         // fetching logs, so the shared base context should not carry one.
         let compaction_context = CompactionContext::new(
-            None,  // rebuild_info
-            100,   // fetch_log_batch_size
-            10,    // fetch_log_concurrency
-            10000, // max_compaction_size
-            1000,  // max_partition_size
+            None, // rebuild_info
+            self.context.fetch_log_batch_size,
+            self.context.fetch_log_concurrency,
+            self.context.max_compaction_size,
+            self.context.max_partition_size,
             self.context.log.clone(),
             self.context.sysdb.clone(),
             self.context.blockfile_provider.clone(),

--- a/rust/worker/src/fn_consumer/server.rs
+++ b/rust/worker/src/fn_consumer/server.rs
@@ -161,6 +161,7 @@ pub async fn fn_consumer_service_entrypoint() {
     // Build and start the manager
     let mut manager = FnConsumerManager::new(
         service_config.fn_consumer.clone(),
+        config.compaction_service.compactor.clone(),
         service_config.my_member_id.clone(),
         system.clone(),
         work_queue_client.clone(),


### PR DESCRIPTION
## Summary
Fix a garbage-collection bug that could delete compaction boundaries still needed by fn-consumer, and make fn-consumer derive its fetch sizing from config instead of hardcoded values.

## Problem
GC only kept one fn-protected version. That allowed intermediate compaction boundaries to be deleted, so fn-consumer could later see a huge jump like version 30 -> 409 and fail with the max_compaction_size boundary-window error.

Fn-consumer also hardcoded fetch sizing values instead of using the configured compactor settings, which made the behavior diverge from service config.

## Changes
- keep every version at or after the fn-protected boundary within the collection
- expand the inline comment in the GC operator to explain why the full chain must be kept
- add a regression test covering the sparse version chain case (30, 409, 410, 411)
- thread compactor sizing config into fn-consumer so it uses configured values for:
  - fetch_log_batch_size
  - fetch_log_concurrency
  - max_compaction_size
  - max_partition_size

## Testing
- cargo fmt --all --check
- cargo clippy -p garbage_collector --tests -- -D warnings
- cargo test -p garbage_collector compute_versions_to_delete
- cargo clippy -p worker --tests -- -D warnings
- cargo test -p worker fn_consumer