### PR TITLE
[BUG]: drop task from required-field guard in Qwen EF build_from_config (#7450)

### DIFF
--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -652,3 +652,25 @@ class TestEmbeddingFunctionSchemas:
 
             # Validate the actual config using the embedding function's validate_config method
             ef_class.validate_config(config)
+
+
+class TestQwenEmbeddingFunctionTaskNone:
+    """Regression tests for #7450: build_from_config should accept task=None."""
+
+    def test_build_from_config_with_task_none(self) -> None:
+        """get_config -> build_from_config round-trip should work when task=None."""
+        import os
+
+        os.environ.setdefault("CHROMA_API_KEY", "dummy")
+        from chromadb.utils.embedding_functions.chroma_cloud_qwen_embedding_function import (
+            ChromaCloudQwenEmbeddingFunction as EF,
+            ChromaCloudQwenEmbeddingModel as M,
+        )
+
+        ef = EF(model=M.QWEN3_EMBEDDING_0p6B, task=None)
+        cfg = ef.get_config()
+        # validate_config should accept task=None (schema permits null)
+        EF.validate_config(cfg)
+        # build_from_config should NOT raise AssertionError for task=None
+        rebuilt = EF.build_from_config(cfg)
+        assert rebuilt is not None

--- a/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
+++ b/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
@@ -167,7 +167,7 @@ class ChromaCloudQwenEmbeddingFunction(EmbeddingFunction[Documents]):
         instructions = config.get("instructions")
         api_key_env_var = config.get("api_key_env_var")
 
-        if model is None or task is None:
+        if model is None:
             assert False, "Config is missing a required field"
 
         # Deserialize instructions dict from string keys to enum keys


### PR DESCRIPTION
## Problem

`ChromaCloudQwenEmbeddingFunction` treats `task` as optional everywhere **except** `build_from_config`, so a collection whose Qwen embedding function was created with `task=None` cannot be reloaded.

- The constructor signature is `task: Optional[str]`, and the docstring says "If None or empty, empty instructions will be used"
- The runtime (`__call__` / `embed_query`) handles `task=None` (`if self.task and ...`)
- The JSON schema `schemas/embedding_functions/chroma-cloud-qwen.json` declares `"task": {"type": ["string", "null"]}`
- `get_config()` emits `{"task": None, ...}` for such an EF, and `validate_config()` accepts it

But `build_from_config` guarded with `if model is None or task is None: assert False`, so reloading a persisted collection whose Qwen EF used `task=None` raises `AssertionError`, which `load_collection_configuration_from_json` re-wraps as `ValueError("Could not build embedding function ...")` — the collection becomes unusable.

## Fix

Only `model` is actually required; drop `task` from the guard:

```diff
-        if model is None or task is None:
+        if model is None:
             assert False, "Config is missing a required field"
```

## Test

Added a real (non-mocked) `get_config` → `build_from_config` round-trip regression test (`TestQwenEmbeddingFunctionTaskNone.test_build_from_config_with_task_none`). The existing parametrized round-trip test mocks `build_from_config`, so it never exercised this path.

Fixes #7450