### PR TITLE
fix(api): reject bool values for HNSW int/float config params (gh-7290)

### DIFF
--- a/chromadb/api/configuration.py
+++ b/chromadb/api/configuration.py
@@ -231,43 +231,57 @@ class HNSWConfigurationInternal(ConfigurationInternal):
         ),
         "ef_construction": ConfigurationDefinition(
             name="ef_construction",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int)
+            and not isinstance(value, bool)
+            and value >= 1,
             is_static=True,
             default_value=100,
         ),
         "ef_search": ConfigurationDefinition(
             name="ef_search",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int)
+            and not isinstance(value, bool)
+            and value >= 1,
             is_static=False,
             default_value=100,
         ),
         "num_threads": ConfigurationDefinition(
             name="num_threads",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int)
+            and not isinstance(value, bool)
+            and value >= 1,
             is_static=False,
             default_value=cpu_count(),  # By default use all cores available
         ),
         "M": ConfigurationDefinition(
             name="M",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int)
+            and not isinstance(value, bool)
+            and value >= 1,
             is_static=True,
             default_value=16,
         ),
         "resize_factor": ConfigurationDefinition(
             name="resize_factor",
-            validator=lambda value: isinstance(value, float) and value >= 1,
+            validator=lambda value: isinstance(value, float)
+            and not isinstance(value, bool)
+            and value >= 1,
             is_static=True,
             default_value=1.2,
         ),
         "batch_size": ConfigurationDefinition(
             name="batch_size",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int)
+            and not isinstance(value, bool)
+            and value >= 1,
             is_static=True,
             default_value=100,
         ),
         "sync_threshold": ConfigurationDefinition(
             name="sync_threshold",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int)
+            and not isinstance(value, bool)
+            and value >= 1,
             is_static=True,
             default_value=1000,
         ),

--- a/chromadb/test/configurations/test_configurations.py
+++ b/chromadb/test/configurations/test_configurations.py
@@ -108,3 +108,33 @@ def test_configuration_validation() -> None:
 def test_hnsw_validation() -> None:
     with pytest.raises(ValueError, match="must be less than or equal"):
         HNSWConfiguration(batch_size=500, sync_threshold=100)
+
+
+def test_hnsw_rejects_bool_for_int_params() -> None:
+    """Regression test for chroma-core/chroma#7290.
+
+    ``bool`` is a subclass of ``int`` in Python, so naive
+    ``isinstance(value, int)`` checks accept ``True``/``False`` as if they
+    were integers. HNSW parameters that must be ``int`` (or ``float`` for
+    ``resize_factor``) should reject ``bool`` values explicitly.
+    """
+    int_params = [
+        "ef_construction",
+        "ef_search",
+        "num_threads",
+        "M",
+        "batch_size",
+        "sync_threshold",
+    ]
+    for name in int_params:
+        with pytest.raises(ValueError):
+            HNSWConfiguration(**{name: True})  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            HNSWConfiguration(**{name: False})  # type: ignore[arg-type]
+
+    # resize_factor must be float; bool is also a subclass of int, not float,
+    # but rejecting it explicitly is the consistent, safe behaviour.
+    with pytest.raises(ValueError):
+        HNSWConfiguration(resize_factor=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        HNSWConfiguration(resize_factor=False)  # type: ignore[arg-type]


### PR DESCRIPTION
## Description of changes

Fixes [issue #7290](https://github.com/chroma-core/chroma/issues/7290).

`bool` is a subclass of `int` in Python, so the `isinstance(value, int)` checks in `HNSWConfigurationInternal.definitions` accepted `True`/`False` as if they were integers. As a consequence, `ef_construction=True` (and the same for the other int/float params) silently passed validation and then got forwarded to the HNSW index, where `True` coerces to `1` — a confusing footgun.

This patch adds an explicit `not isinstance(value, bool)` guard to all six int validators (`ef_construction`, `ef_search`, `num_threads`, `M`, `batch_size`, `sync_threshold`) and to the `resize_factor` float validator. Booleans now raise the same `ValueError` as any other wrong-type value.

- Improvements & Bug fixes
  - Reject `True`/`False` for every int/float HNSW config parameter on `HNSWConfigurationInternal` / `HNSWConfiguration`.
  - Add a regression test (`test_hnsw_rejects_bool_for_int_params`) that constructs `HNSWConfiguration(...=True/False)` for every protected parameter and asserts `ValueError`.

Closes #7290.

## Test plan

- [x] New unit test added in `chromadb/test/configurations/test_configurations.py` covering all 7 protected params and both `True` and `False`.
- [x] Verified the validator logic in isolation (13/13 cases pass: valid ints/floats accepted, `True`/`False` rejected, out-of-range and wrong-type values rejected).
- [ ] Full pytest run needs the rust-built `chroma-hnswlib` wheel which is not available in this environment; existing test fixtures (`test_hnsw_validation`) only exercise the cross-field invariant (`batch_size <= sync_threshold`) and are unaffected.

## Migration plan

No migration needed. The change only tightens an existing validator; previously-accepted `True`/`False` will now raise `ValueError` at construction time, which matches the user-facing type hints (`ef_construction: int = 100`, etc.) already declared on `HNSWConfigurationInterface.__init__`.

## Observability plan

None. Failure mode changes from silent coercion to an explicit `ValueError`, which is the desired behaviour.

## Documentation Changes

None. The public signatures (`ef_construction: int`, `resize_factor: float`, …) were already typed correctly; this just makes the runtime validation match the declared types.