### PR TITLE
[BUG](gc): Strip NUL bytes from FTS5 metadata values

### DIFF
--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -344,6 +344,8 @@ class SqliteMetadataSegment(MetadataReader):
         )
         for key, value in metadata.items():
             if isinstance(value, str):
+                # Embedded NUL bytes corrupt the FTS5 inverted index (gh#7388).
+                value = value.replace("\x00", "")
                 q = q.insert(
                     ParameterValue(id),
                     ParameterValue(key),
@@ -390,13 +392,17 @@ class SqliteMetadataSegment(MetadataReader):
             t = Table("embedding_fulltext_search")
 
             def insert_into_fulltext_search() -> None:
+                doc = metadata["chroma:document"]
+                # Embedded NUL bytes corrupt the FTS5 inverted index (gh#7388).
+                if isinstance(doc, str) and "\x00" in doc:
+                    doc = doc.replace("\x00", "")
                 q = (
                     self._db.querybuilder()
                     .into(t)
                     .columns(t.rowid, t.string_value)
                     .insert(
                         ParameterValue(id),
-                        ParameterValue(metadata["chroma:document"]),
+                        ParameterValue(doc),
                     )
                 )
                 sql, params = get_sql(q)


### PR DESCRIPTION
## Description

Embedded NUL (\x00) bytes in document metadata corrupt the FTS5 inverted index tokenizer, causing errors like "fts5: syntax error near" on full-text search queries.

The fix strips NUL bytes at both insertion points: the metadata table loop (`_insert_metadata`) and the FTS5 virtual table (`insert_into_fulltext_search`).

Fixes #7388