### PR TITLE
[BUG](examples): correct GoogleGenerativeAiEmbeddingFunction name in gemini example

### DIFF
--- a/examples/gemini/load_data.py
+++ b/examples/gemini/load_data.py
@@ -43,7 +43,7 @@ def main(
         google_api_key = os.environ["GOOGLE_API_KEY"]
 
     # create embedding function
-    embedding_function = embedding_functions.GoogleGenerativeAIEmbeddingFunction(
+    embedding_function = embedding_functions.GoogleGenerativeAiEmbeddingFunction(
         api_key=google_api_key
     )
 

--- a/examples/gemini/main.py
+++ b/examples/gemini/main.py
@@ -78,7 +78,7 @@ def main(
     client = chromadb.PersistentClient(path=persist_directory)
 
     # create embedding function
-    embedding_function = embedding_functions.GoogleGenerativeAIEmbeddingFunction(
+    embedding_function = embedding_functions.GoogleGenerativeAiEmbeddingFunction(
         api_key=google_api_key, task_type="RETRIEVAL_QUERY"
     )
 


### PR DESCRIPTION
## Problem

Running the gemini example scripts raises `AttributeError`:

```
AttributeError: module 'chromadb.utils.embedding_functions' has no attribute 'GoogleGenerativeAIEmbeddingFunction'
```

Closes #5977.

## Root cause

The examples used `GoogleGenerativeAIEmbeddingFunction` (uppercase `AI`), but the actual class defined in `chromadb/utils/embedding_functions/google_embedding_function.py` is `GoogleGenerativeAiEmbeddingFunction` (lowercase `i` in `Ai`).

## Fix

Rename the call in `examples/gemini/main.py` and `examples/gemini/load_data.py` to `GoogleGenerativeAiEmbeddingFunction`.

## Verification

- `python -c "import ast; ast.parse(open('examples/gemini/main.py').read()); ast.parse(open('examples/gemini/load_data.py').read())"` passes.
- `grep -rn GoogleGenerative examples/gemini/` now shows only the correct `Ai` spelling.

## Checklist

- [x] Two-file change, examples only
- [x] No new dependencies
- [x] Commit references the issue