### PR TITLE
Use UTF-8 for migration SQL files

### DIFF
--- a/chromadb/db/migrations.py
+++ b/chromadb/db/migrations.py
@@ -253,7 +253,7 @@ def _read_migration_file(file: MigrationFile, hash_alg: str) -> Migration:
         raise FileNotFoundError(
             f"No migration file found for dir {file['dir']} with filename {file['filename']} and scope {file['scope']} at version {file['version']}"
         )
-    sql = file["path"].read_text()
+    sql = file["path"].read_text(encoding="utf-8")
 
     if hash_alg == "md5":
         hash = (


### PR DESCRIPTION
## Summary
- Read migration SQL files with `encoding="utf-8"`.

## Problem
Migration SQL files are repository-managed text files, but `Path.read_text()` currently uses the platform default encoding. The migration loader then hashes `sql.encode("utf-8")`, so decoding the SQL as UTF-8 first makes the read/hash path deterministic across Windows and other non-UTF-8 locales.

## Before / After
Before: SQL migration decoding depended on the local platform default encoding.

After: SQL migration files are decoded as UTF-8 before hashing and returning the SQL content.

## Verification
- `python -m py_compile chromadb/db/migrations.py`