### PR TITLE
fix(sparse): validate index/value/label lengths in normalize_sparse_vector

### DIFF
--- a/chromadb/test/utils/test_sparse_embedding_utils.py
+++ b/chromadb/test/utils/test_sparse_embedding_utils.py
@@ -1,0 +1,42 @@
+import pytest
+
+from chromadb.base_types import SparseVector
+from chromadb.utils.sparse_embedding_utils import normalize_sparse_vector
+
+
+def test_sorts_by_index() -> None:
+    result = normalize_sparse_vector([3, 1, 2], [30.0, 10.0, 20.0])
+    assert result == SparseVector(indices=[1, 2, 3], values=[10.0, 20.0, 30.0])
+
+
+def test_sorts_labels_alongside() -> None:
+    result = normalize_sparse_vector([2, 1], [20.0, 10.0], ["b", "a"])
+    assert result == SparseVector(
+        indices=[1, 2], values=[10.0, 20.0], labels=["a", "b"]
+    )
+
+
+def test_empty_returns_empty() -> None:
+    assert normalize_sparse_vector([], []) == SparseVector(indices=[], values=[])
+
+
+def test_more_indices_than_values_raises() -> None:
+    # zip() would otherwise silently truncate to two elements, dropping index 3
+    # instead of surfacing the mismatch the docstring promises.
+    with pytest.raises(ValueError, match="same length"):
+        normalize_sparse_vector([1, 2, 3], [10.0, 20.0])
+
+
+def test_more_values_than_indices_raises() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        normalize_sparse_vector([1, 2], [10.0, 20.0, 30.0])
+
+
+def test_empty_indices_with_values_raises() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        normalize_sparse_vector([], [10.0])
+
+
+def test_labels_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="labels must have the same length"):
+        normalize_sparse_vector([1, 2], [10.0, 20.0], ["a"])

--- a/chromadb/utils/sparse_embedding_utils.py
+++ b/chromadb/utils/sparse_embedding_utils.py
@@ -27,6 +27,20 @@ def normalize_sparse_vector(
         ValueError: If values are not numeric
         ValueError: If labels is provided and has different length than indices
     """
+    # Validate lengths up front: zip() below silently truncates to the shortest
+    # input, which would equalize the arrays before SparseVector.__post_init__
+    # could detect a mismatch, dropping data instead of raising.
+    if len(indices) != len(values):
+        raise ValueError(
+            f"indices and values must have the same length, "
+            f"got {len(indices)} indices and {len(values)} values"
+        )
+    if labels is not None and len(labels) != len(indices):
+        raise ValueError(
+            f"labels must have the same length as indices, "
+            f"got {len(labels)} labels and {len(indices)} indices"
+        )
+
     if not indices:
         return SparseVector(indices=[], values=[], labels=None)
 


### PR DESCRIPTION
## Description of changes

`normalize_sparse_vector` zips `indices`, `values` and (optionally) `labels` together before constructing a `SparseVector`. Because `zip()` stops at the shortest input, a length mismatch is **silently truncated**: the arrays are equalized *before* `SparseVector.__post_init__` can detect the mismatch, so elements are dropped instead of raising the `ValueError` the docstring promises.

For example:

```python
>>> normalize_sparse_vector([1, 2, 3], [10.0, 20.0])
SparseVector(indices=[1, 2], values=[10.0, 20.0], labels=None)  # index 3 silently discarded
```

The docstring explicitly documents `ValueError: If indices and values have different lengths` and `ValueError: If labels is provided and has different length than indices`, but neither is ever raised today. This helper is reached from the bm25 / splade / fastembed / huggingface sparse-embedding paths, so a malformed embedding loses dimensions silently rather than failing loudly.

**Fix:** validate the lengths up front (before the `zip`) so a mismatch raises `ValueError` as documented. Valid inputs are unaffected - sorting, label handling and the empty-input case behave exactly as before.

## Test plan

Added `chromadb/test/utils/test_sparse_embedding_utils.py`:

- new tests assert `ValueError` for more indices than values, more values than indices, empty indices with non-empty values, and a labels/indices length mismatch. Each **fails on `main`** (silent truncation) and passes with this change.
- existing sort / label-sort / empty-input behaviour is covered to guard against regressions.

```
python -m pytest chromadb/test/utils/test_sparse_embedding_utils.py -q --noconftest
7 passed
```

## Documentation Changes

None - the behaviour is brought in line with the existing docstring.

---

Disclosure: this change was prepared with AI assistance. The bug, fix, and tests were reviewed and verified against the source by me.