### PR TITLE
[BUG](log-service): Fix release build recursion limit overflow

### DIFF
--- a/rust/log-service/src/bin/log.rs
+++ b/rust/log-service/src/bin/log.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 fn main() {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
## Summary

`cargo build --release` fails when compiling the `log_service` binary with a "queries overflow the depth limit" error. Root cause: `rust/log-service/src/bin/log.rs` is a separate crate target from `rust/log-service/src/lib.rs` (see `[[bin]]` in `Cargo.toml`) and doesn't inherit `lib.rs`'s `#![recursion_limit = "256"]` attribute. In release mode, layout computation for the deeply nested async closure in `LogServerWrapper::run` exceeds the default compiler query depth.

This adds the same `#![recursion_limit = "256"]` attribute already used in `rust/worker/src/lib.rs`, `rust/segment/src/lib.rs`, and `rust/garbage_collector/src/lib.rs`.

Fixes #7370.

## Verification

Reproduced independently (macOS ARM64, rustc 1.97.0 — the original report was on Linux x86_64, rustc 1.96.0):

**Before fix:**
```
$ cargo build --release -p chroma-log-service --bin log_service
...
error: queries overflow the depth limit!
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
          attribute to your crate (`log_service`)
  = note: query depth increased by 130 when computing layout of
          `{async block@chroma_log_service::LogServerWrapper::run::{closure#0}::{closure#0}}`
error: could not compile `chroma-log-service` (bin "log_service") due to 1 previous error
```

**After fix:**
```
$ cargo build --release -p chroma-log-service --bin log_service
   Compiling chroma-log-service v0.1.0 (.../rust/log-service)
    Finished `release` profile [optimized + debuginfo] target(s) in 1m 19s
```
Binary produced successfully. Also confirmed `cargo fmt --check -p chroma-log-service` passes.

## Test plan
- [x] Reproduced the reported failure locally before the change
- [x] Confirmed `cargo build --release -p chroma-log-service --bin log_service` succeeds after the change
- [x] `cargo fmt --check -p chroma-log-service` passes