### PR TITLE
[ENH](local): Add collection flush

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -906,6 +906,10 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
     ) -> "IndexingStatus":
         pass
 
+    def _flush(self, collection_id: UUID) -> None:
+        """Persist pending local collection changes."""
+        raise NotImplementedError("Flush is not implemented for this API")
+
     @abstractmethod
     def _search(
         self,

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -93,6 +93,14 @@ class Collection(CollectionCommon["ServerAPI"]):
             database=self.database,
         )
 
+    def flush(self) -> None:
+        """Persist pending writes for a local persistent collection.
+
+        This materializes the collection's HNSW index and records its durable
+        checkpoint. It is only supported by local Chroma clients.
+        """
+        self._client._flush(collection_id=self.id)
+
     def add(
         self,
         ids: OneOrMany[ID],

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -97,7 +97,13 @@ class Collection(CollectionCommon["ServerAPI"]):
         """Persist pending writes for a local persistent collection.
 
         This materializes the collection's HNSW index and records its durable
-        checkpoint. It is only supported by local Chroma clients.
+        checkpoint. Calling it again with no pending writes is a no-op.
+
+        This method is only supported by a local PersistentClient.
+
+        Raises:
+            ValueError: If the collection belongs to an ephemeral client.
+            NotImplementedError: If the collection belongs to a non-local client.
         """
         self._client._flush(collection_id=self.id)
 

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -382,6 +382,14 @@ class RustBindingsAPI(ServerAPI):
         raise NotImplementedError("Indexing status is not implemented for Local Chroma")
 
     @override
+    def _flush(self, collection_id: UUID) -> None:
+        if not self._system.settings.require("is_persistent"):
+            raise ValueError(
+                "Collection.flush() is only supported by a local PersistentClient"
+            )
+        self.bindings.flush(str(collection_id))
+
+    @override
     def _search(
         self,
         collection_id: UUID,

--- a/chromadb/chromadb_rust_bindings.pyi
+++ b/chromadb/chromadb_rust_bindings.pyi
@@ -213,6 +213,7 @@ class Bindings:
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> None: ...
+    def flush(self, collection_id: str) -> None: ...
     def add(
         self,
         ids: IDs,

--- a/chromadb/test/api/test_collection_flush.py
+++ b/chromadb/test/api/test_collection_flush.py
@@ -1,0 +1,35 @@
+from uuid import UUID, uuid4
+
+from chromadb.api.models.Collection import Collection
+from chromadb.types import Collection as CollectionModel
+
+
+class FlushClient:
+    def __init__(self) -> None:
+        self.flushed_collection_ids: list[UUID] = []
+
+    def _flush(self, collection_id: UUID) -> None:
+        self.flushed_collection_ids.append(collection_id)
+
+
+def test_collection_flush_routes_to_internal_api() -> None:
+    collection_id = uuid4()
+    client = FlushClient()
+    collection = Collection(
+        client=client,  # type: ignore[arg-type]
+        model=CollectionModel(
+            id=collection_id,
+            name="flush-test",
+            configuration_json={},
+            serialized_schema=None,
+            metadata=None,
+            dimension=None,
+            tenant="default_tenant",
+            database="default_database",
+        ),
+        embedding_function=None,
+    )
+
+    collection.flush()
+
+    assert client.flushed_collection_ids == [collection_id]

--- a/chromadb/test/api/test_collection_flush.py
+++ b/chromadb/test/api/test_collection_flush.py
@@ -1,6 +1,15 @@
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Sequence, cast
 from uuid import UUID, uuid4
 
+import chromadb
+import pytest
+from chromadb.api.client import Client
 from chromadb.api.models.Collection import Collection
+from chromadb.ingest.impl.utils import create_topic_name
 from chromadb.types import Collection as CollectionModel
 
 
@@ -33,3 +42,92 @@ def test_collection_flush_routes_to_internal_api() -> None:
     collection.flush()
 
     assert client.flushed_collection_ids == [collection_id]
+
+
+def _persistent_flush_state(
+    persist_directory: str, collection_id: UUID
+) -> tuple[int, list[int]]:
+    with sqlite3.connect(Path(persist_directory) / "chroma.sqlite3") as conn:
+        vector_segment = conn.execute(
+            "SELECT id FROM segments WHERE collection = ? AND scope = 'VECTOR'",
+            (str(collection_id),),
+        ).fetchone()
+        assert vector_segment is not None
+
+        checkpoint_row = conn.execute(
+            "SELECT seq_id FROM max_seq_id WHERE segment_id = ?",
+            (vector_segment[0],),
+        ).fetchone()
+        checkpoint = int(checkpoint_row[0]) if checkpoint_row is not None else 0
+
+        topic = create_topic_name("default", "default", collection_id)
+        wal_offsets = [
+            int(row[0])
+            for row in conn.execute(
+                "SELECT seq_id FROM embeddings_queue WHERE topic = ? ORDER BY seq_id",
+                (topic,),
+            ).fetchall()
+        ]
+
+    return checkpoint, wal_offsets
+
+
+def test_collection_flush_persists_and_purges_below_threshold() -> None:
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY"):
+        pytest.skip("Integration test only")
+
+    ids = ["id-1", "id-2", "id-3"]
+    embeddings: list[Sequence[float]] = [
+        [1.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+    ]
+
+    with tempfile.TemporaryDirectory() as persist_directory:
+        client = cast(Client, chromadb.PersistentClient(path=persist_directory))
+        try:
+            collection = client.create_collection(
+                "flush-test",
+                metadata={"hnsw:batch_size": 3, "hnsw:sync_threshold": 100},
+            )
+            collection.upsert(ids=ids, embeddings=embeddings)
+
+            checkpoint_before, wal_before = _persistent_flush_state(
+                persist_directory, collection.id
+            )
+            assert checkpoint_before == 0
+            assert len(wal_before) == len(ids)
+            assert all(offset > checkpoint_before for offset in wal_before)
+
+            collection.flush()
+
+            checkpoint_after, wal_after = _persistent_flush_state(
+                persist_directory, collection.id
+            )
+            assert checkpoint_after == max(wal_before)
+            # SQLite retains the checkpoint record so future sequence IDs are not
+            # reused, but no records remain beyond the materialized checkpoint.
+            assert wal_after == [checkpoint_after]
+
+            # With no pending WAL records, a second flush is an idempotent no-op.
+            collection.flush()
+            assert _persistent_flush_state(persist_directory, collection.id) == (
+                checkpoint_after,
+                wal_after,
+            )
+        finally:
+            client.close()
+            client.clear_system_cache()
+
+        reopened_client = cast(
+            Client, chromadb.PersistentClient(path=persist_directory)
+        )
+        try:
+            reopened = reopened_client.get_collection("flush-test")
+            result = reopened.query(
+                query_embeddings=[embeddings[0]], n_results=len(ids)
+            )
+            assert set(result["ids"][0]) == set(ids)
+        finally:
+            reopened_client.close()
+            reopened_client.clear_system_cache()

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -343,3 +343,48 @@ def test_rust_bindings_api_stop_closes_bindings() -> None:
     bindings.close.assert_called_once_with()
     assert hasattr(api, "bindings") is False
     assert api._running is False
+
+
+def test_rust_bindings_api_flushes_collection() -> None:
+    """Test RustBindingsAPI forwards collection flushes to the bindings."""
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY"):
+        pytest.skip("Integration test only")
+
+    from uuid import uuid4
+
+    from chromadb.api.rust import RustBindingsAPI
+
+    api = RustBindingsAPI.__new__(RustBindingsAPI)
+    bindings = MagicMock()
+    api._system = MagicMock()
+    api._system.settings.require.return_value = True
+    collection_id = uuid4()
+    api.bindings = bindings
+
+    api._flush(collection_id)
+
+    bindings.flush.assert_called_once_with(str(collection_id))
+
+
+def test_rust_bindings_api_rejects_ephemeral_flush() -> None:
+    """Test RustBindingsAPI rejects flushes without persistent storage."""
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY"):
+        pytest.skip("Integration test only")
+
+    from uuid import uuid4
+
+    from chromadb.api.rust import RustBindingsAPI
+
+    api = RustBindingsAPI.__new__(RustBindingsAPI)
+    bindings = MagicMock()
+    api._system = MagicMock()
+    api._system.settings.require.return_value = False
+    api.bindings = bindings
+
+    with pytest.raises(
+        ValueError,
+        match=r"Collection\.flush\(\) is only supported by a local PersistentClient",
+    ):
+        api._flush(uuid4())
+
+    bindings.flush.assert_not_called()

--- a/docs/mintlify/reference/python/collection.mdx
+++ b/docs/mintlify/reference/python/collection.mdx
@@ -26,6 +26,30 @@ Conditional transactions read from a stable snapshot, buffer writes locally, and
 Return the number of records in the collection.
 
 
+### flush
+
+Persist pending writes for a collection owned by a local Python
+`PersistentClient`:
+
+```python
+import chromadb
+
+client = chromadb.PersistentClient(path="/path/to/save/to")
+collection = client.get_collection("my-collection")
+collection.flush()
+```
+
+This materializes writes that have not yet reached the collection's HNSW sync
+threshold and records the durable vector-index checkpoint. When automatic WAL
+pruning is enabled, it also purges materialized write-ahead log entries.
+Databases upgraded from Chroma before 0.5.7 may have automatic pruning disabled
+until `chroma utils vacuum` is run. Calling `flush()` again when no writes are
+pending is a no-op. This can reduce reopen replay work and establish an HNSW sync
+point before a coordinated backup or maintenance operation.
+
+`flush()` is not supported by ephemeral or HTTP clients.
+
+
 ### add
 
 Add records to the collection.

--- a/rust/frontend/src/executor/local.rs
+++ b/rust/frontend/src/executor/local.rs
@@ -81,6 +81,7 @@ impl LocalExecutor {
         }
         let backfill_msg = BackfillMessage {
             collection_id: collection_and_segment.collection.collection_id,
+            force_persist: false,
         };
         self.compactor_handle
             .request(backfill_msg, None)

--- a/rust/log/src/local_compaction_manager.rs
+++ b/rust/log/src/local_compaction_manager.rs
@@ -126,6 +126,7 @@ pub struct PurgeLogsMessage {
 #[derive(Clone, Debug)]
 pub struct BackfillMessage {
     pub collection_id: CollectionUuid,
+    pub force_persist: bool,
 }
 
 #[async_trait]
@@ -257,6 +258,12 @@ impl Handler<BackfillMessage> for LocalCompactionManager {
             .apply_log_chunk(hnsw_data_chunk)
             .await
             .map_err(|_| CompactionManagerError::HnswApplyLogsError)?;
+        if message.force_persist {
+            hnsw_writer
+                .persist()
+                .await
+                .map_err(|_| CompactionManagerError::HnswApplyLogsError)?;
+        }
         Ok(())
     }
 }

--- a/rust/log/src/sqlite_log.rs
+++ b/rust/log/src/sqlite_log.rs
@@ -389,7 +389,10 @@ impl SqliteLog {
         tx.commit().await.map_err(WrappedSqlxError)?;
 
         if let Some(handle) = self.compactor_handle.get() {
-            let backfill_message = BackfillMessage { collection_id };
+            let backfill_message = BackfillMessage {
+                collection_id,
+                force_persist: false,
+            };
             handle.request(backfill_message, None).await??;
             let purge_log_msg = PurgeLogsMessage { collection_id };
             handle.clone().request(purge_log_msg, None).await??;

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -13,7 +13,7 @@ use chroma_frontend::{
 };
 use chroma_log::{
     config::{LogConfig, SqliteLogConfig},
-    LocalCompactionManager,
+    BackfillMessage, LocalCompactionManager, PurgeLogsMessage,
 };
 use chroma_segment::local_segment_manager::LocalSegmentManagerConfig;
 use chroma_sqlite::config::SqliteDBConfig;
@@ -812,6 +812,34 @@ impl Bindings {
         let mut frontend = self.frontend.clone();
         self.runtime
             .block_on(async { frontend.delete_collection(request).await })?;
+        Ok(())
+    }
+
+    fn flush(&self, collection_id: String) -> ChromaPyResult<()> {
+        let collection_id = chroma_types::CollectionUuid(
+            uuid::Uuid::parse_str(&collection_id).map_err(WrappedUuidError)?,
+        );
+        let compactor_handle = self.compactor_handle.clone();
+        self.runtime.block_on(async move {
+            compactor_handle
+                .request(
+                    BackfillMessage {
+                        collection_id,
+                        force_persist: true,
+                    },
+                    None,
+                )
+                .await
+                .map_err(|err| WrappedPyErr::from(PyValueError::new_err(err.to_string())))?
+                .map_err(|err| WrappedPyErr::from(PyValueError::new_err(err.to_string())))?;
+            compactor_handle
+                .request(PurgeLogsMessage { collection_id }, None)
+                .await
+                .map_err(|err| WrappedPyErr::from(PyValueError::new_err(err.to_string())))?
+                .map_err(|err| WrappedPyErr::from(PyValueError::new_err(err.to_string())))?;
+            Ok::<(), WrappedPyErr>(())
+        })?;
+
         Ok(())
     }
 

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -676,7 +676,10 @@ impl LocalHnswSegmentWriter {
         if log_chunk.is_empty() {
             return Ok(next_label);
         }
-        let mut max_seq_id = u64::MIN;
+        // A cached writer can already contain these records even when its
+        // durable checkpoint still trails them. Preserve that in-memory
+        // checkpoint if this chunk contains no newer visible records.
+        let mut max_seq_id = guard.last_seen_seq_id;
         // In order to insert into hnsw index in parallel, we need to collect all the embeddings
         let mut hnsw_batch: HashMap<u32, Vec<(u32, &OperationRecord)>> =
             HashMap::with_capacity(log_chunk.len());
@@ -859,6 +862,31 @@ impl LocalHnswSegmentWriter {
 
         Ok(next_label)
     }
+
+    /// Persist pending HNSW changes without waiting for the configured threshold.
+    pub async fn persist(&mut self) -> Result<(), LocalHnswSegmentWriterError> {
+        let mut guard = self.index.inner.write().await;
+        if guard.num_elements_since_last_persist == 0 {
+            return Ok(());
+        }
+
+        let max_seq_id = guard.last_seen_seq_id;
+        guard = persist(guard).await?;
+        let id = guard.index.id.to_string().into();
+        let max_id = max_seq_id.into();
+        let (query, values) = Query::insert()
+            .into_table(MaxSeqId::Table)
+            .replace()
+            .columns([MaxSeqId::SegmentId, MaxSeqId::SeqId])
+            .values([id, max_id])?
+            .build_sqlx(SqliteQueryBuilder);
+        sqlx::query_with(&query, values)
+            .execute(guard.sqlite.get_conn())
+            .await?;
+        guard.num_elements_since_last_persist = 0;
+
+        Ok(())
+    }
 }
 
 async fn persist(
@@ -894,6 +922,75 @@ mod tests {
         SegmentScope, SegmentType, SegmentUuid,
     };
     use serde_pickle::DeOptions;
+
+    #[tokio::test]
+    async fn writer_persist_preserves_checkpoint_after_reapply() {
+        let sqlite = get_new_sqlite_db().await;
+        let persist_dir = tempfile::tempdir().expect("persist dir");
+        let persist_path = persist_dir.path().to_str().expect("utf-8 path").to_string();
+
+        let mut collection = Collection::test_collection(3);
+        collection.schema = Some(Schema::new_default(KnnIndex::Hnsw));
+
+        let vector_segment = Segment {
+            id: SegmentUuid::new(),
+            r#type: SegmentType::HnswLocalPersisted,
+            scope: SegmentScope::VECTOR,
+            collection: collection.collection_id,
+            metadata: None,
+            file_path: Default::default(),
+        };
+
+        let mut writer = LocalHnswSegmentWriter::from_segment(
+            &collection,
+            &vector_segment,
+            3,
+            Some(persist_path),
+            sqlite.clone(),
+        )
+        .await
+        .expect("writer");
+
+        let log_chunk = Chunk::new(
+            vec![LogRecord {
+                log_offset: 42,
+                record: OperationRecord {
+                    id: "id-1".to_string(),
+                    embedding: Some(vec![1.0, 2.0, 3.0]),
+                    encoding: None,
+                    metadata: None,
+                    document: None,
+                    operation: Operation::Add,
+                },
+            }]
+            .into(),
+        );
+        writer
+            .apply_log_chunk(log_chunk.clone())
+            .await
+            .expect("apply log");
+
+        assert_eq!(
+            get_current_seq_id(&vector_segment, &sqlite).await.unwrap(),
+            0
+        );
+
+        // A forced backfill can replay the same WAL records while this writer
+        // still has unpersisted changes cached in memory.
+        writer
+            .apply_log_chunk(log_chunk)
+            .await
+            .expect("reapply cached log");
+        assert_eq!(writer.index.inner.read().await.last_seen_seq_id, 42);
+
+        writer.persist().await.expect("forced persist");
+        writer.persist().await.expect("idempotent forced persist");
+
+        assert_eq!(
+            get_current_seq_id(&vector_segment, &sqlite).await.unwrap(),
+            42
+        );
+    }
 
     #[tokio::test]
     async fn reader_migrates_legacy_max_seq_id() {


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - force a local HNSW checkpoint through the compaction manager before requesting cleanup of eligible materialized WAL entries
  - preserve the cached writer checkpoint while replaying a forced backfill
- New functionality
  - add `Collection.flush()` for collections owned by a local `PersistentClient`
  - cover below-threshold persistence, checkpoint advancement, idempotency, WAL cleanup, close/reopen, and query behavior through the public Python API
  - document client limits and the legacy automatic-pruning caveat

Fixes #7463.

## Test plan

- [x] Targeted Python and Rust tests pass locally
- `cargo test -p chroma-segment writer_persist_preserves_checkpoint_after_reapply --lib` (1 passed)
- `cargo check -p chromadb_rust_bindings`
- `maturin develop` with Python 3.11 and the native Rust bindings
- `CHROMA_RUST_BINDINGS_TEST_ONLY=1 python -m pytest -q chromadb/test/api/test_collection_flush.py` (2 passed)
- new public persistence/reopen test repeated three times (3/3 passed)
- `python -m pytest -q chromadb/test/test_client.py -k flush` (2 passed, 15 deselected)
- `cargo fmt --all -- --check`
- final pre-commit hooks including Black, Flake8, and mypy
- `git diff --check`

Broad workspace tests, broad Clippy, and Tilt were not run locally; repository CI remains required.

## Migration plan

No schema or configuration migration is required. The API is additive. Existing databases upgraded from Chroma before 0.5.7 may have automatic WAL pruning disabled; `flush()` still advances the durable vector checkpoint, while WAL pruning remains disabled until `chroma utils vacuum` is run.

## Observability plan

No new telemetry or logging is added. `flush()` is synchronous and propagates checkpoint or persistence failures to the caller. The public end-to-end regression inspects the durable checkpoint and WAL state before and after flush, then closes and reopens the database and verifies query results.

## Documentation Changes

- expanded the `Collection.flush()` docstring with idempotency and error behavior
- added the Python collection reference, including the persistent-only scope, coordinated backup use case, and legacy automatic-pruning caveat

## AI assistance

OpenAI Codex assisted with implementation, test design, review, and validation. I reviewed the final diff and verification evidence before pushing.