### PR TITLE
[BUG](api): normalize persist_directory in SharedSystemClient identifier

### DIFF
--- a/chromadb/api/shared_system_client.py
+++ b/chromadb/api/shared_system_client.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, Dict, Optional
 import logging
+import os
 import threading
 import uuid
 from chromadb.api import ServerAPI
@@ -60,10 +61,17 @@ class SharedSystemClient:
             "chromadb.api.rust.RustBindingsAPI",
         ]:
             if settings.is_persistent:
-                identifier = settings.persist_directory
+                # Normalize the persist directory so that different string forms
+                # of the same path (e.g. "./db1" vs "db1", trailing slashes,
+                # relative vs absolute) map to the same system identifier.
+                # Without this, creating a second PersistentClient with a
+                # different-looking but equivalent path raises KeyError from
+                # _create_system_if_not_exists (see issue #7253).
+                identifier = os.path.abspath(settings.persist_directory)
             else:
                 identifier = (
-                    "ephemeral"  # TODO: support pathing and  multiple ephemeral clients
+                    "ephemeral"  # TODO: support pathing and  multiple ephemeral
+                    # clients
                 )
         elif api_impl in [
             "chromadb.api.fastapi.FastAPI",


### PR DESCRIPTION
## Problem

Creating two `PersistentClient` instances with different-looking but equivalent paths in the same process raises `KeyError`:

```python
import chromadb
client1 = chromadb.PersistentClient(path="./db1")
client2 = chromadb.PersistentClient(path="db1")  # raises KeyError
```

Closes #7253.

## Root cause

`SharedSystemClient._get_identifier_from_settings` used `settings.persist_directory` verbatim as the cache key in `_identifier_to_system`. Different string forms of the same path (relative vs absolute, with/without trailing slash, `./db1` vs `db1`) produced different identifiers, so the second client missed the cache and `_create_system_if_not_exists` raised `KeyError`.

## Fix

Normalize the path with `os.path.abspath` before using it as the identifier, so equivalent paths share a single system entry.

## Testing

- `python -c "import ast; ast.parse(open('chromadb/api/shared_system_client.py').read())"` passes.
- Two `PersistentClient` instances with equivalent path strings now resolve to the same cached system instead of raising.

## Checklist

- [x] Change limited to `chromadb/api/shared_system_client.py`
- [x] No new dependencies
- [x] Commit references the issue