### PR TITLE
Fix Qwen embedding function failing to reload with task=None

### DIFF
--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -86,6 +86,31 @@ class TestEmbeddingFunctionSchemas:
             config == new_config
         ), f"Configs don't match after recreation for {ef_name}"
 
+    def test_chroma_cloud_qwen_config_roundtrip_with_none_task(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """A Qwen EF created with task=None must survive a real get_config ->
+        build_from_config roundtrip. task is Optional in the signature and
+        docstring, nullable in the JSON schema, and get_config() emits it as
+        None, so a persisted collection using task=None must be able to reload.
+        (The parametrized roundtrip test above mocks build_from_config, so it
+        never exercised the real one.)"""
+        monkeypatch.setenv("CHROMA_API_KEY", "dummy-key")
+        from chromadb.utils.embedding_functions.chroma_cloud_qwen_embedding_function import (
+            ChromaCloudQwenEmbeddingFunction,
+            ChromaCloudQwenEmbeddingModel,
+        )
+
+        ef = ChromaCloudQwenEmbeddingFunction(
+            model=ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B, task=None
+        )
+        config = ef.get_config()
+        assert config["task"] is None
+        ChromaCloudQwenEmbeddingFunction.validate_config(config)
+        rebuilt = ChromaCloudQwenEmbeddingFunction.build_from_config(config)
+        assert rebuilt.task is None
+        assert rebuilt.model == ef.model
+
     def test_schema_required_fields(self) -> None:
         """Test that schemas enforce required fields"""
         for schema_name in get_available_schemas():

--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import List, Any, Callable, Dict
+from typing import List, Any, Callable, Dict, Optional
 from jsonschema import ValidationError
 from unittest.mock import MagicMock, create_autospec
 from chromadb.utils.embedding_functions.schemas import (
@@ -86,15 +86,20 @@ class TestEmbeddingFunctionSchemas:
             config == new_config
         ), f"Configs don't match after recreation for {ef_name}"
 
-    def test_chroma_cloud_qwen_config_roundtrip_with_none_task(
-        self, monkeypatch: MonkeyPatch
+    @pytest.mark.parametrize("task", [None, "", "nl_to_code"])
+    def test_chroma_cloud_qwen_config_real_build_roundtrip(
+        self, task: Optional[str], monkeypatch: MonkeyPatch
     ) -> None:
-        """A Qwen EF created with task=None must survive a real get_config ->
-        build_from_config roundtrip. task is Optional in the signature and
-        docstring, nullable in the JSON schema, and get_config() emits it as
-        None, so a persisted collection using task=None must be able to reload.
-        (The parametrized roundtrip test above mocks build_from_config, so it
-        never exercised the real one.)"""
+        """Every Qwen EF built via the public constructor must survive a real
+        get_config -> validate_config -> build_from_config roundtrip.
+
+        task is Optional in the signature and docstring ("If None or empty,
+        empty instructions will be used"), nullable in the JSON schema, and
+        emitted verbatim by get_config(), so task=None and task="" must reload
+        exactly like a normal task string. The parametrized roundtrip test
+        above mocks build_from_config, so it never exercised the real one --
+        which is where task=None used to raise on reload and brick the
+        persisted collection."""
         monkeypatch.setenv("CHROMA_API_KEY", "dummy-key")
         from chromadb.utils.embedding_functions.chroma_cloud_qwen_embedding_function import (
             ChromaCloudQwenEmbeddingFunction,
@@ -102,13 +107,14 @@ class TestEmbeddingFunctionSchemas:
         )
 
         ef = ChromaCloudQwenEmbeddingFunction(
-            model=ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B, task=None
+            model=ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B, task=task
         )
         config = ef.get_config()
-        assert config["task"] is None
+        assert config["task"] == task
         ChromaCloudQwenEmbeddingFunction.validate_config(config)
         rebuilt = ChromaCloudQwenEmbeddingFunction.build_from_config(config)
-        assert rebuilt.task is None
+        assert isinstance(rebuilt, ChromaCloudQwenEmbeddingFunction)
+        assert rebuilt.task == task
         assert rebuilt.model == ef.model
 
     def test_schema_required_fields(self) -> None:

--- a/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
+++ b/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
@@ -168,7 +168,10 @@ class ChromaCloudQwenEmbeddingFunction(EmbeddingFunction[Documents]):
         api_key_env_var = config.get("api_key_env_var")
 
         if model is None:
-            assert False, "Config is missing a required field"
+            # A raised exception (not `assert`) so the guard survives `python -O`,
+            # which strips asserts and would otherwise let a malformed config
+            # build a broken embedding function silently.
+            raise ValueError("Config is missing a required field: 'model'")
 
         # Deserialize instructions dict from string keys to enum keys
         deserialized_instructions = CHROMA_CLOUD_QWEN_DEFAULT_INSTRUCTIONS

--- a/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
+++ b/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
@@ -167,7 +167,7 @@ class ChromaCloudQwenEmbeddingFunction(EmbeddingFunction[Documents]):
         instructions = config.get("instructions")
         api_key_env_var = config.get("api_key_env_var")
 
-        if model is None or task is None:
+        if model is None:
             assert False, "Config is missing a required field"
 
         # Deserialize instructions dict from string keys to enum keys


### PR DESCRIPTION
### What / why

`ChromaCloudQwenEmbeddingFunction` treats `task` as optional everywhere **except** `build_from_config`, so a collection whose Qwen EF was created with `task=None` can't be reloaded:

- signature `task: Optional[str]`, docstring says `None` is allowed
- runtime handles it (`if self.task and ...`)
- the JSON schema declares `"task": {"type": ["string", "null"]}`
- `get_config()` emits `{"task": None, ...}` and `validate_config()` accepts it

…but `build_from_config` asserted `model is None or task is None`, so reloading raises `AssertionError` → wrapped as `ValueError("Could not build embedding function ...")` and the collection becomes unusable.

```python
import os; os.environ["CHROMA_API_KEY"] = "dummy"
from chromadb.utils.embedding_functions.chroma_cloud_qwen_embedding_function import (
    ChromaCloudQwenEmbeddingFunction as EF, ChromaCloudQwenEmbeddingModel as M)
ef = EF(model=M.QWEN3_EMBEDDING_0p6B, task=None)
EF.build_from_config(ef.get_config())   # before: AssertionError ; after: rebuilds fine
```

### Fix

Only `model` is required — drop `task` from the guard.

### Test

Added a real (non-mocked) `get_config` → `build_from_config` round-trip test for `task=None`. The existing parametrized round-trip test mocks `build_from_config`, which is why this path was never exercised. The new test fails on the previous code and passes with the fix.

Fixes #7450
