### PR TITLE
fix: use installed package version for /version endpoint

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -1,6 +1,11 @@
 from typing import Dict, Optional, Union
 
-__version__ = "1.5.9"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("chromadb")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
 
 import logging
 from chromadb.api.client import Client as ClientCreator


### PR DESCRIPTION
Fixes #1341

The /version endpoint currently returns a hardcoded version string. This changes __version__ to read from importlib.metadata.version('chromadb') so it reflects the actual installed package version. Falls back to '0.0.0' if the package is not installed.