### PR TITLE
Add search agent usage metering

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -6,6 +6,7 @@ for automatically processing collections.
 """
 
 import functools
+import json
 import pytest
 import time
 import urllib.parse
@@ -84,7 +85,11 @@ def _wait_for_minio_count(
         body = _minio_get_object(parsed.netloc, key)
         if body is not None:
             last_body = body.decode("utf-8").strip()
-            if last_body == str(expected_count):
+            payload = json.loads(last_body)
+            observed_count = (
+                payload.get("count") if isinstance(payload, dict) else payload
+            )
+            if observed_count == expected_count:
                 return
         sleep(5)
 
@@ -324,7 +329,9 @@ def test_functions_allow_one_sync_and_one_async_per_collection(
         is True
     )
     assert (
-        collection.detach_function(attached_async_fn.name, delete_output_collection=True)
+        collection.detach_function(
+            attached_async_fn.name, delete_output_collection=True
+        )
         is True
     )
 
@@ -789,7 +796,9 @@ def test_sync_and_async_count_functions_can_share_one_input_collection(
         is True
     )
     assert (
-        collection.detach_function(async_attached_fn.name, delete_output_collection=True)
+        collection.detach_function(
+            async_attached_fn.name, delete_output_collection=True
+        )
         is True
     )
 

--- a/rust/agent/src/tool.rs
+++ b/rust/agent/src/tool.rs
@@ -22,10 +22,18 @@ use crate::provider::ProviderFormat;
 
 /// Optional structured metadata a tool can attach to its result.
 ///
-/// Extension point for later milestones (e.g. citing chunk ids); no variants
-/// exist yet, so tools return `None`.
+/// Lets tools return non-text facts that the caller may want to aggregate or
+/// project separately from the tool result body.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ToolCallMetadata {}
+pub enum ToolCallMetadata {
+    /// Token usage reported by the deep-research subagent behind
+    /// Foundation's `subagent_search` tool.
+    SubagentUsage {
+        model: String,
+        input_tokens: u64,
+        output_tokens: u64,
+    },
+}
 
 /// THE trait you implement to define a tool.
 ///

--- a/rust/foundation-api/Cargo.toml
+++ b/rust/foundation-api/Cargo.toml
@@ -34,6 +34,7 @@ chroma-agent = { workspace = true }
 chroma-api-types = { workspace = true }
 chroma-config = { workspace = true }
 chroma-error = { workspace = true, features = ["validator", "http"] }
+chroma-metering = { workspace = true }
 chroma-sysdb = { workspace = true }
 chroma-system = { workspace = true }
 chroma-tracing = { workspace = true, features = ["middleware"] }

--- a/rust/foundation-api/src/agent_tools/subagent_search_tool.rs
+++ b/rust/foundation-api/src/agent_tools/subagent_search_tool.rs
@@ -67,7 +67,7 @@ impl Tool for SubagentSearchTool {
         params: Self::ModelSuppliedParams,
         _runtime: Self::RuntimeParams,
     ) -> Result<(String, Option<ToolCallMetadata>), AgentError> {
-        let text = subagent_search_text(
+        let (text, usage) = subagent_search_text(
             self.http.clone(),
             self.url.clone(),
             self.creds.clone(),
@@ -77,6 +77,12 @@ impl Tool for SubagentSearchTool {
         .await
         .map_err(|err| AgentError::Tool(err.to_string()))?;
 
-        Ok((text, None))
+        let metadata = usage.map(|usage| ToolCallMetadata::SubagentUsage {
+            model: usage.model,
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+        });
+
+        Ok((text, metadata))
     }
 }

--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -52,6 +52,24 @@ pub async fn foundation_service_entrypoint_with_config(
     let system = chroma_system::System::new();
     let registry = chroma_config::registry::Registry::new();
 
+    foundation_service_entrypoint_with_config_system_registry(
+        auth,
+        config,
+        init_otel_tracing,
+        system,
+        registry,
+    )
+    .await;
+}
+
+pub async fn foundation_service_entrypoint_with_config_system_registry(
+    auth: Arc<dyn auth::AuthenticateAndAuthorize>,
+    config: &FoundationApiConfig,
+    init_otel_tracing: bool,
+    system: chroma_system::System,
+    registry: chroma_config::registry::Registry,
+) {
+
     if init_otel_tracing {
         init_foundation_otel_tracing(config);
     }

--- a/rust/foundation-api/src/routes/agent/events.rs
+++ b/rust/foundation-api/src/routes/agent/events.rs
@@ -27,7 +27,7 @@ pub(crate) enum AgentSseEvent {
     },
     /// The results of the tool calls from the preceding action.
     Observation { results: Vec<AgentToolResult> },
-    /// Terminal event: the agent finished, with its final user-facing answer.
+    /// Terminal event: the agent finished with its final user-facing answer.
     Done { final_text: String },
     /// The run failed mid-flight; carries a human-readable message.
     Error { message: String },

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -27,13 +27,15 @@ mod events;
 
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::{extract::State, http::HeaderMap, Json};
+use chroma_metering::{MeterEvent, SearchAgentUsageContext};
 use chroma_error::{ChromaError, ChromaValidationError, ErrorCodes};
 use futures::{Stream, StreamExt};
 use serde::Deserialize;
 use validator::Validate;
 
 use chroma_agent::{
-    Agent, AnthropicAgentInferenceModel, AnthropicModel, ObservationBuilder, ToolSet,
+    Agent, AnthropicAgentInferenceModel, AnthropicModel, Observation, ObservationBuilder,
+    ObservationItem, ToolSet,
 };
 use events::{action_event, action_text, observation_event, AgentSseEvent};
 
@@ -153,7 +155,13 @@ pub async fn foundation_agent(
         .map_err(|_| AgentRouteError::UnknownModel(request.model.clone()))?;
 
     let agent = build_agent(&server, &headers, &tenant, &request, model).await?;
-    let stream = drive_agent(agent, request.input).map(|event| sse_event(&event));
+    let stream = drive_agent(
+        agent,
+        request.input,
+        tenant,
+        server.config.foundation.database_name.clone(),
+    )
+    .map(|event| sse_event(&event));
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }
 
@@ -236,7 +244,12 @@ fn sse_event(event: &AgentSseEvent) -> Result<Event, AgentSseError> {
 /// This is the pure loop driver, kept separate from SSE framing so it can be
 /// unit-tested by collecting the typed [`AgentSseEvent`]s; the handler maps the
 /// result through [`sse_event`] to frame each event.
-fn drive_agent(mut agent: Agent, input: String) -> impl Stream<Item = AgentSseEvent> {
+fn drive_agent(
+    mut agent: Agent,
+    input: String,
+    tenant: String,
+    database: String,
+) -> impl Stream<Item = AgentSseEvent> {
     async_stream::stream! {
         agent.reset();
         let mut initial = ObservationBuilder::new();
@@ -270,6 +283,7 @@ fn drive_agent(mut agent: Agent, input: String) -> impl Stream<Item = AgentSseEv
             // observation with `is_error` set.
             match agent.act(action).await {
                 Ok(Some(observation)) => {
+                    submit_subagent_usage_events(&observation, &database, &tenant).await;
                     yield observation_event(&observation);
                     agent.observe(observation);
                 }
@@ -287,6 +301,44 @@ fn drive_agent(mut agent: Agent, input: String) -> impl Stream<Item = AgentSseEv
         }
 
         yield AgentSseEvent::Done { final_text };
+    }
+}
+
+async fn submit_subagent_usage_events(observation: &Observation, database: &str, tenant: &str) {
+    for item in &observation.items {
+        let ObservationItem::ToolResult {
+            metadata:
+                Some(chroma_agent::ToolCallMetadata::SubagentUsage {
+                    model,
+                    input_tokens,
+                    output_tokens,
+                }),
+            ..
+        } = item
+        else {
+            continue;
+        };
+
+        if let Err(error) = MeterEvent::SearchAgentUsage(SearchAgentUsageContext::new(
+            tenant.to_string(),
+            database.to_string(),
+            model.clone(),
+            *input_tokens,
+            *output_tokens,
+        ))
+        .submit()
+        .await
+        {
+            tracing::warn!(
+                error = %error,
+                tenant,
+                database,
+                model,
+                input_tokens,
+                output_tokens,
+                "failed to submit search agent usage meter event"
+            );
+        }
     }
 }
 

--- a/rust/foundation-api/src/routes/agent/tests/01_drive.rs
+++ b/rust/foundation-api/src/routes/agent/tests/01_drive.rs
@@ -87,7 +87,12 @@ fn search_agent(fail: bool) -> Agent {
 
 /// Drives the typed-event loop to completion and collects every event.
 async fn collect_events(agent: Agent, query: &str) -> Vec<AgentSseEvent> {
-    let stream = drive_agent(agent, query.to_string());
+    let stream = drive_agent(
+        agent,
+        query.to_string(),
+        "test-tenant".to_string(),
+        "FOUNDATION".to_string(),
+    );
     futures::pin_mut!(stream);
     let mut events = Vec::new();
     while let Some(event) = stream.next().await {
@@ -117,7 +122,7 @@ async fn drives_loop_and_emits_action_observation_done() {
     assert!(matches!(&events[2], AgentSseEvent::Action { .. }));
     assert!(matches!(
         &events[3],
-        AgentSseEvent::Done { final_text } if final_text == "final answer"
+        AgentSseEvent::Done { final_text, .. } if final_text == "final answer"
     ));
 }
 
@@ -167,7 +172,7 @@ async fn answer_without_tool_calls_emits_action_then_done() {
     }
     assert!(matches!(
         &events[1],
-        AgentSseEvent::Done { final_text } if final_text == "direct answer"
+        AgentSseEvent::Done { final_text, .. } if final_text == "direct answer"
     ));
 }
 
@@ -190,7 +195,7 @@ async fn no_actionable_inference_ends_with_empty_done() {
     assert_eq!(events.len(), 1);
     assert!(matches!(
         &events[0],
-        AgentSseEvent::Done { final_text } if final_text.is_empty()
+        AgentSseEvent::Done { final_text, .. } if final_text.is_empty()
     ));
 }
 

--- a/rust/foundation-api/src/routes/agent/tests/02_live.rs
+++ b/rust/foundation-api/src/routes/agent/tests/02_live.rs
@@ -71,7 +71,12 @@ async fn live_agent_calls_tool_then_answers() {
          answer any question before responding, then summarize what it returned.",
     );
 
-    let stream = drive_agent(agent, "When was Chroma founded?".to_string());
+    let stream = drive_agent(
+        agent,
+        "When was Chroma founded?".to_string(),
+        "test-tenant".to_string(),
+        "FOUNDATION".to_string(),
+    );
     futures::pin_mut!(stream);
 
     let mut events = Vec::new();
@@ -94,7 +99,7 @@ async fn live_agent_calls_tool_then_answers() {
         "expected an observation from the tool: {events:?}"
     );
     match events.last() {
-        Some(AgentSseEvent::Done { final_text }) => {
+        Some(AgentSseEvent::Done { final_text, .. }) => {
             assert!(!final_text.is_empty(), "expected a non-empty final answer");
         }
         other => panic!("expected terminal done, got {other:?}"),

--- a/rust/foundation-api/src/routes/subagent_search/events.rs
+++ b/rust/foundation-api/src/routes/subagent_search/events.rs
@@ -21,6 +21,7 @@ use std::sync::LazyLock;
 pub(crate) enum AgentEvent {
     Action(ActionData),
     Observation(ObservationData),
+    Usage(UsageData),
     Done,
     Error(ErrorData),
     Unknown,
@@ -40,6 +41,7 @@ impl AgentEvent {
             Some("observation") => {
                 from_data(data()).map_or(AgentEvent::Unknown, AgentEvent::Observation)
             }
+            Some("usage") => from_data(data()).map_or(AgentEvent::Unknown, AgentEvent::Usage),
             Some("done") => AgentEvent::Done,
             Some("error") => from_data(data()).map_or(AgentEvent::Unknown, AgentEvent::Error),
             _ => AgentEvent::Unknown,
@@ -86,6 +88,14 @@ pub(crate) struct ObservationData {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct ErrorData {
     pub message: String,
+}
+
+/// The `data` of a `usage` event emitted by the deep-research dependency.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct UsageData {
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
 }
 
 impl ActionData {
@@ -145,6 +155,13 @@ pub(crate) enum SubagentResultError {
     /// The byte stream ended without an explicit `done` or `error` event.
     #[error("subagent stream ended without a terminal event")]
     MissingTerminalEvent,
+}
+
+/// The final structured outcome of a deep-research run.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SubagentSearchResult {
+    pub documents: Vec<RankedDocument>,
+    pub usage: Option<UsageData>,
 }
 
 /// Matches one `<Document id=…><Justification>…</Justification></Document>`

--- a/rust/foundation-api/src/routes/subagent_search/mod.rs
+++ b/rust/foundation-api/src/routes/subagent_search/mod.rs
@@ -33,7 +33,10 @@ use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::{extract::State, http::HeaderMap, Json};
 use chroma_error::{ChromaError, ErrorCodes};
 pub(crate) use events::RankedDocument;
-use events::{parse_ranked_documents, AgentEvent, SubagentResultError, SubagentSearchEvent};
+use events::{
+    parse_ranked_documents, AgentEvent, SubagentResultError, SubagentSearchEvent,
+    SubagentSearchResult, UsageData,
+};
 use futures::{Stream, StreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -224,6 +227,7 @@ fn stream_subagent_search(
                         SubagentSearchEvent::Done,
                     ]
                 }
+                AgentEvent::Usage(_) => Vec::new(),
                 // Unknown / unparseable events carry nothing we can model.
                 AgentEvent::Unknown => Vec::new(),
             };
@@ -355,10 +359,13 @@ pub(crate) async fn subagent_search_text(
     creds: SubagentSearchCreds,
     query: String,
     ui_origin: Option<&str>,
-) -> Result<String, SubagentResultError> {
+) -> Result<(String, Option<UsageData>), SubagentResultError> {
     let tenant = creds.chroma_tenant.clone();
-    let documents = collect_subagent_search_final(http, url, creds, query).await?;
-    Ok(format_ranked_documents(&documents, ui_origin, &tenant))
+    let result = collect_subagent_search_final(http, url, creds, query).await?;
+    Ok((
+        format_ranked_documents(&result.documents, ui_origin, &tenant),
+        result.usage,
+    ))
 }
 
 /// Renders ranked documents (most-relevant first) into a numbered text block
@@ -408,12 +415,13 @@ pub(crate) async fn collect_subagent_search_final(
     url: String,
     creds: SubagentSearchCreds,
     query: String,
-) -> Result<Vec<events::RankedDocument>, SubagentResultError> {
+) -> Result<SubagentSearchResult, SubagentResultError> {
     let stream = subagent_search_data_stream(http, url, creds, query);
     futures::pin_mut!(stream);
 
     // Keep the last action's `user_text` — the agent's final answer.
     let mut final_answer: Option<String> = None;
+    let mut usage: Option<UsageData> = None;
     let mut saw_done = false;
     while let Some(item) = stream.next().await {
         let raw = item.map_err(SubagentResultError::Stream)?;
@@ -430,6 +438,9 @@ pub(crate) async fn collect_subagent_search_final(
                 saw_done = true;
                 break;
             }
+            AgentEvent::Usage(event_usage) => {
+                usage = Some(event_usage);
+            }
             AgentEvent::Observation(_) | AgentEvent::Unknown => {}
         }
     }
@@ -440,10 +451,13 @@ pub(crate) async fn collect_subagent_search_final(
 
     // A completed stream whose answer parses to zero documents is a valid "no
     // hits" result.
-    Ok(final_answer
-        .as_deref()
-        .map(parse_ranked_documents)
-        .unwrap_or_default())
+    Ok(SubagentSearchResult {
+        documents: final_answer
+            .as_deref()
+            .map(parse_ranked_documents)
+            .unwrap_or_default(),
+        usage,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/foundation-api/src/routes/subagent_search/tests/00_unit.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/00_unit.rs
@@ -3,6 +3,7 @@
 
 use super::super::events::{
     parse_ranked_documents, ActionData, AgentEvent, ErrorData, RankedDocument, SubagentSearchEvent,
+    UsageData,
 };
 use super::super::{
     format_ranked_documents, parse_sse_data_line, subagent_search_payload, SubagentSearchCreds,
@@ -36,6 +37,12 @@ fn agent_event_parses_each_kind() {
             &json!({"type":"observation","data":{"step":1,"sources":["a"]}}).to_string()
         ),
         AgentEvent::Observation(_)
+    ));
+    assert!(matches!(
+        AgentEvent::parse(
+            &json!({"type":"usage","data":{"model":"scout","input_tokens":123,"output_tokens":456}}).to_string()
+        ),
+        AgentEvent::Usage(UsageData { model, input_tokens: 123, output_tokens: 456 }) if model == "scout"
     ));
     assert!(matches!(
         AgentEvent::parse(&json!({"type":"done","data":{}}).to_string()),

--- a/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
@@ -24,6 +24,7 @@ async fn streams_and_collects_final_from_mocked_sse() {
         "data: {\"type\":\"action\",\"data\":{\"tools\":[{\"name\":\"search\"}],\"params\":[{\"query\":\"rag\"}]}}\n\n",
         "data: {\"type\":\"observation\",\"data\":{\"sources\":[\"a\"]}}\n\n",
         "data: {\"type\":\"action\",\"data\":{\"tools\":[{\"name\":\"user_text\"}],\"params\":[{\"text\":\"<Document id=doc-1><Justification>Relevant to rag.</Justification></Document>\"}]}}\n\n",
+        "data: {\"type\":\"usage\",\"data\":{\"model\":\"scout\",\"input_tokens\":123,\"output_tokens\":456}}\n\n",
         "data: {\"type\":\"done\",\"data\":{}}\n\n",
     );
     let mock = server
@@ -53,7 +54,7 @@ async fn streams_and_collects_final_from_mocked_sse() {
     assert_eq!(count, 4, "action + observation + result + done");
 
     // The collect core resolves the terminal answer into ranked documents.
-    let documents = collect_subagent_search_final(
+    let result = collect_subagent_search_final(
         reqwest::Client::new(),
         server.base_url(),
         test_creds(),
@@ -62,12 +63,13 @@ async fn streams_and_collects_final_from_mocked_sse() {
     .await
     .expect("documents parse");
     assert_eq!(
-        documents,
+        result.documents,
         vec![RankedDocument {
             id: "doc-1".to_string(),
             justification: "Relevant to rag.".to_string(),
         }]
     );
+    assert_eq!(result.usage.expect("usage should be present").model, "scout");
     assert_eq!(mock.calls(), 2);
 }
 
@@ -164,7 +166,7 @@ async fn answer_with_no_documents_emits_empty_result_then_done() {
     assert!(events.iter().all(|e| e.is_ok()), "no hits is not an error");
 
     // The collect core resolves the same stream to an empty document list.
-    let documents = collect_subagent_search_final(
+    let result = collect_subagent_search_final(
         reqwest::Client::new(),
         server.base_url(),
         test_creds(),
@@ -172,7 +174,8 @@ async fn answer_with_no_documents_emits_empty_result_then_done() {
     )
     .await
     .expect("empty results are Ok");
-    assert!(documents.is_empty());
+    assert!(result.documents.is_empty());
+    assert!(result.usage.is_none());
     assert_eq!(mock.calls(), 2);
 }
 

--- a/rust/foundation-api/src/routes/subagent_search/tests/02_live.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/02_live.rs
@@ -50,6 +50,7 @@ async fn live_subagent_search_streams_events() {
                 }
             }
             AgentEvent::Observation(_) => eprintln!("event: observation"),
+            AgentEvent::Usage(_) => eprintln!("event: usage"),
             AgentEvent::Done => {
                 eprintln!("event: done");
                 saw_done = true;

--- a/rust/metering/src/core.rs
+++ b/rust/metering/src/core.rs
@@ -530,6 +530,36 @@ initialize_metering! {
             }
         }
     }
+
+    ////////////////////////////////// search_agent_usage //////////////////////////////////
+    #[context(capabilities = [], handlers = [])]
+    #[derive(Clone, Debug, PartialEq, Deserialize, Eq, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    pub struct SearchAgentUsageContext {
+        pub tenant: String,
+        pub database: String,
+        pub model: String,
+        pub input_tokens: u64,
+        pub output_tokens: u64,
+    }
+
+    impl SearchAgentUsageContext {
+        pub fn new(
+            tenant: String,
+            database: String,
+            model: String,
+            input_tokens: u64,
+            output_tokens: u64,
+        ) -> Self {
+            SearchAgentUsageContext {
+                tenant,
+                database,
+                model,
+                input_tokens,
+                output_tokens,
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -539,11 +569,12 @@ pub enum MeterEvent {
     CollectionRead(CollectionReadContext),
     CollectionWrite(CollectionWriteContext),
     ExternalCollectionRead(ExternalCollectionReadContext),
+    SearchAgentUsage(SearchAgentUsageContext),
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{CollectionWriteContext, MeterEvent, WriteAction};
+    use super::{CollectionWriteContext, MeterEvent, SearchAgentUsageContext, WriteAction};
     use crate::types::{MeteringAtomicU64, MeteringInstant};
 
     #[test]
@@ -577,7 +608,25 @@ mod tests {
             MeterEvent::ExternalCollectionRead(external_collection_read_context) => {
                 external_collection_read_context.request_received_at = request_received_at
             }
+            MeterEvent::SearchAgentUsage(_) => {}
         }
+        assert_eq!(json_event, event);
+    }
+
+    #[test]
+    fn test_search_agent_usage_serialization() {
+        let event = MeterEvent::SearchAgentUsage(SearchAgentUsageContext::new(
+            "test_tenant".to_string(),
+            "FOUNDATION".to_string(),
+            "context-1".to_string(),
+            123,
+            456,
+        ));
+
+        let json_str = serde_json::to_string(&event).expect("The event should be serializable");
+        let json_event =
+            serde_json::from_str::<MeterEvent>(&json_str).expect("Json should be deserializable");
+
         assert_eq!(json_event, event);
     }
 }

--- a/rust/metering/src/lib.rs
+++ b/rust/metering/src/lib.rs
@@ -9,7 +9,7 @@ pub use {
         CollectionWriteContext, Enterable, ExternalCollectionReadContext, FinishRequest,
         FtsQueryLength, LatestCollectionLogicalSizeBytes, LogSizeBytes, MetadataPredicateCount,
         MeterEvent, MeteredFutureExt, PulledLogSizeBytes, QueryEmbeddingCount, ReadAction,
-        ReturnBytes, StartRequest, WriteAction,
+        ReturnBytes, SearchAgentUsageContext, StartRequest, WriteAction,
     },
     errors::MeteringError,
     types::{MeteringAtomicU64, MeteringInstant},

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -110,8 +110,10 @@ pub enum LogMaterializerError {
     EmbeddingMaterialization,
     #[error("Error reading record segment {0}")]
     RecordSegment(#[from] Box<dyn ChromaError>),
-    #[error("Log index {0} out of bounds when resolving user ID")]
+    #[error("Log index {0} out of bounds")]
     LogIndexOutOfBounds(usize),
+    #[error("Materialized operation has no source log")]
+    MissingOperationLogIndex,
     #[error("Record segment reader required but not available")]
     RecordSegmentReaderShardRequired,
     #[error("Unsupported operation for rebuild: {0:?}")]
@@ -125,6 +127,7 @@ impl ChromaError for LogMaterializerError {
             LogMaterializerError::EmbeddingMaterialization => ErrorCodes::Internal,
             LogMaterializerError::RecordSegment(e) => e.code(),
             LogMaterializerError::LogIndexOutOfBounds(_) => ErrorCodes::Internal,
+            LogMaterializerError::MissingOperationLogIndex => ErrorCodes::Internal,
             LogMaterializerError::RecordSegmentReaderShardRequired => ErrorCodes::Internal,
             LogMaterializerError::UnsupportedOperationForRebuild(_) => ErrorCodes::Internal,
         }
@@ -160,6 +163,8 @@ pub struct MaterializedLogRecord {
     // If log has [Upsert] and the record does not exist in storage then final
     // operation is Insert.
     final_operation: MaterializedLogOperation,
+    // The log entry that produced the final materialized operation.
+    operation_log_index: Option<usize>,
     // This is the metadata obtained by combining all the operations
     // present in the log for this id.
     // E.g. if has log has [Insert(a: h), Update(a: b, c: d), Update(a: e, f: g)] then this
@@ -188,6 +193,7 @@ impl MaterializedLogRecord {
             offset_id: AtomicU32::new(offset_id),
             user_id_at_log_index: None,
             final_operation: MaterializedLogOperation::Initial,
+            operation_log_index: None,
             metadata_to_be_merged: None,
             metadata_to_be_deleted: None,
             final_document_at_log_index: None,
@@ -235,6 +241,7 @@ impl MaterializedLogRecord {
             offset_id: AtomicU32::new(offset_id),
             user_id_at_log_index: Some(log_index),
             final_operation: MaterializedLogOperation::AddNew,
+            operation_log_index: Some(log_index),
             metadata_to_be_merged: merged_metadata,
             metadata_to_be_deleted: deleted_metadata,
             final_document_at_log_index,
@@ -359,6 +366,17 @@ impl<'log_data, 'segment_data: 'log_data> HydratedMaterializedLogRecord<'log_dat
 
     pub fn get_operation(&self) -> MaterializedLogOperation {
         self.materialized_log_record.final_operation
+    }
+
+    pub fn get_operation_log_offset(&self) -> Result<i64, LogMaterializerError> {
+        let log_index = self
+            .materialized_log_record
+            .operation_log_index
+            .ok_or(LogMaterializerError::MissingOperationLogIndex)?;
+        self.logs
+            .get(log_index)
+            .map(|record| record.log_offset)
+            .ok_or(LogMaterializerError::LogIndexOutOfBounds(log_index))
     }
 
     pub fn get_user_id(&self) -> &'log_data str {
@@ -890,6 +908,7 @@ pub async fn materialize_logs(
                             .get_mut(log_record.record.id.as_str())
                             .unwrap();
                         record_from_map.final_operation = MaterializedLogOperation::DeleteExisting;
+                        record_from_map.operation_log_index = Some(log_index);
                         record_from_map.final_document_at_log_index = None;
                         record_from_map.final_embedding_at_log_index = None;
                         record_from_map.metadata_to_be_merged = None;
@@ -936,7 +955,6 @@ pub async fn materialize_logs(
                             return Err(LogMaterializerError::MetadataMaterialization(e));
                         }
                     };
-
                     if log_record.record.document.is_some() {
                         record_from_map.final_document_at_log_index = Some(log_index);
                     }
@@ -948,6 +966,7 @@ pub async fn materialize_logs(
                     match record_from_map.final_operation {
                         MaterializedLogOperation::Initial => {
                             record_from_map.final_operation = MaterializedLogOperation::UpdateExisting;
+                            record_from_map.operation_log_index = Some(log_index);
                         }
                         // State remains as is.
                         MaterializedLogOperation::AddNew
@@ -996,7 +1015,6 @@ pub async fn materialize_logs(
                                                 return Err(LogMaterializerError::MetadataMaterialization(e));
                                             }
                                         };
-
                                         if log_record.record.document.is_some() {
                                             record_from_map.final_document_at_log_index = Some(log_index);
                                         }
@@ -1009,6 +1027,7 @@ pub async fn materialize_logs(
                                             MaterializedLogOperation::Initial => {
                                                 record_from_map.final_operation =
                                                     MaterializedLogOperation::UpdateExisting;
+                                                record_from_map.operation_log_index = Some(log_index);
                                             }
                                             // State remains as is.
                                             MaterializedLogOperation::AddNew
@@ -1041,7 +1060,6 @@ pub async fn materialize_logs(
                                 return Err(LogMaterializerError::MetadataMaterialization(e));
                             }
                         };
-
                         if log_record.record.document.is_some() {
                             record_from_map.final_document_at_log_index = Some(log_index);
                         }

--- a/rust/worker/src/execution/functions/count_to_file_async.rs
+++ b/rust/worker/src/execution/functions/count_to_file_async.rs
@@ -1,15 +1,29 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_segment::blockfile_record::RecordSegmentReaderShard;
 use chroma_storage::{PutOptions, Storage, StorageError};
 use chroma_types::{AttachedFunction, Chunk, LogRecord, MaterializedLogOperation};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::execution::operators::execute_task::{AttachedFunctionExecutor, HydratedInputBatch};
 
 const DEFAULT_PARAM_KEY: &str = "s3_path";
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct CountState {
+    count: i64,
+    pulled_log_offsets: HashMap<String, i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum StoredCountState {
+    Current(CountState),
+    Legacy(i64),
+}
 
 #[derive(Debug)]
 pub struct CountToFileAsyncExecutor {
@@ -31,6 +45,10 @@ pub enum CountToFileAsyncError {
     Read(StorageError),
     #[error("failed to write count file: {0}")]
     Write(StorageError),
+    #[error("invalid count file: {0}")]
+    InvalidState(String),
+    #[error("pulled log offset does not fit in i64: {0}")]
+    InvalidPulledLogOffset(u64),
 }
 
 impl ChromaError for CountToFileAsyncError {
@@ -39,7 +57,9 @@ impl ChromaError for CountToFileAsyncError {
             CountToFileAsyncError::MissingParam(_)
             | CountToFileAsyncError::InvalidParams(_)
             | CountToFileAsyncError::InvalidPath(_)
-            | CountToFileAsyncError::MissingStorage => ErrorCodes::InvalidArgument,
+            | CountToFileAsyncError::MissingStorage
+            | CountToFileAsyncError::InvalidState(_)
+            | CountToFileAsyncError::InvalidPulledLogOffset(_) => ErrorCodes::InvalidArgument,
             CountToFileAsyncError::Read(e) | CountToFileAsyncError::Write(e) => e.code(),
         }
     }
@@ -100,27 +120,30 @@ impl CountToFileAsyncExecutor {
         Ok(&self.path)
     }
 
-    async fn load_existing_count(
+    async fn load_state(
         &self,
         storage: &Storage,
         key: &str,
-    ) -> Result<i64, CountToFileAsyncError> {
+    ) -> Result<CountState, CountToFileAsyncError> {
         match storage.get(key, Default::default()).await {
             Ok(bytes) => {
                 let body = std::str::from_utf8(bytes.as_ref()).map_err(|_| {
-                    CountToFileAsyncError::InvalidPath(format!(
-                        "count file at {} was not valid utf-8",
+                    CountToFileAsyncError::InvalidState(format!(
+                        "{} was not valid utf-8",
                         self.path
                     ))
                 })?;
-                body.trim().parse::<i64>().map_err(|_| {
-                    CountToFileAsyncError::InvalidPath(format!(
-                        "count file at {} did not contain an integer",
-                        self.path
-                    ))
-                })
+                match serde_json::from_str::<StoredCountState>(body.trim()).map_err(|err| {
+                    CountToFileAsyncError::InvalidState(format!("{}: {err}", self.path))
+                })? {
+                    StoredCountState::Current(state) => Ok(state),
+                    StoredCountState::Legacy(count) => Ok(CountState {
+                        count,
+                        pulled_log_offsets: HashMap::new(),
+                    }),
+                }
             }
-            Err(StorageError::NotFound { .. }) => Ok(0),
+            Err(StorageError::NotFound { .. }) => Ok(CountState::default()),
             Err(err) => Err(CountToFileAsyncError::Read(err)),
         }
     }
@@ -137,35 +160,228 @@ impl AttachedFunctionExecutor for CountToFileAsyncExecutor {
             .parse_storage_key(&self.storage)
             .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?;
 
-        let delete_count = input_batches
-            .iter()
-            .flat_map(|batch| batch.records.iter())
-            .filter(|(record, _)| {
-                record.get_operation() == MaterializedLogOperation::DeleteExisting
-            })
-            .count() as i64;
-
-        let insert_count = input_batches
-            .iter()
-            .flat_map(|batch| batch.records.iter())
-            .filter(|(record, _)| record.get_operation() == MaterializedLogOperation::AddNew)
-            .count() as i64;
-
-        let existing_count = self
-            .load_existing_count(&self.storage, key)
+        let mut state = self
+            .load_state(&self.storage, key)
             .await
             .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?;
-        let new_total_count = existing_count + insert_count - delete_count;
+
+        for batch in input_batches {
+            let collection_id = batch.input_collection_id.to_string();
+            let stored_offset = state
+                .pulled_log_offsets
+                .get(&collection_id)
+                .copied()
+                .unwrap_or(-1);
+
+            for (record, _) in batch.records.iter() {
+                let operation_log_offset = record
+                    .get_operation_log_offset()
+                    .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
+                if operation_log_offset <= stored_offset {
+                    continue;
+                }
+
+                match record.get_operation() {
+                    MaterializedLogOperation::AddNew => state.count += 1,
+                    MaterializedLogOperation::DeleteExisting => state.count -= 1,
+                    _ => {}
+                }
+            }
+
+            let pulled_log_offset = i64::try_from(batch.completion_offset).map_err(|_| {
+                Box::new(CountToFileAsyncError::InvalidPulledLogOffset(
+                    batch.completion_offset,
+                )) as Box<dyn ChromaError>
+            })?;
+            state
+                .pulled_log_offsets
+                .entry(collection_id)
+                .and_modify(|offset| *offset = (*offset).max(pulled_log_offset))
+                .or_insert(pulled_log_offset);
+        }
+
+        let bytes = serde_json::to_vec(&state).map_err(|err| {
+            Box::new(CountToFileAsyncError::InvalidState(err.to_string())) as Box<dyn ChromaError>
+        })?;
 
         self.storage
-            .put_bytes(
-                key,
-                new_total_count.to_string().into_bytes(),
-                PutOptions::default(),
-            )
+            .put_bytes(key, bytes, PutOptions::default())
             .await
             .map_err(|err| Box::new(CountToFileAsyncError::Write(err)) as Box<dyn ChromaError>)?;
 
         Ok(Chunk::new(Arc::from(Vec::<LogRecord>::new())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_segment::{
+        blockfile_record::RecordSegmentReaderOptions,
+        types::{materialize_logs, HydratedMaterializedLogRecord, MaterializeLogsResult},
+    };
+    use chroma_storage::local::LocalStorage;
+    use chroma_types::{CollectionUuid, Operation, OperationRecord};
+
+    fn record(log_offset: i64, id: &str, operation: Operation) -> LogRecord {
+        LogRecord {
+            log_offset,
+            record: OperationRecord {
+                id: id.to_string(),
+                embedding: Some(vec![0.0]),
+                encoding: None,
+                metadata: None,
+                document: None,
+                operation,
+            },
+        }
+    }
+
+    fn add_record(log_offset: i64, id: &str) -> LogRecord {
+        record(log_offset, id, Operation::Add)
+    }
+
+    async fn hydrate_records<'a>(
+        materialized: &'a MaterializeLogsResult,
+    ) -> Vec<HydratedMaterializedLogRecord<'a, 'a>> {
+        let mut records = Vec::new();
+        for record in materialized.iter() {
+            records.push(
+                record
+                    .hydrate(None)
+                    .await
+                    .expect("hydration should succeed"),
+            );
+        }
+        records
+    }
+
+    async fn execute_logs(
+        executor: &CountToFileAsyncExecutor,
+        collection_id: CollectionUuid,
+        pulled_log_offset: u64,
+        logs: Vec<LogRecord>,
+    ) {
+        let materialized = materialize_logs(
+            &None,
+            Chunk::new(Arc::from(logs)),
+            None,
+            &RecordSegmentReaderOptions::default(),
+        )
+        .await
+        .expect("logs should materialize");
+        let records = hydrate_records(&materialized).await;
+
+        executor
+            .execute(
+                vec![HydratedInputBatch {
+                    input_collection_id: collection_id,
+                    input_collection_name: "test-input".to_string(),
+                    tenant_id: "test-tenant".to_string(),
+                    database_id: "test-database".to_string(),
+                    completion_offset: pulled_log_offset,
+                    records: Chunk::new(Arc::from(records)),
+                }],
+                None,
+            )
+            .await
+            .expect("count should succeed");
+    }
+
+    #[tokio::test]
+    async fn retries_only_count_new_offsets_per_input_collection() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory should be created");
+        let storage = Storage::Local(LocalStorage::new(
+            temp_dir.path().to_str().expect("temporary path is utf-8"),
+        ));
+        let executor = CountToFileAsyncExecutor {
+            path: "count.json".to_string(),
+            storage: storage.clone(),
+        };
+        let first_collection = CollectionUuid::new();
+        let second_collection = CollectionUuid::new();
+
+        execute_logs(
+            &executor,
+            first_collection,
+            2,
+            vec![add_record(1, "one"), add_record(2, "two")],
+        )
+        .await;
+        execute_logs(
+            &executor,
+            first_collection,
+            4,
+            vec![
+                add_record(1, "one"),
+                add_record(2, "two"),
+                record(3, "one", Operation::Update),
+                add_record(4, "three"),
+            ],
+        )
+        .await;
+        execute_logs(
+            &executor,
+            second_collection,
+            2,
+            vec![add_record(1, "four"), add_record(2, "five")],
+        )
+        .await;
+        execute_logs(
+            &executor,
+            second_collection,
+            2,
+            vec![add_record(1, "four"), add_record(2, "five")],
+        )
+        .await;
+
+        let bytes = storage
+            .get("count.json", Default::default())
+            .await
+            .expect("count state should exist");
+        let state: CountState =
+            serde_json::from_slice(bytes.as_ref()).expect("count state should be valid JSON");
+
+        assert_eq!(state.count, 5);
+        assert_eq!(
+            state.pulled_log_offsets.get(&first_collection.to_string()),
+            Some(&4)
+        );
+        assert_eq!(
+            state.pulled_log_offsets.get(&second_collection.to_string()),
+            Some(&2)
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_integer_count_is_upgraded_on_write() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory should be created");
+        let storage = Storage::Local(LocalStorage::new(
+            temp_dir.path().to_str().expect("temporary path is utf-8"),
+        ));
+        storage
+            .put_bytes("count.json", b"4".to_vec(), PutOptions::default())
+            .await
+            .expect("legacy count should be written");
+        let executor = CountToFileAsyncExecutor {
+            path: "count.json".to_string(),
+            storage: storage.clone(),
+        };
+        let collection_id = CollectionUuid::new();
+
+        execute_logs(&executor, collection_id, 5, vec![add_record(5, "five")]).await;
+
+        let bytes = storage
+            .get("count.json", Default::default())
+            .await
+            .expect("count state should exist");
+        let state: CountState =
+            serde_json::from_slice(bytes.as_ref()).expect("count state should be valid JSON");
+
+        assert_eq!(state.count, 5);
+        assert_eq!(
+            state.pulled_log_offsets.get(&collection_id.to_string()),
+            Some(&5)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a search agent usage metering event to chroma-metering
- emit usage events from foundation-api when subagent search reports token usage
- keep the public /api/agent SSE contract unchanged while threading usage through tool metadata

## Testing
- cargo test -p chroma-metering -p foundation-api --no-run
