### PR TITLE
Fix Collection.get()/query() mutating caller's include list in place

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -279,7 +279,9 @@ class CollectionCommon(Generic[ClientT]):
             )
 
         # Prepare
-        request_include = include
+        # Copy so we don't mutate the caller's include list when we append
+        # "uris" below (needed internally to load "data" via the data loader).
+        request_include = list(include)
         # We need to include uris in the result from the API to load datas
         if "data" in include and "uris" not in include:
             request_include.append("uris")
@@ -343,7 +345,8 @@ class CollectionCommon(Generic[ClientT]):
         request_where_document = filters["where_document"]
 
         # We need to manually include uris in the result from the API to load datas
-        request_include = include
+        # Copy so we don't mutate the caller's include list in place.
+        request_include = list(include)
         if "data" in request_include and "uris" not in request_include:
             request_include.append("uris")
 

--- a/chromadb/test/api/test_types.py
+++ b/chromadb/test/api/test_types.py
@@ -1,6 +1,8 @@
 import pytest
+from types import SimpleNamespace
 from typing import List, cast, Dict, Any
 from chromadb.api.types import Documents, Image, Document, Embeddings
+from chromadb.api.models.CollectionCommon import CollectionCommon
 from chromadb.utils.embedding_functions import (
     EmbeddingFunction,
     register_embedding_function,
@@ -103,3 +105,67 @@ def test_embedding_function_results_format_when_response_is_invalid() -> None:
         from chromadb.api.types import normalize_embeddings
 
         normalize_embeddings(result)
+
+
+def test_get_request_does_not_mutate_caller_include_list() -> None:
+    """Regression test for a bug where _validate_and_prepare_get_request
+    mutated the caller's `include` list in place.
+
+    When "data" is requested, Chroma needs to also fetch "uris" internally
+    so the collection's data loader can resolve the images/documents. The
+    old code did `request_include = include` (an alias, not a copy) and
+    then appended "uris" onto it, which silently mutated whatever list
+    object the caller passed in. A caller reusing a shared/constant include
+    list across multiple get()/query() calls would see it grow a "uris"
+    entry after the first call, which is surprising and can leak URIs into
+    results the caller never asked for on subsequent calls.
+    """
+    fake_self = SimpleNamespace(_data_loader=lambda uris: None)
+    caller_include = ["documents", "data"]
+
+    request = CollectionCommon._validate_and_prepare_get_request(
+        fake_self,
+        ids=None,
+        where=None,
+        where_document=None,
+        include=caller_include,
+    )
+
+    # The caller's original list must be left untouched.
+    assert caller_include == ["documents", "data"]
+    # The internal request still needs "uris" so the data loader can run.
+    assert request["include"] == ["documents", "data", "uris"]
+
+    # Calling it again with the same list object should behave identically,
+    # not accumulate state from the previous call.
+    request_again = CollectionCommon._validate_and_prepare_get_request(
+        fake_self,
+        ids=None,
+        where=None,
+        where_document=None,
+        include=caller_include,
+    )
+    assert caller_include == ["documents", "data"]
+    assert request_again["include"] == ["documents", "data", "uris"]
+
+
+def test_query_request_does_not_mutate_caller_include_list() -> None:
+    """Same regression as above, for _validate_and_prepare_query_request."""
+    fake_self = SimpleNamespace(_data_loader=lambda uris: None)
+    caller_include = ["documents", "data"]
+
+    request = CollectionCommon._validate_and_prepare_query_request(
+        fake_self,
+        query_embeddings=[[0.1, 0.2, 0.3]],
+        query_texts=None,
+        query_images=None,
+        query_uris=None,
+        ids=None,
+        n_results=5,
+        where=None,
+        where_document=None,
+        include=caller_include,
+    )
+
+    assert caller_include == ["documents", "data"]
+    assert request["include"] == ["documents", "data", "uris"]


### PR DESCRIPTION
## Problem

Collection.get() and Collection.query() (and their async/transaction
equivalents) prepare the include list for the wire request in
CollectionCommon._validate_and_prepare_get_request /
_validate_and_prepare_query_request. When "data" is requested, Chroma
also needs "uris" internally so the data loader can resolve the
underlying images/documents, so the code does:

    request_include = include
    if "data" in include and "uris" not in include:
        request_include.append("uris")

request_include = include does not copy the list, it just binds a new
name to the same list object. The subsequent .append("uris") therefore
mutates whatever list the caller passed as include, silently and
permanently.

### Repro

    from types import SimpleNamespace
    from chromadb.api.models.CollectionCommon import CollectionCommon

    fake_self = SimpleNamespace(_data_loader=lambda uris: None)
    caller_include = ["documents", "data"]

    CollectionCommon._validate_and_prepare_get_request(
        fake_self, ids=None, where=None, where_document=None,
        include=caller_include,
    )

    print(caller_include)
    # ['documents', 'data', 'uris']  <- the caller's own list was mutated

Any code that keeps a shared/constant include list around and reuses it
across multiple get()/query() calls (a pretty normal pattern, e.g. a
module-level INCLUDE = ["documents", "data"] used by several call
sites) will see "uris" silently appended to it after the first call.
That's surprising: include is a plain caller-owned list, and nothing
documents that passing it into get()/query() can mutate it.

## Fix

Copy the list before mutating it: request_include = list(include) in
both _validate_and_prepare_get_request and
_validate_and_prepare_query_request in CollectionCommon.py. This is
the only change; the "append uris for data loading" behavior itself is
unchanged.

## Testing

- Added two regression tests to chromadb/test/api/test_types.py:
  test_get_request_does_not_mutate_caller_include_list and
  test_query_request_does_not_mutate_caller_include_list. They call the
  two request-prep methods directly with a fake self
  (SimpleNamespace with a _data_loader) and assert the caller's
  include list is left untouched while the returned request still
  contains "uris".
- Confirmed both new tests fail on the pre-fix code (via git stash on
  just the CollectionCommon.py change) and pass with the fix applied.
- Ran chromadb/test/api/test_types.py and chromadb/test/utils/
  (155 passed, 7 skipped for optional embedding-function dependencies
  that aren't installed) with the fix applied; no regressions.
