### PR TITLE
[CHORE](frontend): raise write scorecard score to 10

### DIFF
--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -75,7 +75,7 @@ scorecard:
   - patterns:
       - "op:write"
       - "collection:*"
-    score: 1
+    score: 10
 circuit_breaker:
   requests: 1000
 enable_span_indexing: true


### PR DESCRIPTION
## Description of changes

Bump the op:write scorecard rule score from 1 to 10 in the
distributed sample config.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
