### PR TITLE
[BUG](js-client): Share concurrent init

### DIFF
--- a/clients/js/packages/chromadb-core/src/ChromaClient.ts
+++ b/clients/js/packages/chromadb-core/src/ChromaClient.ts
@@ -109,15 +109,17 @@ export class ChromaClient {
   /** @ignore */
   async init(): Promise<void> {
     if (!this._initPromise) {
-      if (this.authProvider !== undefined) {
-        await this.getUserIdentity();
-      }
+      this._initPromise = (async () => {
+        if (this.authProvider !== undefined) {
+          await this.getUserIdentity();
+        }
 
-      this._initPromise = validateTenantDatabase(
-        this._adminClient,
-        this.tenant,
-        this.database,
-      );
+        await validateTenantDatabase(
+          this._adminClient,
+          this.tenant,
+          this.database,
+        );
+      })();
     }
 
     return this._initPromise;

--- a/clients/js/packages/chromadb-core/test/client.init.test.ts
+++ b/clients/js/packages/chromadb-core/test/client.init.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import type { AdminClient } from "../src/AdminClient";
+import { ChromaClient } from "../src/ChromaClient";
+
+describe("ChromaClient.init", () => {
+  test("shares initialization across concurrent callers", async () => {
+    const client = new ChromaClient({
+      auth: { provider: "token", credentials: "test-token" },
+    });
+    const adminClient = Reflect.get(client, "_adminClient") as AdminClient;
+
+    let releaseIdentity!: () => void;
+    const identityGate = new Promise<void>((resolve) => {
+      releaseIdentity = resolve;
+    });
+
+    const identitySpy = jest
+      .spyOn(client, "getUserIdentity")
+      .mockImplementation(() => identityGate);
+    const tenantSpy = jest
+      .spyOn(adminClient, "getTenant")
+      .mockResolvedValue({ name: "default_tenant" });
+    const databaseSpy = jest
+      .spyOn(adminClient, "getDatabase")
+      .mockResolvedValue({
+        id: "default_database",
+        tenant: "default_tenant",
+        name: "default_database",
+      });
+
+    const pending = [client.init(), client.init(), client.init()];
+    releaseIdentity();
+    await Promise.all(pending);
+
+    expect(identitySpy).toHaveBeenCalledTimes(1);
+    expect(tenantSpy).toHaveBeenCalledTimes(1);
+    expect(databaseSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This pull request improves the initialization logic of the `ChromaClient` to ensure that concurrent calls to `init()` share the same initialization process and do not trigger duplicate operations. It also adds a new test to verify this behavior.

**Initialization logic improvements:**

* Updated the `ChromaClient.init()` method to wrap the initialization steps in a single promise, ensuring that concurrent callers share the same initialization and do not cause redundant calls to authentication and database validation methods.

**Testing enhancements:**

* Added a new test `client.init.test.ts` to verify that multiple concurrent calls to `ChromaClient.init()` only perform initialization steps once, using spies to assert single invocations of key methods.Assign the initialization promise before awaiting authentication so concurrent callers reuse one identity lookup and tenant/database validation.


## Description of changes

Assign the ChromaClient initialization promise before awaiting
authentication. Concurrent callers now share one identity lookup and one
tenant/database validation instead of starting duplicate initialization work.

Fixes #7487.

## Test plan

- Added a regression test with three overlapping authenticated `init()` calls.
- Verified the regression test fails on the previous implementation.
- Verified the regression test and package build pass after the fix.

## AI usage disclosure

YES — AI assisted with issue triage, implementation, and test drafting. I
reviewed and validated the final changes.