### PR TITLE
[BUG] Fix default pytest fixture list

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -387,19 +387,22 @@ def _fastapi_fixture(
         yield from run(args)
 
 
+@pytest.fixture()
 def fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=False)
+    yield from _fastapi_fixture(is_persistent=False)
 
 
+@pytest.fixture()
 def async_fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(
+    yield from _fastapi_fixture(
         is_persistent=False,
         chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
     )
 
 
+@pytest.fixture()
 def fastapi_persistent() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=True)
+    yield from _fastapi_fixture(is_persistent=True)
 
 
 def fastapi_ssl() -> Generator[System, None, None]:
@@ -753,7 +756,7 @@ def filtered_fixture_names() -> List[str]:
         "fastapi",
         "async_fastapi",
         "fastapi_persistent",
-        "sqlite_fixture",
+        "sqlite",
         "sqlite_persistent",
     ]
 
@@ -777,6 +780,8 @@ def filtered_http_server_fixture_names() -> List[str]:
         not in [
             "python_sqlite_ephemeral",
             "python_sqlite_persistent",
+            "sqlite",
+            "sqlite_persistent",
             "rust_sqlite_ephemeral",
             "rust_sqlite_persistent",
         ]

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -756,8 +756,8 @@ def filtered_fixture_names() -> List[str]:
         "fastapi",
         "async_fastapi",
         "fastapi_persistent",
-        "sqlite",
-        "sqlite_persistent",
+        "python_sqlite_ephemeral",
+        "python_sqlite_persistent",
     ]
 
     if "CHROMA_INTEGRATION_TEST" in os.environ:


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Registers the default FastAPI system helpers as pytest fixtures.
  - Parametrizes the default `system` fixture with concrete `python_sqlite_ephemeral` and `python_sqlite_persistent` fixtures, avoiding nested parametrized fixture lookup.
  - Excludes SQLite fixtures from HTTP-server-only parametrization.

Closes #7395

## Test plan

- [x] `python -m compileall -q chromadb/test/conftest.py`
- [x] `python -m pytest chromadb/test/test_api.py --collect-only -q` (`531 tests collected`)
- [x] Verified collection contains both `python_sqlite_ephemeral` and `python_sqlite_persistent` cases.
- [ ] Focused heartbeat execution requires `chroma-hnswlib`; its Windows build is blocked locally because Microsoft Visual C++ 14+ is not installed.

## Migration plan

No migrations or compatibility changes. Test fixture setup only.

## Observability plan

No runtime observability changes. Test fixture setup only.

## Documentation Changes

No documentation changes required.