### PR TITLE
feat: add warning when embedding_function is missing

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -12,6 +12,7 @@ from typing import (
     cast,
     List,
 )
+import warnings
 from chromadb.types import Metadata
 import numpy as np
 from uuid import UUID
@@ -136,6 +137,16 @@ class CollectionCommon(Generic[ClientT]):
         # Check to make sure the embedding function has the right signature, as defined by the EmbeddingFunction protocol
         if embedding_function is not None:
             validate_embedding_function(embedding_function)
+
+        if embedding_function is None or isinstance(embedding_function, DefaultEmbeddingFunction):
+            warnings.warn(
+                "No embedding_function provided, using default embedding function: DefaultEmbeddingFunction. "
+                "To use your own model, explicitly provide an embedding_function.",
+                category=UserWarning,
+                stacklevel=2
+            )
+
+        self._embedding_function = embedding_function
 
         self._embedding_function = embedding_function
         self._data_loader = data_loader


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Implemented a suppressible `UserWarning` in `CollectionCommon.py` to alert developers when a collection silently falls back to the `DefaultEmbeddingFunction`. ( I spent hours debugging, while I was creating collection with Ollama embedding, but I was unable to see the exact reason)
  - Utilized Python's native `warnings.warn()` instead of `logger.warning()`. This provides a necessary safety net for client-side developers while allowing backend/server architectures to programmatically suppress the output via `warnings.filterwarnings`, avoiding historical server-spam issues.
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Delegated test execution to the automated GitHub Actions CI/CD pipeline due to local Windows MSVC/Maturin compiler constraints preventing the local Rust bindings from building.

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

No migrations or compatibility changes are required. This is a non-breaking, purely informational update. The use of standard Python `warnings` ensures backwards compatibility with existing pipelines.

## Observability plan

_What is the plan to instrument and monitor this change?_

This change inherently improves client-side observability by surfacing implicit model fallbacks. The output threshold is tied natively to standard Python warning filters, requiring no additional telemetry or custom monitoring instrumentation.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

No documentation changes are strictly required, as the API signature and underlying database behavior remain completely unchanged.