### PR TITLE
[BUG]: reject operators as top-level where keys

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1195,10 +1195,21 @@ def validate_where(where: Where) -> None:
     for key, value in where.items():
         if not isinstance(key, str):
             raise ValueError(f"Expected where key to be a str, got {key}")
-        # $contains and $not_contains are only valid as operators within a
-        # field expression (e.g. {"field": {"$contains": val}}), not as
-        # top-level where keys.
-        if key in ("$contains", "$not_contains"):
+        # Query operators are only valid inside a field expression
+        # (e.g. {"field": {"$in": val}}), not as top-level where keys, where a
+        # metadata field name or a logical operator ($and, $or) is expected.
+        if key in (
+            "$gt",
+            "$gte",
+            "$lt",
+            "$lte",
+            "$ne",
+            "$eq",
+            "$in",
+            "$nin",
+            "$contains",
+            "$not_contains",
+        ):
             raise ValueError(
                 f"Expected where key to be a metadata field name or a logical "
                 f"operator ($and, $or), got {key}"
@@ -1206,8 +1217,6 @@ def validate_where(where: Where) -> None:
         if (
             key != "$and"
             and key != "$or"
-            and key != "$in"
-            and key != "$nin"
             and not isinstance(value, (str, int, float, dict))
         ):
             raise ValueError(

--- a/chromadb/test/api/test_types.py
+++ b/chromadb/test/api/test_types.py
@@ -103,3 +103,38 @@ def test_embedding_function_results_format_when_response_is_invalid() -> None:
         from chromadb.api.types import normalize_embeddings
 
         normalize_embeddings(result)
+
+
+@pytest.mark.parametrize(
+    "operator",
+    [
+        "$gt",
+        "$gte",
+        "$lt",
+        "$lte",
+        "$ne",
+        "$eq",
+        "$in",
+        "$nin",
+        "$contains",
+        "$not_contains",
+    ],
+)
+def test_validate_where_rejects_top_level_operator_key(operator: str) -> None:
+    # A query operator used where a metadata field name is expected (i.e. the
+    # user forgot the field name, e.g. {"$in": [1, 2]} instead of
+    # {"field": {"$in": [1, 2]}}) must be rejected, not silently accepted.
+    from chromadb.api.types import validate_where
+
+    operand: Any = [1, 2] if operator in ("$in", "$nin") else 1
+    with pytest.raises(ValueError):
+        validate_where({operator: operand})
+
+
+def test_validate_where_accepts_operator_in_field_expression() -> None:
+    # The same operators remain valid inside a field expression.
+    from chromadb.api.types import validate_where
+
+    validate_where({"age": {"$gt": 5}})
+    validate_where({"tag": {"$in": ["a", "b"]}})
+    validate_where({"$and": [{"age": {"$gt": 5}}, {"age": {"$lt": 10}}]})


### PR DESCRIPTION
## Description of changes

`validate_where` already rejects `$contains`/`$not_contains` when they appear as a **top-level** `where` key — a spot where a metadata field name or a logical operator (`$and`/`$or`) is expected. That guard exists precisely to catch the common typo of writing an operator where a field name belongs.

The remaining query operators leaked through, though:

```python
from chromadb.api.types import validate_where

validate_where({"$contains": "x"})   # ValueError (correct)
validate_where({"$in": [1, 2, 3]})   # silently ACCEPTED  ❌
validate_where({"$gt": 5})           # silently ACCEPTED  ❌
validate_where({"$eq": 5})           # silently ACCEPTED  ❌
```

Two things combined to let them slip:
- a scalar operand (e.g. `{"$gt": 5}`) satisfied the value type-check (`int` is allowed), and no later branch handled the operator-as-key case, so the function returned normally;
- `$in`/`$nin` were **explicitly excluded** from that value type-check (`and key != "$in" and key != "$nin"`), which is exactly what suppressed the type error their list operand would otherwise have raised.

So a user who forgets the field name — `collection.get(where={"$in": [1, 2]})` instead of `where={"field": {"$in": [1, 2]}}` — got no client-side error, unlike the analogous `{"$contains": ...}` typo which is caught with a clear message.

This PR extends the existing top-level-key guard to the full operator set (`$gt $gte $lt $lte $ne $eq $in $nin $contains $not_contains`) and drops the now-dead `$in`/`$nin` exclusion. Operators inside a field expression (`{"field": {"$in": [...]}}`) and `$and`/`$or` keys are unaffected.

## Test plan

Added `test_validate_where_rejects_top_level_operator_key` (parametrized over all ten operators) and `test_validate_where_accepts_operator_in_field_expression` to `chromadb/test/api/test_types.py`.

- On `main` the eight previously-leaking operators fail the new rejection assertions; with this change all ten are rejected and legitimate field/`$and`/`$or` filters still validate.
- `pytest chromadb/test/api/test_types.py` → 13 passed.
- `black --check` and `flake8` clean on both files.

---
Authored with assistance from Claude Code (Anthropic). Bug, fix, and tests were reviewed and verified locally by the contributor.