### PR TITLE
[ENH](frontend): Add enable_transactions config gate

### DIFF
--- a/rust/frontend-core/src/errors.rs
+++ b/rust/frontend-core/src/errors.rs
@@ -6,7 +6,7 @@ use axum::{
 use chroma_api_types::{StaleReadError, STALE_READ_ERROR_NAME};
 use chroma_error::{source_chain_contains, ChromaError};
 use chroma_log::PushLogsError;
-use chroma_types::ConditionalCommitError;
+use chroma_types::{ConditionalCommitError, ConditionalTransactionError};
 use serde::Serialize;
 use std::fmt;
 use utoipa::ToSchema;
@@ -57,7 +57,13 @@ fn error_name(err: &(dyn ChromaError + 'static)) -> &'static str {
     if source_chain_contains(err, |source| {
         matches!(
             source.downcast_ref::<ConditionalCommitError>(),
-            Some(ConditionalCommitError::TransactionsNotSupported { .. })
+            Some(
+                ConditionalCommitError::TransactionsNotSupported { .. }
+                    | ConditionalCommitError::TransactionsDisabled
+            )
+        ) || matches!(
+            source.downcast_ref::<ConditionalTransactionError>(),
+            Some(ConditionalTransactionError::TransactionsDisabled)
         )
     }) {
         return TRANSACTIONS_NOT_SUPPORTED_ERROR_NAME;

--- a/rust/frontend-core/src/errors.rs
+++ b/rust/frontend-core/src/errors.rs
@@ -63,7 +63,10 @@ fn error_name(err: &(dyn ChromaError + 'static)) -> &'static str {
             )
         ) || matches!(
             source.downcast_ref::<ConditionalTransactionError>(),
-            Some(ConditionalTransactionError::TransactionsDisabled)
+            Some(
+                ConditionalTransactionError::UnsupportedLogImplementation { .. }
+                    | ConditionalTransactionError::TransactionsDisabled
+            )
         )
     }) {
         return TRANSACTIONS_NOT_SUPPORTED_ERROR_NAME;

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -87,5 +87,7 @@ tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
 tenants_with_quantization_enabled: []
 tenants_with_maxscore_enabled: []
 tenants_with_token_bitmap_fts_enabled: []
+tenants_with_transactions_enabled:
+- "default_tenant"
 enable_log_scouting: true
-enable_transactions: true
+enable_transactions: false

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -88,3 +88,4 @@ tenants_with_quantization_enabled: []
 tenants_with_maxscore_enabled: []
 tenants_with_token_bitmap_fts_enabled: []
 enable_log_scouting: true
+enable_transactions: true

--- a/rust/frontend/sample_configs/distributed2.yaml
+++ b/rust/frontend/sample_configs/distributed2.yaml
@@ -78,3 +78,4 @@ tenants_with_quantization_enabled: []
 tenants_with_maxscore_enabled: []
 tenants_with_token_bitmap_fts_enabled: []
 enable_log_scouting: true
+enable_transactions: true

--- a/rust/frontend/sample_configs/distributed2.yaml
+++ b/rust/frontend/sample_configs/distributed2.yaml
@@ -77,5 +77,7 @@ tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
 tenants_with_quantization_enabled: []
 tenants_with_maxscore_enabled: []
 tenants_with_token_bitmap_fts_enabled: []
+tenants_with_transactions_enabled:
+- "default_tenant"
 enable_log_scouting: true
-enable_transactions: true
+enable_transactions: false

--- a/rust/frontend/sample_configs/distributed_mcmr.yaml
+++ b/rust/frontend/sample_configs/distributed_mcmr.yaml
@@ -78,3 +78,4 @@ tenants_with_quantization_enabled: []
 tenants_with_maxscore_enabled: []
 tenants_with_token_bitmap_fts_enabled: []
 enable_log_scouting: true
+enable_transactions: true

--- a/rust/frontend/sample_configs/distributed_mcmr.yaml
+++ b/rust/frontend/sample_configs/distributed_mcmr.yaml
@@ -77,5 +77,7 @@ tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
 tenants_with_quantization_enabled: []
 tenants_with_maxscore_enabled: []
 tenants_with_token_bitmap_fts_enabled: []
+tenants_with_transactions_enabled:
+- "default_tenant"
 enable_log_scouting: true
-enable_transactions: true
+enable_transactions: false

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -80,6 +80,8 @@ pub struct FrontendConfig {
     pub tenants_with_token_bitmap_fts_enabled: Vec<String>,
     #[serde(default = "default_enable_log_scouting")]
     pub enable_log_scouting: bool,
+    #[serde(default = "default_enable_transactions")]
+    pub enable_transactions: bool,
 }
 
 impl FrontendConfig {
@@ -105,6 +107,7 @@ impl FrontendConfig {
             tenants_with_maxscore_enabled: vec![],
             tenants_with_token_bitmap_fts_enabled: vec![],
             enable_log_scouting: false,
+            enable_transactions: false,
         }
     }
 }
@@ -138,6 +141,10 @@ fn default_enable_schema() -> bool {
 }
 
 fn default_enable_log_scouting() -> bool {
+    false
+}
+
+fn default_enable_transactions() -> bool {
     false
 }
 
@@ -250,12 +257,14 @@ mod tests {
             _ => {}
         }
         assert!(config.frontend.enable_schema);
+        assert!(config.frontend.enable_transactions);
     }
 
     #[test]
     fn single_node_full_config_valid() {
         let config = FrontendServerConfig::load_from_path("sample_configs/single_node_full.yaml");
         assert_eq!(config.port, 8000);
+        assert!(!config.frontend.enable_transactions);
     }
 
     #[test]
@@ -274,6 +283,7 @@ mod tests {
                 2,
                 "{path}"
             );
+            assert!(config.frontend.enable_transactions, "{path}");
         }
     }
 }

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -78,6 +78,8 @@ pub struct FrontendConfig {
     pub tenants_with_maxscore_enabled: Vec<String>,
     #[serde(default = "Default::default")]
     pub tenants_with_token_bitmap_fts_enabled: Vec<String>,
+    #[serde(default = "Default::default")]
+    pub tenants_with_transactions_enabled: Vec<String>,
     #[serde(default = "default_enable_log_scouting")]
     pub enable_log_scouting: bool,
     #[serde(default = "default_enable_transactions")]
@@ -106,6 +108,7 @@ impl FrontendConfig {
             tenants_with_quantization_enabled: vec![],
             tenants_with_maxscore_enabled: vec![],
             tenants_with_token_bitmap_fts_enabled: vec![],
+            tenants_with_transactions_enabled: vec![],
             enable_log_scouting: false,
             enable_transactions: false,
         }
@@ -257,7 +260,11 @@ mod tests {
             _ => {}
         }
         assert!(config.frontend.enable_schema);
-        assert!(config.frontend.enable_transactions);
+        assert!(!config.frontend.enable_transactions);
+        assert_eq!(
+            config.frontend.tenants_with_transactions_enabled,
+            vec!["default_tenant"]
+        );
     }
 
     #[test]
