### PR TITLE
[BUG](ollama): remove unused testcontainers dependency

### DIFF
--- a/clients/new-js/packages/ai-embeddings/ollama/package.json
+++ b/clients/new-js/packages/ai-embeddings/ollama/package.json
@@ -44,8 +44,7 @@
   },
   "dependencies": {
     "@chroma-core/ai-embeddings-common": "workspace:^",
-    "ollama": "^0.5.15",
-    "testcontainers": "^10.9.0"
+    "ollama": "^0.5.15"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Problem

`@chroma-core/ollama` declares `testcontainers` as a runtime dependency, but it is not imported or used anywhere in the package `src`. Because the `testcontainers` repo itself depends on `@chroma-core/ollama` in one of its in-repo packages, this creates an extra install cycle and ships an unused dependency to consumers.

Closes #6972.

## Fix

Remove `testcontainers` from `dependencies` in `clients/new-js/packages/ai-embeddings/ollama/package.json`.

## Verification

- `grep -rn testcontainers clients/new-js/packages/ai-embeddings/ollama/src/` returns no hits.
- `python -c "import json; json.load(open(...))"` confirms the file is still valid JSON.

## Notes

A previous attempt (#7013) was closed without merging. This is a fresh, minimal change against current `main`.

## Checklist

- [x] Single-file change
- [x] No new dependencies
- [x] Commit references the issue