### PR TITLE
[BUG](js-client): Validate embedding values

### DIFF
--- a/clients/new-js/packages/chromadb/src/utils.ts
+++ b/clients/new-js/packages/chromadb/src/utils.ts
@@ -135,7 +135,13 @@ const validateEmbeddings = ({
     );
   }
 
-  if (!embeddings.filter((e) => e.every((n: any) => typeof n === "number"))) {
+  if (
+    !embeddings.every(
+      (embedding) =>
+        Array.isArray(embedding) &&
+        embedding.every((n: any) => typeof n === "number"),
+    )
+  ) {
     throw new ChromaValueError(
       "Expected each embedding to be an array of numbers",
     );

--- a/clients/new-js/packages/chromadb/test/add.collections.test.ts
+++ b/clients/new-js/packages/chromadb/test/add.collections.test.ts
@@ -89,4 +89,26 @@ describe("add collections", () => {
       );
     }
   });
+
+  test("should error on non-numeric embedding values", async () => {
+    const collection = await client.createCollection({ name: "test" });
+
+    await expect(
+      collection.add({
+        ids: ["id1"],
+        embeddings: [[1, "bad"] as unknown as number[]],
+      }),
+    ).rejects.toThrow("Expected each embedding to be an array of numbers");
+  });
+
+  test("should error on non-array embedding rows", async () => {
+    const collection = await client.createCollection({ name: "test" });
+
+    await expect(
+      collection.add({
+        ids: ["id1"],
+        embeddings: [123 as unknown as number[]],
+      }),
+    ).rejects.toThrow("Expected each embedding to be an array of numbers");
+  });
 });

--- a/clients/new-js/packages/chromadb/test/query.collection.test.ts
+++ b/clients/new-js/packages/chromadb/test/query.collection.test.ts
@@ -62,6 +62,17 @@ describe("query records", () => {
     );
   });
 
+  test("should error on non-numeric query embedding values", async () => {
+    const collection = await client.createCollection({ name: "test" });
+
+    await expect(
+      collection.query({
+        queryEmbeddings: [[1, "bad"] as unknown as number[]],
+        nResults: 1,
+      }),
+    ).rejects.toThrow("Expected each embedding to be an array of numbers");
+  });
+
   // test where_document
   test("it should get embedding with matching documents", async () => {
     const collection = await client.createCollection({ name: "test" });


### PR DESCRIPTION
Fix JS client embedding validation so malformed embedding rows are rejected before requests are prepared.

## What Problem This Solves

`validateEmbeddings` is intended to reject embedding payloads whose rows are not arrays of numeric values before the JS client prepares a write or query request. The current check uses the result of `Array.prototype.filter()` as the condition:

```ts
!embeddings.filter(...)
```

That condition does not behave like a validation predicate. `filter()` always returns an array object, and array objects are truthy in JavaScript, even when the filtered result is empty. Because of that, malformed embedding rows like this can pass the JS client validator instead of producing the existing `ChromaValueError`:

```ts
[[1, "bad"]]
```

There is a second diagnostic issue in the same branch: a non-array inner row can reach `.every()` directly and raise a raw `TypeError` instead of the validator's intended Chroma error. Both cases are SDK runtime validation / developer-experience bugs. This PR does not claim a server-side integrity or security fix.

## Change

The fix changes the validator from "build a filtered array and test whether the array object is falsy" to "require every embedding row to satisfy the row predicate":

```diff
-  if (!embeddings.filter((e) => e.every((n: any) => typeof n === "number"))) {
+  if (
+    !embeddings.every(
+      (embedding) =>
+        Array.isArray(embedding) &&
+        embedding.every((n: any) => typeof n === "number"),
+    )
+  ) {
```

This keeps the change narrow:

- `every()` makes the validation result a real boolean decision across all rows.
- `Array.isArray(embedding)` ensures malformed inner rows use the existing `ChromaValueError` path instead of falling through to a `TypeError`.
- The element contract intentionally stays the same: values are accepted when `typeof n === "number"`.

In particular, this PR does not add `Number.isFinite()` or otherwise change the JS client's existing NaN / Infinity policy.

## Evidence

The failing payload is a normal SDK input shape with one invalid element inside an embedding row:

```ts
await collection.add({
  ids: ["id1"],
  embeddings: [[1, "bad"] as unknown as number[]],
});
```

Before this change, the `filter()` truthiness check did not reject that row at the JS validator boundary. After this change, the same shape is rejected with the validator's existing message:

```text
Expected each embedding to be an array of numbers
```

The test coverage checks both affected validator surfaces:

- `add.collections.test.ts` rejects non-numeric embedding values for `collection.add()`.
- `add.collections.test.ts` rejects a non-array embedding row, covering the previous raw-`TypeError` path.
- `query.collection.test.ts` rejects non-numeric `queryEmbeddings` for `collection.query()`.

No screenshot or media evidence is included because this is a JS SDK validation path; the focused unit tests are the relevant behavior proof.

## Possible call chain / impact

```text
collection.add/update/upsert
  -> prepareRecords
  -> validateBaseRecordSet
  -> validateEmbeddings

collection.query
  -> prepareQuery
  -> validateBaseRecordSet
  -> validateEmbeddings
```

The change is limited to JS SDK runtime validation. It does not change server-side embedding validation or embedding generation behavior.

## Validation

- `git diff --check` passed (with local CRLF conversion warnings only).
- `cd clients/new-js && pnpm --filter chromadb test -- add.collections.test.ts query.collection.test.ts` passed.
- `cd clients/new-js && pnpm --filter chromadb build` was attempted; JS/CJS bundles built, but local DTS generation failed resolving `@chroma-core/default-embed` after the Windows pnpm install hit symlink `EPERM` issues.
