### PR TITLE
[ENH](foundation-api): harden wiki apply-patch and trajectory writes

### DIFF
--- a/rust/foundation-api/src/routes/apply_patch.rs
+++ b/rust/foundation-api/src/routes/apply_patch.rs
@@ -108,11 +108,30 @@ pub async fn foundation_apply_patch(
 
     request.validate().map_err(ChromaValidationError::from)?;
 
-    let response = run_apply_patch(&server, &headers, &tenant, &request).await?;
+    let response = match run_apply_patch(&server, &headers, &tenant, &request).await {
+        Ok(response) => response,
+        Err(err) => {
+            tracing::warn!(
+                tenant = %tenant,
+                slug = %request.slug,
+                code = ?err.code(),
+                error = %err,
+                "wiki apply-patch failed"
+            );
+            return Err(err.into());
+        }
+    };
     Ok(Json(response))
 }
 
 /// Reads, patches, and writes a wiki page through the upsert-page flow.
+#[tracing::instrument(
+    name = "foundation_run_apply_patch",
+    level = "debug",
+    skip_all,
+    fields(tenant = %tenant, slug = %request.slug, expected_version = ?request.expected_version),
+    err(Display)
+)]
 pub(crate) async fn run_apply_patch(
     server: &FoundationApiServer,
     headers: &HeaderMap,
@@ -124,6 +143,7 @@ pub(crate) async fn run_apply_patch(
         .ok_or_else(|| ApplyPatchError::MissingPage {
             slug: request.slug.clone(),
         })?;
+
     let patched = patch_page(page, request)?;
 
     let upsert = UpsertPageRequest {

--- a/rust/foundation-api/src/routes/apply_patch.rs
+++ b/rust/foundation-api/src/routes/apply_patch.rs
@@ -108,20 +108,10 @@ pub async fn foundation_apply_patch(
 
     request.validate().map_err(ChromaValidationError::from)?;
 
-    let response = match run_apply_patch(&server, &headers, &tenant, &request).await {
-        Ok(response) => response,
-        Err(err) => {
-            tracing::warn!(
-                tenant = %tenant,
-                slug = %request.slug,
-                code = ?err.code(),
-                error = %err,
-                "wiki apply-patch failed"
-            );
-            return Err(err.into());
-        }
-    };
-    Ok(Json(response))
+    match run_apply_patch(&server, &headers, &tenant, &request).await {
+        Ok(response) => Ok(Json(response)),
+        Err(err) => Err(err.into()),
+    }
 }
 
 /// Reads, patches, and writes a wiki page through the upsert-page flow.

--- a/rust/foundation-api/src/routes/read_page.rs
+++ b/rust/foundation-api/src/routes/read_page.rs
@@ -28,8 +28,7 @@ use validator::Validate;
 /// Request body for `POST /api/read-page`.
 #[derive(Debug, Deserialize, Validate)]
 pub struct ReadPageRequest {
-    /// Slug of the wiki page to reconstruct in full.
-    #[validate(length(min = 1, message = "slug must not be empty"))]
+    /// Slug of the wiki page to reconstruct in full. Empty string is the wiki root.
     pub slug: String,
 }
 
@@ -332,14 +331,14 @@ mod tests {
     }
 
     #[test]
-    fn read_page_request_rejects_empty_slug() {
+    fn read_page_request_allows_root_slug() {
         let valid: ReadPageRequest =
             serde_json::from_value(serde_json::json!({ "slug": "my-page" })).expect("deserialize");
         assert!(valid.validate().is_ok());
 
-        let empty: ReadPageRequest =
+        let root: ReadPageRequest =
             serde_json::from_value(serde_json::json!({ "slug": "" })).expect("deserialize");
-        assert!(empty.validate().is_err());
+        assert!(root.validate().is_ok());
     }
 
     #[test]

--- a/rust/foundation-api/src/routes/trajectories.rs
+++ b/rust/foundation-api/src/routes/trajectories.rs
@@ -377,6 +377,21 @@ mod tests {
                     write_state: crate::trajectories::WriteState::Finalized,
                 })
                 .code(),
+                TrajectoryRouteError::Trajectory(TrajectoryError::Chroma(
+                    ChromaHttpClientError::ConditionalTransactionError(
+                        chroma_types::ConditionalTransactionError::AddRequiresKnownAbsent {
+                            id: "entry-record".to_string(),
+                        },
+                    ),
+                ))
+                .code(),
+                TrajectoryRouteError::Trajectory(TrajectoryError::Chroma(
+                    ChromaHttpClientError::ApiError(
+                        "ConditionalWriteConflictError".to_string(),
+                        reqwest::StatusCode::CONFLICT,
+                    ),
+                ))
+                .code(),
             ],
             vec![
                 ErrorCodes::Internal,
@@ -390,6 +405,8 @@ mod tests {
                 ErrorCodes::InvalidArgument,
                 ErrorCodes::FailedPrecondition,
                 ErrorCodes::FailedPrecondition,
+                ErrorCodes::FailedPrecondition,
+                ErrorCodes::InvalidArgument,
                 ErrorCodes::FailedPrecondition,
             ]
         );

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -180,20 +180,10 @@ pub async fn foundation_upsert_page(
     request.validate().map_err(ChromaValidationError::from)?;
     let categories = normalize_categories(&request.categories);
 
-    let response = match run_upsert_page(&server, &headers, &tenant, &request, &categories).await {
-        Ok(response) => response,
-        Err(err) => {
-            tracing::warn!(
-                tenant = %tenant,
-                slug = %request.slug,
-                code = ?err.code(),
-                error = %err,
-                "wiki upsert-page failed"
-            );
-            return Err(err.into());
-        }
-    };
-    Ok(Json(response))
+    match run_upsert_page(&server, &headers, &tenant, &request, &categories).await {
+        Ok(response) => Ok(Json(response)),
+        Err(err) => Err(err.into()),
+    }
 }
 
 /// Runs the replace flow against the proxied wiki collection.

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -40,9 +40,11 @@ const DENSE_EMBED_BATCH_SIZE: usize = 100;
 /// upsert records; stale chunks are delete records.
 const MAX_TRANSACTION_WRITES: usize = 300;
 
-/// Read one past the write cap so an oversized existing page is detected
-/// without reading arbitrarily many ids.
-const PAGE_CHUNK_READ_LIMIT: u32 = MAX_TRANSACTION_WRITES as u32 + 1;
+/// Chroma Cloud caps `Get` limit at 300, matching the transaction write cap.
+/// Oversized existing pages are detected with a follow-up one-row read at this
+/// offset instead of asking Chroma for `limit=301`.
+const PAGE_CHUNK_READ_LIMIT: u32 = MAX_TRANSACTION_WRITES as u32;
+const PAGE_CHUNK_OVERFLOW_OFFSET: u32 = MAX_TRANSACTION_WRITES as u32;
 
 /// `^(?:[a-z0-9][a-z0-9-]*|category:[a-z0-9][a-z0-9-]*|)$` — the wiki slug
 /// shape (empty root, lowercase alnum/hyphen, or a `category:<slug>`). The
@@ -178,11 +180,30 @@ pub async fn foundation_upsert_page(
     request.validate().map_err(ChromaValidationError::from)?;
     let categories = normalize_categories(&request.categories);
 
-    let response = run_upsert_page(&server, &headers, &tenant, &request, &categories).await?;
+    let response = match run_upsert_page(&server, &headers, &tenant, &request, &categories).await {
+        Ok(response) => response,
+        Err(err) => {
+            tracing::warn!(
+                tenant = %tenant,
+                slug = %request.slug,
+                code = ?err.code(),
+                error = %err,
+                "wiki upsert-page failed"
+            );
+            return Err(err.into());
+        }
+    };
     Ok(Json(response))
 }
 
 /// Runs the replace flow against the proxied wiki collection.
+#[tracing::instrument(
+    name = "foundation_run_upsert_page",
+    level = "debug",
+    skip_all,
+    fields(tenant = %tenant, slug = %request.slug, expected_version = request.expected_version),
+    err(Display)
+)]
 pub(crate) async fn run_upsert_page(
     server: &FoundationApiServer,
     headers: &HeaderMap,
@@ -229,7 +250,26 @@ pub(crate) async fn run_upsert_page(
         ),
     )
     .await?;
