### PR TITLE
[BUG](fn-consumer): Use live backfill frontier

### DIFF
--- a/rust/worker/src/execution/functions/count_to_file_async.rs
+++ b/rust/worker/src/execution/functions/count_to_file_async.rs
@@ -188,9 +188,9 @@ impl AttachedFunctionExecutor for CountToFileAsyncExecutor {
                 }
             }
 
-            let pulled_log_offset = i64::try_from(batch.completion_offset).map_err(|_| {
+            let pulled_log_offset = i64::try_from(batch.pulled_log_offset).map_err(|_| {
                 Box::new(CountToFileAsyncError::InvalidPulledLogOffset(
-                    batch.completion_offset,
+                    batch.pulled_log_offset,
                 )) as Box<dyn ChromaError>
             })?;
             state
@@ -279,7 +279,7 @@ mod tests {
                     input_collection_name: "test-input".to_string(),
                     tenant_id: "test-tenant".to_string(),
                     database_id: "test-database".to_string(),
-                    completion_offset: pulled_log_offset,
+                    pulled_log_offset,
                     records: Chunk::new(Arc::from(records)),
                 }],
                 None,

--- a/rust/worker/src/execution/functions/http_currents.rs
+++ b/rust/worker/src/execution/functions/http_currents.rs
@@ -286,7 +286,7 @@ impl AttachedFunctionExecutor for HttpCurrentsExecutor {
             database_name: self.database_name.clone(),
             wiki_collection: batch.input_collection_name.clone(),
             currents_collection: self.output_collection.clone(),
-            wiki_write_offset: batch.completion_offset,
+            wiki_write_offset: batch.pulled_log_offset,
         };
 
         tracing::info!(

--- a/rust/worker/src/execution/functions/http_generate.rs
+++ b/rust/worker/src/execution/functions/http_generate.rs
@@ -319,7 +319,7 @@ impl AttachedFunctionExecutor for HttpGenerateExecutor {
                 output_collection: self.output_collection.clone(),
                 base_collection: None,
                 records,
-                completion_offset: batch.completion_offset,
+                completion_offset: batch.pulled_log_offset,
             });
         }
 

--- a/rust/worker/src/execution/functions/revision_history.rs
+++ b/rust/worker/src/execution/functions/revision_history.rs
@@ -559,7 +559,7 @@ mod tests {
             input_collection_name: "test-input".to_string(),
             tenant_id: "test-tenant".to_string(),
             database_id: "test-database".to_string(),
-            completion_offset: 0,
+            pulled_log_offset: 0,
             records,
         }
     }

--- a/rust/worker/src/execution/functions/statistics.rs
+++ b/rust/worker/src/execution/functions/statistics.rs
@@ -560,7 +560,7 @@ mod tests {
             input_collection_name: "test-input".to_string(),
             tenant_id: "test-tenant".to_string(),
             database_id: "test-database".to_string(),
-            completion_offset: 0,
+            pulled_log_offset: 0,
             records,
         }
     }

--- a/rust/worker/src/execution/operators/execute_task.rs
+++ b/rust/worker/src/execution/operators/execute_task.rs
@@ -268,7 +268,7 @@ pub struct ExecuteAttachedFunctionBatchInput {
     pub input_collection_name: String,
     pub tenant_id: String,
     pub database_id: String,
-    pub completion_offset: u64,
+    pub pulled_log_offset: u64,
 }
 
 /// Hydrated records for one input collection, passed to the executor after shard hydration.
@@ -277,7 +277,7 @@ pub struct HydratedInputBatch<'me, 'q> {
     pub input_collection_name: String,
     pub tenant_id: String,
     pub database_id: String,
-    pub completion_offset: u64,
+    pub pulled_log_offset: u64,
     pub records: Chunk<HydratedMaterializedLogRecord<'me, 'q>>,
 }
 
@@ -434,7 +434,7 @@ impl Operator<ExecuteAttachedFunctionInput, ExecuteAttachedFunctionOutput>
                 input_collection_name: batch.input_collection_name.clone(),
                 tenant_id: batch.tenant_id.clone(),
                 database_id: batch.database_id.clone(),
-                completion_offset: batch.completion_offset,
+                pulled_log_offset: batch.pulled_log_offset,
                 records: Chunk::new(std::sync::Arc::from(hydrated_records)),
             });
         }
