### PR TITLE
[BUG](worker): Wire fn consumer compactor

### DIFF
--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -99,6 +99,10 @@ pub struct FnConsumerServiceConfig {
     #[serde(default)]
     pub fn_consumer: crate::fn_consumer::config::FnConsumerConfig,
 
+    /// The configuration for compactor-derived sizing and batching behavior.
+    #[serde(default)]
+    pub compactor: crate::compactor::config::CompactorConfig,
+
     /// The configuration for connecting to the log service.
     #[serde(default)]
     pub log: LogConfig,

--- a/rust/worker/src/fn_consumer/server.rs
+++ b/rust/worker/src/fn_consumer/server.rs
@@ -161,7 +161,7 @@ pub async fn fn_consumer_service_entrypoint() {
     // Build and start the manager
     let mut manager = FnConsumerManager::new(
         service_config.fn_consumer.clone(),
-        config.compaction_service.compactor.clone(),
+        service_config.compactor.clone(),
         service_config.my_member_id.clone(),
         system.clone(),
         work_queue_client.clone(),

--- a/rust/worker/tests/config_from_specific_path.rs
+++ b/rust/worker/tests/config_from_specific_path.rs
@@ -153,6 +153,13 @@ fn test_config_from_specific_path() {
                         policy:
                             delete_percentage:
                                 threshold: 10.0
+
+            fn_consumer_service:
+                compactor:
+                    max_compaction_size: 321
+                    max_partition_size: 123
+                    fetch_log_batch_size: 77
+                    fetch_log_concurrency: 9
             "#,
         );
         let config = RootConfig::load_from_path("random_path.yaml");
@@ -213,6 +220,10 @@ fn test_config_from_specific_path() {
             }
             _ => panic!("Expected DeletePercentage policy"),
         }
+        assert_eq!(config.fn_consumer_service.compactor.max_compaction_size, 321);
+        assert_eq!(config.fn_consumer_service.compactor.max_partition_size, 123);
+        assert_eq!(config.fn_consumer_service.compactor.fetch_log_batch_size, 77);
+        assert_eq!(config.fn_consumer_service.compactor.fetch_log_concurrency, 9);
         Ok(())
     });
 }

--- a/rust/worker/tests/config_from_specific_path.rs
+++ b/rust/worker/tests/config_from_specific_path.rs
@@ -220,10 +220,19 @@ fn test_config_from_specific_path() {
             }
             _ => panic!("Expected DeletePercentage policy"),
         }
-        assert_eq!(config.fn_consumer_service.compactor.max_compaction_size, 321);
+        assert_eq!(
+            config.fn_consumer_service.compactor.max_compaction_size,
+            321
+        );
         assert_eq!(config.fn_consumer_service.compactor.max_partition_size, 123);
-        assert_eq!(config.fn_consumer_service.compactor.fetch_log_batch_size, 77);
-        assert_eq!(config.fn_consumer_service.compactor.fetch_log_concurrency, 9);
+        assert_eq!(
+            config.fn_consumer_service.compactor.fetch_log_batch_size,
+            77
+        );
+        assert_eq!(
+            config.fn_consumer_service.compactor.fetch_log_concurrency,
+            9
+        );
         Ok(())
     });
 }


### PR DESCRIPTION
## Description of changes

fn-consumer needs to get compactor related configs from its own compactor config fields

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
