### PR TITLE
[CHORE](ci): Fix test inventory target for python tests

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -211,7 +211,7 @@ jobs:
           CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
           CHROMA_TEST_INVENTORY_JOB: test-rust-bindings
           CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
-          CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test-glob }}
+          CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test_target.args }}
       - name: Upload test inventory shard
         if: always()
         uses: actions/upload-artifact@v7
@@ -363,7 +363,7 @@ jobs:
         CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
         CHROMA_TEST_INVENTORY_JOB: test-rust-single-node-integration
         CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
-        CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test-glob }}
+        CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test_target.args }}
         PYTEST_SHARD_INDEX: ${{ matrix.test_target.shard_index }}
         PYTEST_SHARD_COUNT: ${{ matrix.test_target.shard_count }}
     - name: Upload test inventory shard
@@ -435,7 +435,7 @@ jobs:
           CHROMA_TEST_INVENTORY_JSON: ${{ runner.temp }}/python-test-inventory/shard.json
           CHROMA_TEST_INVENTORY_JOB: test-rust-thin-client
           CHROMA_TEST_INVENTORY_PYTHON: ${{ matrix.python }}
-          CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test-glob }}
+          CHROMA_TEST_INVENTORY_TARGET: ${{ matrix.test_target.args }}
           PYTEST_SHARD_INDEX: ${{ matrix.test_target.shard_index }}
           PYTEST_SHARD_COUNT: ${{ matrix.test_target.shard_count }}
       - name: Upload test inventory shard


### PR DESCRIPTION
## Description of changes

The CHROMA_TEST_INVENTORY_TARGET env var referenced
matrix.test-glob, which is no longer the matrix key carrying the
test target. Point it at matrix.test_target.args so the recorded
inventory target matches the tests actually run across the
rust-bindings, single-node-integration, and thin-client jobs.

## Test plan

CI, exclusively, as this affects the job reporting there.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