@@ -265,6 +272,7 @@ mod tests {
         let config = FrontendServerConfig::load_from_path("sample_configs/single_node_full.yaml");
         assert_eq!(config.port, 8000);
         assert!(!config.frontend.enable_transactions);
+        assert!(config.frontend.tenants_with_transactions_enabled.is_empty());
     }
 
     #[test]
@@ -283,7 +291,12 @@ mod tests {
                 2,
                 "{path}"
             );
-            assert!(config.frontend.enable_transactions, "{path}");
+            assert!(!config.frontend.enable_transactions, "{path}");
+            assert_eq!(
+                config.frontend.tenants_with_transactions_enabled,
+                vec!["default_tenant"],
+                "{path}"
+            );
         }
     }
 }

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -145,15 +145,36 @@ pub struct ServiceBasedFrontend {
     tenants_with_quantization_enabled: Vec<String>,
     tenants_with_maxscore_enabled: Vec<String>,
     tenants_with_token_bitmap_fts_enabled: Vec<String>,
+    tenants_with_transactions_enabled: Vec<String>,
     enable_log_scouting: bool,
     enable_transactions: bool,
 }
 
 impl ServiceBasedFrontend {
+    fn tenant_list_contains(tenants: &[String], tenant_id: &str) -> bool {
+        tenants.iter().any(|t| t == "*" || t == tenant_id)
+    }
+
     pub fn ensure_conditional_transactions_supported(
         &self,
     ) -> Result<(), ConditionalTransactionError> {
-        if !self.enable_transactions {
+        if !self.enable_transactions && self.tenants_with_transactions_enabled.is_empty() {
+            return Err(ConditionalTransactionError::TransactionsDisabled);
+        }
+        if self.log_client.supports_conditional_transactions() {
+            return Ok(());
+        }
+
+        Err(ConditionalTransactionError::UnsupportedLogImplementation {
+            implementation: self.log_client.implementation_name().to_string(),
+        })
+    }
+
+    pub fn ensure_conditional_transactions_supported_for_tenant(
+        &self,
+        tenant_id: &str,
+    ) -> Result<(), ConditionalTransactionError> {
+        if !self.should_enable_transactions_for_tenant(tenant_id) {
             return Err(ConditionalTransactionError::TransactionsDisabled);
         }
         if self.log_client.supports_conditional_transactions() {
@@ -166,7 +187,23 @@ impl ServiceBasedFrontend {
     }
 
     pub fn ensure_conditional_commit_supported(&self) -> Result<(), ConditionalCommitError> {
-        if !self.enable_transactions {
+        if !self.enable_transactions && self.tenants_with_transactions_enabled.is_empty() {
+            return Err(ConditionalCommitError::TransactionsDisabled);
+        }
+        if self.log_client.supports_conditional_transactions() {
+            return Ok(());
+        }
+
+        Err(ConditionalCommitError::TransactionsNotSupported {
+            implementation: self.log_client.implementation_name().to_string(),
+        })
+    }
+
+    pub fn ensure_conditional_commit_supported_for_tenant(
+        &self,
+        tenant_id: &str,
+    ) -> Result<(), ConditionalCommitError> {
+        if !self.should_enable_transactions_for_tenant(tenant_id) {
             return Err(ConditionalCommitError::TransactionsDisabled);
         }
         if self.log_client.supports_conditional_transactions() {
@@ -192,6 +229,7 @@ impl ServiceBasedFrontend {
         tenants_with_quantization_enabled: Vec<String>,
         tenants_with_maxscore_enabled: Vec<String>,
         tenants_with_token_bitmap_fts_enabled: Vec<String>,
+        tenants_with_transactions_enabled: Vec<String>,
         enable_log_scouting: bool,
         enable_transactions: bool,
     ) -> Self {
@@ -243,6 +281,7 @@ impl ServiceBasedFrontend {
             tenants_with_quantization_enabled,
             tenants_with_maxscore_enabled,
             tenants_with_token_bitmap_fts_enabled,
+            tenants_with_transactions_enabled,
             enable_log_scouting,
             enable_transactions,
         }
@@ -1011,24 +1050,24 @@ impl ServiceBasedFrontend {
     /// - The list contains "*" (all tenants), OR
     /// - The tenant_id is in the list
     fn should_enable_quantization_for_tenant(&self, tenant_id: &str) -> bool {
-        self.tenants_with_quantization_enabled
-            .iter()
-            .any(|t| t == "*" || t == tenant_id)
+        Self::tenant_list_contains(&self.tenants_with_quantization_enabled, tenant_id)
     }
 
     /// Check if MaxScore sparse index should be enabled for the given tenant.
     /// Returns true if the list contains "*" (all tenants) or the exact tenant_id.
     fn should_enable_maxscore_for_tenant(&self, tenant_id: &str) -> bool {
-        self.tenants_with_maxscore_enabled
-            .iter()
-            .any(|t| t == "*" || t == tenant_id)
+        Self::tenant_list_contains(&self.tenants_with_maxscore_enabled, tenant_id)
     }
 
     /// Check if TokenBitmap FTS index should be enabled for the given tenant.
     fn should_enable_token_bitmap_fts_for_tenant(&self, tenant_id: &str) -> bool {
-        self.tenants_with_token_bitmap_fts_enabled
-            .iter()
-            .any(|t| t == "*" || t == tenant_id)
+        Self::tenant_list_contains(&self.tenants_with_token_bitmap_fts_enabled, tenant_id)
+    }
+
+    /// Check if conditional transactions should be enabled for the given tenant.
+    fn should_enable_transactions_for_tenant(&self, tenant_id: &str) -> bool {
+        self.enable_transactions
+            || Self::tenant_list_contains(&self.tenants_with_transactions_enabled, tenant_id)
     }
 
     pub fn get_default_knn_index(&self) -> KnnIndex {
@@ -1897,13 +1936,15 @@ impl ServiceBasedFrontend {
         request: ConditionalCommitRequest,
         region: String,
     ) -> Result<ConditionalCommitResult, ConditionalCommitError> {
-        self.ensure_conditional_commit_supported()?;
         if request.buffered_writes.is_empty() {
+            self.ensure_conditional_commit_supported()?;
             return Ok(ConditionalCommitResult {
                 first_inserted_record_offset: None,
                 record_count: 0,
             });
         }
+        let (tenant_id, _, _) = validate_conditional_commit_scope(&request)?;
+        self.ensure_conditional_commit_supported_for_tenant(&tenant_id)?;
         let record_count = request.record_count();
         let first_inserted_record_offset = self.conditional_commit_append(request, &region).await?;
         Ok(ConditionalCommitResult {
@@ -3346,6 +3387,7 @@ impl Configurable<(FrontendConfig, System)> for ServiceBasedFrontend {
             config.tenants_with_quantization_enabled.clone(),
             config.tenants_with_maxscore_enabled.clone(),
             config.tenants_with_token_bitmap_fts_enabled.clone(),
+            config.tenants_with_transactions_enabled.clone(),
             config.enable_log_scouting,
             config.enable_transactions,
         ))
@@ -3363,6 +3405,26 @@ mod tests {
     use chroma_types::CreateCollectionPayload;
 
     use super::*;
+
+    fn conditional_commit_request_for_tenant(tenant_id: &str) -> ConditionalCommitRequest {
+        let add = AddCollectionRecordsRequest::try_new(
+            tenant_id.to_string(),
+            "database".to_string(),
+            CollectionUuid::default(),
+            vec!["id".to_string()],
+            vec![vec![1.0]],
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        ConditionalCommitRequest {
+            buffered_writes: vec![ConditionalBufferedWrite::Add(add)],
+            observed_log_offset: None,
+            read_ids: Vec::new(),
+        }
+    }
 
     #[test]
     fn conditional_commit_record_conversion_preserves_order_and_delete_shape() {
@@ -3502,6 +3564,54 @@ mod tests {
                     observed_log_offset: None,
                     read_ids: Vec::new(),
                 },
+                String::new(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ConditionalCommitError::TransactionsNotSupported { ref implementation }
+                if implementation == "sqlite"
+        ));
+        assert_eq!(ErrorCodes::Unimplemented, err.code());
+    }
+
+    #[tokio::test]
+    async fn conditional_commit_non_allowlisted_tenant_returns_transactions_disabled() {
+        let registry = Registry::new();
+        let system = System::new();
+        let mut config = FrontendConfig::sqlite_in_memory();
+        config.tenants_with_transactions_enabled = vec!["enabled_tenant".to_string()];
+        let mut frontend = ServiceBasedFrontend::try_from_config(&(config, system), &registry)
+            .await
+            .unwrap();
+
+        let err = frontend
+            .conditional_commit(
+                conditional_commit_request_for_tenant("disabled_tenant"),
+                String::new(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ConditionalCommitError::TransactionsDisabled));
+        assert_eq!(ErrorCodes::Unimplemented, err.code());
+    }
+
+    #[tokio::test]
+    async fn conditional_commit_allowlisted_tenant_checks_log_support() {
+        let registry = Registry::new();
+        let system = System::new();
+        let mut config = FrontendConfig::sqlite_in_memory();
+        config.tenants_with_transactions_enabled = vec!["enabled_tenant".to_string()];
+        let mut frontend = ServiceBasedFrontend::try_from_config(&(config, system), &registry)
+            .await
+            .unwrap();
+
+        let err = frontend
+            .conditional_commit(
+                conditional_commit_request_for_tenant("enabled_tenant"),
                 String::new(),
             )
             .await

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -146,12 +146,16 @@ pub struct ServiceBasedFrontend {
     tenants_with_maxscore_enabled: Vec<String>,
     tenants_with_token_bitmap_fts_enabled: Vec<String>,
     enable_log_scouting: bool,
+    enable_transactions: bool,
 }
 
 impl ServiceBasedFrontend {
     pub fn ensure_conditional_transactions_supported(
         &self,
     ) -> Result<(), ConditionalTransactionError> {
+        if !self.enable_transactions {
+            return Err(ConditionalTransactionError::TransactionsDisabled);
+        }
         if self.log_client.supports_conditional_transactions() {
             return Ok(());
         }
@@ -162,6 +166,9 @@ impl ServiceBasedFrontend {
     }
 
     pub fn ensure_conditional_commit_supported(&self) -> Result<(), ConditionalCommitError> {
+        if !self.enable_transactions {
+            return Err(ConditionalCommitError::TransactionsDisabled);
+        }
         if self.log_client.supports_conditional_transactions() {
             return Ok(());
         }
@@ -186,6 +193,7 @@ impl ServiceBasedFrontend {
         tenants_with_maxscore_enabled: Vec<String>,
         tenants_with_token_bitmap_fts_enabled: Vec<String>,
         enable_log_scouting: bool,
+        enable_transactions: bool,
     ) -> Self {
         let meter = global::meter("chroma");
         let fork_retries_counter = meter.u64_counter("fork_retries").build();
@@ -236,6 +244,7 @@ impl ServiceBasedFrontend {
             tenants_with_maxscore_enabled,
             tenants_with_token_bitmap_fts_enabled,
             enable_log_scouting,
+            enable_transactions,
         }
     }
 
@@ -3338,6 +3347,7 @@ impl Configurable<(FrontendConfig, System)> for ServiceBasedFrontend {
             config.tenants_with_maxscore_enabled.clone(),
             config.tenants_with_token_bitmap_fts_enabled.clone(),
             config.enable_log_scouting,
+            config.enable_transactions,
         ))
     }
 }
@@ -3451,10 +3461,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn conditional_commit_unsupported_log_returns_transactions_not_supported() {
+    async fn conditional_commit_disabled_returns_transactions_disabled() {
         let registry = Registry::new();
         let system = System::new();
         let config = FrontendConfig::sqlite_in_memory();
+        let mut frontend = ServiceBasedFrontend::try_from_config(&(config, system), &registry)
+            .await
+            .unwrap();
+
+        let err = frontend
+            .conditional_commit(
+                ConditionalCommitRequest {
+                    buffered_writes: Vec::new(),
+                    observed_log_offset: None,
+                    read_ids: Vec::new(),
+                },
+                String::new(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ConditionalCommitError::TransactionsDisabled));
+        assert_eq!(ErrorCodes::Unimplemented, err.code());
+    }
+
+    #[tokio::test]
+    async fn conditional_commit_unsupported_log_returns_transactions_not_supported() {
+        let registry = Registry::new();
+        let system = System::new();
+        let mut config = FrontendConfig::sqlite_in_memory();
+        config.enable_transactions = true;
         let mut frontend = ServiceBasedFrontend::try_from_config(&(config, system), &registry)
             .await
             .unwrap();

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -3027,7 +3027,7 @@ async fn collection_conditional_get(
     server.metrics.collection_conditional_get.add(1, &[]);
     server
         .frontend
-        .ensure_conditional_transactions_supported()?;
+        .ensure_conditional_transactions_supported_for_tenant(&tenant)?;
     let (database_name, collection_id) = parse_collection_scope(&database, &collection_id)?;
     let requester_identity = server
         .authenticate_and_authorize_collection(
@@ -3167,7 +3167,9 @@ async fn collection_conditional_commit(
     Json(payload): Json<ConditionalCommitPayload>,
 ) -> Result<Json<ConditionalCommitResult>, ServerError> {
     server.metrics.collection_conditional_commit.add(1, &[]);
-    server.frontend.ensure_conditional_commit_supported()?;
+    server
+        .frontend
+        .ensure_conditional_commit_supported_for_tenant(&tenant)?;
     let (database_name, collection_id) = parse_collection_scope(&database, &collection_id)?;
     let mut authz_actions = BTreeSet::new();
     for operation in &payload.operations {

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -507,6 +507,7 @@ impl Bindings {
             tenants_with_quantization_enabled: vec![],
             tenants_with_maxscore_enabled: vec![],
             tenants_with_token_bitmap_fts_enabled: vec![],
+            tenants_with_transactions_enabled: vec![],
             enable_log_scouting: false,
             enable_transactions: false,
         };
@@ -1019,6 +1020,8 @@ impl Bindings {
         database: String,
         py: Python<'_>,
     ) -> ChromaPyResult<GetResponse> {
+        self.frontend
+            .ensure_conditional_transactions_supported_for_tenant(&tenant)?;
         let r#where = chroma_types::RawWhereFields::from_json_str(
             r#where.as_deref(),
             where_document.as_deref(),

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -508,6 +508,7 @@ impl Bindings {
             tenants_with_maxscore_enabled: vec![],
             tenants_with_token_bitmap_fts_enabled: vec![],
             enable_log_scouting: false,
+            enable_transactions: false,
         };
 
         let frontend = runtime.block_on(async {

--- a/rust/python_bindings/src/errors.rs
+++ b/rust/python_bindings/src/errors.rs
@@ -42,7 +42,10 @@ impl From<ChromaPyError> for PyErr {
         if source_chain_contains(chroma_error, |err| {
             matches!(
                 err.downcast_ref::<ConditionalCommitError>(),
-                Some(ConditionalCommitError::TransactionsNotSupported { .. })
+                Some(
+                    ConditionalCommitError::TransactionsNotSupported { .. }
+                        | ConditionalCommitError::TransactionsDisabled
+                )
             )
         }) {
             return TransactionsNotSupportedError::new_err(message);

--- a/rust/python_bindings/src/errors.rs
+++ b/rust/python_bindings/src/errors.rs
@@ -1,7 +1,7 @@
 use chroma_api_types::{StaleReadError as ApiStaleReadError, CONDITIONAL_WRITE_CONFLICT_MESSAGE};
 use chroma_error::{source_chain_contains, ChromaError, ErrorCodes};
 use chroma_log::PushLogsError;
-use chroma_types::ConditionalCommitError;
+use chroma_types::{ConditionalCommitError, ConditionalTransactionError};
 use pyo3::PyErr;
 use thiserror::Error;
 
@@ -45,6 +45,12 @@ impl From<ChromaPyError> for PyErr {
                 Some(
                     ConditionalCommitError::TransactionsNotSupported { .. }
                         | ConditionalCommitError::TransactionsDisabled
+                )
+            ) || matches!(
+                err.downcast_ref::<ConditionalTransactionError>(),
+                Some(
+                    ConditionalTransactionError::UnsupportedLogImplementation { .. }
+                        | ConditionalTransactionError::TransactionsDisabled
                 )
             )
         }) {

--- a/rust/types/src/conditional_transaction.rs
+++ b/rust/types/src/conditional_transaction.rs
@@ -444,6 +444,8 @@ pub enum ConditionalTransactionError {
     DuplicateBufferedWrite { id: String },
     #[error("transactional writes do not support operation {operation:?}")]
     UnsupportedWriteOperation { operation: Operation },
+    #[error("conditional transactions are disabled by frontend configuration")]
+    TransactionsDisabled,
     #[error(
         "conditional transactions require the gRPC log implementation; configured log is {implementation}"
     )]
@@ -477,6 +479,7 @@ impl ChromaError for ConditionalTransactionError {
             | ConditionalTransactionError::UnsupportedLogImplementation { .. } => {
                 ErrorCodes::InvalidArgument
             }
+            ConditionalTransactionError::TransactionsDisabled => ErrorCodes::Unimplemented,
             ConditionalTransactionError::MissingReadToken
             | ConditionalTransactionError::ReadTokenMismatch { .. }
             | ConditionalTransactionError::ReadTokenOutOfRange { .. } => {
@@ -494,6 +497,8 @@ pub enum ConditionalCommitError {
         "conditional transactions require the gRPC log implementation; configured log is {implementation}"
     )]
     TransactionsNotSupported { implementation: String },
+    #[error("conditional transactions are disabled by frontend configuration")]
+    TransactionsDisabled,
     #[error("Backoff and retry")]
     Backoff,
     #[error("Invalid database name")]
@@ -508,7 +513,8 @@ impl ChromaError for ConditionalCommitError {
     fn code(&self) -> ErrorCodes {
         match self {
             ConditionalCommitError::Transaction(err) => err.code(),
-            ConditionalCommitError::TransactionsNotSupported { .. } => ErrorCodes::Unimplemented,
+            ConditionalCommitError::TransactionsNotSupported { .. }
+            | ConditionalCommitError::TransactionsDisabled => ErrorCodes::Unimplemented,
             ConditionalCommitError::Backoff => ErrorCodes::ResourceExhausted,
             ConditionalCommitError::InvalidDatabaseName => ErrorCodes::InvalidArgument,
             ConditionalCommitError::InvalidArgument(_) => ErrorCodes::InvalidArgument,
@@ -770,6 +776,17 @@ mod tests {
         assert_eq!(ErrorCodes::Unimplemented, err.code());
         assert_eq!(
             "conditional transactions require the gRPC log implementation; configured log is sqlite",
+            err.to_string()
+        );
+    }
+
+    #[test]
+    fn transactions_disabled_commit_error_uses_unimplemented_code() {
+        let err = ConditionalCommitError::TransactionsDisabled;
+
+        assert_eq!(ErrorCodes::Unimplemented, err.code());
+        assert_eq!(
+            "conditional transactions are disabled by frontend configuration",
             err.to_string()
         );
     }


### PR DESCRIPTION
## Description of changes

Introduce an enable_transactions flag on FrontendConfig so
conditional transactions can be turned off independently of the log
backend support. When disabled, ensure_conditional_transactions_supported
and ensure_conditional_commit_supported now short-circuit with a new
TransactionsDisabled error variant.

Details:
- Add TransactionsDisabled to ConditionalTransactionError and
  ConditionalCommitError, both mapping to ErrorCodes::Unimplemented.
- Map the new variant to TRANSACTIONS_NOT_SUPPORTED_ERROR_NAME in
  frontend-core and to TransactionsNotSupportedError in the python
  bindings so clients see a consistent error.
- Thread enable_transactions through ServiceBasedFrontend and its
  constructor, defaulting to false.
- Enable transactions in the distributed sample configs.

## Test plan

CI

## Migration plan

Defaults to failing.  Will have to enable to launch.  This is intentional.

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
