### PR TITLE
[ENH](foundation-api): stamp last_written_by on wiki writes

### DIFF
--- a/rust/foundation-api/src/agent_tools/read_page_tool.rs
+++ b/rust/foundation-api/src/agent_tools/read_page_tool.rs
@@ -108,6 +108,7 @@ mod tests {
             source_ids: Vec::new(),
             version: 7,
             updated_at: Some(1700),
+            last_written_by: None,
             content: "# Welcome\nBody text.".to_string(),
             url: url.map(str::to_string),
         }

--- a/rust/foundation-api/src/routes/apply_patch.rs
+++ b/rust/foundation-api/src/routes/apply_patch.rs
@@ -43,9 +43,17 @@ pub struct ApplyPatchRequest {
     /// patches the current version it just read.
     pub expected_version: Option<u32>,
     /// Optional caller-supplied reason for this change. Forwarded to
-    /// `/api/upsert-page`, which logs only presence.
+    /// `/api/upsert-page` but not persisted on the page.
     #[validate(length(max = 350, message = "reason must be at most 350 characters"))]
     pub reason: Option<String>,
+    /// Identifier of the trajectory that produced this patch. Forwarded to
+    /// `/api/upsert-page` and stamped onto page and revision metadata.
+    #[validate(length(
+        min = 1,
+        max = 128,
+        message = "last_written_by must be 1 to 128 characters"
+    ))]
+    pub last_written_by: String,
 }
 
 /// Response body for `POST /api/apply-patch`.
@@ -142,6 +150,7 @@ pub(crate) async fn run_apply_patch(
         source_ids: patched.source_ids,
         categories: patched.categories,
         reason: request.reason.clone(),
+        last_written_by: request.last_written_by.clone(),
         expected_version: request.expected_version.unwrap_or(patched.base_version),
     };
     let categories = normalize_categories(&upsert.categories);
@@ -225,6 +234,7 @@ mod tests {
             source_ids: vec!["slack_master:old".to_string()],
             version: 7,
             updated_at: Some(1700),
+            last_written_by: Some("00000000-0000-0000-0000-000000000000".to_string()),
             content: content.to_string(),
             url: None,
         }
@@ -242,6 +252,7 @@ mod tests {
             categories: vec!["product".to_string(), "infra".to_string()],
             expected_version: None,
             reason: None,
+            last_written_by: "00000000-0000-0000-0000-000000000001".to_string(),
         }
     }
 
@@ -299,5 +310,9 @@ mod tests {
         let mut invalid_category = request("Old", "New");
         invalid_category.categories = vec!["BadCategory".to_string()];
         assert!(invalid_category.validate().is_err());
+
+        let mut missing_writer = request("Old", "New");
+        missing_writer.last_written_by.clear();
+        assert!(missing_writer.validate().is_err());
     }
 }

--- a/rust/foundation-api/src/routes/read_page.rs
+++ b/rust/foundation-api/src/routes/read_page.rs
@@ -46,6 +46,8 @@ pub(crate) struct FoundationPage {
     pub source_ids: Vec<String>,
     pub version: u32,
     pub updated_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_written_by: Option<String>,
     pub content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -230,6 +232,7 @@ fn assemble_page(slug: &str, mut chunks: Vec<(String, Metadata)>) -> Option<Foun
             .and_then(|version| u32::try_from(version).ok())
             .unwrap_or(0),
         updated_at: meta_int(head, "updated_at"),
+        last_written_by: meta_str(head, "last_written_by"),
         content,
         url: None,
     })
@@ -247,6 +250,10 @@ mod tests {
             MetadataValue::Str("My Page".to_string()),
         );
         meta.insert("updated_at".to_string(), MetadataValue::Int(1700));
+        meta.insert(
+            "last_written_by".to_string(),
+            MetadataValue::Str("00000000-0000-0000-0000-000000000001".to_string()),
+        );
         meta.insert(
             "categories".to_string(),
             MetadataValue::StringArray(vec!["eng".to_string()]),
@@ -275,6 +282,10 @@ mod tests {
         assert_eq!(page.source_ids, vec!["slack_master:abc".to_string()]);
         assert_eq!(page.version, 7);
         assert_eq!(page.updated_at, Some(1700));
+        assert_eq!(
+            page.last_written_by,
+            Some("00000000-0000-0000-0000-000000000001".to_string())
+        );
         // Chunks are joined with no separator.
         assert_eq!(page.content, "hello world");
     }
@@ -290,6 +301,7 @@ mod tests {
         assert!(page.source_ids.is_empty());
         assert_eq!(page.version, 0);
         assert_eq!(page.updated_at, None);
+        assert_eq!(page.last_written_by, None);
     }
 
     #[test]

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -80,10 +80,17 @@ pub struct UpsertPageRequest {
     pub categories: Vec<String>,
     /// Optional caller-supplied reason for this change. Deliberately not
     /// persisted on the page: the text can be large and may carry sensitive
-    /// context, so we only log that a reason was supplied (not its content) as
-    /// an audit signal.
+    /// context.
     #[validate(length(max = 350, message = "reason must be at most 350 characters"))]
     pub reason: Option<String>,
+    /// Identifier of the trajectory that produced this page write. Stamped on
+    /// every chunk as `last_written_by` and copied into revision history.
+    #[validate(length(
+        min = 1,
+        max = 128,
+        message = "last_written_by must be 1 to 128 characters"
+    ))]
+    pub last_written_by: String,
     /// The version the caller expects to be replacing: the page's current
     /// `version` on an update, or `0` when the caller expects to create a new
     /// page.
