### PR TITLE
[BUG](blockstore): Fix legacy V1 rank

### DIFF
--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -829,7 +829,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                 .sum::<u32>() as usize;
         } else {
             self.load_blocks(&block_ids).await;
-            for block_id in block_ids.iter().take(block_ids.len() - 1) {
+            for block_id in &block_ids {
                 let block = self
                     .get_block(*block_id, StorageRequestPriority::P0)
                     .await
@@ -2503,6 +2503,10 @@ mod tests {
         assert_eq!(reader.get("prefix", "f").await.unwrap(), Some("value_b"));
         assert_eq!(reader.count().await.unwrap(), 2);
         assert_eq!(reader.root.version, Version::V1);
+        assert_eq!(reader.rank("prefix", "a").await.unwrap(), 0);
+        assert_eq!(reader.rank("prefix", "b").await.unwrap(), 1);
+        assert_eq!(reader.rank("prefix", "f").await.unwrap(), 1);
+        assert_eq!(reader.rank("prefix", "g").await.unwrap(), 2);
 
         ////////////////////////// STEP 3 //////////////////////////
 


### PR DESCRIPTION
## Description of changes

- Fix legacy V1 blockfile rank calculation after the target block was separated from the predecessor list.
- Count every predecessor block instead of dropping the immediate predecessor or underflowing when the target is in the first block.
- Add regression coverage for positions before, within, and after the two-block V1 fixture.

The regression was introduced when block range scanning changed in #4467. V1.1 and newer roots use sparse-index counts and are unchanged.

## Test plan

- [x] `cargo test -p chroma-blockstore test_v1_to_v1_1_migration_partially_new -- --nocapture`
- [x] `cargo test -p chroma-blockstore` (96 unit tests and 1 integration test)
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Migration plan

No migration is required. This restores correct reads for existing V1 blockfiles without changing the on-disk format.

## Observability plan

No new instrumentation is needed for this localized read-path correction.

## Documentation Changes

None. There is no public API or configuration change.
