### PR TITLE
[DOC](agents): Add Cursor Cloud setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,42 @@
 # Chroma Codebase Guidelines for AI Agents
 
 See [CLAUDE.md](./CLAUDE.md) for codebase conventions (commit message format, etc.).
+
+## Cursor Cloud specific instructions
+
+Scope that is set up in this environment: the **single-node (embedded) Chroma
+server** — the Rust core + Python `chromadb` package. The distributed stack
+(Tilt / Kubernetes / Docker) is NOT set up here; those tests
+(`test_k8s_integration`, `chromadb/test/distributed/*`) require `tilt up` and
+will fail without it. See `DEVELOP.md` for the standard commands.
+
+Non-obvious environment notes:
+
+- **Python venv lives at `./venv`.** Activate with `source venv/bin/activate`
+  before running `maturin`, `pytest`, `chroma`, etc. Deps are installed there,
+  not system-wide (system pip is externally-managed on this Ubuntu 24.04 box).
+- **Rust must be stable ≥ 1.85** (a dependency, `rmcp-macros`, needs
+  `edition2024`). The pinned-in-CI-as-"stable" toolchain is `rustup default
+  stable`; the shipped 1.83 is too old. `cargo` is on PATH at
+  `/usr/local/cargo/bin`.
+- **`protoc` is required** to compile the Rust workspace (`rust/types/build.rs`
+  compiles protobufs) and therefore for `maturin develop`. Installed at
+  `/usr/local/bin/protoc`.
+- **Build the Python bindings with `maturin develop`** (from inside the venv).
+  This compiles the whole Rust workspace the first time. The compiled
+  extension does NOT hot-reload — after changing Rust code you must re-run
+  `maturin develop` for Python to pick it up.
+- **Python gRPC proto stubs are generated, not committed.** Regenerate with
+  `make -C idl proto_python` (uses `grpc_tools` from the venv). Only needed for
+  distributed-mode modules/tests; the embedded path does not import them.
+- **Run the single-node server:** `chroma run --path ./chroma_data` (listens on
+  `:8000`; Swagger UI at `/docs/`, health at `/api/v2/heartbeat`). The first
+  embedding query downloads the default ONNX model (~79 MB) to
+  `~/.cache/chroma` and needs network.
+- **Tests:** embedded Python tests run with `CHROMA_RUST_BINDINGS_TEST_ONLY=1
+  python -m pytest chromadb/test/...`. Full single-node integration tests:
+  `bin/rust-integration-test.sh <pytest-args>`. Rust tests use `cargo nextest`
+  in CI (not installed here) but plain `cargo test -p <crate>` works.
+- **Lint** (matches CI): `pre-commit run --all-files black` and `... flake8`
+  for Python; `cargo fmt --all -- --check` and `cargo clippy` for Rust. Note
+  `flake8` only exists inside the pre-commit hook env, not as a direct dep.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the **single-node (embedded) Chroma** development
environment for Cursor Cloud agents, and records durable, non-obvious setup
caveats in `AGENTS.md` under a new `## Cursor Cloud specific instructions`
section.

This is a docs-only change; no product code is modified. The actual dependency
installation / build steps are captured by the environment snapshot + update
script (not in this diff).

## What was set up

- System deps: `protoc` (v28.3), `build-essential`, `libstdc++-14-dev` (fixes
  the C++ `hnswlib` build under clang), `python3.12-venv`.
- Rust toolchain updated to stable ≥ 1.85 (`edition2024` is required by a dep).
- Python venv at `./venv` with `requirements.txt` + `requirements_dev.txt`.
- Generated Python gRPC stubs (`make -C idl proto_python`).
- Built the Rust→Python bindings (`maturin develop`) and the `chroma` CLI
  (`cargo build --bin chroma`).

## Verification

- Ran `chroma run --path ./chroma_data` and completed a hello-world: created a
  collection, added documents, and queried — the nearest-neighbor result was
  correct.
- Browser check of the live Swagger UI at `/docs/` and `/api/v2/heartbeat`.
- Lint: `cargo fmt --all -- --check`, `pre-commit run --all-files black/flake8`.
- Tests: embedded `pytest chromadb/test/test_config.py` and a subset of
  `test_api.py`; Rust `cargo test -p chroma-distance`.

[chroma_server_swagger_ui_demo.mp4](https://cursor.com/agents/bc-f2ee4ca6-0a77-4866-b8d2-f97841fa9b08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchroma_server_swagger_ui_demo.mp4)

[Chroma Swagger UI](https://cursor.com/agents/bc-f2ee4ca6-0a77-4866-b8d2-f97841fa9b08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchroma_swagger_ui.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2ee4ca6-0a77-4866-b8d2-f97841fa9b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2ee4ca6-0a77-4866-b8d2-f97841fa9b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

