### PR TITLE
[BUG](js-client): Validate whereDocument operands

### DIFF
--- a/clients/new-js/packages/chromadb/src/types.ts
+++ b/clients/new-js/packages/chromadb/src/types.ts
@@ -157,8 +157,6 @@ export type Where =
 type WhereDocumentOperator =
   | "$contains"
   | "$not_contains"
-  | "$matches"
-  | "$not_matches"
   | "$regex"
   | "$not_regex"
   | LogicalOperator;
@@ -170,8 +168,6 @@ type WhereDocumentOperator =
 export type WhereDocument =
   | { $contains: string }
   | { $not_contains: string }
-  | { $matches: string }
-  | { $not_matches: string }
   | { $regex: string }
   | { $not_regex: string }
   | { $and: WhereDocument[] }

--- a/clients/new-js/packages/chromadb/src/utils.ts
+++ b/clients/new-js/packages/chromadb/src/utils.ts
@@ -664,8 +664,6 @@ export const validateWhereDocument = (whereDocument: WhereDocument) => {
     ![
       "$contains",
       "$not_contains",
-      "$matches",
-      "$not_matches",
       "$regex",
       "$not_regex",
       "$and",
@@ -673,7 +671,7 @@ export const validateWhereDocument = (whereDocument: WhereDocument) => {
     ].includes(operator)
   ) {
     throw new ChromaValueError(
-      `Expected 'whereDocument' operator to be one of $contains, $not_contains, $matches, $not_matches, $regex, $not_regex, $and, or $or, but got ${operator}`,
+      `Expected 'whereDocument' operator to be one of $contains, $not_contains, $regex, $not_regex, $and, or $or, but got ${operator}`,
     );
   }
 
@@ -691,15 +689,10 @@ export const validateWhereDocument = (whereDocument: WhereDocument) => {
     }
 
     operand.forEach((item) => validateWhereDocument(item));
+    return;
   }
 
