### PR TITLE
[BUG](worker): Backfill async fn on purge

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -78,6 +78,9 @@ pub mod state_hash_table;
 
 use crate::state_hash_table::StateHashTable;
 
+const PULL_LOGS_REASON_MD_KEY: &str = "pull-logs-reason";
+const PULL_LOGS_REASON_PURGED: &str = "purged";
+
 ///////////////////////////////////////////// helpers //////////////////////////////////////////////
 
 /// The gRPC metadata key for the backoff reason.
@@ -2763,7 +2766,14 @@ impl LogServer {
                 })?,
         };
         if !fragments.is_empty() && fragments[0].start.offset() > req.start_from_offset {
-            return Err(Status::not_found("Some entries have been purged"));
+            let mut status = Status::not_found("Some entries have been purged");
+            status.metadata_mut().insert(
+                PULL_LOGS_REASON_MD_KEY,
+                PULL_LOGS_REASON_PURGED
+                    .parse()
+                    .expect("valid metadata value"),
+            );
+            return Err(status);
         }
         let storage_prefix = collection_id.storage_prefix_for_log();
         let absolute_offsets = topology_name.is_none();
@@ -3126,7 +3136,14 @@ impl LogServer {
         if records.len() != pull_logs.batch_size as usize
             || (!records.is_empty() && records[0].log_offset != pull_logs.start_from_offset)
         {
-            return Err(Status::not_found("Some entries have been purged"));
+            let mut status = Status::not_found("Some entries have been purged");
+            status.metadata_mut().insert(
+                PULL_LOGS_REASON_MD_KEY,
+                PULL_LOGS_REASON_PURGED
+                    .parse()
+                    .expect("valid metadata value"),
+            );
+            return Err(status);
         }
         Ok(Response::new(PullLogsResponse { records }))
     }

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -114,6 +114,17 @@ fn status_with_backoff_reason(
     Status::with_metadata(code, message, metadata)
 }
 
+fn purged_logs_status() -> Status {
+    let mut status = Status::not_found("Some entries have been purged");
+    // SAFETY(tanuj): This static ASCII value is covered by
+    // `purged_logs_status_has_reason_metadata` below.
+    status.metadata_mut().insert(
+        PULL_LOGS_REASON_MD_KEY,
+        tonic::metadata::MetadataValue::from_static(PULL_LOGS_REASON_PURGED),
+    );
+    status
+}
+
 fn normalize_conditional_ids<'a>(
     ids: impl IntoIterator<Item = &'a str>,
     empty_id_message: &'static str,
@@ -2766,14 +2777,7 @@ impl LogServer {
                 })?,
         };
         if !fragments.is_empty() && fragments[0].start.offset() > req.start_from_offset {
-            let mut status = Status::not_found("Some entries have been purged");
-            status.metadata_mut().insert(
-                PULL_LOGS_REASON_MD_KEY,
-                PULL_LOGS_REASON_PURGED
-                    .parse()
-                    .expect("valid metadata value"),
-            );
-            return Err(status);
+            return Err(purged_logs_status());
         }
         let storage_prefix = collection_id.storage_prefix_for_log();
         let absolute_offsets = topology_name.is_none();
@@ -3136,14 +3140,7 @@ impl LogServer {
         if records.len() != pull_logs.batch_size as usize
             || (!records.is_empty() && records[0].log_offset != pull_logs.start_from_offset)
         {
-            let mut status = Status::not_found("Some entries have been purged");
-            status.metadata_mut().insert(
-                PULL_LOGS_REASON_MD_KEY,
-                PULL_LOGS_REASON_PURGED
-                    .parse()
-                    .expect("valid metadata value"),
-            );
-            return Err(status);
+            return Err(purged_logs_status());
         }
         Ok(Response::new(PullLogsResponse { records }))
     }
@@ -8288,6 +8285,21 @@ mod tests {
         BACKOFF_REASON_MD_KEY
             .parse::<tonic::metadata::MetadataKey<tonic::metadata::Ascii>>()
             .expect("BACKOFF_REASON_MD_KEY must be a valid ASCII metadata key");
+    }
+
+    #[test]
+    fn purged_logs_status_has_reason_metadata() {
+        let status = purged_logs_status();
+
+        assert_eq!(status.code(), Code::NotFound);
+        assert_eq!(status.message(), "Some entries have been purged");
+        assert_eq!(
+            status
+                .metadata()
+                .get(PULL_LOGS_REASON_MD_KEY)
+                .and_then(|value| value.to_str().ok()),
+            Some(PULL_LOGS_REASON_PURGED)
+        );
     }
 
     #[cfg(feature = "faults")]

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -33,10 +33,21 @@ use crate::{GarbageCollectError, PushLogsResult};
 
 /// The gRPC metadata key carrying the backoff reason.
 const BACKOFF_REASON_MD_KEY: &str = "backoff-reason";
