### PR TITLE
[ENH](wal3): split batches on incompatible fragment start

### DIFF
--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -69,29 +69,43 @@ impl ManagerState {
     }
 }
 
-fn required_fragment_start_for_selected(
-    selected: &[AppendWork],
-) -> Result<Option<LogPosition>, Error> {
+fn required_fragment_start_for_selected(selected: &[AppendWork]) -> Option<LogPosition> {
     let mut required_fragment_start = None;
     for work in selected {
         let Some(next_required_fragment_start) = work.required_fragment_start() else {
             continue;
         };
         if let Some(required_fragment_start) = required_fragment_start {
+            debug_assert_eq!(required_fragment_start, next_required_fragment_start);
+        } else {
+            required_fragment_start = Some(next_required_fragment_start);
+        }
+    }
+    required_fragment_start
+}
+
+fn count_compatible_required_fragment_starts(selected: &[AppendWork]) -> usize {
+    let mut required_fragment_start = None;
+    for (index, work) in selected.iter().enumerate() {
+        let Some(next_required_fragment_start) = work.required_fragment_start() else {
+            continue;
+        };
+        if let Some(required_fragment_start) = required_fragment_start {
             if required_fragment_start != next_required_fragment_start {
-                tracing::error!(
+                tracing::info!(
                     ?required_fragment_start,
                     ?next_required_fragment_start,
                     selected_work_count = selected.len(),
-                    "selected wal3 batch has incompatible required_fragment_start values"
+                    compatible_work_count = index,
+                    "splitting wal3 batch on incompatible required_fragment_start"
                 );
-                return Err(Error::LogContentionRetry);
+                return index;
             }
         } else {
             required_fragment_start = Some(next_required_fragment_start);
         }
     }
-    Ok(required_fragment_start)
+    selected.len()
 }
 
 fn take_selected_work(state: &mut ManagerState, split_off: usize) -> Vec<AppendWork> {
@@ -272,18 +286,17 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
             self.write_finished.notify_one();
             return Ok(None);
         }
+        let compatible_split_off =
+            count_compatible_required_fragment_starts(&state.enqueued[..split_off]);
+        if compatible_split_off < split_off {
+            split_off = compatible_split_off;
+            acc_count = state.enqueued[..split_off]
+                .iter()
+                .map(AppendWork::record_count)
+                .sum();
+        }
         let required_fragment_start =
-            match required_fragment_start_for_selected(&state.enqueued[..split_off]) {
-                Ok(required_fragment_start) => required_fragment_start,
-                Err(err) => {
-                    let work = take_selected_work(&mut state, split_off);
-                    if refresh_backoff_after_split(&mut state, &self.options) {
-                        self.write_finished.notify_one();
-                    }
-                    reject_selected_work(work, err);
-                    return Ok(None);
-                }
-            };
+            required_fragment_start_for_selected(&state.enqueued[..split_off]);
         let Some(pointer) =
             state.select_for_write(&self.options.throttle_fragment, manifest_manager, acc_count)?
         else {
@@ -675,81 +688,6 @@ mod tests {
         rx
     }
 
-    struct PanickingS3ManifestPublisher;
-
-    #[async_trait::async_trait]
-    impl ManifestPublisher<(FragmentSeqNo, LogPosition)> for PanickingS3ManifestPublisher {
-        async fn recover(&mut self) -> Result<(), Error> {
-            unreachable!("recover is not used in required-start selection tests")
-        }
-
-        async fn manifest_and_witness(&self) -> Result<ManifestAndWitness, Error> {
-            unreachable!("manifest_and_witness is not used in required-start selection tests")
-        }
-
-        fn assign_timestamp(&self, _record_count: usize) -> Option<(FragmentSeqNo, LogPosition)> {
-            unreachable!("incompatible required starts should fail before timestamp assignment")
-        }
-
-        async fn publish_fragment(
-            &self,
-            _pointer: &(FragmentSeqNo, LogPosition),
-            _path: &str,
-            _messages_len: u64,
-            _num_bytes: u64,
-            _setsum: Setsum,
-            _required_fragment_start: Option<LogPosition>,
-            _successful_regions: &[String],
-        ) -> Result<LogPosition, Error> {
-            unreachable!("publish_fragment is not used in required-start selection tests")
-        }
-
-        async fn garbage_applies_cleanly(&self, _garbage: &Garbage) -> Result<bool, Error> {
-            unreachable!("garbage_applies_cleanly is not used in required-start selection tests")
-        }
-
-        async fn apply_garbage(&self, _garbage: Garbage) -> Result<(), Error> {
-            unreachable!("apply_garbage is not used in required-start selection tests")
-        }
-
-        async fn compute_garbage(
-            &self,
-            _options: &crate::GarbageCollectionOptions,
-            _first_to_keep: LogPosition,
-        ) -> Result<Option<Garbage>, Error> {
-            unreachable!("compute_garbage is not used in required-start selection tests")
-        }
-
-        async fn snapshot_load(
-            &self,
-            _pointer: &SnapshotPointer,
-        ) -> Result<Option<Snapshot>, Error> {
-            unreachable!("snapshot_load is not used in required-start selection tests")
-        }
-
-        async fn snapshot_install(&self, _snapshot: &Snapshot) -> Result<SnapshotPointer, Error> {
-            unreachable!("snapshot_install is not used in required-start selection tests")
-        }
-
-        async fn manifest_head(&self, _witness: &ManifestWitness) -> Result<bool, Error> {
-            unreachable!("manifest_head is not used in required-start selection tests")
-        }
-
-        async fn manifest_load(&self) -> Result<Option<(Manifest, ManifestWitness)>, Error> {
-            unreachable!("manifest_load is not used in required-start selection tests")
-        }
-
-        fn shutdown(&self) {}
-
-        async fn destroy(&self) -> Result<(), Error> {
-            unreachable!("destroy is not used in required-start selection tests")
-        }
-
-        async fn load_intrinsic_cursor(&self) -> Result<Option<LogPosition>, Error> {
-            unreachable!("load_intrinsic_cursor is not used in required-start selection tests")
-        }
-    }
-
     struct FixedS3ManifestPublisher {
         assigned_fragment_start: LogPosition,
     }
@@ -955,9 +893,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mismatched_required_fragment_starts_reject_selected_batch() {
+    async fn mismatched_required_fragment_starts_split_selected_batch() {
         let batch_manager = s3_batch_manager();
-        let first_rx = enqueue_s3(
+        let _first_rx = enqueue_s3(
             &batch_manager,
             Vec::from("first"),
             Some(
@@ -966,7 +904,7 @@ mod tests {
             ),
         )
         .await;
-        let second_rx = enqueue_s3(
+        let mut second_rx = enqueue_s3(
             &batch_manager,
             Vec::from("second"),
             Some(
@@ -977,23 +915,22 @@ mod tests {
         .await;
 
         let selected = batch_manager
-            .take_work(&PanickingS3ManifestPublisher)
+            .take_work(&FixedS3ManifestPublisher {
+                assigned_fragment_start: LogPosition::from_offset(10),
+            })
             .await
-            .expect("required-start rejection should not fail take_work");
+            .expect("required-start split should not fail take_work")
+            .expect("compatible prefix should be selected");
 
-        assert!(selected.is_none());
-        assert_eq!(0, batch_manager.count_waiters());
+        let ((_seq_no, log_position), required_fragment_start, work) = selected;
+        assert_eq!(LogPosition::from_offset(10), log_position);
+        assert_eq!(Some(LogPosition::from_offset(10)), required_fragment_start);
+        assert_eq!(1, work.len());
+        assert_eq!(vec![Vec::from("first")], work[0].messages);
+        assert_eq!(1, batch_manager.count_waiters());
         assert!(matches!(
-            first_rx
-                .await
-                .expect("first append should receive a result"),
-            Err(Error::LogContentionRetry)
-        ));
-        assert!(matches!(
-            second_rx
-                .await
-                .expect("second append should receive a result"),
-            Err(Error::LogContentionRetry)
+            second_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
         ));
     }
 

--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -69,43 +69,30 @@ impl ManagerState {
     }
 }
 
-fn required_fragment_start_for_selected(selected: &[AppendWork]) -> Option<LogPosition> {
-    let mut required_fragment_start = None;
-    for work in selected {
-        let Some(next_required_fragment_start) = work.required_fragment_start() else {
-            continue;
-        };
-        if let Some(required_fragment_start) = required_fragment_start {
-            debug_assert_eq!(required_fragment_start, next_required_fragment_start);
-        } else {
-            required_fragment_start = Some(next_required_fragment_start);
-        }
-    }
-    required_fragment_start
-}
-
-fn count_compatible_required_fragment_starts(selected: &[AppendWork]) -> usize {
-    let mut required_fragment_start = None;
+fn count_compatible_required_fragment_starts(
+    selected: &[AppendWork],
+) -> (usize, Option<LogPosition>) {
+    let mut required_fragment_start: Option<LogPosition> = None;
     for (index, work) in selected.iter().enumerate() {
         let Some(next_required_fragment_start) = work.required_fragment_start() else {
             continue;
         };
-        if let Some(required_fragment_start) = required_fragment_start {
-            if required_fragment_start != next_required_fragment_start {
+        if let Some(current_required_fragment_start) = required_fragment_start {
+            if current_required_fragment_start != next_required_fragment_start {
                 tracing::info!(
-                    ?required_fragment_start,
+                    required_fragment_start = ?current_required_fragment_start,
                     ?next_required_fragment_start,
                     selected_work_count = selected.len(),
                     compatible_work_count = index,
                     "splitting wal3 batch on incompatible required_fragment_start"
                 );
-                return index;
+                return (index, Some(current_required_fragment_start));
             }
         } else {
             required_fragment_start = Some(next_required_fragment_start);
         }
     }
-    selected.len()
+    (selected.len(), required_fragment_start)
 }
 
 fn take_selected_work(state: &mut ManagerState, split_off: usize) -> Vec<AppendWork> {
@@ -286,7 +273,7 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
             self.write_finished.notify_one();
             return Ok(None);
         }
-        let compatible_split_off =
+        let (compatible_split_off, required_fragment_start) =
             count_compatible_required_fragment_starts(&state.enqueued[..split_off]);
         if compatible_split_off < split_off {
             split_off = compatible_split_off;
@@ -295,8 +282,6 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
                 .map(AppendWork::record_count)
                 .sum();
         }
-        let required_fragment_start =
-            required_fragment_start_for_selected(&state.enqueued[..split_off]);
         let Some(pointer) =
             state.select_for_write(&self.options.throttle_fragment, manifest_manager, acc_count)?
         else {

--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -654,6 +654,18 @@ mod tests {
         BatchManager::new(LogWriterOptions::default(), NoopS3Uploader).unwrap()
     }
 
+    fn immediate_s3_batch_manager() -> BatchManager<(FragmentSeqNo, LogPosition), NoopS3Uploader> {
+        let options = LogWriterOptions {
+            throttle_fragment: ThrottleOptions {
+                throughput: 2_000_000,
+                batch_interval_us: 0,
+                ..ThrottleOptions::default()
+            },
+            ..LogWriterOptions::default()
+        };
+        BatchManager::new(options, NoopS3Uploader).unwrap()
+    }
+
     async fn enqueue(
         batch_manager: &BatchManager<FragmentUuid, NoopUploader>,
         message: Vec<u8>,
@@ -686,6 +698,91 @@ mod tests {
             ))
             .await;
         rx
+    }
+
+    async fn enqueue_s3_with_required_start(
+        batch_manager: &BatchManager<(FragmentSeqNo, LogPosition), NoopS3Uploader>,
+        message: &str,
+        required_fragment_start: Option<u64>,
+    ) -> tokio::sync::oneshot::Receiver<Result<LogPosition, Error>> {
+        let options = required_fragment_start.map(|offset| {
+            append_options(&[message])
+                .with_required_fragment_start(LogPosition::from_offset(offset))
+        });
+        enqueue_s3(batch_manager, Vec::from(message), options).await
+    }
+
+    async fn take_s3_work(
+        batch_manager: &BatchManager<(FragmentSeqNo, LogPosition), NoopS3Uploader>,
+        assigned_fragment_start: u64,
+    ) -> (
+        (FragmentSeqNo, LogPosition),
+        Option<LogPosition>,
+        Vec<AppendWork>,
+    ) {
+        batch_manager
+            .take_work(&FixedS3ManifestPublisher {
+                assigned_fragment_start: LogPosition::from_offset(assigned_fragment_start),
+            })
+            .await
+            .expect("required-start selection should not fail take_work")
+            .expect("compatible prefix should be selected")
+    }
+
+    fn assert_s3_work(
+        selected: (
+            (FragmentSeqNo, LogPosition),
+            Option<LogPosition>,
+            Vec<AppendWork>,
+        ),
+        assigned_fragment_start: u64,
+        required_fragment_start: Option<u64>,
+        messages: &[&str],
+    ) -> Vec<AppendWork> {
+        let ((seq_no, log_position), selected_required_fragment_start, work) = selected;
+        assert_eq!(FragmentSeqNo::BEGIN, seq_no);
+        assert_eq!(
+            LogPosition::from_offset(assigned_fragment_start),
+            log_position
+        );
+        assert_eq!(
+            required_fragment_start.map(LogPosition::from_offset),
+            selected_required_fragment_start
+        );
+        assert_eq!(messages.len(), work.len());
+        let selected_messages: Vec<Vec<Vec<u8>>> =
+            work.iter().map(|work| work.messages.clone()).collect();
+        let expected_messages: Vec<Vec<Vec<u8>>> = messages
+            .iter()
+            .map(|message| vec![Vec::from(*message)])
+            .collect();
+        assert_eq!(expected_messages, selected_messages);
+        work
+    }
+
+    async fn commit_s3_work(
+        batch_manager: &BatchManager<(FragmentSeqNo, LogPosition), NoopS3Uploader>,
+        mut log_position: LogPosition,
+        work: Vec<AppendWork>,
+    ) {
+        for work in work {
+            let record_count = work.record_count();
+            assert!(work.tx.send(Ok(log_position)).is_ok());
+            log_position += record_count;
+        }
+        batch_manager.finish_write().await;
+    }
+
+    async fn expect_committed(
+        rx: tokio::sync::oneshot::Receiver<Result<LogPosition, Error>>,
+        log_position: u64,
+    ) {
+        assert_eq!(
+            LogPosition::from_offset(log_position),
+            rx.await
+                .expect("append should receive a result")
+                .expect("append should commit")
+        );
     }
 
     struct FixedS3ManifestPublisher {
@@ -894,44 +991,92 @@ mod tests {
 
     #[tokio::test]
     async fn mismatched_required_fragment_starts_split_selected_batch() {
-        let batch_manager = s3_batch_manager();
-        let _first_rx = enqueue_s3(
-            &batch_manager,
-            Vec::from("first"),
-            Some(
-                append_options(&["first"])
-                    .with_required_fragment_start(LogPosition::from_offset(10)),
-            ),
-        )
-        .await;
-        let mut second_rx = enqueue_s3(
-            &batch_manager,
-            Vec::from("second"),
-            Some(
-                append_options(&["second"])
-                    .with_required_fragment_start(LogPosition::from_offset(11)),
-            ),
-        )
-        .await;
+        let batch_manager = immediate_s3_batch_manager();
+        let first_rx = enqueue_s3_with_required_start(&batch_manager, "first", Some(10)).await;
+        let mut second_rx =
+            enqueue_s3_with_required_start(&batch_manager, "second", Some(11)).await;
 
-        let selected = batch_manager
-            .take_work(&FixedS3ManifestPublisher {
-                assigned_fragment_start: LogPosition::from_offset(10),
-            })
-            .await
-            .expect("required-start split should not fail take_work")
-            .expect("compatible prefix should be selected");
-
-        let ((_seq_no, log_position), required_fragment_start, work) = selected;
-        assert_eq!(LogPosition::from_offset(10), log_position);
-        assert_eq!(Some(LogPosition::from_offset(10)), required_fragment_start);
-        assert_eq!(1, work.len());
-        assert_eq!(vec![Vec::from("first")], work[0].messages);
+        let work = assert_s3_work(
+            take_s3_work(&batch_manager, 10).await,
+            10,
+            Some(10),
+            &["first"],
+        );
         assert_eq!(1, batch_manager.count_waiters());
         assert!(matches!(
             second_rx.try_recv(),
             Err(tokio::sync::oneshot::error::TryRecvError::Empty)
         ));
+        commit_s3_work(&batch_manager, LogPosition::from_offset(10), work).await;
+        expect_committed(first_rx, 10).await;
+
+        let work = assert_s3_work(
+            take_s3_work(&batch_manager, 11).await,
+            11,
+            Some(11),
+            &["second"],
+        );
+        assert_eq!(0, batch_manager.count_waiters());
+        commit_s3_work(&batch_manager, LogPosition::from_offset(11), work).await;
+        expect_committed(second_rx, 11).await;
+    }
+
+    #[tokio::test]
+    async fn compatible_required_fragment_start_prefix_commits_before_requeue() {
+        let batch_manager = immediate_s3_batch_manager();
+        let first_rx = enqueue_s3_with_required_start(&batch_manager, "first", Some(10)).await;
+        let second_rx = enqueue_s3_with_required_start(&batch_manager, "second", Some(10)).await;
+        let third_rx = enqueue_s3_with_required_start(&batch_manager, "third", Some(20)).await;
+
+        let work = assert_s3_work(
+            take_s3_work(&batch_manager, 10).await,
+            10,
+            Some(10),
+            &["first", "second"],
+        );
+        assert_eq!(1, batch_manager.count_waiters());
+        commit_s3_work(&batch_manager, LogPosition::from_offset(10), work).await;
+        expect_committed(first_rx, 10).await;
+        expect_committed(second_rx, 11).await;
+
+        let work = assert_s3_work(
+            take_s3_work(&batch_manager, 20).await,
+            20,
+            Some(20),
+            &["third"],
+        );
+        assert_eq!(0, batch_manager.count_waiters());
+        commit_s3_work(&batch_manager, LogPosition::from_offset(20), work).await;
+        expect_committed(third_rx, 20).await;
+    }
+
+    #[tokio::test]
+    async fn none_required_fragment_start_between_mismatches_stays_with_prefix() {
+        let batch_manager = immediate_s3_batch_manager();
+        let first_rx = enqueue_s3_with_required_start(&batch_manager, "first", Some(10)).await;
+        let second_rx = enqueue_s3_with_required_start(&batch_manager, "second", None).await;
+        let third_rx = enqueue_s3_with_required_start(&batch_manager, "third", Some(20)).await;
+
+        let work = assert_s3_work(
+            take_s3_work(&batch_manager, 10).await,
+            10,
+            Some(10),
+            &["first", "second"],
+        );
+        assert_eq!(1, batch_manager.count_waiters());
+        commit_s3_work(&batch_manager, LogPosition::from_offset(10), work).await;
+        expect_committed(first_rx, 10).await;
+        expect_committed(second_rx, 11).await;
+
+        let work = assert_s3_work(
+            take_s3_work(&batch_manager, 20).await,
+            20,
+            Some(20),
+            &["third"],
+        );
+        assert_eq!(0, batch_manager.count_waiters());
+        commit_s3_work(&batch_manager, LogPosition::from_offset(20), work).await;
+        expect_committed(third_rx, 20).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description of changes

When a selected batch mixes incompatible required_fragment_start
values, take the compatible prefix and requeue the remainder instead of
rejecting the whole batch with LogContentionRetry. This lets compatible
work make progress rather than forcing every waiter to retry.

Split required_fragment_start_for_selected into a pure accessor plus
count_compatible_required_fragment_starts, which returns the length of
the compatible prefix, and truncate the batch accordingly before
selecting for write.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
