### PR TITLE
[BUG](worker): Make async count idempotent

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -6,6 +6,7 @@ for automatically processing collections.
 """
 
 import functools
+import json
 import pytest
 import time
 import urllib.parse
@@ -84,7 +85,11 @@ def _wait_for_minio_count(
         body = _minio_get_object(parsed.netloc, key)
         if body is not None:
             last_body = body.decode("utf-8").strip()
-            if last_body == str(expected_count):
+            payload = json.loads(last_body)
+            observed_count = (
+                payload.get("count") if isinstance(payload, dict) else payload
+            )
+            if observed_count == expected_count:
                 return
         sleep(5)
 
@@ -324,7 +329,9 @@ def test_functions_allow_one_sync_and_one_async_per_collection(
         is True
     )
     assert (
-        collection.detach_function(attached_async_fn.name, delete_output_collection=True)
+        collection.detach_function(
+            attached_async_fn.name, delete_output_collection=True
+        )
         is True
     )
 
@@ -789,7 +796,9 @@ def test_sync_and_async_count_functions_can_share_one_input_collection(
         is True
     )
     assert (
-        collection.detach_function(async_attached_fn.name, delete_output_collection=True)
+        collection.detach_function(
+            async_attached_fn.name, delete_output_collection=True
+        )
         is True
     )
 

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -110,8 +110,10 @@ pub enum LogMaterializerError {
     EmbeddingMaterialization,
     #[error("Error reading record segment {0}")]
     RecordSegment(#[from] Box<dyn ChromaError>),
-    #[error("Log index {0} out of bounds when resolving user ID")]
+    #[error("Log index {0} out of bounds")]
     LogIndexOutOfBounds(usize),
+    #[error("Materialized operation has no source log")]
+    MissingOperationLogIndex,
     #[error("Record segment reader required but not available")]
     RecordSegmentReaderShardRequired,
     #[error("Unsupported operation for rebuild: {0:?}")]
@@ -125,6 +127,7 @@ impl ChromaError for LogMaterializerError {
             LogMaterializerError::EmbeddingMaterialization => ErrorCodes::Internal,
             LogMaterializerError::RecordSegment(e) => e.code(),
             LogMaterializerError::LogIndexOutOfBounds(_) => ErrorCodes::Internal,
+            LogMaterializerError::MissingOperationLogIndex => ErrorCodes::Internal,
             LogMaterializerError::RecordSegmentReaderShardRequired => ErrorCodes::Internal,
             LogMaterializerError::UnsupportedOperationForRebuild(_) => ErrorCodes::Internal,
         }
@@ -160,6 +163,8 @@ pub struct MaterializedLogRecord {
     // If log has [Upsert] and the record does not exist in storage then final
     // operation is Insert.
     final_operation: MaterializedLogOperation,
+    // The log entry that produced the final materialized operation.
+    operation_log_index: Option<usize>,
     // This is the metadata obtained by combining all the operations
     // present in the log for this id.
     // E.g. if has log has [Insert(a: h), Update(a: b, c: d), Update(a: e, f: g)] then this
@@ -188,6 +193,7 @@ impl MaterializedLogRecord {
             offset_id: AtomicU32::new(offset_id),
             user_id_at_log_index: None,
             final_operation: MaterializedLogOperation::Initial,
+            operation_log_index: None,
             metadata_to_be_merged: None,
             metadata_to_be_deleted: None,
             final_document_at_log_index: None,
@@ -235,6 +241,7 @@ impl MaterializedLogRecord {
             offset_id: AtomicU32::new(offset_id),
             user_id_at_log_index: Some(log_index),
             final_operation: MaterializedLogOperation::AddNew,
+            operation_log_index: Some(log_index),
             metadata_to_be_merged: merged_metadata,
             metadata_to_be_deleted: deleted_metadata,
             final_document_at_log_index,
@@ -359,6 +366,17 @@ impl<'log_data, 'segment_data: 'log_data> HydratedMaterializedLogRecord<'log_dat
 
     pub fn get_operation(&self) -> MaterializedLogOperation {
         self.materialized_log_record.final_operation
+    }
+
+    pub fn get_operation_log_offset(&self) -> Result<i64, LogMaterializerError> {
+        let log_index = self
+            .materialized_log_record
+            .operation_log_index
+            .ok_or(LogMaterializerError::MissingOperationLogIndex)?;
+        self.logs
+            .get(log_index)
+            .map(|record| record.log_offset)
+            .ok_or(LogMaterializerError::LogIndexOutOfBounds(log_index))
     }
 
     pub fn get_user_id(&self) -> &'log_data str {
@@ -890,6 +908,7 @@ pub async fn materialize_logs(
                             .get_mut(log_record.record.id.as_str())
                             .unwrap();
                         record_from_map.final_operation = MaterializedLogOperation::DeleteExisting;
+                        record_from_map.operation_log_index = Some(log_index);
                         record_from_map.final_document_at_log_index = None;
                         record_from_map.final_embedding_at_log_index = None;
                         record_from_map.metadata_to_be_merged = None;
@@ -936,7 +955,6 @@ pub async fn materialize_logs(
                             return Err(LogMaterializerError::MetadataMaterialization(e));
                         }
                     };
-
                     if log_record.record.document.is_some() {
                         record_from_map.final_document_at_log_index = Some(log_index);
                     }
@@ -948,6 +966,7 @@ pub async fn materialize_logs(
                     match record_from_map.final_operation {
                         MaterializedLogOperation::Initial => {
                             record_from_map.final_operation = MaterializedLogOperation::UpdateExisting;
+                            record_from_map.operation_log_index = Some(log_index);
                         }
                         // State remains as is.
                         MaterializedLogOperation::AddNew
@@ -996,7 +1015,6 @@ pub async fn materialize_logs(
                                                 return Err(LogMaterializerError::MetadataMaterialization(e));
                                             }
                                         };
-
                                         if log_record.record.document.is_some() {
                                             record_from_map.final_document_at_log_index = Some(log_index);
                                         }
@@ -1009,6 +1027,7 @@ pub async fn materialize_logs(
                                             MaterializedLogOperation::Initial => {
                                                 record_from_map.final_operation =
                                                     MaterializedLogOperation::UpdateExisting;
+                                                record_from_map.operation_log_index = Some(log_index);
                                             }
                                             // State remains as is.
                                             MaterializedLogOperation::AddNew
@@ -1041,7 +1060,6 @@ pub async fn materialize_logs(
                                 return Err(LogMaterializerError::MetadataMaterialization(e));
                             }
                         };
-
                         if log_record.record.document.is_some() {
                             record_from_map.final_document_at_log_index = Some(log_index);
                         }

--- a/rust/worker/src/execution/functions/count_to_file_async.rs
+++ b/rust/worker/src/execution/functions/count_to_file_async.rs
@@ -1,15 +1,29 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_segment::blockfile_record::RecordSegmentReaderShard;
 use chroma_storage::{PutOptions, Storage, StorageError};
 use chroma_types::{AttachedFunction, Chunk, LogRecord, MaterializedLogOperation};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::execution::operators::execute_task::{AttachedFunctionExecutor, HydratedInputBatch};
 
 const DEFAULT_PARAM_KEY: &str = "s3_path";
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct CountState {
+    count: i64,
+    pulled_log_offsets: HashMap<String, i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum StoredCountState {
+    Current(CountState),
+    Legacy(i64),
+}
 
 #[derive(Debug)]
 pub struct CountToFileAsyncExecutor {
@@ -31,6 +45,10 @@ pub enum CountToFileAsyncError {
     Read(StorageError),
     #[error("failed to write count file: {0}")]
     Write(StorageError),
+    #[error("invalid count file: {0}")]
+    InvalidState(String),
+    #[error("pulled log offset does not fit in i64: {0}")]
+    InvalidPulledLogOffset(u64),
 }
 
 impl ChromaError for CountToFileAsyncError {
@@ -39,7 +57,9 @@ impl ChromaError for CountToFileAsyncError {
             CountToFileAsyncError::MissingParam(_)
             | CountToFileAsyncError::InvalidParams(_)
             | CountToFileAsyncError::InvalidPath(_)
-            | CountToFileAsyncError::MissingStorage => ErrorCodes::InvalidArgument,
+            | CountToFileAsyncError::MissingStorage
+            | CountToFileAsyncError::InvalidState(_)
+            | CountToFileAsyncError::InvalidPulledLogOffset(_) => ErrorCodes::InvalidArgument,
             CountToFileAsyncError::Read(e) | CountToFileAsyncError::Write(e) => e.code(),
         }
     }
@@ -100,27 +120,30 @@ impl CountToFileAsyncExecutor {
         Ok(&self.path)
     }
 
-    async fn load_existing_count(
+    async fn load_state(
         &self,
         storage: &Storage,
         key: &str,
-    ) -> Result<i64, CountToFileAsyncError> {
+    ) -> Result<CountState, CountToFileAsyncError> {
         match storage.get(key, Default::default()).await {
             Ok(bytes) => {
                 let body = std::str::from_utf8(bytes.as_ref()).map_err(|_| {
-                    CountToFileAsyncError::InvalidPath(format!(
-                        "count file at {} was not valid utf-8",
+                    CountToFileAsyncError::InvalidState(format!(
+                        "{} was not valid utf-8",
                         self.path
                     ))
                 })?;
-                body.trim().parse::<i64>().map_err(|_| {
-                    CountToFileAsyncError::InvalidPath(format!(
-                        "count file at {} did not contain an integer",
-                        self.path
-                    ))
-                })
+                match serde_json::from_str::<StoredCountState>(body.trim()).map_err(|err| {
+                    CountToFileAsyncError::InvalidState(format!("{}: {err}", self.path))
+                })? {
+                    StoredCountState::Current(state) => Ok(state),
+                    StoredCountState::Legacy(count) => Ok(CountState {
+                        count,
+                        pulled_log_offsets: HashMap::new(),
+                    }),
+                }
             }
-            Err(StorageError::NotFound { .. }) => Ok(0),
+            Err(StorageError::NotFound { .. }) => Ok(CountState::default()),
             Err(err) => Err(CountToFileAsyncError::Read(err)),
         }
     }
@@ -137,35 +160,228 @@ impl AttachedFunctionExecutor for CountToFileAsyncExecutor {
             .parse_storage_key(&self.storage)
             .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?;
 
-        let delete_count = input_batches
-            .iter()
-            .flat_map(|batch| batch.records.iter())
-            .filter(|(record, _)| {
-                record.get_operation() == MaterializedLogOperation::DeleteExisting
-            })
-            .count() as i64;
-
-        let insert_count = input_batches
-            .iter()
-            .flat_map(|batch| batch.records.iter())
-            .filter(|(record, _)| record.get_operation() == MaterializedLogOperation::AddNew)
-            .count() as i64;
-
-        let existing_count = self
-            .load_existing_count(&self.storage, key)
+        let mut state = self
+            .load_state(&self.storage, key)
             .await
             .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?;
-        let new_total_count = existing_count + insert_count - delete_count;
+
+        for batch in input_batches {
+            let collection_id = batch.input_collection_id.to_string();
+            let stored_offset = state
+                .pulled_log_offsets
+                .get(&collection_id)
+                .copied()
+                .unwrap_or(-1);
+
+            for (record, _) in batch.records.iter() {
+                let operation_log_offset = record
+                    .get_operation_log_offset()
+                    .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
+                if operation_log_offset <= stored_offset {
+                    continue;
+                }
+
+                match record.get_operation() {
+                    MaterializedLogOperation::AddNew => state.count += 1,
+                    MaterializedLogOperation::DeleteExisting => state.count -= 1,
+                    _ => {}
+                }
+            }
+
+            let pulled_log_offset = i64::try_from(batch.completion_offset).map_err(|_| {
+                Box::new(CountToFileAsyncError::InvalidPulledLogOffset(
+                    batch.completion_offset,
+                )) as Box<dyn ChromaError>
+            })?;
+            state
+                .pulled_log_offsets
+                .entry(collection_id)
+                .and_modify(|offset| *offset = (*offset).max(pulled_log_offset))
+                .or_insert(pulled_log_offset);
+        }
+
+        let bytes = serde_json::to_vec(&state).map_err(|err| {
+            Box::new(CountToFileAsyncError::InvalidState(err.to_string())) as Box<dyn ChromaError>
+        })?;
 
         self.storage
-            .put_bytes(
-                key,
-                new_total_count.to_string().into_bytes(),
-                PutOptions::default(),
-            )
+            .put_bytes(key, bytes, PutOptions::default())
             .await
             .map_err(|err| Box::new(CountToFileAsyncError::Write(err)) as Box<dyn ChromaError>)?;
 
         Ok(Chunk::new(Arc::from(Vec::<LogRecord>::new())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_segment::{
+        blockfile_record::RecordSegmentReaderOptions,
+        types::{materialize_logs, HydratedMaterializedLogRecord, MaterializeLogsResult},
+    };
+    use chroma_storage::local::LocalStorage;
+    use chroma_types::{CollectionUuid, Operation, OperationRecord};
+
+    fn record(log_offset: i64, id: &str, operation: Operation) -> LogRecord {
+        LogRecord {
+            log_offset,
+            record: OperationRecord {
+                id: id.to_string(),
+                embedding: Some(vec![0.0]),
+                encoding: None,
+                metadata: None,
+                document: None,
+                operation,
+            },
+        }
+    }
+
+    fn add_record(log_offset: i64, id: &str) -> LogRecord {
+        record(log_offset, id, Operation::Add)
+    }
+
+    async fn hydrate_records<'a>(
+        materialized: &'a MaterializeLogsResult,
+    ) -> Vec<HydratedMaterializedLogRecord<'a, 'a>> {
+        let mut records = Vec::new();
+        for record in materialized.iter() {
+            records.push(
+                record
+                    .hydrate(None)
+                    .await
+                    .expect("hydration should succeed"),
+            );
+        }
+        records
+    }
+
+    async fn execute_logs(
+        executor: &CountToFileAsyncExecutor,
+        collection_id: CollectionUuid,
+        pulled_log_offset: u64,
+        logs: Vec<LogRecord>,
+    ) {
+        let materialized = materialize_logs(
+            &None,
+            Chunk::new(Arc::from(logs)),
+            None,
+            &RecordSegmentReaderOptions::default(),
+        )
+        .await
+        .expect("logs should materialize");
+        let records = hydrate_records(&materialized).await;
+
+        executor
+            .execute(
+                vec![HydratedInputBatch {
+                    input_collection_id: collection_id,
+                    input_collection_name: "test-input".to_string(),
+                    tenant_id: "test-tenant".to_string(),
+                    database_id: "test-database".to_string(),
+                    completion_offset: pulled_log_offset,
+                    records: Chunk::new(Arc::from(records)),
+                }],
+                None,
+            )
+            .await
+            .expect("count should succeed");
+    }
+
+    #[tokio::test]
+    async fn retries_only_count_new_offsets_per_input_collection() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory should be created");
+        let storage = Storage::Local(LocalStorage::new(
+            temp_dir.path().to_str().expect("temporary path is utf-8"),
+        ));
+        let executor = CountToFileAsyncExecutor {
+            path: "count.json".to_string(),
+            storage: storage.clone(),
+        };
+        let first_collection = CollectionUuid::new();
+        let second_collection = CollectionUuid::new();
+
+        execute_logs(
+            &executor,
+            first_collection,
+            2,
+            vec![add_record(1, "one"), add_record(2, "two")],
+        )
+        .await;
+        execute_logs(
+            &executor,
+            first_collection,
+            4,
+            vec![
+                add_record(1, "one"),
+                add_record(2, "two"),
+                record(3, "one", Operation::Update),
+                add_record(4, "three"),
+            ],
+        )
+        .await;
+        execute_logs(
+            &executor,
+            second_collection,
+            2,
+            vec![add_record(1, "four"), add_record(2, "five")],
+        )
+        .await;
+        execute_logs(
+            &executor,
+            second_collection,
+            2,
+            vec![add_record(1, "four"), add_record(2, "five")],
+        )
+        .await;
+
+        let bytes = storage
+            .get("count.json", Default::default())
+            .await
+            .expect("count state should exist");
+        let state: CountState =
+            serde_json::from_slice(bytes.as_ref()).expect("count state should be valid JSON");
+
+        assert_eq!(state.count, 5);
+        assert_eq!(
+            state.pulled_log_offsets.get(&first_collection.to_string()),
+            Some(&4)
+        );
+        assert_eq!(
+            state.pulled_log_offsets.get(&second_collection.to_string()),
+            Some(&2)
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_integer_count_is_upgraded_on_write() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory should be created");
+        let storage = Storage::Local(LocalStorage::new(
+            temp_dir.path().to_str().expect("temporary path is utf-8"),
+        ));
+        storage
+            .put_bytes("count.json", b"4".to_vec(), PutOptions::default())
+            .await
+            .expect("legacy count should be written");
+        let executor = CountToFileAsyncExecutor {
+            path: "count.json".to_string(),
+            storage: storage.clone(),
+        };
+        let collection_id = CollectionUuid::new();
+
+        execute_logs(&executor, collection_id, 5, vec![add_record(5, "five")]).await;
+
+        let bytes = storage
+            .get("count.json", Default::default())
+            .await
+            .expect("count state should exist");
+        let state: CountState =
+            serde_json::from_slice(bytes.as_ref()).expect("count state should be valid JSON");
+
+        assert_eq!(state.count, 5);
+        assert_eq!(
+            state.pulled_log_offsets.get(&collection_id.to_string()),
+            Some(&5)
+        );
     }
 }


### PR DESCRIPTION
## Description of changes

- Persist the async count and pulled log offsets per input collection in the configured S3 object.
- Skip materialized count operations whose source log offset is already covered by the stored input frontier.
- Preserve the source log offset that produced each final materialized operation.
- Read legacy integer count files and upgrade them to structured JSON on the next write.

## Test plan

- cargo test -p worker count_to_file_async::tests -- --nocapture
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --keep-going -- -D warnings -D clippy::large_futures -D clippy::all
- Black and repository commit hooks

## Migration plan

Existing integer-only count files remain readable. New writes use the JSON state format and include per-input pulled log offsets.

## Observability plan

Existing attached-function execution failures surface malformed state or storage read/write errors.

## Documentation Changes

None. This changes the internal test function state format only.
