### PR TITLE
fix: register fastapi fixtures and fix default fixture list in conftest.py

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -387,19 +387,22 @@ def _fastapi_fixture(
         yield from run(args)
 
 
+@pytest.fixture(scope="function")
 def fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=False)
+    yield from _fastapi_fixture(is_persistent=False)
 
 
+@pytest.fixture(scope="function")
 def async_fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(
+    yield from _fastapi_fixture(
         is_persistent=False,
         chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
     )
 
 
+@pytest.fixture(scope="function")
 def fastapi_persistent() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=True)
+    yield from _fastapi_fixture(is_persistent=True)
 
 
 def fastapi_ssl() -> Generator[System, None, None]:
@@ -753,7 +756,7 @@ def filtered_fixture_names() -> List[str]:
         "fastapi",
         "async_fastapi",
         "fastapi_persistent",
-        "sqlite_fixture",
+        "sqlite",
         "sqlite_persistent",
     ]
 


### PR DESCRIPTION
Fixes #7395

The default pytest fixture list in `chromadb/test/conftest.py` was broken because:

1. **`fastapi`, `async_fastapi`, `fastapi_persistent`** were defined as plain functions without `@pytest.fixture` decorators. The functions also used `return` instead of `yield from`, so they returned generator objects instead of behaving as proper generator fixtures.

2. **`sqlite_fixture`** referenced a fixture name that doesn't exist. The actual ephemeral sqlite fixture is named `sqlite` (line 738). Fixed by renaming to `sqlite`.