### PR TITLE
[ENH]: Meter foundation search agent usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3668,6 +3668,7 @@ dependencies = [
  "chroma-api-types",
  "chroma-config",
  "chroma-error",
+ "chroma-metering",
  "chroma-sysdb",
  "chroma-system",
  "chroma-tracing",

--- a/rust/agent/src/agent.rs
+++ b/rust/agent/src/agent.rs
@@ -21,7 +21,7 @@
 use futures::future::join_all;
 
 use crate::error::AgentError;
-use crate::inference::{AgentInferenceModel, InferenceContext};
+use crate::inference::{AgentInferenceModel, InferenceContext, InferenceStep};
 use crate::tool::{ToolCallMetadata, ToolSet};
 use crate::trajectory::{
     Action, ActionItem, Call, Entry, Observation, ObservationBuilder, Trajectory, TrajectoryBuilder,
@@ -175,6 +175,12 @@ impl Agent {
     /// Returns `Err(MaxTrajectoryLengthExceeded)` if the trajectory has already
     /// hit its cap, or `Ok(None)` when the model returns nothing actionable.
     pub async fn infer(&mut self) -> Result<Option<Action>, AgentError> {
+        Ok(self.infer_with_usage().await?.action)
+    }
+
+    /// Produce the next action and any provider-reported usage from the
+    /// current (masked) trajectory view.
+    pub async fn infer_with_usage(&mut self) -> Result<InferenceStep, AgentError> {
         if self.builder.len() >= self.max_trajectory_length {
             return Err(AgentError::MaxTrajectoryLengthExceeded(
                 self.max_trajectory_length,
@@ -192,7 +198,7 @@ impl Agent {
             behavior.prepare_for_inference(&mut ctx);
         }
 
-        self.inference_model.infer(&ctx).await
+        self.inference_model.infer_with_usage(&ctx).await
     }
 
     /// Record `action`, then execute its tool calls (in parallel) and return the

--- a/rust/agent/src/inference/anthropic.rs
+++ b/rust/agent/src/inference/anthropic.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
-use super::{AgentInferenceModel, InferenceContext};
+use super::{AgentInferenceModel, InferenceContext, InferenceStep, InferenceUsage};
 use crate::error::AgentError;
 use crate::provider::ProviderFormat;
 use crate::tool::ToolSet;
@@ -216,6 +216,13 @@ impl AnthropicAgentInferenceModel {
 #[async_trait]
 impl AgentInferenceModel for AnthropicAgentInferenceModel {
     async fn infer(&self, ctx: &InferenceContext<'_>) -> Result<Option<Action>, AgentError> {
+        Ok(self.infer_with_usage(ctx).await?.action)
+    }
+
+    async fn infer_with_usage(
+        &self,
+        ctx: &InferenceContext<'_>,
+    ) -> Result<InferenceStep, AgentError> {
         let mut request = self
             .client
             .post(format!("{ANTHROPIC_BASE_URL}/v1/messages"))
@@ -229,8 +236,22 @@ impl AgentInferenceModel for AnthropicAgentInferenceModel {
 
         let response: Value = request.send().await?.error_for_status()?.json().await?;
 
-        parse_anthropic_response(&response, ctx.toolset)
+        Ok(InferenceStep {
+            action: parse_anthropic_response(&response, ctx.toolset)?,
+            usage: parse_anthropic_usage(&response, self.model),
+        })
     }
+}
+
+fn parse_anthropic_usage(response: &Value, model: AnthropicModel) -> Option<InferenceUsage> {
+    let usage = response.get("usage")?;
+    let input_tokens = usage.get("input_tokens")?.as_u64()?;
+    let output_tokens = usage.get("output_tokens")?.as_u64()?;
+    Some(InferenceUsage {
+        model: model.id().to_string(),
+        input_tokens,
+        output_tokens,
+    })
 }
 
 /// Parse an Anthropic Messages response body into an [`Action`].

--- a/rust/agent/src/inference/anthropic.rs
+++ b/rust/agent/src/inference/anthropic.rs
@@ -247,10 +247,20 @@ fn parse_anthropic_usage(response: &Value, model: AnthropicModel) -> Option<Infe
     let usage = response.get("usage")?;
     let input_tokens = usage.get("input_tokens")?.as_u64()?;
     let output_tokens = usage.get("output_tokens")?.as_u64()?;
+    let cache_read_tokens = usage
+        .get("cache_read_input_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let cache_write_tokens = usage
+        .get("cache_creation_input_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
     Some(InferenceUsage {
         model: model.id().to_string(),
         input_tokens,
         output_tokens,
+        cache_read_tokens,
+        cache_write_tokens,
     })
 }
 

--- a/rust/agent/src/inference/mod.rs
+++ b/rust/agent/src/inference/mod.rs
@@ -17,6 +17,21 @@ use crate::error::AgentError;
 use crate::tool::ToolSet;
 use crate::trajectory::{Action, Trajectory};
 
+/// Token usage reported by an inference provider for a single model call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceUsage {
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+/// The next action plus any provider usage emitted while producing it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InferenceStep {
+    pub action: Option<Action>,
+    pub usage: Option<InferenceUsage>,
+}
+
 /// Everything an [`AgentInferenceModel`] needs to produce the next action.
 ///
 /// `trajectory` is the (possibly masked) view to send to the model; `toolset`
@@ -38,4 +53,14 @@ pub struct InferenceContext<'a> {
 #[async_trait]
 pub trait AgentInferenceModel: Send + Sync {
     async fn infer(&self, ctx: &InferenceContext<'_>) -> Result<Option<Action>, AgentError>;
+
+    async fn infer_with_usage(
+        &self,
+        ctx: &InferenceContext<'_>,
+    ) -> Result<InferenceStep, AgentError> {
+        Ok(InferenceStep {
+            action: self.infer(ctx).await?,
+            usage: None,
+        })
+    }
 }

--- a/rust/agent/src/inference/mod.rs
+++ b/rust/agent/src/inference/mod.rs
@@ -23,6 +23,8 @@ pub struct InferenceUsage {
     pub model: String,
     pub input_tokens: u64,
     pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
 }
 
 /// The next action plus any provider usage emitted while producing it.

--- a/rust/agent/src/lib.rs
+++ b/rust/agent/src/lib.rs
@@ -20,7 +20,8 @@ pub use agent::{Agent, AgentBehavior, ToolErrorPolicy};
 pub use error::AgentError;
 pub use inference::{
     AgentInferenceModel, AnthropicAgentInferenceModel, AnthropicBeta, AnthropicBetas,
-    AnthropicModel, AnthropicRequestConfig, InferenceContext, UnknownAnthropicModel,
+    AnthropicModel, AnthropicRequestConfig, InferenceContext, InferenceStep, InferenceUsage,
+    UnknownAnthropicModel,
 };
 pub use provider::ProviderFormat;
 pub use tool::{DynTool, Tool, ToolCallMetadata, ToolSet};

--- a/rust/agent/src/tool.rs
+++ b/rust/agent/src/tool.rs
@@ -32,6 +32,8 @@ pub enum ToolCallMetadata {
         model: String,
         input_tokens: u64,
         output_tokens: u64,
+        cache_read_tokens: u64,
+        cache_write_tokens: u64,
     },
 }
 

--- a/rust/agent/src/tool.rs
+++ b/rust/agent/src/tool.rs
@@ -22,10 +22,18 @@ use crate::provider::ProviderFormat;
 
 /// Optional structured metadata a tool can attach to its result.
 ///
-/// Extension point for later milestones (e.g. citing chunk ids); no variants
-/// exist yet, so tools return `None`.
+/// Lets tools return non-text facts that the caller may want to aggregate or
+/// project separately from the tool result body.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ToolCallMetadata {}
+pub enum ToolCallMetadata {
+    /// Token usage reported by the deep-research subagent behind
+    /// Foundation's `subagent_search` tool.
+    SubagentUsage {
+        model: String,
+        input_tokens: u64,
+        output_tokens: u64,
+    },
+}
 
 /// THE trait you implement to define a tool.
 ///

--- a/rust/foundation-api/Cargo.toml
+++ b/rust/foundation-api/Cargo.toml
@@ -34,6 +34,7 @@ chroma-agent = { workspace = true }
 chroma-api-types = { workspace = true }
 chroma-config = { workspace = true }
 chroma-error = { workspace = true, features = ["validator", "http"] }
+chroma-metering = { workspace = true }
 chroma-sysdb = { workspace = true }
 chroma-system = { workspace = true }
 chroma-tracing = { workspace = true, features = ["middleware"] }

--- a/rust/foundation-api/src/agent_tools/subagent_search_tool.rs
+++ b/rust/foundation-api/src/agent_tools/subagent_search_tool.rs
@@ -67,7 +67,7 @@ impl Tool for SubagentSearchTool {
         params: Self::ModelSuppliedParams,
         _runtime: Self::RuntimeParams,
     ) -> Result<(String, Option<ToolCallMetadata>), AgentError> {
-        let text = subagent_search_text(
+        let (text, usage) = subagent_search_text(
             self.http.clone(),
             self.url.clone(),
             self.creds.clone(),
@@ -77,6 +77,12 @@ impl Tool for SubagentSearchTool {
         .await
         .map_err(|err| AgentError::Tool(err.to_string()))?;
 
-        Ok((text, None))
+        let metadata = usage.map(|usage| ToolCallMetadata::SubagentUsage {
+            model: usage.model,
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+        });
+
+        Ok((text, metadata))
     }
 }

--- a/rust/foundation-api/src/agent_tools/subagent_search_tool.rs
+++ b/rust/foundation-api/src/agent_tools/subagent_search_tool.rs
@@ -81,6 +81,8 @@ impl Tool for SubagentSearchTool {
             model: usage.model,
             input_tokens: usage.input_tokens,
             output_tokens: usage.output_tokens,
+            cache_read_tokens: usage.cache_read_tokens,
+            cache_write_tokens: usage.cache_write_tokens,
         });
 
         Ok((text, metadata))

--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -52,7 +52,10 @@ impl Handler<MeterEvent> for LoggingMeterEventReceiver {
     type Result = ();
 
     async fn handle(&mut self, message: MeterEvent, _ctx: &ComponentContext<Self>) -> Self::Result {
-        tracing::info!(event = ?message, "processed foundation-api meter event");
+        tracing::warn!(
+            event = ?message,
+            "processed foundation-api meter event via fallback receiver; no billing ingestion receiver is installed"
+        );
     }
 }
 
@@ -105,8 +108,8 @@ pub async fn foundation_service_entrypoint_with_config_system_registry(
 
     if !meter_event_receiver_initialized() {
         system.start_component(LoggingMeterEventReceiver);
-        tracing::info!(
-            "Initialized default foundation-api meter-event receiver; hosted deployments can override this by installing a receiver before startup"
+        tracing::warn!(
+            "Initialized fallback foundation-api meter-event receiver; search-agent usage events will be logged but not forwarded to billing ingestion"
         );
     }
 

--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -52,6 +52,24 @@ pub async fn foundation_service_entrypoint_with_config(
     let system = chroma_system::System::new();
     let registry = chroma_config::registry::Registry::new();
 
+    foundation_service_entrypoint_with_config_system_registry(
+        auth,
+        config,
+        init_otel_tracing,
+        system,
+        registry,
+    )
+    .await;
+}
+
+pub async fn foundation_service_entrypoint_with_config_system_registry(
+    auth: Arc<dyn auth::AuthenticateAndAuthorize>,
+    config: &FoundationApiConfig,
+    init_otel_tracing: bool,
+    system: chroma_system::System,
+    registry: chroma_config::registry::Registry,
+) {
+
     if init_otel_tracing {
         init_foundation_otel_tracing(config);
     }

--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -69,7 +69,6 @@ pub async fn foundation_service_entrypoint_with_config_system_registry(
     system: chroma_system::System,
     registry: chroma_config::registry::Registry,
 ) {
-
     if init_otel_tracing {
         init_foundation_otel_tracing(config);
     }

--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -7,6 +7,7 @@
 //! types, and OTEL bootstrap. It does NOT depend on `chroma-frontend`, and it
 //! does NOT serve any Chroma CRUD routes.
 
+use async_trait::async_trait;
 use std::sync::Arc;
 
 pub(crate) mod agent_tools;
@@ -21,10 +22,39 @@ pub(crate) mod wiki;
 
 pub use frontend_core::{ac, auth, errors, middleware as server_middleware, traced_json};
 
+use chroma_metering::{meter_event_receiver_initialized, MeterEvent};
+use chroma_system::{Component, ComponentContext, Handler};
 use config::FoundationApiConfig;
 use server::FoundationApiServer;
 
 pub const CONFIG_PATH_ENV_VAR: &str = "CONFIG_PATH";
+
+#[derive(Debug, Default)]
+struct LoggingMeterEventReceiver;
+
+#[async_trait]
+impl Component for LoggingMeterEventReceiver {
+    fn get_name() -> &'static str {
+        "foundation-api-meter-event-receiver"
+    }
+
+    fn queue_size(&self) -> usize {
+        1024
+    }
+
+    async fn on_start(&mut self, ctx: &ComponentContext<Self>) {
+        MeterEvent::init_receiver(ctx.receiver());
+    }
+}
+
+#[async_trait]
+impl Handler<MeterEvent> for LoggingMeterEventReceiver {
+    type Result = ();
+
+    async fn handle(&mut self, message: MeterEvent, _ctx: &ComponentContext<Self>) -> Self::Result {
+        tracing::info!(event = ?message, "processed foundation-api meter event");
+    }
+}
 
 pub async fn foundation_service_entrypoint(
     auth: Arc<dyn auth::AuthenticateAndAuthorize>,
@@ -71,6 +101,13 @@ pub async fn foundation_service_entrypoint_with_config_system_registry(
 ) {
     if init_otel_tracing {
         init_foundation_otel_tracing(config);
+    }
+
+    if !meter_event_receiver_initialized() {
+        system.start_component(LoggingMeterEventReceiver);
+        tracing::info!(
+            "Initialized default foundation-api meter-event receiver; hosted deployments can override this by installing a receiver before startup"
+        );
     }
 
     let sysdb = match <chroma_sysdb::SysDb as chroma_config::Configurable<(

--- a/rust/foundation-api/src/routes/agent/events.rs
+++ b/rust/foundation-api/src/routes/agent/events.rs
@@ -27,7 +27,7 @@ pub(crate) enum AgentSseEvent {
     },
     /// The results of the tool calls from the preceding action.
     Observation { results: Vec<AgentToolResult> },
-    /// Terminal event: the agent finished, with its final user-facing answer.
+    /// Terminal event: the agent finished with its final user-facing answer.
     Done { final_text: String },
     /// The run failed mid-flight; carries a human-readable message.
     Error { message: String },

--- a/rust/foundation-api/src/routes/agent/events.rs
+++ b/rust/foundation-api/src/routes/agent/events.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 /// The events `/api/agent` emits, one JSON object per SSE frame.
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 #[serde(tag = "type", content = "data", rename_all = "lowercase")]
 pub(crate) enum AgentSseEvent {
     /// One inference step: the model's reasoning, any user-facing text, and the
@@ -34,7 +34,7 @@ pub(crate) enum AgentSseEvent {
 }
 
 /// A single tool call requested by the model in an [`AgentSseEvent::Action`].
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 pub(crate) struct AgentToolCall {
     pub id: String,
     pub name: String,
@@ -42,7 +42,7 @@ pub(crate) struct AgentToolCall {
 }
 
 /// A single tool result in an [`AgentSseEvent::Observation`].
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 pub(crate) struct AgentToolResult {
     pub call_id: String,
     pub text: String,

--- a/rust/foundation-api/src/routes/agent/events.rs
+++ b/rust/foundation-api/src/routes/agent/events.rs
@@ -95,7 +95,6 @@ pub(crate) fn observation_event(observation: &Observation) -> AgentSseEvent {
     AgentSseEvent::Observation { results }
 }
 
-
 /// The user-facing text of an action (its `SendUserText` items joined), used to
 /// track the agent's terminal answer.
 pub(crate) fn action_text(action: &Action) -> String {

--- a/rust/foundation-api/src/routes/agent/events.rs
+++ b/rust/foundation-api/src/routes/agent/events.rs
@@ -7,7 +7,7 @@
 //! values (from `chroma-agent`) into these events, so the stream driver in the
 //! parent module stays a thin loop.
 
-use chroma_agent::{Action, ActionItem, Observation, ObservationItem};
+use chroma_agent::{Action, ActionItem, InferenceUsage, Observation, ObservationItem};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -27,6 +27,12 @@ pub(crate) enum AgentSseEvent {
     },
     /// The results of the tool calls from the preceding action.
     Observation { results: Vec<AgentToolResult> },
+    /// Token usage reported by either the planner model or a subagent tool.
+    Usage {
+        model: String,
+        input_tokens: u64,
+        output_tokens: u64,
+    },
     /// Terminal event: the agent finished with its final user-facing answer.
     Done { final_text: String },
     /// The run failed mid-flight; carries a human-readable message.
@@ -93,6 +99,16 @@ pub(crate) fn observation_event(observation: &Observation) -> AgentSseEvent {
         })
         .collect();
     AgentSseEvent::Observation { results }
+}
+
+/// Projects provider-reported token usage into the wire event emitted on the
+/// SSE stream.
+pub(crate) fn usage_event(usage: &InferenceUsage) -> AgentSseEvent {
+    AgentSseEvent::Usage {
+        model: usage.model.clone(),
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+    }
 }
 
 /// The user-facing text of an action (its `SendUserText` items joined), used to

--- a/rust/foundation-api/src/routes/agent/events.rs
+++ b/rust/foundation-api/src/routes/agent/events.rs
@@ -7,7 +7,7 @@
 //! values (from `chroma-agent`) into these events, so the stream driver in the
 //! parent module stays a thin loop.
 
-use chroma_agent::{Action, ActionItem, InferenceUsage, Observation, ObservationItem};
+use chroma_agent::{Action, ActionItem, Observation, ObservationItem};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -27,12 +27,6 @@ pub(crate) enum AgentSseEvent {
     },
     /// The results of the tool calls from the preceding action.
     Observation { results: Vec<AgentToolResult> },
-    /// Token usage reported by either the planner model or a subagent tool.
-    Usage {
-        model: String,
-        input_tokens: u64,
-        output_tokens: u64,
-    },
     /// Terminal event: the agent finished with its final user-facing answer.
     Done { final_text: String },
     /// The run failed mid-flight; carries a human-readable message.
@@ -101,15 +95,6 @@ pub(crate) fn observation_event(observation: &Observation) -> AgentSseEvent {
     AgentSseEvent::Observation { results }
 }
 
-/// Projects provider-reported token usage into the wire event emitted on the
-/// SSE stream.
-pub(crate) fn usage_event(usage: &InferenceUsage) -> AgentSseEvent {
-    AgentSseEvent::Usage {
-        model: usage.model.clone(),
-        input_tokens: usage.input_tokens,
-        output_tokens: usage.output_tokens,
-    }
-}
 
 /// The user-facing text of an action (its `SendUserText` items joined), used to
 /// track the agent's terminal answer.

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -355,16 +355,16 @@ async fn submit_search_agent_usage_event(
     tenant: &str,
     collection_id: &str,
 ) {
-    if let Err(error) = MeterEvent::SearchAgentUsage(SearchAgentUsageContext::new(
-        tenant.to_string(),
-        database.to_string(),
-        collection_id.to_string(),
-        usage.model.clone(),
-        usage.input_tokens,
-        usage.output_tokens,
-        usage.cache_read_tokens,
-        usage.cache_write_tokens,
-    ))
+    if let Err(error) = MeterEvent::SearchAgentUsage(SearchAgentUsageContext {
+        tenant: tenant.to_string(),
+        database: database.to_string(),
+        collection_id: collection_id.to_string(),
+        model: usage.model.clone(),
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_read_tokens: usage.cache_read_tokens,
+        cache_write_tokens: usage.cache_write_tokens,
+    })
     .submit()
     .await
     {

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -27,13 +27,15 @@ mod events;
 
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::{extract::State, http::HeaderMap, Json};
+use chroma_metering::{MeterEvent, SearchAgentUsageContext};
 use chroma_error::{ChromaError, ChromaValidationError, ErrorCodes};
 use futures::{Stream, StreamExt};
 use serde::Deserialize;
 use validator::Validate;
 
 use chroma_agent::{
-    Agent, AnthropicAgentInferenceModel, AnthropicModel, ObservationBuilder, ToolSet,
+    Agent, AnthropicAgentInferenceModel, AnthropicModel, Observation, ObservationBuilder,
+    ObservationItem, ToolSet,
 };
 use events::{action_event, action_text, observation_event, AgentSseEvent};
 
@@ -153,7 +155,13 @@ pub async fn foundation_agent(
         .map_err(|_| AgentRouteError::UnknownModel(request.model.clone()))?;
 
     let agent = build_agent(&server, &headers, &tenant, &request, model).await?;
-    let stream = drive_agent(agent, request.input).map(|event| sse_event(&event));
+    let stream = drive_agent(
+        agent,
+        request.input,
+        tenant,
+        server.config.foundation.database_name.clone(),
+    )
+    .map(|event| sse_event(&event));
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }
 
@@ -236,7 +244,12 @@ fn sse_event(event: &AgentSseEvent) -> Result<Event, AgentSseError> {
 /// This is the pure loop driver, kept separate from SSE framing so it can be
 /// unit-tested by collecting the typed [`AgentSseEvent`]s; the handler maps the
 /// result through [`sse_event`] to frame each event.
-fn drive_agent(mut agent: Agent, input: String) -> impl Stream<Item = AgentSseEvent> {
+fn drive_agent(
+    mut agent: Agent,
+    input: String,
+    tenant: String,
+    database: String,
+) -> impl Stream<Item = AgentSseEvent> {
     async_stream::stream! {
         agent.reset();
         let mut initial = ObservationBuilder::new();
@@ -270,6 +283,7 @@ fn drive_agent(mut agent: Agent, input: String) -> impl Stream<Item = AgentSseEv
             // observation with `is_error` set.
             match agent.act(action).await {
                 Ok(Some(observation)) => {
+                    submit_subagent_usage_events(&observation, &database, &tenant).await;
                     yield observation_event(&observation);
                     agent.observe(observation);
                 }
@@ -287,6 +301,44 @@ fn drive_agent(mut agent: Agent, input: String) -> impl Stream<Item = AgentSseEv
         }
 
         yield AgentSseEvent::Done { final_text };
+    }
+}
+
+async fn submit_subagent_usage_events(observation: &Observation, database: &str, tenant: &str) {
+    for item in &observation.items {
+        let ObservationItem::ToolResult {
+            metadata:
+                Some(chroma_agent::ToolCallMetadata::SubagentUsage {
+                    model,
+                    input_tokens,
+                    output_tokens,
+                }),
+            ..
+        } = item
+        else {
+            continue;
+        };
+
+        if let Err(error) = MeterEvent::SearchAgentUsage(SearchAgentUsageContext::new(
+            tenant.to_string(),
+            database.to_string(),
+            model.clone(),
+            *input_tokens,
+            *output_tokens,
+        ))
+        .submit()
+        .await
+        {
+            tracing::warn!(
+                error = %error,
+                tenant,
+                database,
+                model,
+                input_tokens,
+                output_tokens,
+                "failed to submit search agent usage meter event"
+            );
+        }
     }
 }
 

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -27,8 +27,8 @@ mod events;
 
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::{extract::State, http::HeaderMap, Json};
-use chroma_metering::{MeterEvent, SearchAgentUsageContext};
 use chroma_error::{ChromaError, ChromaValidationError, ErrorCodes};
+use chroma_metering::{MeterEvent, SearchAgentUsageContext};
 use futures::{Stream, StreamExt};
 use serde::Deserialize;
 use validator::Validate;
@@ -323,20 +323,20 @@ fn extract_subagent_usages(observation: &Observation) -> Vec<InferenceUsage> {
         .items
         .iter()
         .filter_map(|item| {
-        let ObservationItem::ToolResult {
-            metadata:
-                Some(chroma_agent::ToolCallMetadata::SubagentUsage {
-                    model,
-                    input_tokens,
-                    output_tokens,
-                }),
-            ..
-        } = item
-        else {
-            return None;
-        };
+            let ObservationItem::ToolResult {
+                metadata:
+                    Some(chroma_agent::ToolCallMetadata::SubagentUsage {
+                        model,
+                        input_tokens,
+                        output_tokens,
+                    }),
+                ..
+            } = item
+            else {
+                return None;
+            };
 
-        Some(InferenceUsage {
+            Some(InferenceUsage {
                 model: model.clone(),
                 input_tokens: *input_tokens,
                 output_tokens: *output_tokens,

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -37,7 +37,7 @@ use chroma_agent::{
     Agent, AnthropicAgentInferenceModel, AnthropicModel, InferenceUsage, Observation,
     ObservationBuilder, ObservationItem, ToolSet,
 };
-use events::{action_event, action_text, observation_event, usage_event, AgentSseEvent};
+use events::{action_event, action_text, observation_event, AgentSseEvent};
 
 use crate::agent_tools::{ReadPageTool, SearchTool, SubagentSearchTool};
 use crate::routes::subagent_search::SubagentSearchCreds;
@@ -276,7 +276,6 @@ fn drive_agent(
             };
             if let Some(usage) = step.usage.as_ref() {
                 submit_search_agent_usage_event(usage, &database, &tenant, &collection_id).await;
-                yield usage_event(usage);
             }
             let Some(action) = step.action else {
                 break;
@@ -298,7 +297,6 @@ fn drive_agent(
                     for usage in extract_subagent_usages(&observation) {
                         submit_search_agent_usage_event(&usage, &database, &tenant, &collection_id)
                             .await;
-                        yield usage_event(&usage);
                     }
                     yield observation_event(&observation);
                     agent.observe(observation);

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -329,6 +329,8 @@ fn extract_subagent_usages(observation: &Observation) -> Vec<InferenceUsage> {
                         model,
                         input_tokens,
                         output_tokens,
+                        cache_read_tokens,
+                        cache_write_tokens,
                     }),
                 ..
             } = item
@@ -340,6 +342,8 @@ fn extract_subagent_usages(observation: &Observation) -> Vec<InferenceUsage> {
                 model: model.clone(),
                 input_tokens: *input_tokens,
                 output_tokens: *output_tokens,
+                cache_read_tokens: *cache_read_tokens,
+                cache_write_tokens: *cache_write_tokens,
             })
         })
         .collect()
@@ -358,6 +362,8 @@ async fn submit_search_agent_usage_event(
         usage.model.clone(),
         usage.input_tokens,
         usage.output_tokens,
+        usage.cache_read_tokens,
+        usage.cache_write_tokens,
     ))
     .submit()
     .await
@@ -369,6 +375,8 @@ async fn submit_search_agent_usage_event(
             model = usage.model,
             input_tokens = usage.input_tokens,
             output_tokens = usage.output_tokens,
+            cache_read_tokens = usage.cache_read_tokens,
+            cache_write_tokens = usage.cache_write_tokens,
             "failed to submit search agent usage meter event"
         );
     }

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -25,6 +25,8 @@
 
 mod events;
 
+use std::collections::HashMap;
+
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::{extract::State, http::HeaderMap, Json};
 use chroma_error::{ChromaError, ChromaValidationError, ErrorCodes};
@@ -264,6 +266,7 @@ fn drive_agent(
 
         // The terminal answer is the last action's user-facing text.
         let mut final_text = String::new();
+        let mut usage_by_model = HashMap::new();
 
         loop {
             let step = match agent.infer_with_usage().await {
@@ -275,7 +278,7 @@ fn drive_agent(
                 }
             };
             if let Some(usage) = step.usage.as_ref() {
-                submit_search_agent_usage_event(usage, &database, &tenant, &collection_id).await;
+                record_search_agent_usage(&mut usage_by_model, usage);
             }
             let Some(action) = step.action else {
                 break;
@@ -295,8 +298,7 @@ fn drive_agent(
             match agent.act(action).await {
                 Ok(Some(observation)) => {
                     for usage in extract_subagent_usages(&observation) {
-                        submit_search_agent_usage_event(&usage, &database, &tenant, &collection_id)
-                            .await;
+                        record_search_agent_usage(&mut usage_by_model, &usage);
                     }
                     yield observation_event(&observation);
                     agent.observe(observation);
@@ -314,8 +316,24 @@ fn drive_agent(
             }
         }
 
+        submit_search_agent_usage_events(&usage_by_model, &database, &tenant, &collection_id).await;
         yield AgentSseEvent::Done { final_text };
     }
+}
+
+fn record_search_agent_usage(
+    usage_by_model: &mut HashMap<String, InferenceUsage>,
+    usage: &InferenceUsage,
+) {
+    usage_by_model
+        .entry(usage.model.clone())
+        .and_modify(|total| {
+            total.input_tokens += usage.input_tokens;
+            total.output_tokens += usage.output_tokens;
+            total.cache_read_tokens += usage.cache_read_tokens;
+            total.cache_write_tokens += usage.cache_write_tokens;
+        })
+        .or_insert_with(|| usage.clone());
 }
 
 fn extract_subagent_usages(observation: &Observation) -> Vec<InferenceUsage> {
@@ -349,36 +367,38 @@ fn extract_subagent_usages(observation: &Observation) -> Vec<InferenceUsage> {
         .collect()
 }
 
-async fn submit_search_agent_usage_event(
-    usage: &InferenceUsage,
+async fn submit_search_agent_usage_events(
+    usage_by_model: &HashMap<String, InferenceUsage>,
     database: &str,
     tenant: &str,
     collection_id: &str,
 ) {
-    if let Err(error) = MeterEvent::SearchAgentUsage(SearchAgentUsageContext {
-        tenant: tenant.to_string(),
-        database: database.to_string(),
-        collection_id: collection_id.to_string(),
-        model: usage.model.clone(),
-        input_tokens: usage.input_tokens,
-        output_tokens: usage.output_tokens,
-        cache_read_tokens: usage.cache_read_tokens,
-        cache_write_tokens: usage.cache_write_tokens,
-    })
-    .submit()
-    .await
-    {
-        tracing::warn!(
-            error = %error,
-            tenant,
-            database,
-            model = usage.model,
-            input_tokens = usage.input_tokens,
-            output_tokens = usage.output_tokens,
-            cache_read_tokens = usage.cache_read_tokens,
-            cache_write_tokens = usage.cache_write_tokens,
-            "failed to submit search agent usage meter event"
-        );
+    for usage in usage_by_model.values() {
+        if let Err(error) = MeterEvent::SearchAgentUsage(SearchAgentUsageContext {
+            tenant: tenant.to_string(),
+            database: database.to_string(),
+            collection_id: collection_id.to_string(),
+            model: usage.model.clone(),
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cache_read_tokens: usage.cache_read_tokens,
+            cache_write_tokens: usage.cache_write_tokens,
+        })
+        .submit()
+        .await
+        {
+            tracing::warn!(
+                error = %error,
+                tenant,
+                database,
+                model = usage.model,
+                input_tokens = usage.input_tokens,
+                output_tokens = usage.output_tokens,
+                cache_read_tokens = usage.cache_read_tokens,
+                cache_write_tokens = usage.cache_write_tokens,
+                "failed to submit search agent usage meter event"
+            );
+        }
     }
 }
 

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -34,10 +34,10 @@ use serde::Deserialize;
 use validator::Validate;
 
 use chroma_agent::{
-    Agent, AnthropicAgentInferenceModel, AnthropicModel, Observation, ObservationBuilder,
-    ObservationItem, ToolSet,
+    Agent, AnthropicAgentInferenceModel, AnthropicModel, InferenceUsage, Observation,
+    ObservationBuilder, ObservationItem, ToolSet,
 };
-use events::{action_event, action_text, observation_event, AgentSseEvent};
+use events::{action_event, action_text, observation_event, usage_event, AgentSseEvent};
 
 use crate::agent_tools::{ReadPageTool, SearchTool, SubagentSearchTool};
 use crate::routes::subagent_search::SubagentSearchCreds;
@@ -154,12 +154,13 @@ pub async fn foundation_agent(
         .parse::<AnthropicModel>()
         .map_err(|_| AgentRouteError::UnknownModel(request.model.clone()))?;
 
-    let agent = build_agent(&server, &headers, &tenant, &request, model).await?;
+    let (agent, collection_id) = build_agent(&server, &headers, &tenant, &request, model).await?;
     let stream = drive_agent(
         agent,
         request.input,
         tenant,
         server.config.foundation.database_name.clone(),
+        collection_id,
     )
     .map(|event| sse_event(&event));
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
@@ -179,7 +180,7 @@ async fn build_agent(
     tenant: &str,
     request: &AgentRequest,
     model: AnthropicModel,
-) -> Result<Agent, AgentRouteError> {
+) -> Result<(Agent, String), AgentRouteError> {
     let wiki_client = server
         .wiki_client
         .as_ref()
@@ -188,6 +189,7 @@ async fn build_agent(
         .ok_or(AgentRouteError::MissingToken)?
         .to_string();
     let collection = wiki_client.wiki_collection(tenant, &token).await?;
+    let collection_id = collection.id().to_string();
 
     let ui_origin = server.config.foundation.foundation_ui_origin.clone();
 
@@ -221,7 +223,10 @@ async fn build_agent(
         .map_err(|err| AgentRouteError::Inference(err.to_string()))?
         .with_client(server.shared_http_client.clone());
 
-    Ok(Agent::new(toolset, Box::new(inference)).with_system_prompt(request.system.clone()))
+    Ok((
+        Agent::new(toolset, Box::new(inference)).with_system_prompt(request.system.clone()),
+        collection_id,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -249,6 +254,7 @@ fn drive_agent(
     input: String,
     tenant: String,
     database: String,
+    collection_id: String,
 ) -> impl Stream<Item = AgentSseEvent> {
     async_stream::stream! {
         agent.reset();
@@ -260,14 +266,20 @@ fn drive_agent(
         let mut final_text = String::new();
 
         loop {
-            let action = match agent.infer().await {
-                Ok(Some(action)) => action,
+            let step = match agent.infer_with_usage().await {
+                Ok(step) => step,
                 // Nothing actionable: end with whatever answer we have.
-                Ok(None) => break,
                 Err(err) => {
                     yield AgentSseEvent::Error { message: err.to_string() };
                     return;
                 }
+            };
+            if let Some(usage) = step.usage.as_ref() {
+                submit_search_agent_usage_event(usage, &database, &tenant, &collection_id).await;
+                yield usage_event(usage);
+            }
+            let Some(action) = step.action else {
+                break;
             };
 
             let text = action_text(&action);
@@ -283,7 +295,11 @@ fn drive_agent(
             // observation with `is_error` set.
             match agent.act(action).await {
                 Ok(Some(observation)) => {
-                    submit_subagent_usage_events(&observation, &database, &tenant).await;
+                    for usage in extract_subagent_usages(&observation) {
+                        submit_search_agent_usage_event(&usage, &database, &tenant, &collection_id)
+                            .await;
+                        yield usage_event(&usage);
+                    }
                     yield observation_event(&observation);
                     agent.observe(observation);
                 }
@@ -304,8 +320,11 @@ fn drive_agent(
     }
 }
 
-async fn submit_subagent_usage_events(observation: &Observation, database: &str, tenant: &str) {
-    for item in &observation.items {
+fn extract_subagent_usages(observation: &Observation) -> Vec<InferenceUsage> {
+    observation
+        .items
+        .iter()
+        .filter_map(|item| {
         let ObservationItem::ToolResult {
             metadata:
                 Some(chroma_agent::ToolCallMetadata::SubagentUsage {
@@ -316,29 +335,44 @@ async fn submit_subagent_usage_events(observation: &Observation, database: &str,
             ..
         } = item
         else {
-            continue;
+            return None;
         };
 
-        if let Err(error) = MeterEvent::SearchAgentUsage(SearchAgentUsageContext::new(
-            tenant.to_string(),
-            database.to_string(),
-            model.clone(),
-            *input_tokens,
-            *output_tokens,
-        ))
-        .submit()
-        .await
-        {
-            tracing::warn!(
-                error = %error,
-                tenant,
-                database,
-                model,
-                input_tokens,
-                output_tokens,
-                "failed to submit search agent usage meter event"
-            );
-        }
+        Some(InferenceUsage {
+                model: model.clone(),
+                input_tokens: *input_tokens,
+                output_tokens: *output_tokens,
+            })
+        })
+        .collect()
+}
+
+async fn submit_search_agent_usage_event(
+    usage: &InferenceUsage,
+    database: &str,
+    tenant: &str,
+    collection_id: &str,
+) {
+    if let Err(error) = MeterEvent::SearchAgentUsage(SearchAgentUsageContext::new(
+        tenant.to_string(),
+        database.to_string(),
+        collection_id.to_string(),
+        usage.model.clone(),
+        usage.input_tokens,
+        usage.output_tokens,
+    ))
+    .submit()
+    .await
+    {
+        tracing::warn!(
+            error = %error,
+            tenant,
+            database,
+            model = usage.model,
+            input_tokens = usage.input_tokens,
+            output_tokens = usage.output_tokens,
+            "failed to submit search agent usage meter event"
+        );
     }
 }
 

--- a/rust/foundation-api/src/routes/agent/tests/00_unit.rs
+++ b/rust/foundation-api/src/routes/agent/tests/00_unit.rs
@@ -2,10 +2,10 @@
 //! the wire serialization of [`AgentSseEvent`].
 
 use super::super::events::{
-    action_event, action_text, observation_event, usage_event, AgentSseEvent, AgentToolCall,
+    action_event, action_text, observation_event, AgentSseEvent, AgentToolCall,
 };
 use super::super::{default_model, default_system_prompt, AgentRequest};
-use chroma_agent::{ActionBuilder, AnthropicModel, Call, InferenceUsage, ObservationBuilder, Reasoning};
+use chroma_agent::{ActionBuilder, AnthropicModel, Call, ObservationBuilder, Reasoning};
 use serde_json::json;
 use validator::Validate;
 
@@ -147,14 +147,4 @@ fn events_serialize_with_type_and_data_tags() {
     assert_eq!(done["type"], "done");
     assert_eq!(done["data"]["final_text"], "answer");
 
-    let usage = serde_json::to_value(usage_event(&InferenceUsage {
-        model: "scout".to_string(),
-        input_tokens: 123,
-        output_tokens: 456,
-    }))
-    .expect("serialize");
-    assert_eq!(usage["type"], "usage");
-    assert_eq!(usage["data"]["model"], "scout");
-    assert_eq!(usage["data"]["input_tokens"], 123);
-    assert_eq!(usage["data"]["output_tokens"], 456);
 }

--- a/rust/foundation-api/src/routes/agent/tests/00_unit.rs
+++ b/rust/foundation-api/src/routes/agent/tests/00_unit.rs
@@ -146,5 +146,4 @@ fn events_serialize_with_type_and_data_tags() {
     .expect("serialize");
     assert_eq!(done["type"], "done");
     assert_eq!(done["data"]["final_text"], "answer");
-
 }

--- a/rust/foundation-api/src/routes/agent/tests/00_unit.rs
+++ b/rust/foundation-api/src/routes/agent/tests/00_unit.rs
@@ -2,10 +2,10 @@
 //! the wire serialization of [`AgentSseEvent`].
 
 use super::super::events::{
-    action_event, action_text, observation_event, AgentSseEvent, AgentToolCall,
+    action_event, action_text, observation_event, usage_event, AgentSseEvent, AgentToolCall,
 };
 use super::super::{default_model, default_system_prompt, AgentRequest};
-use chroma_agent::{ActionBuilder, AnthropicModel, Call, ObservationBuilder, Reasoning};
+use chroma_agent::{ActionBuilder, AnthropicModel, Call, InferenceUsage, ObservationBuilder, Reasoning};
 use serde_json::json;
 use validator::Validate;
 
@@ -146,4 +146,15 @@ fn events_serialize_with_type_and_data_tags() {
     .expect("serialize");
     assert_eq!(done["type"], "done");
     assert_eq!(done["data"]["final_text"], "answer");
+
+    let usage = serde_json::to_value(usage_event(&InferenceUsage {
+        model: "scout".to_string(),
+        input_tokens: 123,
+        output_tokens: 456,
+    }))
+    .expect("serialize");
+    assert_eq!(usage["type"], "usage");
+    assert_eq!(usage["data"]["model"], "scout");
+    assert_eq!(usage["data"]["input_tokens"], 123);
+    assert_eq!(usage["data"]["output_tokens"], 456);
 }

--- a/rust/foundation-api/src/routes/agent/tests/01_drive.rs
+++ b/rust/foundation-api/src/routes/agent/tests/01_drive.rs
@@ -125,7 +125,7 @@ async fn drives_loop_and_emits_action_observation_done() {
     assert!(matches!(&events[2], AgentSseEvent::Action { .. }));
     assert!(matches!(
         &events[3],
-        AgentSseEvent::Done { final_text, .. } if final_text == "final answer"
+        AgentSseEvent::Done { final_text } if final_text == "final answer"
     ));
 }
 
@@ -143,7 +143,10 @@ async fn tool_error_is_reported_as_observation_then_done() {
         }
         other => panic!("expected observation, got {other:?}"),
     }
-    assert!(matches!(events.last(), Some(AgentSseEvent::Done { .. })));
+    assert!(matches!(
+        events.last(),
+        Some(AgentSseEvent::Done { final_text: _ })
+    ));
 }
 
 /// Answers immediately with text and never requests a tool.
@@ -175,7 +178,7 @@ async fn answer_without_tool_calls_emits_action_then_done() {
     }
     assert!(matches!(
         &events[1],
-        AgentSseEvent::Done { final_text, .. } if final_text == "direct answer"
+        AgentSseEvent::Done { final_text } if final_text == "direct answer"
     ));
 }
 
@@ -198,7 +201,7 @@ async fn no_actionable_inference_ends_with_empty_done() {
     assert_eq!(events.len(), 1);
     assert!(matches!(
         &events[0],
-        AgentSseEvent::Done { final_text, .. } if final_text.is_empty()
+        AgentSseEvent::Done { final_text } if final_text.is_empty()
     ));
 }
 

--- a/rust/foundation-api/src/routes/agent/tests/01_drive.rs
+++ b/rust/foundation-api/src/routes/agent/tests/01_drive.rs
@@ -123,10 +123,12 @@ async fn drives_loop_and_emits_action_observation_done() {
         other => panic!("expected observation, got {other:?}"),
     }
     assert!(matches!(&events[2], AgentSseEvent::Action { .. }));
-    assert!(matches!(
-        &events[3],
-        AgentSseEvent::Done { final_text } if final_text == "final answer"
-    ));
+    assert_eq!(
+        events[3],
+        AgentSseEvent::Done {
+            final_text: "final answer".to_string(),
+        }
+    );
 }
 
 #[tokio::test]
@@ -143,10 +145,12 @@ async fn tool_error_is_reported_as_observation_then_done() {
         }
         other => panic!("expected observation, got {other:?}"),
     }
-    assert!(matches!(
+    assert_eq!(
         events.last(),
-        Some(AgentSseEvent::Done { final_text: _ })
-    ));
+        Some(&AgentSseEvent::Done {
+            final_text: "final answer".to_string(),
+        })
+    );
 }
 
 /// Answers immediately with text and never requests a tool.
@@ -176,10 +180,12 @@ async fn answer_without_tool_calls_emits_action_then_done() {
         }
         other => panic!("expected action, got {other:?}"),
     }
-    assert!(matches!(
-        &events[1],
-        AgentSseEvent::Done { final_text } if final_text == "direct answer"
-    ));
+    assert_eq!(
+        events[1],
+        AgentSseEvent::Done {
+            final_text: "direct answer".to_string(),
+        }
+    );
 }
 
 /// Returns nothing actionable on the first inference (the model declined).
@@ -199,10 +205,12 @@ async fn no_actionable_inference_ends_with_empty_done() {
 
     // No action was produced, so the only event is a `done` with no answer.
     assert_eq!(events.len(), 1);
-    assert!(matches!(
-        &events[0],
-        AgentSseEvent::Done { final_text } if final_text.is_empty()
-    ));
+    assert_eq!(
+        events[0],
+        AgentSseEvent::Done {
+            final_text: String::new(),
+        }
+    );
 }
 
 /// An inference model that always errors, to exercise the in-band error event

--- a/rust/foundation-api/src/routes/agent/tests/01_drive.rs
+++ b/rust/foundation-api/src/routes/agent/tests/01_drive.rs
@@ -2,12 +2,12 @@
 //! tools, asserting the emitted [`AgentSseEvent`] sequence (incl. the
 //! tool-error-as-observation and inference-error paths) without any network.
 
-use super::super::drive_agent;
 use super::super::events::AgentSseEvent;
+use super::super::{drive_agent, record_search_agent_usage};
 use async_trait::async_trait;
 use chroma_agent::{
     Action, ActionBuilder, Agent, AgentError, AgentInferenceModel, Call, Entry, InferenceContext,
-    ObservationItem, Tool, ToolCallMetadata, ToolSet,
+    InferenceUsage, ObservationItem, Tool, ToolCallMetadata, ToolSet,
 };
 use futures::StreamExt;
 use schemars::JsonSchema;
@@ -234,4 +234,47 @@ async fn inference_error_ends_stream_with_error_event() {
         &events[0],
         AgentSseEvent::Error { message } if message.contains("inference boom")
     ));
+}
+
+#[test]
+fn accumulates_search_agent_usage_by_model() {
+    let mut usage_by_model = std::collections::HashMap::new();
+    let planner_usage = InferenceUsage {
+        model: "claude-sonnet".to_string(),
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_tokens: 10,
+        cache_write_tokens: 5,
+    };
+    let additional_planner_usage = InferenceUsage {
+        model: "claude-sonnet".to_string(),
+        input_tokens: 200,
+        output_tokens: 30,
+        cache_read_tokens: 40,
+        cache_write_tokens: 15,
+    };
+    let scout_usage = InferenceUsage {
+        model: "scout".to_string(),
+        input_tokens: 300,
+        output_tokens: 50,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+    };
+
+    record_search_agent_usage(&mut usage_by_model, &planner_usage);
+    record_search_agent_usage(&mut usage_by_model, &additional_planner_usage);
+    record_search_agent_usage(&mut usage_by_model, &scout_usage);
+
+    assert_eq!(usage_by_model.len(), 2);
+    assert_eq!(
+        usage_by_model.get("claude-sonnet"),
+        Some(&InferenceUsage {
+            model: "claude-sonnet".to_string(),
+            input_tokens: 300,
+            output_tokens: 50,
+            cache_read_tokens: 50,
+            cache_write_tokens: 20,
+        })
+    );
+    assert_eq!(usage_by_model.get("scout"), Some(&scout_usage));
 }

--- a/rust/foundation-api/src/routes/agent/tests/01_drive.rs
+++ b/rust/foundation-api/src/routes/agent/tests/01_drive.rs
@@ -18,6 +18,7 @@ use serde_json::json;
 struct StubTool {
     name: &'static str,
     fail: bool,
+    usage: Option<ToolCallMetadata>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -45,7 +46,7 @@ impl Tool for StubTool {
         if self.fail {
             Err(AgentError::Tool("stub tool failed".to_string()))
         } else {
-            Ok(("stub result".to_string(), None))
+            Ok(("stub result".to_string(), self.usage.clone()))
         }
     }
 }
@@ -76,11 +77,12 @@ impl AgentInferenceModel for CallThenAnswer {
     }
 }
 
-fn search_agent(fail: bool) -> Agent {
+fn search_agent(fail: bool, usage: Option<ToolCallMetadata>) -> Agent {
     let mut toolset = ToolSet::new();
     toolset.add(StubTool {
         name: "search",
         fail,
+        usage,
     });
     Agent::new(toolset, Box::new(CallThenAnswer))
 }
@@ -92,6 +94,7 @@ async fn collect_events(agent: Agent, query: &str) -> Vec<AgentSseEvent> {
         query.to_string(),
         "test-tenant".to_string(),
         "FOUNDATION".to_string(),
+        "00000000-0000-0000-0000-000000000000".to_string(),
     );
     futures::pin_mut!(stream);
     let mut events = Vec::new();
@@ -103,7 +106,7 @@ async fn collect_events(agent: Agent, query: &str) -> Vec<AgentSseEvent> {
 
 #[tokio::test]
 async fn drives_loop_and_emits_action_observation_done() {
-    let events = collect_events(search_agent(false), "hello").await;
+    let events = collect_events(search_agent(false, None), "hello").await;
 
     // action(call) -> observation -> action(text) -> done.
     assert_eq!(events.len(), 4, "events: {events:?}");
@@ -128,7 +131,7 @@ async fn drives_loop_and_emits_action_observation_done() {
 
 #[tokio::test]
 async fn tool_error_is_reported_as_observation_then_done() {
-    let events = collect_events(search_agent(true), "hello").await;
+    let events = collect_events(search_agent(true, None), "hello").await;
 
     // The failed call still yields an observation (is_error) and the run
     // continues to a terminal answer rather than aborting.
@@ -141,6 +144,36 @@ async fn tool_error_is_reported_as_observation_then_done() {
         other => panic!("expected observation, got {other:?}"),
     }
     assert!(matches!(events.last(), Some(AgentSseEvent::Done { .. })));
+}
+
+#[tokio::test]
+async fn subagent_usage_emits_usage_event() {
+    let events = collect_events(
+        search_agent(
+            false,
+            Some(ToolCallMetadata::SubagentUsage {
+                model: "scout".to_string(),
+                input_tokens: 123,
+                output_tokens: 456,
+            }),
+        ),
+        "hello",
+    )
+    .await;
+
+    assert_eq!(events.len(), 5, "events: {events:?}");
+    assert!(matches!(&events[0], AgentSseEvent::Action { .. }));
+    assert!(matches!(
+        &events[1],
+        AgentSseEvent::Usage {
+            model,
+            input_tokens: 123,
+            output_tokens: 456,
+        } if model == "scout"
+    ));
+    assert!(matches!(&events[2], AgentSseEvent::Observation { .. }));
+    assert!(matches!(&events[3], AgentSseEvent::Action { .. }));
+    assert!(matches!(&events[4], AgentSseEvent::Done { .. }));
 }
 
 /// Answers immediately with text and never requests a tool.

--- a/rust/foundation-api/src/routes/agent/tests/01_drive.rs
+++ b/rust/foundation-api/src/routes/agent/tests/01_drive.rs
@@ -146,35 +146,6 @@ async fn tool_error_is_reported_as_observation_then_done() {
     assert!(matches!(events.last(), Some(AgentSseEvent::Done { .. })));
 }
 
-#[tokio::test]
-async fn subagent_usage_emits_usage_event() {
-    let events = collect_events(
-        search_agent(
-            false,
-            Some(ToolCallMetadata::SubagentUsage {
-                model: "scout".to_string(),
-                input_tokens: 123,
-                output_tokens: 456,
-            }),
-        ),
-        "hello",
-    )
-    .await;
-
-    assert_eq!(events.len(), 5, "events: {events:?}");
-    assert!(matches!(&events[0], AgentSseEvent::Action { .. }));
-    assert!(matches!(
-        &events[1],
-        AgentSseEvent::Usage {
-            model,
-            input_tokens: 123,
-            output_tokens: 456,
-        } if model == "scout"
-    ));
-    assert!(matches!(&events[2], AgentSseEvent::Observation { .. }));
-    assert!(matches!(&events[3], AgentSseEvent::Action { .. }));
-    assert!(matches!(&events[4], AgentSseEvent::Done { .. }));
-}
 
 /// Answers immediately with text and never requests a tool.
 struct AnswerImmediately;

--- a/rust/foundation-api/src/routes/agent/tests/01_drive.rs
+++ b/rust/foundation-api/src/routes/agent/tests/01_drive.rs
@@ -87,7 +87,12 @@ fn search_agent(fail: bool) -> Agent {
 
 /// Drives the typed-event loop to completion and collects every event.
 async fn collect_events(agent: Agent, query: &str) -> Vec<AgentSseEvent> {
-    let stream = drive_agent(agent, query.to_string());
+    let stream = drive_agent(
+        agent,
+        query.to_string(),
+        "test-tenant".to_string(),
+        "FOUNDATION".to_string(),
+    );
     futures::pin_mut!(stream);
     let mut events = Vec::new();
     while let Some(event) = stream.next().await {
@@ -117,7 +122,7 @@ async fn drives_loop_and_emits_action_observation_done() {
     assert!(matches!(&events[2], AgentSseEvent::Action { .. }));
     assert!(matches!(
         &events[3],
-        AgentSseEvent::Done { final_text } if final_text == "final answer"
+        AgentSseEvent::Done { final_text, .. } if final_text == "final answer"
     ));
 }
 
@@ -167,7 +172,7 @@ async fn answer_without_tool_calls_emits_action_then_done() {
     }
     assert!(matches!(
         &events[1],
-        AgentSseEvent::Done { final_text } if final_text == "direct answer"
+        AgentSseEvent::Done { final_text, .. } if final_text == "direct answer"
     ));
 }
 
@@ -190,7 +195,7 @@ async fn no_actionable_inference_ends_with_empty_done() {
     assert_eq!(events.len(), 1);
     assert!(matches!(
         &events[0],
-        AgentSseEvent::Done { final_text } if final_text.is_empty()
+        AgentSseEvent::Done { final_text, .. } if final_text.is_empty()
     ));
 }
 

--- a/rust/foundation-api/src/routes/agent/tests/01_drive.rs
+++ b/rust/foundation-api/src/routes/agent/tests/01_drive.rs
@@ -146,7 +146,6 @@ async fn tool_error_is_reported_as_observation_then_done() {
     assert!(matches!(events.last(), Some(AgentSseEvent::Done { .. })));
 }
 
-
 /// Answers immediately with text and never requests a tool.
 struct AnswerImmediately;
 

--- a/rust/foundation-api/src/routes/agent/tests/02_live.rs
+++ b/rust/foundation-api/src/routes/agent/tests/02_live.rs
@@ -76,6 +76,7 @@ async fn live_agent_calls_tool_then_answers() {
         "When was Chroma founded?".to_string(),
         "test-tenant".to_string(),
         "FOUNDATION".to_string(),
+        "00000000-0000-0000-0000-000000000000".to_string(),
     );
     futures::pin_mut!(stream);
 

--- a/rust/foundation-api/src/routes/agent/tests/02_live.rs
+++ b/rust/foundation-api/src/routes/agent/tests/02_live.rs
@@ -71,7 +71,12 @@ async fn live_agent_calls_tool_then_answers() {
          answer any question before responding, then summarize what it returned.",
     );
 
-    let stream = drive_agent(agent, "When was Chroma founded?".to_string());
+    let stream = drive_agent(
+        agent,
+        "When was Chroma founded?".to_string(),
+        "test-tenant".to_string(),
+        "FOUNDATION".to_string(),
+    );
     futures::pin_mut!(stream);
 
     let mut events = Vec::new();
@@ -94,7 +99,7 @@ async fn live_agent_calls_tool_then_answers() {
         "expected an observation from the tool: {events:?}"
     );
     match events.last() {
-        Some(AgentSseEvent::Done { final_text }) => {
+        Some(AgentSseEvent::Done { final_text, .. }) => {
             assert!(!final_text.is_empty(), "expected a non-empty final answer");
         }
         other => panic!("expected terminal done, got {other:?}"),

--- a/rust/foundation-api/src/routes/mcp/server.rs
+++ b/rust/foundation-api/src/routes/mcp/server.rs
@@ -242,7 +242,7 @@ impl FoundationMcpServer {
             Err(err) => return CallToolResult::error(vec![Content::text(err.to_string())]),
         };
 
-        let body = self.enrich_ranked_documents(&tenant, documents);
+        let body = self.enrich_ranked_documents(&tenant, documents.documents);
         match serde_json::to_value(body) {
             Ok(value) => CallToolResult::structured(value),
             Err(err) => CallToolResult::error(vec![Content::text(err.to_string())]),

--- a/rust/foundation-api/src/routes/subagent_search/events.rs
+++ b/rust/foundation-api/src/routes/subagent_search/events.rs
@@ -96,6 +96,10 @@ pub(crate) struct UsageData {
     pub model: String,
     pub input_tokens: u64,
     pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    #[serde(default)]
+    pub cache_write_tokens: u64,
 }
 
 impl ActionData {

--- a/rust/foundation-api/src/routes/subagent_search/events.rs
+++ b/rust/foundation-api/src/routes/subagent_search/events.rs
@@ -21,6 +21,7 @@ use std::sync::LazyLock;
 pub(crate) enum AgentEvent {
     Action(ActionData),
     Observation(ObservationData),
+    Usage(UsageData),
     Done,
     Error(ErrorData),
     Unknown,
@@ -40,6 +41,7 @@ impl AgentEvent {
             Some("observation") => {
                 from_data(data()).map_or(AgentEvent::Unknown, AgentEvent::Observation)
             }
+            Some("usage") => from_data(data()).map_or(AgentEvent::Unknown, AgentEvent::Usage),
             Some("done") => AgentEvent::Done,
             Some("error") => from_data(data()).map_or(AgentEvent::Unknown, AgentEvent::Error),
             _ => AgentEvent::Unknown,
@@ -86,6 +88,14 @@ pub(crate) struct ObservationData {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct ErrorData {
     pub message: String,
+}
+
+/// The `data` of a `usage` event emitted by the deep-research dependency.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct UsageData {
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
 }
 
 impl ActionData {
@@ -145,6 +155,13 @@ pub(crate) enum SubagentResultError {
     /// The byte stream ended without an explicit `done` or `error` event.
     #[error("subagent stream ended without a terminal event")]
     MissingTerminalEvent,
+}
+
+/// The final structured outcome of a deep-research run.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SubagentSearchResult {
+    pub documents: Vec<RankedDocument>,
+    pub usage: Option<UsageData>,
 }
 
 /// Matches one `<Document id=…><Justification>…</Justification></Document>`

--- a/rust/foundation-api/src/routes/subagent_search/mod.rs
+++ b/rust/foundation-api/src/routes/subagent_search/mod.rs
@@ -33,7 +33,10 @@ use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::{extract::State, http::HeaderMap, Json};
 use chroma_error::{ChromaError, ErrorCodes};
 pub(crate) use events::RankedDocument;
-use events::{parse_ranked_documents, AgentEvent, SubagentResultError, SubagentSearchEvent};
+use events::{
+    parse_ranked_documents, AgentEvent, SubagentResultError, SubagentSearchEvent,
+    SubagentSearchResult, UsageData,
+};
 use futures::{Stream, StreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -224,6 +227,7 @@ fn stream_subagent_search(
                         SubagentSearchEvent::Done,
                     ]
                 }
+                AgentEvent::Usage(_) => Vec::new(),
                 // Unknown / unparseable events carry nothing we can model.
                 AgentEvent::Unknown => Vec::new(),
             };
@@ -355,10 +359,13 @@ pub(crate) async fn subagent_search_text(
     creds: SubagentSearchCreds,
     query: String,
     ui_origin: Option<&str>,
-) -> Result<String, SubagentResultError> {
+) -> Result<(String, Option<UsageData>), SubagentResultError> {
     let tenant = creds.chroma_tenant.clone();
-    let documents = collect_subagent_search_final(http, url, creds, query).await?;
-    Ok(format_ranked_documents(&documents, ui_origin, &tenant))
+    let result = collect_subagent_search_final(http, url, creds, query).await?;
+    Ok((
+        format_ranked_documents(&result.documents, ui_origin, &tenant),
+        result.usage,
+    ))
 }
 
 /// Renders ranked documents (most-relevant first) into a numbered text block
@@ -408,12 +415,13 @@ pub(crate) async fn collect_subagent_search_final(
     url: String,
     creds: SubagentSearchCreds,
     query: String,
-) -> Result<Vec<events::RankedDocument>, SubagentResultError> {
+) -> Result<SubagentSearchResult, SubagentResultError> {
     let stream = subagent_search_data_stream(http, url, creds, query);
     futures::pin_mut!(stream);
 
     // Keep the last action's `user_text` — the agent's final answer.
     let mut final_answer: Option<String> = None;
+    let mut usage: Option<UsageData> = None;
     let mut saw_done = false;
     while let Some(item) = stream.next().await {
         let raw = item.map_err(SubagentResultError::Stream)?;
@@ -430,6 +438,9 @@ pub(crate) async fn collect_subagent_search_final(
                 saw_done = true;
                 break;
             }
+            AgentEvent::Usage(event_usage) => {
+                usage = Some(event_usage);
+            }
             AgentEvent::Observation(_) | AgentEvent::Unknown => {}
         }
     }
@@ -440,10 +451,13 @@ pub(crate) async fn collect_subagent_search_final(
 
     // A completed stream whose answer parses to zero documents is a valid "no
     // hits" result.
-    Ok(final_answer
-        .as_deref()
-        .map(parse_ranked_documents)
-        .unwrap_or_default())
+    Ok(SubagentSearchResult {
+        documents: final_answer
+            .as_deref()
+            .map(parse_ranked_documents)
+            .unwrap_or_default(),
+        usage,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/foundation-api/src/routes/subagent_search/tests/00_unit.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/00_unit.rs
@@ -42,7 +42,13 @@ fn agent_event_parses_each_kind() {
         AgentEvent::parse(
             &json!({"type":"usage","data":{"model":"scout","input_tokens":123,"output_tokens":456}}).to_string()
         ),
-        AgentEvent::Usage(UsageData { model, input_tokens: 123, output_tokens: 456 }) if model == "scout"
+        AgentEvent::Usage(UsageData {
+            model,
+            input_tokens: 123,
+            output_tokens: 456,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+        }) if model == "scout"
     ));
     assert!(matches!(
         AgentEvent::parse(&json!({"type":"done","data":{}}).to_string()),

--- a/rust/foundation-api/src/routes/subagent_search/tests/00_unit.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/00_unit.rs
@@ -3,6 +3,7 @@
 
 use super::super::events::{
     parse_ranked_documents, ActionData, AgentEvent, ErrorData, RankedDocument, SubagentSearchEvent,
+    UsageData,
 };
 use super::super::{
     format_ranked_documents, parse_sse_data_line, subagent_search_payload, SubagentSearchCreds,
@@ -36,6 +37,12 @@ fn agent_event_parses_each_kind() {
             &json!({"type":"observation","data":{"step":1,"sources":["a"]}}).to_string()
         ),
         AgentEvent::Observation(_)
+    ));
+    assert!(matches!(
+        AgentEvent::parse(
+            &json!({"type":"usage","data":{"model":"scout","input_tokens":123,"output_tokens":456}}).to_string()
+        ),
+        AgentEvent::Usage(UsageData { model, input_tokens: 123, output_tokens: 456 }) if model == "scout"
     ));
     assert!(matches!(
         AgentEvent::parse(&json!({"type":"done","data":{}}).to_string()),

--- a/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
@@ -24,6 +24,7 @@ async fn streams_and_collects_final_from_mocked_sse() {
         "data: {\"type\":\"action\",\"data\":{\"tools\":[{\"name\":\"search\"}],\"params\":[{\"query\":\"rag\"}]}}\n\n",
         "data: {\"type\":\"observation\",\"data\":{\"sources\":[\"a\"]}}\n\n",
         "data: {\"type\":\"action\",\"data\":{\"tools\":[{\"name\":\"user_text\"}],\"params\":[{\"text\":\"<Document id=doc-1><Justification>Relevant to rag.</Justification></Document>\"}]}}\n\n",
+        "data: {\"type\":\"usage\",\"data\":{\"model\":\"scout\",\"input_tokens\":123,\"output_tokens\":456}}\n\n",
         "data: {\"type\":\"done\",\"data\":{}}\n\n",
     );
     let mock = server
@@ -53,7 +54,7 @@ async fn streams_and_collects_final_from_mocked_sse() {
     assert_eq!(count, 4, "action + observation + result + done");
 
     // The collect core resolves the terminal answer into ranked documents.
-    let documents = collect_subagent_search_final(
+    let result = collect_subagent_search_final(
         reqwest::Client::new(),
         server.base_url(),
         test_creds(),
@@ -62,12 +63,13 @@ async fn streams_and_collects_final_from_mocked_sse() {
     .await
     .expect("documents parse");
     assert_eq!(
-        documents,
+        result.documents,
         vec![RankedDocument {
             id: "doc-1".to_string(),
             justification: "Relevant to rag.".to_string(),
         }]
     );
+    assert_eq!(result.usage.expect("usage should be present").model, "scout");
     assert_eq!(mock.calls(), 2);
 }
 
@@ -164,7 +166,7 @@ async fn answer_with_no_documents_emits_empty_result_then_done() {
     assert!(events.iter().all(|e| e.is_ok()), "no hits is not an error");
 
     // The collect core resolves the same stream to an empty document list.
-    let documents = collect_subagent_search_final(
+    let result = collect_subagent_search_final(
         reqwest::Client::new(),
         server.base_url(),
         test_creds(),
@@ -172,7 +174,8 @@ async fn answer_with_no_documents_emits_empty_result_then_done() {
     )
     .await
     .expect("empty results are Ok");
-    assert!(documents.is_empty());
+    assert!(result.documents.is_empty());
+    assert!(result.usage.is_none());
     assert_eq!(mock.calls(), 2);
 }
 

--- a/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
@@ -69,7 +69,10 @@ async fn streams_and_collects_final_from_mocked_sse() {
             justification: "Relevant to rag.".to_string(),
         }]
     );
-    assert_eq!(result.usage.expect("usage should be present").model, "scout");
+    assert_eq!(
+        result.usage.expect("usage should be present").model,
+        "scout"
+    );
     assert_eq!(mock.calls(), 2);
 }
 

--- a/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/01_integration.rs
@@ -69,10 +69,12 @@ async fn streams_and_collects_final_from_mocked_sse() {
             justification: "Relevant to rag.".to_string(),
         }]
     );
-    assert_eq!(
-        result.usage.expect("usage should be present").model,
-        "scout"
-    );
+    let usage = result.usage.expect("usage should be present");
+    assert_eq!(usage.model, "scout");
+    assert_eq!(usage.input_tokens, 123);
+    assert_eq!(usage.output_tokens, 456);
+    assert_eq!(usage.cache_read_tokens, 0);
+    assert_eq!(usage.cache_write_tokens, 0);
     assert_eq!(mock.calls(), 2);
 }
 

--- a/rust/foundation-api/src/routes/subagent_search/tests/02_live.rs
+++ b/rust/foundation-api/src/routes/subagent_search/tests/02_live.rs
@@ -50,6 +50,7 @@ async fn live_subagent_search_streams_events() {
                 }
             }
             AgentEvent::Observation(_) => eprintln!("event: observation"),
+            AgentEvent::Usage(_) => eprintln!("event: usage"),
             AgentEvent::Done => {
                 eprintln!("event: done");
                 saw_done = true;

--- a/rust/metering/src/core.rs
+++ b/rust/metering/src/core.rs
@@ -538,6 +538,7 @@ initialize_metering! {
     pub struct SearchAgentUsageContext {
         pub tenant: String,
         pub database: String,
+        pub collection_id: String,
         pub model: String,
         pub input_tokens: u64,
         pub output_tokens: u64,
@@ -547,6 +548,7 @@ initialize_metering! {
         pub fn new(
             tenant: String,
             database: String,
+            collection_id: String,
             model: String,
             input_tokens: u64,
             output_tokens: u64,
@@ -554,6 +556,7 @@ initialize_metering! {
             SearchAgentUsageContext {
                 tenant,
                 database,
+                collection_id,
                 model,
                 input_tokens,
                 output_tokens,
@@ -618,6 +621,7 @@ mod tests {
         let event = MeterEvent::SearchAgentUsage(SearchAgentUsageContext::new(
             "test_tenant".to_string(),
             "FOUNDATION".to_string(),
+            "test_collection".to_string(),
             "context-1".to_string(),
             123,
             456,

--- a/rust/metering/src/core.rs
+++ b/rust/metering/src/core.rs
@@ -546,29 +546,6 @@ initialize_metering! {
         pub cache_write_tokens: u64,
     }
 
-    impl SearchAgentUsageContext {
-        pub fn new(
-            tenant: String,
-            database: String,
-            collection_id: String,
-            model: String,
-            input_tokens: u64,
-            output_tokens: u64,
-            cache_read_tokens: u64,
-            cache_write_tokens: u64,
-        ) -> Self {
-            SearchAgentUsageContext {
-                tenant,
-                database,
-                collection_id,
-                model,
-                input_tokens,
-                output_tokens,
-                cache_read_tokens,
-                cache_write_tokens,
-            }
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -624,16 +601,16 @@ mod tests {
 
     #[test]
     fn test_search_agent_usage_serialization() {
-        let event = MeterEvent::SearchAgentUsage(SearchAgentUsageContext::new(
-            "test_tenant".to_string(),
-            "FOUNDATION".to_string(),
-            "test_collection".to_string(),
-            "context-1".to_string(),
-            123,
-            456,
-            78,
-            90,
-        ));
+        let event = MeterEvent::SearchAgentUsage(SearchAgentUsageContext {
+            tenant: "test_tenant".to_string(),
+            database: "FOUNDATION".to_string(),
+            collection_id: "test_collection".to_string(),
+            model: "context-1".to_string(),
+            input_tokens: 123,
+            output_tokens: 456,
+            cache_read_tokens: 78,
+            cache_write_tokens: 90,
+        });
 
         let json_str = serde_json::to_string(&event).expect("The event should be serializable");
         let json_event =

--- a/rust/metering/src/core.rs
+++ b/rust/metering/src/core.rs
@@ -542,6 +542,8 @@ initialize_metering! {
         pub model: String,
         pub input_tokens: u64,
         pub output_tokens: u64,
+        pub cache_read_tokens: u64,
+        pub cache_write_tokens: u64,
     }
 
     impl SearchAgentUsageContext {
@@ -552,6 +554,8 @@ initialize_metering! {
             model: String,
             input_tokens: u64,
             output_tokens: u64,
+            cache_read_tokens: u64,
+            cache_write_tokens: u64,
         ) -> Self {
             SearchAgentUsageContext {
                 tenant,
@@ -560,6 +564,8 @@ initialize_metering! {
                 model,
                 input_tokens,
                 output_tokens,
+                cache_read_tokens,
+                cache_write_tokens,
             }
         }
     }
@@ -625,6 +631,8 @@ mod tests {
             "context-1".to_string(),
             123,
             456,
+            78,
+            90,
         ));
 
         let json_str = serde_json::to_string(&event).expect("The event should be serializable");

--- a/rust/metering/src/core.rs
+++ b/rust/metering/src/core.rs
@@ -530,6 +530,36 @@ initialize_metering! {
             }
         }
     }
+
+    ////////////////////////////////// search_agent_usage //////////////////////////////////
+    #[context(capabilities = [], handlers = [])]
+    #[derive(Clone, Debug, PartialEq, Deserialize, Eq, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    pub struct SearchAgentUsageContext {
+        pub tenant: String,
+        pub database: String,
+        pub model: String,
+        pub input_tokens: u64,
+        pub output_tokens: u64,
+    }
+
+    impl SearchAgentUsageContext {
+        pub fn new(
+            tenant: String,
+            database: String,
+            model: String,
+            input_tokens: u64,
+            output_tokens: u64,
+        ) -> Self {
+            SearchAgentUsageContext {
+                tenant,
+                database,
+                model,
+                input_tokens,
+                output_tokens,
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -539,11 +569,12 @@ pub enum MeterEvent {
     CollectionRead(CollectionReadContext),
     CollectionWrite(CollectionWriteContext),
     ExternalCollectionRead(ExternalCollectionReadContext),
+    SearchAgentUsage(SearchAgentUsageContext),
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{CollectionWriteContext, MeterEvent, WriteAction};
+    use super::{CollectionWriteContext, MeterEvent, SearchAgentUsageContext, WriteAction};
     use crate::types::{MeteringAtomicU64, MeteringInstant};
 
     #[test]
@@ -577,7 +608,25 @@ mod tests {
             MeterEvent::ExternalCollectionRead(external_collection_read_context) => {
                 external_collection_read_context.request_received_at = request_received_at
             }
+            MeterEvent::SearchAgentUsage(_) => {}
         }
+        assert_eq!(json_event, event);
+    }
+
+    #[test]
+    fn test_search_agent_usage_serialization() {
+        let event = MeterEvent::SearchAgentUsage(SearchAgentUsageContext::new(
+            "test_tenant".to_string(),
+            "FOUNDATION".to_string(),
+            "context-1".to_string(),
+            123,
+            456,
+        ));
+
+        let json_str = serde_json::to_string(&event).expect("The event should be serializable");
+        let json_event =
+            serde_json::from_str::<MeterEvent>(&json_str).expect("Json should be deserializable");
+
         assert_eq!(json_event, event);
     }
 }

--- a/rust/metering/src/lib.rs
+++ b/rust/metering/src/lib.rs
@@ -12,5 +12,6 @@ pub use {
         ReturnBytes, SearchAgentUsageContext, StartRequest, WriteAction,
     },
     errors::MeteringError,
+    receiver::meter_event_receiver_initialized,
     types::{MeteringAtomicU64, MeteringInstant},
 };

--- a/rust/metering/src/lib.rs
+++ b/rust/metering/src/lib.rs
@@ -9,7 +9,7 @@ pub use {
         CollectionWriteContext, Enterable, ExternalCollectionReadContext, FinishRequest,
         FtsQueryLength, LatestCollectionLogicalSizeBytes, LogSizeBytes, MetadataPredicateCount,
         MeterEvent, MeteredFutureExt, PulledLogSizeBytes, QueryEmbeddingCount, ReadAction,
-        ReturnBytes, StartRequest, WriteAction,
+        ReturnBytes, SearchAgentUsageContext, StartRequest, WriteAction,
     },
     errors::MeteringError,
     types::{MeteringAtomicU64, MeteringInstant},

--- a/rust/metering/src/receiver.rs
+++ b/rust/metering/src/receiver.rs
@@ -7,6 +7,10 @@ use crate::{core::MeterEvent, MeteringError};
 pub static METER_EVENT_RECEIVER: OnceLock<Box<dyn ReceiverForMessage<MeterEvent>>> =
     OnceLock::new();
 
+pub fn meter_event_receiver_initialized() -> bool {
+    METER_EVENT_RECEIVER.get().is_some()
+}
+
 impl MeterEvent {
     pub fn init_receiver(receiver: Box<dyn ReceiverForMessage<MeterEvent>>) {
         if METER_EVENT_RECEIVER.set(receiver).is_err() {


### PR DESCRIPTION
## Summary
- add a search agent usage metering event to chroma-metering
- meter both planner calls and search subagent calls in `foundation-api`
- keep the public `/api/agent` SSE contract unchanged in this PR

## Testing
- cargo test -p chroma-agent -p chroma-metering -p foundation-api --no-run
- cargo test -p foundation-api routes::agent::tests:: -- --nocapture