-    if existing.ids.len() > MAX_TRANSACTION_WRITES {
+    if existing.ids.len() == MAX_TRANSACTION_WRITES {
+        let overflow = record_op(
+            wiki_client,
+            tenant,
+            txn.get(
+                None,
+                Some(where_slug(slug)),
+                Some(1),
+                Some(PAGE_CHUNK_OVERFLOW_OFFSET),
+                Some(IncludeList(vec![Include::Metadata])),
+            ),
+        )
+        .await?;
+        if !overflow.ids.is_empty() {
+            return Err(UpsertPageError::TooManyTransactionWrites {
+                writes: MAX_TRANSACTION_WRITES + 1,
+                limit: MAX_TRANSACTION_WRITES,
+            });
+        }
+    } else if existing.ids.len() > MAX_TRANSACTION_WRITES {
         return Err(UpsertPageError::TooManyTransactionWrites {
             writes: existing.ids.len(),
             limit: MAX_TRANSACTION_WRITES,
@@ -645,6 +685,12 @@ mod tests {
             vec!["a".to_string(), "b".to_string()]
         );
         assert_eq!(normalize_categories(&[]), Vec::<String>::new());
+    }
+
+    #[test]
+    fn page_chunk_read_limit_stays_within_chroma_get_limit() {
+        assert_eq!(PAGE_CHUNK_READ_LIMIT as usize, MAX_TRANSACTION_WRITES);
+        assert_eq!(PAGE_CHUNK_OVERFLOW_OFFSET as usize, MAX_TRANSACTION_WRITES);
     }
 
     #[test]

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -595,6 +595,15 @@ pub(crate) fn normalize_categories(categories: &[String]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::FoundationApiConfig;
+    use crate::routes::CHROMA_TOKEN_HEADER;
+    use axum::http::HeaderValue;
+    use chroma_sysdb::{SysDb, TestSysDb};
+    use chroma_system::System;
+    use chroma_types::{Collection, CollectionUuid};
+    use httpmock::MockServer;
+    use serde_json::{json, Value};
+    use std::sync::Arc;
 
     fn request(
         slug: &str,
@@ -610,6 +619,54 @@ mod tests {
             reason: None,
             expected_version: 0,
         }
+    }
+
+    fn test_server(frontend_ingress_url: String) -> FoundationApiServer {
+        let mut config = FoundationApiConfig::default();
+        config.foundation.frontend_ingress_url = Some(frontend_ingress_url);
+
+        FoundationApiServer::new(
+            config,
+            Arc::new(()),
+            SysDb::Test(TestSysDb::new()),
+            vec![],
+            System::new(),
+        )
+    }
+
+    fn wiki_collection() -> Collection {
+        Collection {
+            collection_id: CollectionUuid::default(),
+            name: "wiki".to_string(),
+            tenant: "tenant".to_string(),
+            database: "FOUNDATION".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn collection_path(collection: &Collection, suffix: &str) -> String {
+        format!(
+            "/api/v2/tenants/{}/databases/{}/collections/{}/{}",
+            collection.tenant, collection.database, collection.collection_id, suffix
+        )
+    }
+
+    fn conditional_get_response(ids: Vec<String>) -> Value {
+        json!({
+            "ids": ids,
+            "embeddings": null,
+            "documents": null,
+            "uris": null,
+            "metadatas": null,
+            "include": ["metadatas"],
+            "read_token": 42,
+        })
+    }
+
+    fn chunk_ids(slug: &str, count: usize) -> Vec<String> {
+        (0..count)
+            .map(|chunk_id| ChunkRecordId::new(slug, chunk_id).to_string())
+            .collect()
     }
 
     fn chunk_meta(chunk_id: i64, version: Option<i64>) -> Metadata {
@@ -707,6 +764,118 @@ mod tests {
             }
         ));
         assert_eq!(err.code(), ErrorCodes::ResourceExhausted);
+    }
+
+    #[tokio::test]
+    async fn run_upsert_page_rejects_non_empty_overflow_read() {
+        let mock_server = MockServer::start_async().await;
+        let server = test_server(mock_server.base_url());
+        let collection = wiki_collection();
+        let slug = "foo";
+        let chunk0 = ChunkRecordId::new(slug, 0).to_string();
+        let where_slug_json = serde_json::to_value(where_slug(slug)).expect("serialize where");
+        let mut headers = HeaderMap::new();
+        headers.insert(CHROMA_TOKEN_HEADER, HeaderValue::from_static("user-token"));
+
+        let get_collection_path = format!(
+            "/api/v2/tenants/{}/databases/{}/collections/{}",
+            collection.tenant, collection.database, collection.name
+        );
+        let get_collection_body =
+            serde_json::to_value(collection.clone()).expect("serialize collection");
+        let get_collection_mock = mock_server
+            .mock_async(move |when, then| {
+                when.method("GET").path(get_collection_path);
+                then.status(200).json_body(get_collection_body.clone());
+            })
+            .await;
+
+        let conditional_get_path = collection_path(&collection, "conditional/get");
+        let chunk0_get_path = conditional_get_path.clone();
+        let chunk0_get = chunk0.clone();
+        let chunk0_get_mock = mock_server
+            .mock_async(move |when, then| {
+                when.method("POST").path(chunk0_get_path).json_body(json!({
+                    "ids": [chunk0_get],
+                    "where": null,
+                    "where_document": null,
+                    "limit": null,
+                    "offset": 0,
+                    "include": ["metadatas"],
+                    "read_token": null,
+                }));
+                then.status(200)
+                    .json_body(conditional_get_response(vec![chunk0.clone()]));
+            })
+            .await;
+
+        let existing_get_path = conditional_get_path.clone();
+        let existing_where = where_slug_json.clone();
+        let existing_get_mock = mock_server
+            .mock_async(move |when, then| {
+                when.method("POST")
+                    .path(existing_get_path)
+                    .json_body(json!({
+                        "ids": null,
+                        "where": existing_where,
+                        "where_document": null,
+                        "limit": PAGE_CHUNK_READ_LIMIT,
+                        "offset": 0,
+                        "include": ["metadatas"],
+                        "read_token": 42,
+                    }));
+                then.status(200)
+                    .json_body(conditional_get_response(chunk_ids(
+                        slug,
+                        MAX_TRANSACTION_WRITES,
+                    )));
+            })
+            .await;
+
+        let overflow_get_mock = mock_server
+            .mock_async(move |when, then| {
+                when.method("POST")
+                    .path(conditional_get_path)
+                    .json_body(json!({
+                        "ids": null,
+                        "where": where_slug_json,
+                        "where_document": null,
+                        "limit": 1,
+                        "offset": PAGE_CHUNK_OVERFLOW_OFFSET,
+                        "include": ["metadatas"],
+                        "read_token": 42,
+                    }));
+                then.status(200)
+                    .json_body(conditional_get_response(vec![ChunkRecordId::new(
+                        slug,
+                        MAX_TRANSACTION_WRITES,
+                    )
+                    .to_string()]));
+            })
+            .await;
+
+        let err = run_upsert_page(
+            &server,
+            &headers,
+            "tenant",
+            &request(slug, "# Title\n\nBody", &[], &[]),
+            &[],
+        )
+        .await
+        .expect_err("overflow read should reject the upsert");
+
+        assert!(matches!(
+            err,
+            UpsertPageError::TooManyTransactionWrites {
+                writes: 301,
+                limit: MAX_TRANSACTION_WRITES,
+            }
+        ));
+        assert_eq!(err.code(), ErrorCodes::ResourceExhausted);
+        assert_eq!(get_collection_mock.calls(), 1);
+        assert_eq!(chunk0_get_mock.calls(), 1);
+        assert_eq!(existing_get_mock.calls(), 1);
+        assert_eq!(overflow_get_mock.calls(), 1);
     }
 
     #[test]

--- a/rust/foundation-api/src/trajectories/error.rs
+++ b/rust/foundation-api/src/trajectories/error.rs
@@ -165,7 +165,7 @@ impl ChromaError for TrajectoryError {
             TrajectoryError::NotOpen { .. }
             | TrajectoryError::EntryCountMismatch { .. }
             | TrajectoryError::FinalizedRequired { .. } => ErrorCodes::FailedPrecondition,
-            TrajectoryError::Chroma(_) => ErrorCodes::Internal,
+            TrajectoryError::Chroma(err) => chroma_client_error_code(err),
             TrajectoryError::Json(_)
             | TrajectoryError::Utf8(_)
             | TrajectoryError::IntConversion(_)
@@ -178,6 +178,28 @@ impl ChromaError for TrajectoryError {
             | TrajectoryError::HashMismatch { .. } => ErrorCodes::InvalidArgument,
         }
     }
+}
+
+fn chroma_client_error_code(err: &ChromaHttpClientError) -> ErrorCodes {
+    match err {
+        ChromaHttpClientError::ValidationError(err) => err.code(),
+        ChromaHttpClientError::ConditionalTransactionError(err) => err.code(),
+        ChromaHttpClientError::StaleReadError(err) => err.code(),
+        ChromaHttpClientError::ApiError(message, status) => {
+            if is_conditional_conflict(message, *status) {
+                ErrorCodes::FailedPrecondition
+            } else {
+                ErrorCodes::from(*status)
+            }
+        }
+        _ => ErrorCodes::Internal,
+    }
+}
+
+fn is_conditional_conflict(message: &str, status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::PRECONDITION_FAILED
+        || (status == reqwest::StatusCode::CONFLICT
+            && (message.contains("conditional") || message.contains("ConditionalWriteConflict")))
 }
 
 impl TrajectoryError {

--- a/rust/foundation-api/src/trajectories/tests.rs
+++ b/rust/foundation-api/src/trajectories/tests.rs
@@ -371,6 +371,20 @@ fn reasoning_file_deserializes_from_pruned_json() -> TestResult {
     Ok(())
 }
 
+/// Construct citations that include the empty wiki root slug everywhere slugs
+/// are used as durable logical keys.
+fn sample_citations_with_root_slug() -> Citations {
+    Citations {
+        input_ids: Vec::new(),
+        surfaced_page_ids: vec!["wiki_master:".to_string()],
+        read_page_ids: vec!["wiki_master:".to_string()],
+        final_citations: BTreeMap::from([(
+            String::new(),
+            json!(["wiki_master:", "slack_master:source"]),
+        )]),
+    }
+}
+
 #[test]
 /// Verifies that UUIDs round-trip through trajectory id encoding.
 fn uuid_tid_roundtrips() -> TestResult {
@@ -623,6 +637,26 @@ fn citations_roundtrip_deduplicates_and_orders() -> TestResult {
 }
 
 #[test]
+/// Verifies the empty wiki root slug is a valid citation key.
+fn citations_roundtrip_root_slug() -> TestResult {
+    let tid = uuid_to_tid(Uuid::parse_str("00000000-0000-0000-0000-000000000016")?)?;
+    let citations = sample_citations_with_root_slug();
+    let mut records = Vec::new();
+    write_citations(&mut records, &tid, &citations)?;
+    let documents = documents_from_records(&records);
+
+    assert!(
+        documents.contains_key(&format!(
+            "gt/{tid}/citations/final_citations/{}/metadata",
+            sha256_base36(b"")?
+        )),
+        "root slug final citation should be keyed by the hash of empty bytes"
+    );
+    assert_eq!(read_citations(&documents, &tid)?, citations);
+    Ok(())
+}
+
+#[test]
 /// Verifies empty citation records round-trip to the complete empty shape.
 fn empty_citations_roundtrip_to_complete_empty_shape() -> TestResult {
     let tid = uuid_to_tid(Uuid::parse_str("00000000-0000-0000-0000-000000000008")?)?;
@@ -735,6 +769,22 @@ fn save_and_load_finalized_file_roundtrips_pruned_data() -> TestResult {
 
     let documents = documents_from_records(&records);
     let loaded = load_one_from_documents(&documents, file.trajectory.id, true)?;
+    assert_eq!(loaded, file);
+    Ok(())
+}
+
+#[test]
+/// Verifies trajectory storage preserves root-slug writes and citations.
+fn save_and_load_file_with_root_slug_roundtrips() -> TestResult {
+    let id = Uuid::parse_str("00000000-0000-0000-0000-000000000017")?;
+    let mut file = sample_file(id);
+    file.citations = Some(sample_citations_with_root_slug());
+    file.trajectory.entries = vec![reasoning_entry(Some("read root".to_string()), &[""])];
+
+    let records = records_for_file(&file, WriteState::Finalized)?;
+    let documents = documents_from_records(&records);
+    let loaded = load_one_from_documents(&documents, file.trajectory.id, true)?;
+
     assert_eq!(loaded, file);
     Ok(())
 }
@@ -892,6 +942,103 @@ async fn create_open_trajectory_reads_absence_before_add() -> TestResult {
 
     assert_eq!(result.record_count, 1);
     assert_eq!(get_mock.calls(), 1);
+    assert_eq!(commit_mock.calls(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+/// Verifies transactional appends update headers after adding root-slug entries.
+async fn append_open_trajectory_with_root_slug_commits() -> TestResult {
+    let server = MockServer::start_async().await;
+    let collection = mocked_collection(&server);
+    let id = Uuid::parse_str("00000000-0000-0000-0000-000000000018")?;
+    let entries = vec![reasoning_entry(Some("read root".to_string()), &[""])];
+    let mut file = sample_file(id);
+    file.trajectory.entries.clear();
+    file.citations = None;
+
+    let tid = uuid_to_tid(file.trajectory.id)?;
+    let header_key = trajectory_header_key(file.trajectory.id)?;
+    let header_document = records_for_file(&file, WriteState::Open)?
+        .into_iter()
+        .find(|record| record.id == header_key)
+        .ok_or_else(|| test_error(format!("missing header record {header_key}")))?
+        .document;
+
+    let mut entry_records = Vec::new();
+    for (index, entry) in entries.iter().enumerate() {
+        collect_entry_records(&mut entry_records, &tid, index, entry)?;
+    }
+    let entry_ids = entry_records
+        .iter()
+        .map(|record| record.id.clone())
+        .collect::<Vec<_>>();
+
+    let get_path = collection_path(&collection, "conditional/get");
+    let commit_path = collection_path(&collection, "conditional/commit");
+
+    let header_get_mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path(&get_path).json_body(json!({
+                "ids": [header_key],
+                "where": null,
+                "where_document": null,
+                "limit": 1,
+                "offset": 0,
+                "include": ["documents", "metadatas"],
+                "read_token": null,
+            }));
+            then.status(200).json_body(json!({
+                "ids": [header_key],
+                "embeddings": null,
+                "documents": [header_document],
+                "uris": null,
+                "metadatas": null,
+                "include": ["documents", "metadatas"],
+                "read_token": 42,
+            }));
+        })
+        .await;
+    let absence_get_mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path(&get_path).json_body(json!({
+                "ids": entry_ids,
+                "where": null,
+                "where_document": null,
+                "limit": null,
+                "offset": 0,
+                "include": [],
+                "read_token": 42,
+            }));
+            then.status(200).json_body(json!({
+                "ids": [],
+                "embeddings": null,
+                "documents": null,
+                "uris": null,
+                "metadatas": null,
+                "include": [],
+                "read_token": 42,
+            }));
+        })
+        .await;
+    let commit_mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path(commit_path);
+            then.status(200).json_body(json!({
+                "first_inserted_record_offset": 19,
+                "record_count": entry_records.len() + 1,
+            }));
+        })
+        .await;
+
+    let mut txn = collection.conditional();
+    let next_entry = chroma_extend_open_trajectory_at(&mut txn, id, 0, &entries).await?;
+    let result = txn.commit().await?;
+
+    assert_eq!(next_entry, entries.len());
+    assert_eq!(result.record_count, entry_records.len() + 1);
+    assert_eq!(header_get_mock.calls(), 1);
+    assert_eq!(absence_get_mock.calls(), 1);
     assert_eq!(commit_mock.calls(), 1);
     Ok(())
 }


### PR DESCRIPTION
## Description of changes

Self-review pass on the atomic wiki apply-patch flow:

- Allow the empty root slug in read-page requests and cover it in
  citation, file round-trip, and open-trajectory append tests.

- Keep page-chunk reads within the Chroma Cloud Get limit of 300.
  Detect oversized existing pages with a follow-up one-row read at the
  overflow offset instead of requesting limit=301.

- Map wrapped Chroma client errors to precise ErrorCodes in
  TrajectoryError, translating conditional-write conflicts to
  FailedPrecondition and validation errors to InvalidArgument.

- Log apply-patch and upsert-page failures with tenant, slug, and
  error code, and instrument the run helpers for tracing.

## Test plan

CI + local ingest passed

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
