### PR TITLE
[ENH](frontend-core): Map granola to source kind

### DIFF
--- a/rust/frontend-core/src/foundation.rs
+++ b/rust/frontend-core/src/foundation.rs
@@ -28,6 +28,9 @@ pub fn source_kind_for_collection_name(
     if collection_name.contains("coding") || collection_name.contains("agent_sessions") {
         return Ok("coding_agent_session");
     }
+    if collection_name.contains("granola") {
+        return Ok("granola");
+    }
     Err(FoundationSourceKindError::UnknownSourceCollection(
         collection_name.to_string(),
     ))
@@ -93,6 +96,18 @@ mod tests {
         assert_eq!(
             source_kind_for_collection_name("agent_sessions_hammad").unwrap(),
             "coding_agent_session"
+        );
+    }
+
+    #[test]
+    fn detects_granola_source_kind() {
+        assert_eq!(
+            source_kind_for_collection_name("granola").unwrap(),
+            "granola"
+        );
+        assert_eq!(
+            source_kind_for_collection_name("granola_master").unwrap(),
+            "granola"
         );
     }
 }


### PR DESCRIPTION
## What

`source_kind_for_collection_name` — the function that tags each Foundation source collection with a "source kind" — did not recognize `granola`. This adds it.

## Why it matters

Foundation synthesizes ingested source collections (slack, notion, gdrive, coding-agent sessions) into a `wiki` collection. The synthesis worker asks `source_kind_for_collection_name` which kind a collection is, then hands its records to the generate service tagged with that kind. Granola was added as a synthesis input (config, #7362) but this mapping was never updated — so every granola record hit `UnknownSourceCollection` and errored **before** reaching the generate service. Granola notes ingest into `FOUNDATION/granola` fine, but none synthesize into the wiki.

## The change

Map any collection name containing `granola` to the `"granola"` source kind — the string the foundation-research generate service resolves to its new `GranolaParser`.

## Ships with

One half of a two-repo fix. The generate service needs the matching `GranolaParser`: **chroma-core/foundation-research#176**. Granola synthesis stays broken until **both** land and deploy (this worker rebuilt on the data plane + a foundation-research Modal deploy). Neither half alone regresses anything — granola already doesn't synthesize.

## Reference

`rust/frontend-core/src/foundation.rs` — the `granola` branch + a unit test (`detects_granola_source_kind`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
