### PR TITLE
[BUG](worker): Purge deleted fn work

### DIFF
--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -1,12 +1,19 @@
 use chroma_error::{source_chain_contains, ChromaError};
 use chroma_log::grpc_log::GrpcPullLogsError;
-use chroma_system::System;
-use chroma_types::{AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName};
+<<<<<<< HEAD
+use chroma_system::{Operator, System};
+use chroma_types::{
+    AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName,
+    GetCollectionWithSegmentsError,
+};
 use std::error::Error;
+use tonic::Code;
 use uuid::Uuid;
 
 use crate::execution::operators::{
-    fetch_log::FetchLogError, materialize_logs::MaterializeLogOutput,
+    fetch_log::FetchLogError,
+    finish_async_work::{FinishAsyncWorkItem, FinishAsyncWorkOperator},
+    materialize_logs::MaterializeLogOutput,
 };
 
 use super::{
@@ -190,32 +197,113 @@ impl FunctionExecutionContext {
             .is_some_and(|pull_error| Self::is_purged_pull_error(pull_error.as_ref()))
     }
 
-    async fn resolve_shared_input_database_name(
+    fn is_stale_input_collection_error(error: &GetCollectionWithSegmentsError) -> bool {
+        match error {
+            GetCollectionWithSegmentsError::NotFound(_) => true,
+            GetCollectionWithSegmentsError::Grpc(status) => {
+                status.code() == Code::NotFound
+                    || (status.code() == Code::FailedPrecondition
+                        && status.message().contains("soft deleted"))
+            }
+            _ => false,
+        }
+    }
+
+    async fn purge_deleted(
         compaction_context: CompactionContext,
-        fn_inputs: &[FunctionExecutionInput],
-    ) -> Result<DatabaseName, CompactionError> {
-        let Some(first_input) = fn_inputs.first() else {
+        attached_function_id: AttachedFunctionUuid,
+        work_items: Vec<FinishAsyncWorkItem>,
+    ) -> Result<(), CompactionError> {
+        if work_items.is_empty() {
+            return Ok(());
+        }
+
+        let Some(work_queue_client) = compaction_context.work_queue_client.clone() else {
             return Err(CompactionError::InvariantViolation(
-                "Function execution requires at least one input collection",
+                "Work queue client not available for async function",
             ));
         };
 
-        let mut sysdb = compaction_context.sysdb.clone();
-        // TODO(tanujnay112): This does not support MCMR yet because work queue records
-        // do not carry the database name. Pass the database name from the work queue
-        // service and remove this unscoped lookup once that metadata is available.
-        let collection_info = sysdb
-            .get_collection_with_segments(None, first_input.collection_id)
+        FinishAsyncWorkOperator::new()
+            .run(
+                &crate::execution::operators::finish_async_work::FinishAsyncWorkInput::new(
+                    attached_function_id,
+                    work_items,
+                    work_queue_client,
+                ),
+            )
             .await
             .map_err(|_| {
-                CompactionError::InvariantViolation(
-                    "Failed to resolve function input collection database",
-                )
+                CompactionError::InvariantViolation("Failed to purge deleted fn-consumer work item")
             })?;
 
-        DatabaseName::new(&collection_info.collection.database).ok_or(
-            CompactionError::InvariantViolation("Invalid function input collection database name"),
+        Ok(())
+    }
+
+    async fn partition_live_and_stale_inputs(
+        compaction_context: CompactionContext,
+        attached_function_id: AttachedFunctionUuid,
+        fn_inputs: &[FunctionExecutionInput],
+    ) -> Result<(Option<DatabaseName>, Vec<FunctionExecutionInput>), CompactionError> {
+        if fn_inputs.is_empty() {
+            return Err(CompactionError::InvariantViolation(
+                "Function execution requires at least one input collection",
+            ));
+        }
+
+        let mut sysdb = compaction_context.sysdb.clone();
+        let mut live_inputs = Vec::with_capacity(fn_inputs.len());
+        let mut stale_work_items = Vec::new();
+        let mut shared_database_name = None;
+
+        for input in fn_inputs.iter().cloned() {
+            // TODO(tanujnay112): This does not support MCMR yet because work queue records
+            // do not carry the database name. Pass the database name from the work queue
+            // service and remove this unscoped lookup once that metadata is available.
+            match sysdb
+                .get_collection_with_segments(None, input.collection_id)
+                .await
+            {
+                Ok(collection_info) => {
+                    if shared_database_name.is_none() {
+                        shared_database_name = Some(
+                            DatabaseName::new(&collection_info.collection.database).ok_or(
+                                CompactionError::InvariantViolation(
+                                    "Invalid function input collection database name",
+                                ),
+                            )?,
+                        );
+                    }
+                    live_inputs.push(input);
+                }
+                Err(error) if Self::is_stale_input_collection_error(&error) => {
+                    tracing::info!(
+                        collection_id = %input.collection_id,
+                        attached_function_id = %attached_function_id,
+                        error = %error,
+                        "Finishing stale fn-consumer work for deleted input collection"
+                    );
+                    stale_work_items.push(FinishAsyncWorkItem {
+                        input_collection_id: input.collection_id,
+                        completion_offset: input.queue_compaction_offset,
+                    });
+                }
+                Err(_) => {
+                    return Err(CompactionError::InvariantViolation(
+                        "Failed to resolve function input collection database",
+                    ));
+                }
+            }
+        }
+
+        Self::purge_deleted(
+            compaction_context,
+            attached_function_id,
+            stale_work_items,
         )
+        .await?;
+
+        Ok((shared_database_name, live_inputs))
     }
 
     #[tracing::instrument(skip(self, system))]
@@ -232,10 +320,23 @@ impl FunctionExecutionContext {
         }
 
         let base_context = self.compaction_context;
+        let (shared_database_name, live_inputs) = Self::partition_live_and_stale_inputs(
+            base_context.clone(),
+            attached_function_id,
+            &fn_inputs,
+        )
+        .await?;
+        if live_inputs.is_empty() {
+            return Ok(CompactionResponse::Success {
+                job_id: attached_function_id.into(),
+            });
+        }
         let shared_database_name =
-            Self::resolve_shared_input_database_name(base_context.clone(), &fn_inputs).await?;
+            shared_database_name.ok_or(CompactionError::InvariantViolation(
+                "Function execution requires at least one live input collection",
+            ))?;
         let mut input_collection_data = Vec::with_capacity(fn_inputs.len());
-        for input in fn_inputs {
+        for input in live_inputs {
             let collection_data = Box::pin(Self::fetch_function_input_collection_data(
                 base_context.clone(),
                 input.collection_id,
@@ -310,6 +411,7 @@ mod tests {
     };
     use chroma_error::ChromaError;
     use chroma_log::grpc_log::GrpcPullLogsError;
+    use chroma_types::GetCollectionWithSegmentsError;
     use tonic::Status;
 
     #[test]
@@ -351,6 +453,31 @@ mod tests {
 
         assert!(!FunctionExecutionContext::should_backfill_on_fetch_error(
             &err
+        ));
+    }
+
+    #[test]
+    fn deleted_collection_not_found_is_treated_as_stale_input() {
+        assert!(FunctionExecutionContext::is_stale_input_collection_error(
+            &GetCollectionWithSegmentsError::NotFound("missing".to_string())
+        ));
+    }
+
+    #[test]
+    fn soft_deleted_collection_is_treated_as_stale_input() {
+        assert!(FunctionExecutionContext::is_stale_input_collection_error(
+            &GetCollectionWithSegmentsError::Grpc(Status::failed_precondition(
+                "collection soft deleted",
+            ))
+        ));
+    }
+
+    #[test]
+    fn unrelated_failed_precondition_is_not_treated_as_stale_input() {
+        assert!(!FunctionExecutionContext::is_stale_input_collection_error(
+            &GetCollectionWithSegmentsError::Grpc(Status::failed_precondition(
+                "different precondition failure",
+            ))
         ));
     }
 }

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -1,13 +1,10 @@
 use chroma_error::{source_chain_contains, ChromaError};
 use chroma_log::grpc_log::GrpcPullLogsError;
-<<<<<<< HEAD
+use chroma_sysdb::GetCollectionsOptions;
 use chroma_system::{Operator, System};
-use chroma_types::{
-    AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName,
-    GetCollectionWithSegmentsError,
-};
+use chroma_types::{AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName};
+use std::collections::HashSet;
 use std::error::Error;
-use tonic::Code;
 use uuid::Uuid;
 
 use crate::execution::operators::{
@@ -197,18 +194,6 @@ impl FunctionExecutionContext {
             .is_some_and(|pull_error| Self::is_purged_pull_error(pull_error.as_ref()))
     }
 
-    fn is_stale_input_collection_error(error: &GetCollectionWithSegmentsError) -> bool {
-        match error {
-            GetCollectionWithSegmentsError::NotFound(_) => true,
-            GetCollectionWithSegmentsError::Grpc(status) => {
-                status.code() == Code::NotFound
-                    || (status.code() == Code::FailedPrecondition
-                        && status.message().contains("soft deleted"))
-            }
-            _ => false,
-        }
-    }
-
     async fn purge_deleted(
         compaction_context: CompactionContext,
         attached_function_id: AttachedFunctionUuid,
@@ -250,47 +235,45 @@ impl FunctionExecutionContext {
         }
 
         let mut sysdb = compaction_context.sysdb.clone();
+        let collections = sysdb
+            .get_collections(GetCollectionsOptions {
+                collection_ids: Some(fn_inputs.iter().map(|input| input.collection_id).collect()),
+                include_soft_deleted: false,
+                limit: Some(fn_inputs.len() as u32),
+                ..Default::default()
+            })
+            .await
+            .map_err(|_| {
+                CompactionError::InvariantViolation("Failed to resolve function input collections")
+            })?;
+        let live_collection_ids: HashSet<_> = collections
+            .iter()
+            .map(|collection| collection.collection_id)
+            .collect();
+        let shared_database_name = collections
+            .first()
+            .map(|collection| {
+                DatabaseName::new(&collection.database).ok_or(CompactionError::InvariantViolation(
+                    "Invalid function input collection database name",
+                ))
+            })
+            .transpose()?;
         let mut live_inputs = Vec::with_capacity(fn_inputs.len());
         let mut stale_work_items = Vec::new();
-        let mut shared_database_name = None;
 
         for input in fn_inputs.iter().cloned() {
-            // TODO(tanujnay112): This does not support MCMR yet because work queue records
-            // do not carry the database name. Pass the database name from the work queue
-            // service and remove this unscoped lookup once that metadata is available.
-            match sysdb
-                .get_collection_with_segments(None, input.collection_id)
-                .await
-            {
-                Ok(collection_info) => {
-                    if shared_database_name.is_none() {
-                        shared_database_name = Some(
-                            DatabaseName::new(&collection_info.collection.database).ok_or(
-                                CompactionError::InvariantViolation(
-                                    "Invalid function input collection database name",
-                                ),
-                            )?,
-                        );
-                    }
-                    live_inputs.push(input);
-                }
-                Err(error) if Self::is_stale_input_collection_error(&error) => {
-                    tracing::info!(
-                        collection_id = %input.collection_id,
-                        attached_function_id = %attached_function_id,
-                        error = %error,
-                        "Finishing stale fn-consumer work for deleted input collection"
-                    );
-                    stale_work_items.push(FinishAsyncWorkItem {
-                        input_collection_id: input.collection_id,
-                        completion_offset: input.queue_compaction_offset,
-                    });
-                }
-                Err(_) => {
-                    return Err(CompactionError::InvariantViolation(
-                        "Failed to resolve function input collection database",
-                    ));
-                }
+            if live_collection_ids.contains(&input.collection_id) {
+                live_inputs.push(input);
+            } else {
+                tracing::info!(
+                    collection_id = %input.collection_id,
+                    attached_function_id = %attached_function_id,
+                    "Finishing stale fn-consumer work for deleted input collection"
+                );
+                stale_work_items.push(FinishAsyncWorkItem {
+                    input_collection_id: input.collection_id,
+                    completion_offset: input.queue_compaction_offset,
+                });
             }
         }
 
@@ -404,7 +387,6 @@ mod tests {
     };
     use chroma_error::ChromaError;
     use chroma_log::grpc_log::GrpcPullLogsError;
-    use chroma_types::GetCollectionWithSegmentsError;
     use tonic::Status;
 
     #[test]
@@ -446,31 +428,6 @@ mod tests {
 
         assert!(!FunctionExecutionContext::should_backfill_on_fetch_error(
             &err
-        ));
-    }
-
-    #[test]
-    fn deleted_collection_not_found_is_treated_as_stale_input() {
-        assert!(FunctionExecutionContext::is_stale_input_collection_error(
-            &GetCollectionWithSegmentsError::NotFound("missing".to_string())
-        ));
-    }
-
-    #[test]
-    fn soft_deleted_collection_is_treated_as_stale_input() {
-        assert!(FunctionExecutionContext::is_stale_input_collection_error(
-            &GetCollectionWithSegmentsError::Grpc(Status::failed_precondition(
-                "collection soft deleted",
-            ))
-        ));
-    }
-
-    #[test]
-    fn unrelated_failed_precondition_is_not_treated_as_stale_input() {
-        assert!(!FunctionExecutionContext::is_stale_input_collection_error(
-            &GetCollectionWithSegmentsError::Grpc(Status::failed_precondition(
-                "different precondition failure",
-            ))
         ));
     }
 }

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::execution::operators::{
     fetch_log::FetchLogError,
-    finish_async_work::{FinishAsyncWorkItem, FinishAsyncWorkOperator},
+    finish_async_work::{FinishAsyncWorkInput, FinishAsyncWorkItem, FinishAsyncWorkOperator},
     materialize_logs::MaterializeLogOutput,
 };
 
@@ -225,13 +225,11 @@ impl FunctionExecutionContext {
         };
 
         FinishAsyncWorkOperator::new()
-            .run(
-                &crate::execution::operators::finish_async_work::FinishAsyncWorkInput::new(
-                    attached_function_id,
-                    work_items,
-                    work_queue_client,
-                ),
-            )
+            .run(&FinishAsyncWorkInput::new(
+                attached_function_id,
+                work_items,
+                work_queue_client,
+            ))
             .await
             .map_err(|_| {
                 CompactionError::InvariantViolation("Failed to purge deleted fn-consumer work item")

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -296,12 +296,7 @@ impl FunctionExecutionContext {
             }
         }
 
-        Self::purge_deleted(
-            compaction_context,
-            attached_function_id,
-            stale_work_items,
-        )
-        .await?;
+        Self::purge_deleted(compaction_context, attached_function_id, stale_work_items).await?;
 
         Ok((shared_database_name, live_inputs))
     }

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -315,11 +315,11 @@ impl FunctionExecutionContext {
         }
 
         let base_context = self.compaction_context;
-        let (shared_database_name, live_inputs) = Self::partition_live_and_stale_inputs(
+        let (shared_database_name, live_inputs) = Box::pin(Self::partition_live_and_stale_inputs(
             base_context.clone(),
             attached_function_id,
             &fn_inputs,
-        )
+        ))
         .await?;
         if live_inputs.is_empty() {
             return Ok(CompactionResponse::Success {
@@ -330,7 +330,7 @@ impl FunctionExecutionContext {
             shared_database_name.ok_or(CompactionError::InvariantViolation(
                 "Function execution requires at least one live input collection",
             ))?;
-        let mut input_collection_data = Vec::with_capacity(fn_inputs.len());
+        let mut input_collection_data = Vec::with_capacity(live_inputs.len());
         for input in live_inputs {
             let collection_data = Box::pin(Self::fetch_function_input_collection_data(
                 base_context.clone(),

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -12,6 +12,7 @@ use chroma_types::chroma_proto::TryFinishAsyncAttachedFunctionInvocationRequest;
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use std::time::Duration;
 use tokio::sync::oneshot;
+use tonic::Code;
 
 // Message types
 #[derive(Debug)]
@@ -240,13 +241,17 @@ impl WorkQueueManager {
     }
 
     // Update sysdb's completion offset for an async attached function invocation.
+    fn is_stale_async_invocation_not_found(status: &tonic::Status) -> bool {
+        status.code() == Code::NotFound
+    }
+
     #[tracing::instrument(name = "WorkQueueManager::try_finish_invocation", skip(self))]
     async fn try_finish_invocation(
         &mut self,
         fn_id: &AttachedFunctionUuid,
         input_coll_id: &CollectionUuid,
         completion_offset: i64,
-    ) -> Result<(), WorkQueueError> {
+    ) -> Result<FinishResult, WorkQueueError> {
         let request = TryFinishAsyncAttachedFunctionInvocationRequest {
             attached_function_id: fn_id.to_string(),
             collection_id: input_coll_id.to_string(),
@@ -256,8 +261,20 @@ impl WorkQueueManager {
         self.sysdb
             .try_finish_async_attached_function_invocation(request)
             .await
-            .map_err(|e| WorkQueueError::TryFinishFailed(e.message().to_string()))?;
-        Ok(())
+            .map(|_| FinishResult::Success)
+            .or_else(|status| {
+                if Self::is_stale_async_invocation_not_found(&status) {
+                    tracing::info!(
+                        fn_id = %fn_id,
+                        input_coll_id = %input_coll_id,
+                        status = %status,
+                        "Dropping stale fn-consumer work item after SysDB reported deleted invocation"
+                    );
+                    Ok(FinishResult::Success)
+                } else {
+                    Err(WorkQueueError::TryFinishFailed(status.message().to_string()))
+                }
+            })
     }
 }
 
@@ -332,26 +349,28 @@ impl Handler<FinishWorkMessage> for WorkQueueManager {
 
     async fn handle(&mut self, msg: FinishWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
         // Call sysdb
-        if let Err(e) = self
+        let finish_result = match self
             .try_finish_invocation(&msg.fn_id, &msg.input_coll_id, msg.new_completion_offset)
             .await
         {
-            if msg.response_tx.send(Err(e)).is_err() {
-                tracing::error!("Failed to send error response");
+            Ok(finish_result) => finish_result,
+            Err(e) => {
+                if msg.response_tx.send(Err(e)).is_err() {
+                    tracing::error!("Failed to send error response");
+                }
+                return;
             }
-            return;
-        }
+        };
 
         // Use the queued compaction frontier to decide whether to remove or advance the entry.
         self.state
             .finish_work_success(&msg.fn_id, &msg.input_coll_id, msg.new_completion_offset);
 
         // Send immediate success response
-        if msg.response_tx.send(Ok(FinishResult::Success)).is_err() {
-            tracing::error!("Failed to send finish work success response - receiver dropped");
+        if msg.response_tx.send(Ok(finish_result)).is_err() {
+            tracing::error!("Failed to send error response");
         }
 
-        // Check if persist needed
         if self.should_persist() {
             let _ = self.persist().await;
         }
@@ -653,5 +672,19 @@ mod tests {
         // Finish remaining work
         state.finish_work_success(&fn_id, &coll_id, 300);
         assert_eq!(state.pending_work.len(), 0);
+    }
+
+    #[test]
+    fn not_found_finish_error_is_treated_as_stale_invocation() {
+        assert!(WorkQueueManager::is_stale_async_invocation_not_found(
+            &tonic::Status::not_found("collection not found")
+        ));
+    }
+
+    #[test]
+    fn internal_finish_error_is_not_treated_as_stale_invocation() {
+        assert!(!WorkQueueManager::is_stale_async_invocation_not_found(
+            &tonic::Status::internal("boom")
+        ));
     }
 }

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -368,7 +368,7 @@ impl Handler<FinishWorkMessage> for WorkQueueManager {
 
         // Send immediate success response
         if msg.response_tx.send(Ok(finish_result)).is_err() {
-            tracing::error!("Failed to send error response");
+            tracing::error!("Failed to send finish work response");
         }
 
         if self.should_persist() {


### PR DESCRIPTION
## What changed
This updates the fn-consumer worker so deleted or soft-deleted input collections are treated as terminal stale work instead of retryable failures.

## Why
A function execution batch could wedge forever when its first input collection had been deleted. `resolve_shared_input_database_name` failed before any stale-work short-circuit ran, and the queue item was redelivered indefinitely.

## Root cause
The worker resolved the shared input database name by looking up the first queued input collection and mapped any lookup failure to an invariant violation. That turned permanent delete-state failures like `NotFound` and soft-deleted collections into blocking retries.

## Fix
- classify `GetCollectionWithSegments` `NotFound` and soft-deleted failures as stale deleted inputs
- wrap the deleted-input cleanup path in `purge_deleted`
- call `FinishWork` with the queued offset already carried by the work item so the row leaves the queue peacefully
- treat `FinishWork` `NotFound` during async invocation finalization as stale-success in the work queue manager

## Impact
Deleted input collections no longer block fn-consumer batches or cause repeated queue redelivery loops.

## Validation
- `cargo test -p worker function_execution::tests -- --nocapture`
- `cargo test -p worker work_queue::work_queue_manager::tests -- --nocapture`
