### PR TITLE
fix: copy include list before mutation in get()/query() request preparation

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -279,7 +279,7 @@ class CollectionCommon(Generic[ClientT]):
             )
 
         # Prepare
-        request_include = include
+        request_include = list(include)
         # We need to include uris in the result from the API to load datas
         if "data" in include and "uris" not in include:
             request_include.append("uris")
@@ -343,7 +343,7 @@ class CollectionCommon(Generic[ClientT]):
         request_where_document = filters["where_document"]
 
         # We need to manually include uris in the result from the API to load datas
-        request_include = include
+        request_include = list(include)
         if "data" in request_include and "uris" not in request_include:
             request_include.append("uris")
 

--- a/chromadb/test/api/test_collection.py
+++ b/chromadb/test/api/test_collection.py
@@ -1,8 +1,13 @@
 from concurrent.futures import ThreadPoolExecutor
+from typing import List, Optional, Sequence
 import uuid
+import numpy as np
+from numpy.typing import NDArray
 from chromadb.api import ClientAPI
+from chromadb.api.types import URI, DataLoader, Image
 from chromadb.errors import ChromaError, UniqueConstraintError
 from chromadb.test.conftest import multi_region_test
+from chromadb.test.ef.test_multimodal_ef import hashing_multimodal_ef
 
 
 @multi_region_test
@@ -74,3 +79,42 @@ def test_multithreaded_get_or_create(client: ClientAPI) -> None:
                 future.result()
             except Exception as e:
                 assert False, f"Thread raised an exception: {e}"
+
+
+class _StubDataLoader(DataLoader[List[Optional[Image]]]):
+    def __call__(self, uris: Sequence[Optional[URI]]) -> List[Optional[Image]]:
+        def load(uri: Optional[URI]) -> Optional[NDArray[np.uint8]]:
+            return None if uri is None else np.array(uri.encode())
+
+        return [load(uri) for uri in uris]
+
+
+def test_include_data_parameter_not_mutated(client: ClientAPI) -> None:
+    """Regression test for issue #5857: an `include` list containing "data" must not be
+    mutated in-place with an appended "uris" entry. This specifically requires "data" to
+    be in `include`, since that's the only branch that appends to `request_include`; a
+    collection needs a data_loader configured or "data" is rejected before that point."""
+    collection = client.get_or_create_collection(
+        name="test_include_data_mutation",
+        data_loader=_StubDataLoader(),
+        embedding_function=hashing_multimodal_ef(),
+    )
+    collection.add(ids=["id1", "id2"], uris=["uri_1", "uri_2"])
+
+    include_get: List[str] = ["documents", "data"]
+    collection.get(include=include_get)
+    assert include_get == [
+        "documents",
+        "data",
+    ], "get() must not mutate the include parameter"
+
+    include_query: List[str] = ["documents", "data"]
+    collection.query(
+        query_uris=["uri_1"],
+        n_results=1,
+        include=include_query,
+    )
+    assert include_query == [
+        "documents",
+        "data",
+    ], "query() must not mutate the include parameter"


### PR DESCRIPTION
Fixes #5857.

## Summary

`_validate_and_prepare_get_request` and `_validate_and_prepare_query_request` (`chromadb/api/models/CollectionCommon.py`) both did `request_include = include` (no copy) and then, when `"data"` was requested without `"uris"` already present, appended `"uris"` to it in place. Since `request_include` aliased the caller's own list object, this permanently mutated whatever list a caller passed as `include=...`, visible on their own reference after `get()`/`query()` returned, and corrupting the list further on any repeated call with the same object.

## Fix

Copy `include` into a new list before any in-place modification, in both methods.

## Prior attempt

There's an earlier PR for this same issue, #6675, closed without merging back in April. @itaismith asked for the regression test to live in `test_collection.py` instead of `test_data_loader.py`, and the PR wasn't updated after that. I've put it there this time.

One thing worth flagging: that earlier PR's test used `include=["documents", "metadatas"]`, no `"data"` in the list. Looking at the code, the mutating line only runs when `"data" in include`, so a test without `"data"` never exercises the append at all, it would pass whether or not `request_include` aliases the caller's list. The new test here uses `include=["documents", "data"]` on a collection actually configured with a `data_loader` (required, since `"data"` in `include` without a data loader raises before reaching that code), so it genuinely exercises the mutating branch.

## Testing

`chromadb`'s test suite needs `hnswlib`/`fastapi`/etc. compiled and installed, which I couldn't get working locally (no C++ build tools in this environment). Instead I verified with `chromadb.EphemeralClient()` directly:

Against the unfixed code:
```
get(): include before = ['documents', 'data']  after = ['documents', 'data', 'uris']
get() did NOT mutate caller's include list: False
query(): include before = ['documents', 'data']  after = ['documents', 'data', 'uris']
query() did NOT mutate caller's include list: False
```

Against the fixed code:
```
get(): include before = ['documents', 'data']  after = ['documents', 'data']
get() did NOT mutate caller's include list: True
query(): include before = ['documents', 'data']  after = ['documents', 'data']
query() did NOT mutate caller's include list: True
```

The new pytest test in `test_collection.py` follows the exact same setup and assertions, so it should reproduce this locally for anyone who can run the full suite, happy to have someone confirm it in CI.