-  if (
-    (operand === "$contains" ||
-      operand === "$not_contains" ||
-      operand === "$regex" ||
-      operand === "$not_regex") &&
-    (typeof (operator as any) !== "string" || operator.length === 0)
-  ) {
+  if (typeof operand !== "string" || operand.length === 0) {
     throw new ChromaValueError(
       `Expected operand for ${operator} to be a non empty string, but got ${operand}`,
     );

--- a/clients/new-js/packages/chromadb/test/validation.test.ts
+++ b/clients/new-js/packages/chromadb/test/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@jest/globals";
-import { validateMetadata } from "../src/utils";
+import { validateMetadata, validateWhereDocument } from "../src/utils";
 
 describe("validateMetadata", () => {
   test("accepts scalar values", () => {
@@ -86,5 +86,52 @@ describe("validateMetadata", () => {
         scores: [1, 2, 3],
       }),
     ).not.toThrow();
+  });
+});
+
+describe("validateWhereDocument", () => {
+  test("accepts document string operators", () => {
+    expect(() => validateWhereDocument({ $contains: "hello" })).not.toThrow();
+    expect(() =>
+      validateWhereDocument({ $not_contains: "hello" }),
+    ).not.toThrow();
+    expect(() => validateWhereDocument({ $regex: "hello.*" })).not.toThrow();
+    expect(() =>
+      validateWhereDocument({ $not_regex: "hello.*" }),
+    ).not.toThrow();
+  });
+
+  test("accepts nested logical operators", () => {
+    expect(() =>
+      validateWhereDocument({
+        $and: [{ $contains: "hello" }, { $not_contains: "goodbye" }],
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects non-string operands", () => {
+    expect(() => validateWhereDocument({ $contains: 2 } as any)).toThrow(
+      "Expected operand for $contains to be a non empty string",
+    );
+  });
+
+  test("rejects empty string operands", () => {
+    expect(() => validateWhereDocument({ $contains: "" })).toThrow(
+      "Expected operand for $contains to be a non empty string",
+    );
+  });
+
+  test("rejects unsupported document operators", () => {
+    expect(() => validateWhereDocument({ $matches: "hello" } as any)).toThrow(
+      "Expected 'whereDocument' operator to be one of $contains, $not_contains, $regex, $not_regex, $and, or $or",
+    );
+  });
+
+  test("rejects invalid nested operands", () => {
+    expect(() =>
+      validateWhereDocument({
+        $and: [{ $contains: "hello" }, { $contains: 2 } as any],
+      }),
+    ).toThrow("Expected operand for $contains to be a non empty string");
   });
 });


### PR DESCRIPTION
## Description of changes

Fixes a new JS client `whereDocument` validation drift where direct operands were checked against the wrong side of the operator/operand pair.

### What Problem This Solves

`validateWhereDocument` extracts `[operator, operand]`, but the final direct-operand check compared `operand` to strings such as `$contains` and `$regex`. Because real payloads put those strings in `operator`, malformed clauses like these were not rejected by the JS client validator:

```ts
{ $contains: 2 }
{ $contains: "" }
{ $matches: "abc" }
{ $and: [{ $contains: "a" }, { $contains: 2 }] }
```

Those payloads can reach request preparation through the shared validator used by `get`, `query`, and `delete`, then fail later at the service boundary instead of producing the expected JS SDK runtime validation error.

### Change

- Validate direct `whereDocument` operands based on `operator`, requiring `$contains`, `$not_contains`, `$regex`, and `$not_regex` operands to be non-empty strings.
- Return after recursively validating `$and` / `$or` children so logical operands are not treated as direct string operands.
- Remove unsupported `$matches` / `$not_matches` from the new JS client's `WhereDocument` type and runtime allowlist to align with the Python/Rust/documented contract.

This does not add JS-side regex compilation/finite validation; it keeps the PR scoped to the direct operand contract and unsupported operator drift.

### Evidence

Added focused validator coverage for valid string operators, nested logical operators, non-string operands, empty string operands, unsupported `$matches`, and invalid nested operands.

```text
PASS packages/chromadb/test/validation.test.ts
Test Suites: 1 passed, 1 total
Tests:       20 passed, 20 total
```

### Possible call chain / impact

```text
get()    -> validateGetRequest() -> validateWhereDocument()
query()  -> prepareQuery()       -> validateWhereDocument()
delete() -> validateDelete()     -> validateWhereDocument()
```

The impact is client-side runtime validation / DX correctness: invalid `whereDocument` payloads are rejected by the JS SDK before request preparation instead of drifting to backend validation.

## Test plan

_How are these changes tested?_

- [x] Focused validator Jest test passed on Windows with a temporary Jest config that skips Chroma server global setup: `jest --runInBand --config %TEMP%/chroma-validator-jest.config.cjs`
- [x] Focused validator Jest test passed on WSL Ubuntu 22.04 with the same no-global-setup config: `jest --runInBand --config /tmp/chroma-validator-jest.config.cjs`
- [x] `pnpm exec prettier --check packages/chromadb/src/utils.ts packages/chromadb/src/types.ts packages/chromadb/test/validation.test.ts`
- [x] `git diff --check`
- [x] `pnpm --filter chromadb build` on Windows
- [x] `pnpm --filter chromadb build` on WSL Ubuntu 22.04

Local validation notes:

- `pnpm --filter chromadb test -- validation.test.ts` was attempted, but the package's Chroma server global setup builds the Rust binary before running even this validator-only test. On the Windows checkout, that setup is blocked by the repo symlink `rust/types/idl`: with `core.symlinks=false`, it is checked out as a text file containing `../../idl`, so the Rust build reports `protoc failed: Could not make proto path relative: idl/chromadb/proto/chroma.proto`.
- A temporary WSL clone restores `rust/types/idl` as a real symlink and the focused validator test passes there. The full package test still requires the Chroma Rust server build first; that local build did not complete within the available WSL run window, so the focused no-global-setup validator test is the direct coverage for this JS-only change.
- `pnpm --filter chromadb build` passed after restoring workspace links with `pnpm install --ignore-scripts` and building the required workspace declaration dependencies first: `@chroma-core/ai-embeddings-common` and `@chroma-core/default-embed`.

## Migration plan

No data migration. This tightens new JS client validation for payloads that are not supported by the shared Python/Rust/documented `whereDocument` contract.

## Observability plan

No observability changes required. The change is limited to client-side validation and focused tests.

## Documentation Changes

No documentation changes required. Existing docs describe `$contains`, `$not_contains`, `$regex`, and `$not_regex`; this PR aligns the new JS client with those documented operators.