### PR TITLE
[BUG]: remove pysqlite3-binary auto-install via subprocess at import time

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -113,6 +113,18 @@ logger = logging.getLogger(__name__)
 
 __settings = Settings()
 
+
+
+# Workaround to deal with Colab's old sqlite3 version
+def is_in_colab() -> bool:
+    try:
+        import google.colab  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 is_client = False
 try:
     from chromadb.is_thin_client import is_thin_client

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -113,20 +113,6 @@ logger = logging.getLogger(__name__)
 
 __settings = Settings()
 
-
-
-# Workaround to deal with Colab's old sqlite3 version
-def is_in_colab() -> bool:
-    try:
-        import google.colab  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
-
-
-IN_COLAB = is_in_colab()
-
 is_client = False
 try:
     from chromadb.is_thin_client import is_thin_client
@@ -139,24 +125,13 @@ if not is_client:
     import sqlite3
 
     if sqlite3.sqlite_version_info < (3, 35, 0):
-        if IN_COLAB:
-            # In Colab, hotswap to pysqlite-binary if it's too old
-            import subprocess
-            import sys
-
-            subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", "pysqlite3-binary"]
-            )
-            __import__("pysqlite3")
-            sys.modules["sqlite3"] = sys.modules.pop("pysqlite3")
-        else:
-            raise RuntimeError(
-                "\033[91mYour system has an unsupported version of sqlite3. Chroma \
-                    requires sqlite3 >= 3.35.0.\033[0m\n"
-                "\033[94mPlease visit \
-                    https://docs.trychroma.com/troubleshooting#sqlite to learn how \
-                    to upgrade.\033[0m"
-            )
+        raise RuntimeError(
+            "\033[91mYour system has an unsupported version of sqlite3. Chroma \
+                requires sqlite3 >= 3.35.0.\033[0m\n"
+            "\033[94mPlease visit \
+                https://docs.trychroma.com/troubleshooting#sqlite to learn how \
+                to upgrade.\033[0m"
+        )
 
 
 def configure(**kwargs) -> None:  # type: ignore

--- a/chromadb/telemetry/product/events.py
+++ b/chromadb/telemetry/product/events.py
@@ -6,10 +6,12 @@ from chromadb.telemetry.product import ProductTelemetryEvent
 class ClientStartEvent(ProductTelemetryEvent):
     def __init__(self) -> None:
         super().__init__()
-        # Lazy import to avoid circular imports
-        from chromadb import is_in_colab
+        try:
+            import google.colab  # noqa: F401
 
-        self.in_colab = is_in_colab()
+            self.in_colab = True
+        except ImportError:
+            self.in_colab = False
 
 
 class ServerStartEvent(ProductTelemetryEvent):


### PR DESCRIPTION
## Summary

Removes the  that runs at import time when Chroma detects an old SQLite version in Google Colab.

## Problem

Running `pip install` via subprocess at import time is fragile:
- Fails on non-standard architectures (ppc64, arm64 variants, etc.) where the user needs to specify a custom package index
- Is generally considered bad practice — package dependencies should be managed by the package manager, not at runtime
- The auto-install path was only triggered in Colab, but the same underlying issue (old SQLite) exists everywhere

## Fix

- Removed the `subprocess.check_call` auto-install block
- Removed the now-unused `is_in_colab()` helper and `IN_COLAB` constant
- The Colab path now raises the same clear `RuntimeError` as the non-Colab path, directing users to the troubleshooting guide

Closes #7402