@@ -359,6 +366,7 @@ pub(crate) async fn run_upsert_page(
         i64::from(version),
         categories,
         &request.source_ids,
+        &request.last_written_by,
     );
 
     let doc_batch: Vec<Option<String>> = chunks
@@ -388,18 +396,6 @@ pub(crate) async fn run_upsert_page(
     }
 
     record_op(wiki_client, tenant, txn.commit()).await?;
-
-    // `reason` is logged as a presence flag only — never its content, which can
-    // be large and may leak sensitive context.
-    tracing::info!(
-        slug = %slug,
-        op,
-        version,
-        num_chunks,
-        expected_version = request.expected_version,
-        reason_provided = request.reason.is_some(),
-        "wiki upsert-page complete"
-    );
 
     Ok(UpsertPageResponse {
         slug: slug.to_string(),
@@ -607,6 +603,7 @@ mod tests {
             source_ids: source_ids.iter().map(|s| s.to_string()).collect(),
             categories: categories.iter().map(|s| s.to_string()).collect(),
             reason: None,
+            last_written_by: "00000000-0000-0000-0000-000000000001".to_string(),
             expected_version: 0,
         }
     }
@@ -963,6 +960,13 @@ mod tests {
         req.validate().unwrap();
 
         req.reason = Some("a".repeat(351));
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn request_validate_requires_last_written_by() {
+        let mut req = request("foo", "body", &[], &[]);
+        req.last_written_by.clear();
         assert!(req.validate().is_err());
     }
 }

--- a/rust/foundation-api/src/wiki/page.rs
+++ b/rust/foundation-api/src/wiki/page.rs
@@ -32,6 +32,7 @@ pub(crate) fn build_metadatas(
     version: i64,
     categories: &[String],
     source_ids: &[String],
+    last_written_by: &str,
 ) -> Vec<Metadata> {
     chunks
         .iter()
@@ -52,6 +53,10 @@ pub(crate) fn build_metadatas(
             meta.insert("created_at".to_string(), MetadataValue::Int(created_at));
             meta.insert("updated_at".to_string(), MetadataValue::Int(updated_at));
             meta.insert("version".to_string(), MetadataValue::Int(version));
+            meta.insert(
+                "last_written_by".to_string(),
+                MetadataValue::Str(last_written_by.to_string()),
+            );
             meta.insert(
                 SPARSE_KEY.to_string(),
                 MetadataValue::SparseVector(sparse_vec),
@@ -142,6 +147,7 @@ mod tests {
             3,
             &["a".to_string()],
             &["slack_master:abc".to_string()],
+            "00000000-0000-0000-0000-000000000001",
         );
 
         assert_eq!(metas.len(), 2);
@@ -157,6 +163,12 @@ mod tests {
         assert_eq!(first.get("created_at"), Some(&MetadataValue::Int(10)));
         assert_eq!(first.get("updated_at"), Some(&MetadataValue::Int(20)));
         assert_eq!(first.get("version"), Some(&MetadataValue::Int(3)));
+        assert_eq!(
+            first.get("last_written_by"),
+            Some(&MetadataValue::Str(
+                "00000000-0000-0000-0000-000000000001".to_string()
+            ))
+        );
         assert_eq!(
             first.get("categories"),
             Some(&MetadataValue::StringArray(vec!["a".to_string()]))
@@ -187,6 +199,7 @@ mod tests {
             1,
             &[],
             &[],
+            "00000000-0000-0000-0000-000000000001",
         );
 
         assert!(!metas[0].contains_key("categories"));

--- a/rust/worker/src/execution/functions/revision_history.rs
+++ b/rust/worker/src/execution/functions/revision_history.rs
@@ -645,7 +645,15 @@ mod tests {
         let records = vec![
             build_record(
                 "page-1",
-                HashMap::from([("version".to_string(), UpdateMetadataValue::Int(1))]),
+                HashMap::from([
+                    ("version".to_string(), UpdateMetadataValue::Int(1)),
+                    (
+                        "last_written_by".to_string(),
+                        UpdateMetadataValue::Str(
+                            "00000000-0000-0000-0000-000000000001".to_string(),
+                        ),
+                    ),
+                ]),
             ),
             build_record(
                 "page-2",
@@ -689,6 +697,12 @@ mod tests {
         assert_eq!(
             meta.get("original_id"),
             Some(&UpdateMetadataValue::Str("page-1".to_string()))
+        );
+        assert_eq!(
+            meta.get("last_written_by"),
+            Some(&UpdateMetadataValue::Str(
+                "00000000-0000-0000-0000-000000000001".to_string()
+            ))
         );
         assert!(meta.get("archived_at").is_some());
         assert_eq!(rev1.record.document.as_deref(), Some("doc content"));


### PR DESCRIPTION
## Description of changes

Thread a required last_written_by trajectory identifier through the
upsert-page and apply-patch routes so every wiki page write records
which trajectory produced it.

- Add last_written_by to UpsertPageRequest and ApplyPatchRequest,
  validated to 1-128 characters, and forward it from apply-patch.
- Stamp last_written_by onto every chunk's metadata in build_metadatas
  and surface it on FoundationPage reads.
- Copy last_written_by into revision-history metadata in the worker.
- Drop the reason presence log from upsert-page; reason is no longer
  persisted or logged.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
