### PR TITLE
[BLD](docker): cache Rust deps as a durable layer via cargo-chef

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,9 +1,15 @@
-FROM rust:1.92.0 AS builder
+# syntax=docker/dockerfile:1
 
-ARG RELEASE_MODE=
+# ============================================================================
+# chef: shared toolchain base (rust + protoc + cargo-chef).
+#
+# This is the slow-changing setup layer. It is shared by the `planner` and
+# `builder` stages below so the toolchain/protoc install is built and cached
+# once, regardless of source changes.
+# ============================================================================
+FROM rust:1.92.0 AS chef
+
 ARG PROTOC_VERSION=31.1
-ARG ENABLE_AVX512=
-ARG LOG_SERVICE_CARGO_FEATURES=
 
 # ADDRESS_SANITIZER is an optional build argument to enable Address Sanitizer.
 ARG ADDRESS_SANITIZER
@@ -14,13 +20,6 @@ RUN if [ "$ADDRESS_SANITIZER" = "1" ]; then \
   rustup default nightly && \
   rustup target add x86_64-unknown-linux-gnu ; \
   fi
-ENV RUSTFLAGS=${ADDRESS_SANITIZER:+'-Z sanitizer=address'}
-ENV CC_x86_64_unknown_linux_gnu=${ADDRESS_SANITIZER:+gcc}
-ENV CXX_x86_64_unknown_linux_gnu=${ADDRESS_SANITIZER:+g++}
-ENV AR_x86_64_unknown_linux_gnu=${ADDRESS_SANITIZER:+ar}
-ENV CARGO_INCREMENTAL=0
-
-WORKDIR /chroma
 
 RUN ARCH=$(uname -m) && \
   if [ "$ARCH" = "x86_64" ]; then \
@@ -37,26 +36,99 @@ RUN ARCH=$(uname -m) && \
   chmod +x /usr/local/bin/protoc && \
   protoc --version  # Verify installed version
 
+# cargo-chef lets us cache the dependency compile as a content-addressed image
+# LAYER (keyed on the dependency graph) instead of leaving it in a volatile
+# `--mount=type=cache` directory that is wiped on a cold/contended builder.
+RUN --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+  cargo install cargo-chef --locked
+
+WORKDIR /chroma
+
+# ============================================================================
+# planner: emit recipe.json (the dependency graph only).
+#
+# This stage is cheap. Its only purpose is to produce a `recipe.json` that
+# changes ONLY when dependencies change (Cargo.toml / Cargo.lock), giving the
+# `builder` stage a stable cache key for the dependency compile.
+# ============================================================================
+FROM chef AS planner
+
 COPY idl/ idl/
 COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 COPY rust/ rust/
 
-# Skip building these as they're not needed by images (and if Python bindings are built, the final binaries are unnecessarily linked against Python).
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ============================================================================
+# builder: cook dependencies into a durable layer, then build the workspace.
+#
+# `cargo chef cook` compiles ONLY third-party dependencies, writing them to
+# ./target. Because this step's only input is recipe.json (and we do NOT mount
+# a cache over ./target), its result is captured as a regular image layer:
+#   * content-addressed on recipe.json -> reused on every build whose deps are
+#     unchanged (the common case: app-only source change),
+#   * never thrashed cross-arch (each arch builds its own layer),
+#   * exportable to a registry (a `--mount=type=cache` dir can never be).
+#
+# The subsequent `cargo build` then compiles only the first-party workspace
+# crates, reusing the cooked dependencies already present in ./target.
+# ============================================================================
+FROM chef AS builder
+
+ARG RELEASE_MODE=
+ARG ENABLE_AVX512=
+ARG LOG_SERVICE_CARGO_FEATURES=
+ARG ADDRESS_SANITIZER
+
+ENV RUSTFLAGS=${ADDRESS_SANITIZER:+'-Z sanitizer=address'}
+ENV CC_x86_64_unknown_linux_gnu=${ADDRESS_SANITIZER:+gcc}
+ENV CXX_x86_64_unknown_linux_gnu=${ADDRESS_SANITIZER:+g++}
+ENV AR_x86_64_unknown_linux_gnu=${ADDRESS_SANITIZER:+ar}
+ENV CARGO_INCREMENTAL=0
+
+# Skip building these as they're not needed by images (and if Python bindings
+# are built, the final binaries are unnecessarily linked against Python).
 ENV EXCLUDED_PACKAGES="chromadb_rust_bindings chromadb-js-bindings chroma-benchmark "
 
