### PR TITLE
fix(js): dedupe concurrent CloudClient _path identity lookups

### DIFF
--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -84,6 +84,9 @@ export class ChromaClient {
   private _preflightChecks: ChecklistResponse | undefined;
   private _headers: Record<string, string> | undefined;
   private readonly apiClient: ReturnType<typeof createClient>;
+  // Lazily resolved identity path. Shared promise prevents TOCTOU where concurrent
+  // callers each hit getUserIdentity before tenant/database are populated (#7494).
+  private _pathPromise: Promise<{ tenant: string; database: string }> | undefined;
 
   /**
    * Creates a new ChromaClient instance.
@@ -188,23 +191,35 @@ export class ChromaClient {
 
   /** @ignore */
   public async _path(): Promise<{ tenant: string; database: string }> {
-    if (!this._tenant || !this._database) {
-      const { tenant, databases } = await this.getUserIdentity();
-      const uniqueDBs = [...new Set(databases)];
-      this._tenant = tenant;
-      if (uniqueDBs.length === 0) {
-        throw new ChromaUnauthorizedError(
-          `Your API key does not have access to any DBs for tenant ${this.tenant}`,
-        );
-      }
-      if (uniqueDBs.length > 1 || uniqueDBs[0] === "*") {
-        throw new ChromaValueError(
-          "Your API key is scoped to more than 1 DB. Please provide a DB name to the CloudClient constructor",
-        );
-      }
-      this._database = uniqueDBs[0];
+    if (this._tenant && this._database) {
+      return { tenant: this._tenant, database: this._database };
     }
-    return { tenant: this._tenant, database: this._database };
+    if (!this._pathPromise) {
+      this._pathPromise = (async () => {
+        try {
+          const { tenant, databases } = await this.getUserIdentity();
+          const uniqueDBs = [...new Set(databases)];
+          this._tenant = tenant;
+          if (uniqueDBs.length === 0) {
+            throw new ChromaUnauthorizedError(
+              `Your API key does not have access to any DBs for tenant ${this.tenant}`,
+            );
+          }
+          if (uniqueDBs.length > 1 || uniqueDBs[0] === "*") {
+            throw new ChromaValueError(
+              "Your API key is scoped to more than 1 DB. Please provide a DB name to the CloudClient constructor",
+            );
+          }
+          this._database = uniqueDBs[0];
+          return { tenant: this._tenant, database: this._database };
+        } catch (err) {
+          // Allow a later call to retry after a transient failure.
+          this._pathPromise = undefined;
+          throw err;
+        }
+      })();
+    }
+    return this._pathPromise;
   }
 
   /**

--- a/clients/new-js/packages/chromadb/test/path.toctou.test.ts
+++ b/clients/new-js/packages/chromadb/test/path.toctou.test.ts
@@ -1,0 +1,33 @@
+import { ChromaClient } from "../src/chroma-client";
+
+/**
+ * Regression for #7494: concurrent _path() callers must share a single
+ * getUserIdentity resolution instead of racing.
+ */
+describe("ChromaClient._path TOCTOU", () => {
+  it("dedupes concurrent getUserIdentity calls", async () => {
+    let calls = 0;
+    class TestClient extends ChromaClient {
+      public async getUserIdentity() {
+        calls += 1;
+        // Yield so concurrent callers both enter before resolution.
+        await new Promise((r) => setTimeout(r, 20));
+        return { tenant: "t1", databases: ["db1"] } as any;
+      }
+    }
+
+    const client = new TestClient({ host: "localhost", port: 8000 });
+    // Force identity lookup path
+    (client as any)._tenant = undefined;
+    (client as any)._database = undefined;
+
+    const [a, b] = await Promise.all([
+      (client as any)._path(),
+      (client as any)._path(),
+    ]);
+
+    expect(calls).toBe(1);
+    expect(a).toEqual({ tenant: "t1", database: "db1" });
+    expect(b).toEqual({ tenant: "t1", database: "db1" });
+  });
+});


### PR DESCRIPTION
## Summary

`ChromaClient._path()` had a TOCTOU race: concurrent callers could each see unset `tenant`/`database`, each call `getUserIdentity()`, and race on assignment (#7494). Same class of bug as the earlier `init()` fix.

## Fix

- Store a shared `_pathPromise` for lazy identity resolution
- Concurrent callers await the same promise
- Clear the promise on failure so a later call can retry

## Tests

Added `path.toctou.test.ts` asserting concurrent `_path()` invokes `getUserIdentity` only once.

Fixes #7494