### PR TITLE
fix: respect settings.persist_directory when path is not passed to PersistentClient

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -199,7 +199,7 @@ def EphemeralClient(
 
 
 def PersistentClient(
-    path: Union[str, Path] = "./chroma",
+    path: Optional[Union[str, Path]] = None,
     settings: Optional[Settings] = None,
     tenant: str = DEFAULT_TENANT,
     database: str = DEFAULT_DATABASE,
@@ -210,7 +210,8 @@ def PersistentClient(
     prefer a server-backed Chroma instance.
 
     Args:
-        path: Directory to store persisted data.
+        path: Directory to store persisted data. If not provided, falls back to
+            ``settings.persist_directory``, then to ``"./chroma"``.
         settings: Optional settings to override defaults.
         tenant: Tenant name to use for requests.
         database: Database name to use for requests.
@@ -220,7 +221,11 @@ def PersistentClient(
     """
     if settings is None:
         settings = Settings()
-    settings.persist_directory = str(path)
+
+    # Priority: explicit path > settings.persist_directory (Settings defaults to "./chroma")
+    if path is not None:
+        settings.persist_directory = str(path)
+
     settings.is_persistent = True
 
     # Make sure paramaters are the correct types -- users can pass anything.


### PR DESCRIPTION
## Description

Fixes #7277

`PersistentClient` silently ignored `settings.persist_directory` when the `path` parameter was not explicitly passed. The `path` parameter defaulted to `"./chroma"`, which always overwrote `settings.persist_directory` even when the user had configured a custom path in the `Settings` object.

## Change

- Changed the default value of `path` from `"./chroma"` to `None`
- Only overwrite `settings.persist_directory` when `path` is explicitly provided
- When `path` is not given, the value from `settings.persist_directory` (which defaults to `"./chroma"` in `Settings`) is preserved

## Priority logic

1. If `path` is explicitly passed → use it
2. If `path` is not passed but `settings.persist_directory` is set → use that
3. If neither is set → default to `"./chroma"` (via `Settings` default)

## Backward compatibility

This change is fully backward compatible. Explicitly passing `path="./chroma"` works exactly as before.