-# Note: Using flag ENABLE_AVX512 to build AVX512 optimizations for hnswlib, and AVX for Rust.
-# Once Rust supports AVX512, the target-features will be updated to use AVX512.
-RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
-  --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+# Packages whose bins we ship in images. Used for `cargo chef cook -p ...`
+# because cook does not support `--exclude` (LukeMathWalker/cargo-chef#181);
+# cooking the full workspace would also pull in pyo3/napi build deps.
+ENV COOK_PACKAGES="chroma-cli garbage_collector chroma-load chroma-log-service s3heap-service worker rust-sysdb spanner-migrations"
+
+# --- Dependency compile (durable layer, keyed on recipe.json) ----------------
+# Note: cache mounts are kept ONLY for the crate download dirs (registry/git);
+# the compiled output in ./target is intentionally a layer, not a mount, which
+# is what makes cargo-chef effective.
+COPY --from=planner /chroma/recipe.json recipe.json
+RUN --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
   --mount=type=cache,sharing=locked,target=/usr/local/cargo/git/ \
   if [ "$ENABLE_AVX512" = "1" ]; then \
   export CXXFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
   export CFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
-  export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+avx,+fma" && \
-  echo "Building with AVX512 optimizations for hnswlib and AVX for Rust"; \
-  else \
-  echo "Building without AVX512 optimizations"; \
+  export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+avx,+fma" ; \
+  fi && \
+  build_target=$( [ "${ADDRESS_SANITIZER}" = "1" ] && echo '--target x86_64-unknown-linux-gnu' || echo '' ) && \
+  release_flag=$( [ "$RELEASE_MODE" = "1" ] && echo '--release' || echo '' ) && \
+  cargo chef cook ${build_target} $(printf -- '-p %s ' $COOK_PACKAGES) ${release_flag} --recipe-path recipe.json
+
+# --- Workspace compile (first-party crates) ----------------------------------
+COPY idl/ idl/
+COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
+COPY rust/ rust/
+
+# Note: Using flag ENABLE_AVX512 to build AVX512 optimizations for hnswlib, and
+# AVX for Rust. Once Rust supports AVX512, the target-features will be updated
+# to use AVX512.
+# No `--mount=type=cache` on ./target here: the cooked dependencies live in the
+# layer produced above, and mounting a cache over ./target would shadow them.
+RUN --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+  --mount=type=cache,sharing=locked,target=/usr/local/cargo/git/ \
+  if [ "$ENABLE_AVX512" = "1" ]; then \
+  export CXXFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
+  export CFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
+  export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+avx,+fma" ; \
   fi && \
   build_target=$( [ "${ADDRESS_SANITIZER}" = "1" ] && echo '--target x86_64-unknown-linux-gnu' || echo '' ) && \
   release_flag=$( [ "$RELEASE_MODE" = "1" ] && echo '--release' || echo '' ) && \


### PR DESCRIPTION
## Summary
- Restructure `rust/Dockerfile` into chef / planner / builder stages so dependency compiles land in a durable, content-addressed image layer (keyed on `recipe.json`) instead of a volatile `--mount=type=cache` `./target` dir.
- App-only source changes can reuse cooked deps; registry/git cache mounts are kept for downloads only.
- Takes over [@piob-io](https://github.com/piob-io)'s work from #7365 (thanks!). That branch was ~50 commits behind and CI was red for unrelated reasons (clippy already fixed on main) plus a real bug: `cargo chef cook` does not support `--exclude` ([cargo-chef#181](https://github.com/LukeMathWalker/cargo-chef/issues/181)).

## Fix vs #7365
`cargo chef cook` cannot take `--exclude`, and cooking the full workspace would pull pyo3/napi for the bindings crates. This PR cooks only the image binary packages via `-p`, and keeps `--exclude` on the final `cargo build`.

## Test plan
- [ ] CI Docker image bake succeeds
- [ ] Warm rebuild with unchanged Cargo.lock reuses the cook layer (deps not recompiled)
- [ ] Changing only first-party Rust source still produces working service images