+const PULL_LOGS_REASON_MD_KEY: &str = "pull-logs-reason";
+const PULL_LOGS_REASON_PURGED: &str = "purged";
 
 /// Extract the `backoff-reason` value from a `tonic::Status` metadata map.
 fn backoff_reason_from_status(status: &tonic::Status) -> Option<&str> {
     status.metadata().get(BACKOFF_REASON_MD_KEY)?.to_str().ok()
+}
+
+fn is_purged_pull_logs_status(status: &tonic::Status) -> bool {
+    status.code() == tonic::Code::NotFound
+        && status
+            .metadata()
+            .get(PULL_LOGS_REASON_MD_KEY)
+            .and_then(|value| value.to_str().ok())
+            == Some(PULL_LOGS_REASON_PURGED)
 }
 
 fn is_retryable_transport_status(status: &tonic::Status) -> bool {
@@ -65,6 +76,8 @@ fn is_retryable_transport_status(status: &tonic::Status) -> bool {
 pub enum GrpcPullLogsError {
     #[error("Please backoff exponentially and retry")]
     Backoff,
+    #[error("Requested logs have been purged")]
+    Purged,
     #[error("Failed to fetch: {0}")]
     FailedToPullLogs(#[from] tonic::Status),
     #[error("Failed to scout logs: {0}")]
@@ -79,6 +92,7 @@ impl ChromaError for GrpcPullLogsError {
     fn code(&self) -> ErrorCodes {
         match self {
             GrpcPullLogsError::Backoff => ErrorCodes::Unavailable,
+            GrpcPullLogsError::Purged => ErrorCodes::NotFound,
             GrpcPullLogsError::FailedToPullLogs(err) => err.code().into(),
             GrpcPullLogsError::FailedToScoutLogs(err) => err.code().into(),
             GrpcPullLogsError::ConversionError(_) => ErrorCodes::Internal,
@@ -456,6 +470,8 @@ impl GrpcLog {
             Err(e) => {
                 if e.code() == chroma_error::ErrorCodes::Unavailable.into() {
                     Err(GrpcPullLogsError::Backoff)
+                } else if is_purged_pull_logs_status(&e) {
+                    Err(GrpcPullLogsError::Purged)
                 } else if e.code() == chroma_error::ErrorCodes::NotFound.into() {
                     Err(GrpcPullLogsError::FailedToPullLogs(e))
                 } else {

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -715,7 +715,7 @@ impl CompactionContext {
     ) -> Result<Vec<AttachedFunctionUuid>, CompactionError> {
         let collection_info = self.get_collection_info()?;
         let collection_id = collection_info.collection_id;
-        let log_position = collection_info.collection.log_position;
+        let compaction_offset = collection_info.collection.log_position;
 
         // Create the operator and wrap it as a task
         let operator = Box::new(GetAttachedFunctionOperator::new(
@@ -757,22 +757,26 @@ impl CompactionContext {
             .into_inner()
             .map_err(|_| CompactionError::InvariantViolation("GetAttachedFunction task failed"))?;
 
-        let log_position_u64 = log_position.max(0) as u64;
+        let compaction_offset_u64 = compaction_offset.max(0) as u64;
         let mut stale_function_ids = Vec::new();
 
         for function in &output.attached_functions {
-            if log_position_u64 < function.completion_offset {
+            if compaction_offset_u64 < function.completion_offset {
                 return Err(CompactionError::InvariantViolation(
                     "Log position is less than completion offset",
                 ));
             }
 
-            if function.completion_offset < log_position_u64 {
+            if Self::needs_sync_function_backfill(function.completion_offset, compaction_offset) {
                 stale_function_ids.push(function.id);
             }
         }
 
         Ok(stale_function_ids)
+    }
+
+    fn needs_sync_function_backfill(completion_offset: u64, compaction_offset: i64) -> bool {
+        completion_offset < compaction_offset.max(0) as u64
     }
 
     async fn run_backfill_attached_function_workflow(
@@ -5236,5 +5240,15 @@ mod tests {
         // Clean up - delete the collections
         // Note: We don't have segment IDs easily available here, so we can't delete
         // the collections. In a real test cleanup, you'd want to track the segment IDs.
+    }
+
+    #[test]
+    fn sync_backfill_only_runs_when_completion_is_before_compaction_offset() {
+        assert!(!CompactionContext::needs_sync_function_backfill(0, -1));
+        assert!(!CompactionContext::needs_sync_function_backfill(0, 0));
+        assert!(CompactionContext::needs_sync_function_backfill(0, 1));
+        assert!(CompactionContext::needs_sync_function_backfill(29, 30));
+        assert!(!CompactionContext::needs_sync_function_backfill(30, 30));
+        assert!(!CompactionContext::needs_sync_function_backfill(31, 30));
     }
 }

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -124,6 +124,9 @@ impl FunctionExecutionContext {
                 (success.materialized, success.collection_info)
             }
             LogFetchOrchestratorResponse::RequireFunctionBackfill(_) => {
+                // This branch is reached when we read an explicit BackfillFn record
+                // from the logs. The purged-log retry above is a separate trigger,
+                // but both cases backfill by replaying from compacted logs here.
                 match Self::fetch_function_input_logs(
                     log_fetch_context,
                     collection_id,

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -1,5 +1,7 @@
 use std::cell::OnceCell;
 
+use chroma_error::source_chain_contains;
+use chroma_log::grpc_log::GrpcPullLogsError;
 use chroma_system::System;
 use chroma_types::{AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName};
 use uuid::Uuid;
@@ -8,8 +10,9 @@ use crate::execution::operators::materialize_logs::MaterializeLogOutput;
 
 use super::{
     compact::{CollectionCompactInfo, CompactionContext, CompactionError, CompactionResponse},
-    log_fetch_orchestrator::LogFetchOrchestratorResponse,
+    log_fetch_orchestrator::{LogFetchOrchestratorError, LogFetchOrchestratorResponse},
 };
+use crate::execution::operators::fetch_log::FetchLogError;
 
 #[derive(Debug, Clone)]
 pub struct FunctionInputCollectionData {
@@ -79,14 +82,42 @@ impl FunctionExecutionContext {
     ) -> Result<FunctionInputCollectionData, CompactionError> {
         let log_fetch_context =
             Self::build_log_fetch_context(compaction_context, completion_offset);
-        let result = Self::fetch_function_input_logs(
+        let result = match Self::fetch_function_input_logs(
             log_fetch_context.clone(),
             collection_id,
             database_name.clone(),
             system.clone(),
             false,
         )
-        .await?;
+        .await
+        {
+            Ok(result) => result,
+            Err(err) if Self::should_backfill_on_fetch_error(&err) => {
+                match Self::fetch_function_input_logs(
+                    log_fetch_context,
+                    collection_id,
+                    database_name,
+                    system,
+                    true,
+                )
+                .await?
+                {
+                    LogFetchOrchestratorResponse::Success(success) => {
+                        return Ok(FunctionInputCollectionData {
+                            collection_info: success.collection_info,
+                            materialized_log_data: success.materialized,
+                        });
+                    }
+                    LogFetchOrchestratorResponse::RequireCompactionOffsetRepair(_)
+                    | LogFetchOrchestratorResponse::RequireFunctionBackfill(_) => {
+                        return Err(CompactionError::InvariantViolation(
+                            "Function execution backfill fetch should only return success",
+                        ));
+                    }
+                }
+            }
+            Err(err) => return Err(err),
+        };
 
         let (materialized_log_data, collection_info) = match result {
             LogFetchOrchestratorResponse::Success(success) => {
@@ -124,6 +155,20 @@ impl FunctionExecutionContext {
             collection_info,
             materialized_log_data,
         })
+    }
+
+    fn should_backfill_on_fetch_error(error: &CompactionError) -> bool {
+        match error {
+            CompactionError::DataFetchError(LogFetchOrchestratorError::FetchLog(
+                FetchLogError::PullLog(err),
+            )) => source_chain_contains(err.as_ref(), |source| {
+                source
+                    .downcast_ref::<GrpcPullLogsError>()
+                    .map(|pull_err| matches!(pull_err, GrpcPullLogsError::Purged))
+                    .unwrap_or(false)
+            }),
+            _ => false,
+        }
     }
 
     async fn resolve_shared_input_database_name(
@@ -207,5 +252,42 @@ impl FunctionExecutionContext {
         Ok(CompactionResponse::Success {
             job_id: attached_function_id.into(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FunctionExecutionContext;
+    use crate::execution::{
+        operators::fetch_log::FetchLogError,
+        orchestration::{
+            compact::CompactionError, log_fetch_orchestrator::LogFetchOrchestratorError,
+        },
+    };
+    use chroma_log::grpc_log::GrpcPullLogsError;
+    use tonic::Status;
+
+    #[test]
+    fn purged_pull_logs_error_triggers_backfill() {
+        let err = CompactionError::DataFetchError(LogFetchOrchestratorError::FetchLog(
+            FetchLogError::PullLog(Box::new(GrpcPullLogsError::Purged)),
+        ));
+
+        assert!(FunctionExecutionContext::should_backfill_on_fetch_error(
+            &err
+        ));
+    }
+
+    #[test]
+    fn generic_not_found_does_not_trigger_backfill() {
+        let err = CompactionError::DataFetchError(LogFetchOrchestratorError::FetchLog(
+            FetchLogError::PullLog(Box::new(GrpcPullLogsError::FailedToPullLogs(
+                Status::not_found("unrelated not found"),
+            ))),
+        ));
+
+        assert!(!FunctionExecutionContext::should_backfill_on_fetch_error(
+            &err
+        ));
     }
 }

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -123,29 +123,10 @@ impl FunctionExecutionContext {
             LogFetchOrchestratorResponse::Success(success) => {
                 (success.materialized, success.collection_info)
             }
-            LogFetchOrchestratorResponse::RequireFunctionBackfill(_) => {
-                // This branch is reached when we read an explicit BackfillFn record
-                // from the logs. The purged-log retry above is a separate trigger,
-                // but both cases backfill by replaying from compacted logs here.
-                match Self::fetch_function_input_logs(
-                    log_fetch_context,
-                    collection_id,
-                    database_name,
-                    system,
-                    true,
-                )
-                .await?
-                {
-                    LogFetchOrchestratorResponse::Success(success) => {
-                        (success.materialized, success.collection_info)
-                    }
-                    LogFetchOrchestratorResponse::RequireCompactionOffsetRepair(_)
-                    | LogFetchOrchestratorResponse::RequireFunctionBackfill(_) => {
-                        return Err(CompactionError::InvariantViolation(
-                            "Function execution backfill fetch should only return success",
-                        ));
-                    }
-                }
+            LogFetchOrchestratorResponse::RequireFunctionBackfill(backfill) => {
+                // BackfillFn forces compaction and schedules async work. Fn-consumers
+                // only backfill when their incremental log offset has been purged.
+                (backfill.materialized, backfill.collection_info)
             }
             LogFetchOrchestratorResponse::RequireCompactionOffsetRepair(_) => {
                 return Err(CompactionError::InvariantViolation(

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -339,6 +339,10 @@ impl Orchestrator for LogFetchOrchestrator {
 }
 
 impl LogFetchOrchestrator {
+    fn should_resolve_async_fn_boundary(is_fn_consumer: bool, is_rebuild: bool) -> bool {
+        is_fn_consumer && !is_rebuild
+    }
+
     async fn get_async_fn_fetch_boundaries(
         collection: &chroma_types::Collection,
         record_segment: &chroma_types::Segment,
@@ -539,7 +543,12 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
         let mut pulled_log_offset = collection.log_position;
         let mut log_upper_bound_offset = None;
 
-        if self.context.is_fn_consumer {
+        // Compacted-state backfill reads the whole live segment and is not
+        // constrained by the incremental max_compaction_size window.
+        if Self::should_resolve_async_fn_boundary(
+            self.context.is_fn_consumer,
+            self.context.is_rebuild(),
+        ) {
             let completion_offset = match self.context.log_start_offset {
                 Some(offset) => offset,
                 None => {
@@ -1246,5 +1255,23 @@ impl Handler<TaskResult<MaterializeLogOutput, MaterializeLogOperatorError>>
             self.terminate_with_result(Ok(Success::new(materialized, collection_info).into()), ctx)
                 .await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LogFetchOrchestrator;
+
+    #[test]
+    fn compacted_backfill_skips_async_boundary_resolution() {
+        assert!(LogFetchOrchestrator::should_resolve_async_fn_boundary(
+            true, false
+        ));
+        assert!(!LogFetchOrchestrator::should_resolve_async_fn_boundary(
+            true, true
+        ));
+        assert!(!LogFetchOrchestrator::should_resolve_async_fn_boundary(
+            false, false
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- Detect purged WAL reads through structured gRPC metadata and retry async function execution from compacted state.
- Keep sync backfill gated on `completion_offset < compaction_offset`.
- Treat `BackfillFn` as a compaction/scheduling signal for async functions instead of backfilling every existing function.
- Bypass async boundary resolution and `max_compaction_size` when rebuilding from the live compacted segment.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy -p worker --all-targets -- -D warnings`
- `cargo test -p worker execution::orchestration::function_execution::tests -- --nocapture`
- `cargo test -p worker compacted_backfill_skips_async_boundary_resolution -- --nocapture`
- `cargo test -p worker sync_backfill_only_runs_when_completion_is_before_compaction_offset -- --nocapture`

## Migration plan

No migration required.

## Observability plan

Existing fn-consumer fetch and backfill tracing will show structured purge-triggered fallback and function completion progress.

## Documentation changes

No user-facing documentation changes.
