### PR TITLE
[BUG](test): register fastapi fixtures and correct sqlite fixture name in conftest

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -387,24 +387,28 @@ def _fastapi_fixture(
         yield from run(args)
 
 
+@pytest.fixture()
 def fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=False)
+    yield from _fastapi_fixture(is_persistent=False)
 
 
+@pytest.fixture()
 def async_fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(
+    yield from _fastapi_fixture(
         is_persistent=False,
         chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
     )
 
 
+@pytest.fixture()
 def fastapi_persistent() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=True)
+    yield from _fastapi_fixture(is_persistent=True)
 
 
+@pytest.fixture()
 def fastapi_ssl() -> Generator[System, None, None]:
     generate_self_signed_certificate()
-    return _fastapi_fixture(
+    yield from _fastapi_fixture(
         is_persistent=False,
         chroma_server_ssl_certfile="./servercert.pem",
         chroma_server_ssl_keyfile="./serverkey.pem",
@@ -753,7 +757,7 @@ def filtered_fixture_names() -> List[str]:
         "fastapi",
         "async_fastapi",
         "fastapi_persistent",
-        "sqlite_fixture",
+        "sqlite",
         "sqlite_persistent",
     ]
 


### PR DESCRIPTION
## Problem

Following the local test instructions in `DEVELOP.md`, running pytest without special environment variables fails during fixture setup with:

```
fixture 'fastapi' not found
```

Closes #7395.

## Root cause

In `chromadb/test/conftest.py`:

1. `fastapi`, `async_fastapi`, and `fastapi_persistent` were plain generator functions that `return _fastapi_fixture(...)` instead of yielding from it. Because they were not decorated with `@pytest.fixture()` and did not yield, pytest never registered them as fixtures, so the default fixture list could not resolve them.
2. `filtered_fixture_names()` referenced `sqlite_fixture`, but the actual fixture is named `sqlite` (parametrized over `python_sqlite_ephemeral`/`rust_sqlite_ephemeral`).

## Fix

- Decorate `fastapi`, `async_fastapi`, `fastapi_persistent`, and `fastapi_ssl` with `@pytest.fixture()` and `yield from _fastapi_fixture(...)` so pytest registers them as fixtures.
- Correct the `sqlite_fixture` reference in `filtered_fixture_names()` to `sqlite`.

## Testing

- `python -c "import ast; ast.parse(open('chromadb/test/conftest.py').read())"` passes.
- `pytest --collect-only` now resolves the default fixture list without `fixture 'fastapi' not found`.

## Checklist

- [x] Changes are limited to `chromadb/test/conftest.py`
- [x] Commit message references the issue
- [x] No new dependencies