### PR TITLE
Replace asyncio.iscoroutinefunction with inspect.iscoroutinefunction in telemetry

### DIFF
--- a/chromadb/telemetry/opentelemetry/__init__.py
+++ b/chromadb/telemetry/opentelemetry/__init__.py
@@ -1,4 +1,4 @@
-import asyncio
+import inspect
 import os
 from functools import wraps
 from enum import Enum
@@ -125,7 +125,7 @@ def trace_method(
     """A decorator that traces a method."""
 
     def decorator(f: T) -> T:
-        if asyncio.iscoroutinefunction(f):
+        if inspect.iscoroutinefunction(f):
 
             @wraps(f)
             async def async_wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]

--- a/chromadb/test/telemetry/test_opentelemetry.py
+++ b/chromadb/test/telemetry/test_opentelemetry.py
@@ -1,0 +1,38 @@
+import asyncio
+import inspect
+import warnings
+
+from chromadb.telemetry.opentelemetry import (
+    OpenTelemetryGranularity,
+    trace_method,
+)
+
+
+def test_trace_method_uses_inspect_for_coroutine_check() -> None:
+    """trace_method should use inspect.iscoroutinefunction, not asyncio.iscoroutinefunction.
+
+    asyncio.iscoroutinefunction is deprecated since Python 3.12 and scheduled for
+    removal in Python 3.16.
+    """
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+
+        @trace_method("sync_span", OpenTelemetryGranularity.NONE)
+        def sync_func() -> int:
+            return 1
+
+        @trace_method("async_span", OpenTelemetryGranularity.NONE)
+        async def async_func() -> int:
+            return 2
+
+        assert sync_func() == 1
+        assert inspect.iscoroutinefunction(async_func)
+        assert asyncio.run(async_func()) == 2
+
+    deprecation_warnings = [
+        warning
+        for warning in recorded
+        if issubclass(warning.category, DeprecationWarning)
+        and "iscoroutinefunction" in str(warning.message)
+    ]
+    assert not deprecation_warnings


### PR DESCRIPTION
Fixes #6729

Replaces the deprecated asyncio.iscoroutinefunction call in trace_method with inspect.iscoroutinefunction, which avoids the DeprecationWarning on Python 3.12+ and the upcoming AttributeError in Python 3.16. Adds a regression test to verify sync and async decorators still work without emitting the deprecation warning.