### PR TITLE
Ban relative imports via flake8-tidy-imports (closes #2334)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,14 @@ repos:
     hooks:
       - id: flake8
         args:
-          - "--extend-ignore=E203,E501,E503"
+          # I250 (unnecessary import alias) is left off intentionally: the
+          # codebase uses explicit `import x as x` re-exports. Only the
+          # relative-import ban (I252) from flake8-tidy-imports is enforced.
+          - "--extend-ignore=E203,E501,E503,I250"
           - "--max-line-length=88"
+          - "--ban-relative-imports=true"
+        additional_dependencies:
+          - flake8-tidy-imports
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -8,7 +8,7 @@ It can be used to get information about available schemas and their versions.
 from typing import Dict, List, Set
 import os
 import json
-from .schema_utils import SCHEMAS_DIR
+from chromadb.utils.embedding_functions.schemas.schema_utils import SCHEMAS_DIR
 
 
 def get_available_schemas() -> List[str]:


### PR DESCRIPTION
Closes #2334.

The project prefers absolute imports. This adds the `flake8-tidy-imports` plugin to the flake8 pre-commit hook with `--ban-relative-imports=true`, so flake8 (`I252`) now flags any relative import.

- `I250` (unnecessary import alias) is deliberately left ignored — the codebase uses explicit `import x as x` re-exports (needed for mypy `--strict` re-export), and enabling it would flag dozens of intentional lines unrelated to this issue.
- Converted the single existing relative import to absolute:
  `chromadb/utils/embedding_functions/schemas/registry.py` — `from .schema_utils import ...` → `from chromadb.utils.embedding_functions.schemas.schema_utils import ...`

**Verification:** `flake8 --ban-relative-imports=true` reports zero `I252` violations across `chromadb/`, and fires correctly on a test relative import. The one changed source file passes flake8 cleanly.