@@ -604,7 +604,7 @@ mod tests {
                         input_collection_name: "input-a".to_string(),
                         tenant_id: output_segment.collection.tenant.clone(),
                         database_id: output_segment.collection.database_id.to_string(),
-                        completion_offset: 0,
+                        pulled_log_offset: 0,
                     },
                     ExecuteAttachedFunctionBatchInput {
                         materialized_logs: vec![materialized_b],
@@ -613,7 +613,7 @@ mod tests {
                         input_collection_name: "input-b".to_string(),
                         tenant_id: output_segment.collection.tenant.clone(),
                         database_id: output_segment.collection.database_id.to_string(),
-                        completion_offset: 0,
+                        pulled_log_offset: 0,
                     },
                 ],
                 output_collection_id: output_segment.collection.collection_id,

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -61,6 +61,18 @@ use crate::execution::{
 use super::compact::{CollectionCompactInfo, CompactWriters};
 use chroma_types::AdvanceAttachedFunctionError;
 
+fn resolve_pulled_log_offset(
+    is_for_backfill: bool,
+    pulled_log_offset: i64,
+    collection_log_position: i64,
+) -> i64 {
+    if is_for_backfill {
+        collection_log_position
+    } else {
+        pulled_log_offset
+    }
+}
+
 #[derive(Debug)]
 pub struct AttachedFunctionOrchestrator {
     input_collection_data: Vec<FunctionInputCollectionData>,
@@ -483,9 +495,14 @@ impl AttachedFunctionOrchestrator {
                 .iter()
                 .map(|input_collection_data| FunctionExecutionProgress {
                     input_collection_id: input_collection_data.collection_info.collection_id,
-                    updated_completion_offset: input_collection_data
-                        .collection_info
-                        .pulled_log_offset as u64,
+                    updated_completion_offset: resolve_pulled_log_offset(
+                        self.is_for_backfill,
+                        input_collection_data.collection_info.pulled_log_offset,
+                        input_collection_data
+                            .collection_info
+                            .collection
+                            .log_position,
+                    ) as u64,
                 })
                 .collect();
         }
@@ -1013,7 +1030,11 @@ impl Handler<TaskResult<CollectionAndSegments, GetCollectionAndSegmentsError>>
                         input_collection_name: collection_info.collection.name.clone(),
                         tenant_id: collection_info.collection.tenant.clone(),
                         database_id: collection_info.collection.database_id.to_string(),
-                        completion_offset: collection_info.pulled_log_offset as u64,
+                        pulled_log_offset: resolve_pulled_log_offset(
+                            self.is_for_backfill,
+                            collection_info.pulled_log_offset,
+                            collection_info.collection.log_position,
+                        ) as u64,
                     }
                 })
                 .collect(),
@@ -1088,5 +1109,16 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
         // For async-only functions, we don't have any output records to apply.
         // The function will be processed asynchronously by an external consumer.
         self.finish_no_attached_function(ctx).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_pulled_log_offset;
+
+    #[test]
+    fn test_resolve_pulled_log_offset() {
+        assert_eq!(resolve_pulled_log_offset(true, 199, 299), 299);
+        assert_eq!(resolve_pulled_log_offset(false, 199, 299), 199);
     }
 }


### PR DESCRIPTION
## Description of changes

During attached-function backfill, the executor processes the live record segment through the collection's current log position, but the batch was labeled with the earlier incremental fetch frontier. Idempotent functions therefore saved a frontier behind the records they had actually processed, allowing later executions to count overlapping records again.

- Derive the executor's pulled log offset from the existing `is_for_backfill` signal.
- Use the input collection's live log position for both the backfill batch frontier and the completion progress recorded after execution.
- Keep ordinary execution on the fetched `pulled_log_offset`.
- Rename the executor batch field from `completion_offset` to `pulled_log_offset` to reflect its actual meaning.

## Test plan

- `cargo test -p worker test_resolve_pulled_log_offset`
- `cargo test -p worker count_to_file_async::tests`
- `cargo clippy -p worker --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

## Migration plan

No migration required. This changes an internal Rust field name and attached-function backfill frontier selection.

## Observability plan

Existing attached-function completion logs expose the resulting completion frontier.

## Documentation Changes

None; no user-facing API changes.