### PR TITLE
[BUG](security): Harden client EF poisoning

### DIFF
--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -210,6 +210,16 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         if embedding_function is not None and configuration_ef is None:
             configuration["embedding_function"] = embedding_function
 
+        # Prefer an explicitly trusted configuration EF over the default so
+        # create()+add() still works after CollectionCommon refuses to auto-
+        # execute non-default persisted embedding configs.
+        collection_embedding_function = embedding_function
+        if configuration_ef is not None and (
+            embedding_function is None
+            or isinstance(embedding_function, DefaultEmbeddingFunction)
+        ):
+            collection_embedding_function = configuration_ef
+
         model = await self._server.create_collection(
             name=name,
             schema=schema,
@@ -222,7 +232,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         return AsyncCollection(
             client=self._server,
             model=model,
-            embedding_function=embedding_function,
+            embedding_function=collection_embedding_function,
             data_loader=data_loader,
         )
 
@@ -316,6 +326,14 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
 
         if embedding_function is not None and configuration_ef is None:
             configuration["embedding_function"] = embedding_function
+
+        collection_embedding_function = embedding_function
+        if configuration_ef is not None and (
+            embedding_function is None
+            or isinstance(embedding_function, DefaultEmbeddingFunction)
+        ):
+            collection_embedding_function = configuration_ef
+
         model = await self._server.get_or_create_collection(
             name=name,
             schema=schema,
@@ -328,13 +346,13 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         persisted_ef_config = model.configuration_json.get("embedding_function")
 
         validate_embedding_function_conflict_on_get(
-            embedding_function, persisted_ef_config
+            collection_embedding_function, persisted_ef_config
         )
 
         return AsyncCollection(
             client=self._server,
             model=model,
-            embedding_function=embedding_function,
+            embedding_function=collection_embedding_function,
             data_loader=data_loader,
         )
 

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -228,6 +228,16 @@ class Client(SharedSystemClient, ClientAPI):
         if embedding_function is not None and configuration_ef is None:
             configuration["embedding_function"] = embedding_function
 
+        # Prefer an explicitly trusted configuration EF over the default so
+        # create()+add() still works after CollectionCommon refuses to auto-
+        # execute non-default persisted embedding configs.
+        collection_embedding_function = embedding_function
+        if configuration_ef is not None and (
+            embedding_function is None
+            or isinstance(embedding_function, DefaultEmbeddingFunction)
+        ):
+            collection_embedding_function = configuration_ef
+
         model = self._server.create_collection(
             name=name,
             schema=schema,
@@ -240,7 +250,7 @@ class Client(SharedSystemClient, ClientAPI):
         return Collection(
             client=self._server,
             model=model,
-            embedding_function=embedding_function,
+            embedding_function=collection_embedding_function,
             data_loader=data_loader,
         )
 
@@ -367,6 +377,14 @@ class Client(SharedSystemClient, ClientAPI):
 
         if embedding_function is not None and configuration_ef is None:
             configuration["embedding_function"] = embedding_function
+
+        collection_embedding_function = embedding_function
+        if configuration_ef is not None and (
+            embedding_function is None
+            or isinstance(embedding_function, DefaultEmbeddingFunction)
+        ):
+            collection_embedding_function = configuration_ef
+
         model = self._server.get_or_create_collection(
             name=name,
             schema=schema,
@@ -379,13 +397,13 @@ class Client(SharedSystemClient, ClientAPI):
         persisted_ef_config = model.configuration_json.get("embedding_function")
 
         validate_embedding_function_conflict_on_get(
-            embedding_function, persisted_ef_config
+            collection_embedding_function, persisted_ef_config
         )
 
         return Collection(
             client=self._server,
             model=model,
-            embedding_function=embedding_function,
+            embedding_function=collection_embedding_function,
             data_loader=data_loader,
         )
 

--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -752,6 +752,22 @@ class CollectionCommon(Generic[ClientT]):
             else:
                 return self._embedding_function(input=input)
 
+        # Do not hydrate / execute a persisted non-default EF from untrusted
+        # configuration_json. Use configuration_json (not .configuration) so we
+        # never call build_from_config before this check (#6717 client RCE).
+        persisted_ef_config = self.configuration_json.get("embedding_function")
+        if (
+            persisted_ef_config is not None
+            and persisted_ef_config.get("type") != "legacy"
+            and persisted_ef_config.get("name") not in (None, "default")
+        ):
+            raise ValueError(
+                "An explicit embedding function is required to compute embeddings "
+                "for collections with a non-default embedding function in their "
+                "configuration. Provide an embedding_function when retrieving the "
+                "collection, or provide embeddings directly."
+            )
+
         config_ef = self.configuration.get("embedding_function")
         if config_ef is not None:
             if is_query:

--- a/chromadb/test/utils/test_embedding_function_config_validation.py
+++ b/chromadb/test/utils/test_embedding_function_config_validation.py
@@ -1,4 +1,6 @@
 from typing import Any, Dict, List
+from uuid import uuid4
+import sys
 
 import pytest
 
@@ -7,7 +9,9 @@ from chromadb.api.collection_configuration import (
     load_create_collection_configuration_from_json,
     load_update_collection_configuration_from_json,
 )
+from chromadb.api.models.Collection import Collection
 from chromadb.api.types import (
+    DefaultEmbeddingFunction,
     Documents,
     Embeddings,
     EmbeddingFunction,
@@ -15,6 +19,7 @@ from chromadb.api.types import (
     SparseEmbeddingFunction,
     SparseVector,
 )
+from chromadb.types import Collection as CollectionModel
 from chromadb.utils.embedding_functions import (
     known_embedding_functions,
     sparse_known_embedding_functions,
@@ -22,6 +27,9 @@ from chromadb.utils.embedding_functions import (
 from chromadb.utils.embedding_functions.config_validation import (
     validate_embedding_function_config_is_safe,
     validate_embedding_function_kwargs_are_safe,
+)
+from chromadb.utils.embedding_functions.sentence_transformer_embedding_function import (
+    SentenceTransformerEmbeddingFunction,
 )
 
 LOCAL_MODEL_LOADERS = [
@@ -255,3 +263,70 @@ def test_schema_deserialize_drops_sparse_nested_trust_remote_code(
         schema.defaults.sparse_vector.sparse_vector_index.config.embedding_function
         is None
     )
+
+
+def test_sentence_transformer_forces_trust_remote_code_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin trust_remote_code=False even when constructing with empty kwargs."""
+    captured: Dict[str, Any] = {}
+
+    class FakeSentenceTransformer:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            captured.update(kwargs)
+            del args
+
+    class FakeModule:
+        SentenceTransformer = FakeSentenceTransformer
+
+    monkeypatch.setitem(sys.modules, "sentence_transformers", FakeModule)  # type: ignore[arg-type]
+    # Reset cached models so construction is re-run.
+    SentenceTransformerEmbeddingFunction.models.clear()
+    SentenceTransformerEmbeddingFunction(model_name="unit-test-model")
+    assert captured.get("trust_remote_code") is False
+
+
+def test_default_client_embedding_does_not_execute_persisted_non_default_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clients must not auto-build persisted non-default EFs (#6717 client RCE)."""
+    ExplodingEmbeddingFunction.build_calls = 0
+    monkeypatch.setitem(
+        known_embedding_functions,
+        "sentence_transformer",
+        ExplodingEmbeddingFunction,
+    )
+
+    # Payload without trust_remote_code: older servers may have stored this.
+    # Default clients must refuse to hydrate / execute it on embed.
+    poisoned_config = {
+        "embedding_function": {
+            "name": "sentence_transformer",
+            "type": "known",
+            "config": {
+                "model_name": "attacker/model",
+                "device": "cpu",
+                "normalize_embeddings": False,
+            },
+        }
+    }
+    model = CollectionModel(
+        id=uuid4(),
+        name="poisoned_collection",
+        configuration_json=poisoned_config,
+        serialized_schema=None,
+        metadata=None,
+        dimension=None,
+        tenant="default_tenant",
+        database="default_database",
+    )
+    collection = Collection(
+        client=None,  # type: ignore[arg-type]
+        model=model,
+        embedding_function=DefaultEmbeddingFunction(),
+    )
+
+    with pytest.raises(ValueError, match="explicit embedding function is required"):
+        collection._embed(input=["poison"])
+
+    assert ExplodingEmbeddingFunction.build_calls == 0

--- a/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
@@ -57,8 +57,13 @@ class HuggingFaceSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
         self.kwargs = kwargs
 
         if model_name not in self.models:
+            # Always pin trust_remote_code=False so remote model code cannot
+            # execute even if an earlier validation layer is bypassed.
             self.models[model_name] = SparseEncoder(
-                model_name_or_path=model_name, device=device, **kwargs
+                model_name_or_path=model_name,
+                device=device,
+                trust_remote_code=False,
+                **kwargs,
             )
         self._model = self.models[model_name]
 

--- a/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
+++ b/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
@@ -45,8 +45,13 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         self.kwargs = kwargs
 
         if model_name not in self.models:
+            # Always pin trust_remote_code=False so remote model code cannot
+            # execute even if an earlier validation layer is bypassed.
             self.models[model_name] = SentenceTransformer(
-                model_name_or_path=model_name, device=device, **kwargs
+                model_name_or_path=model_name,
+                device=device,
+                trust_remote_code=False,
+                **kwargs,
             )
         self._model = self.models[model_name]
 


### PR DESCRIPTION
## Summary
- Block default clients from auto-hydrating/executing persisted non-default embedding functions (CVE follow-up / #6717 client RCE path), checking `configuration_json` before `build_from_config`.
- Force `trust_remote_code=False` when constructing SentenceTransformer and SparseEncoder as defense in depth on top of #7237.
- Wire trusted configuration EFs on create/get_or_create so create→add still works when an EF is supplied at create time.

## Test plan
- [x] `pytest chromadb/test/utils/test_embedding_function_config_validation.py chromadb/test/server/test_fastapi_security.py` (80 passed)
- [ ] Confirm `get_collection()` without an explicit EF raises when embedding docs for a non-default persisted EF
- [ ] Confirm create_collection with configuration EF still supports immediate add()