### PR TITLE
docs(examples): add hybrid BM25 + dense retrieval RAG notebook

### DIFF
--- a/examples/advanced/hybrid_retrieval_rag.ipynb
+++ b/examples/advanced/hybrid_retrieval_rag.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hybrid BM25 + Dense Retrieval RAG with ChromaDB\n",
+    "\n",
+    "This notebook demonstrates a **hybrid retrieval** Retrieval-Augmented Generation (RAG) pipeline combining:\n",
+    "- **BM25** (sparse, keyword-based retrieval) via `rank_bm25`\n",
+    "- **Dense vector retrieval** via ChromaDB with sentence-transformers embeddings\n",
+    "- **Reciprocal Rank Fusion (RRF)** to merge results from both retrievers\n",
+    "\n",
+    "Hybrid retrieval consistently outperforms either method alone, especially on multi-hop and factoid QA tasks. This pattern is used in production RAG systems to balance lexical precision with semantic recall.\n",
+    "\n",
+    "**Requirements:**\n",
+    "```\n",
+    "pip install chromadb rank_bm25 sentence-transformers\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies\n",
+    "# !pip install chromadb rank_bm25 sentence-transformers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import chromadb\n",
+    "from chromadb.utils import embedding_functions\n",
+    "from rank_bm25 import BM25Okapi\n",
+    "import re\n",
+    "from typing import List, Dict, Tuple"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Sample Corpus\n",
+    "\n",
+    "We use a small corpus of factual passages for demonstration. In production, replace this with your document chunks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corpus = [\n",
+    "    \"ChromaDB is an open-source vector database designed for AI applications and LLM-powered systems.\",\n",
+    "    \"Retrieval-Augmented Generation (RAG) combines a retriever with a language model to answer questions grounded in a knowledge base.\",\n",
+    "    \"BM25 is a probabilistic ranking function used in information retrieval, effective for keyword-heavy queries.\",\n",
+    "    \"Dense retrieval uses neural embeddings to find semantically similar documents even when keywords don't overlap.\",\n",
+    "    \"Reciprocal Rank Fusion (RRF) merges ranked lists from multiple retrievers by summing reciprocal ranks.\",\n",
+    "    \"Sentence transformers produce fixed-size embeddings from variable-length text using transformer encoder models.\",\n",
+    "    \"Hybrid search combines sparse and dense retrieval to improve recall and precision over either method alone.\",\n",
+    "    \"HotPotQA is a multi-hop question answering dataset requiring reasoning over multiple documents.\",\n",
+    "    \"Cross-encoder reranking re-scores retrieved candidates using a model that jointly encodes the query and document.\",\n",
+    "    \"Vector databases store and index high-dimensional embeddings, enabling fast approximate nearest-neighbor search.\",\n",
+    "]\n",
+    "\n",
+    "doc_ids = [f\"doc_{i}\" for i in range(len(corpus))]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Set Up ChromaDB Collection (Dense Retriever)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use a local sentence-transformer model — no API key needed\n",
+    "embedding_fn = embedding_functions.SentenceTransformerEmbeddingFunction(\n",
+    "    model_name=\"all-MiniLM-L6-v2\"\n",
+    ")\n",
+    "\n",
+    "client = chromadb.Client()\n",
+    "collection = client.get_or_create_collection(\n",
+    "    name=\"hybrid_rag_demo\",\n",
+    "    embedding_function=embedding_fn,\n",
+    "    metadata={\"hnsw:space\": \"cosine\"},\n",
+    ")\n",
+    "\n",
+    "# Index documents\n",
+    "collection.add(\n",
+    "    ids=doc_ids,\n",
+    "    documents=corpus,\n",
+    ")\n",
+    "\n",
+    "print(f\"Indexed {collection.count()} documents into ChromaDB.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Set Up BM25 (Sparse Retriever)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tokenize(text: str) -> List[str]:\n",
+    "    \"\"\"Simple whitespace + lowercase tokenizer for BM25.\"\"\"\n",
+    "    return re.sub(r\"[^a-z0-9\\s]\", \"\", text.lower()).split()\n",
+    "\n",
+    "tokenized_corpus = [tokenize(doc) for doc in corpus]\n",
+    "bm25 = BM25Okapi(tokenized_corpus)\n",
+    "\n",
+    "print(\"BM25 index built.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Hybrid Retrieval with Reciprocal Rank Fusion (RRF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def dense_retrieve(query: str, top_k: int = 5) -> List[Tuple[str, float]]:\n",
+    "    \"\"\"Retrieve top-k documents using ChromaDB dense search.\"\"\"\n",
+    "    results = collection.query(query_texts=[query], n_results=top_k)\n",
+    "    ids = results[\"ids\"][0]\n",
+    "    distances = results[\"distances\"][0]\n",
+    "    # Convert cosine distance to similarity score\n",
+    "    return [(doc_id, 1 - dist) for doc_id, dist in zip(ids, distances)]\n",
+    "\n",
+    "\n",
+    "def bm25_retrieve(query: str, top_k: int = 5) -> List[Tuple[str, float]]:\n",
+    "    \"\"\"Retrieve top-k documents using BM25 sparse search.\"\"\"\n",
+    "    tokenized_query = tokenize(query)\n",
+    "    scores = bm25.get_scores(tokenized_query)\n",
+    "    ranked = sorted(enumerate(scores), key=lambda x: x[1], reverse=True)[:top_k]\n",
+    "    return [(doc_ids[idx], score) for idx, score in ranked]\n",
+    "\n",
+    "\n",
+    "def reciprocal_rank_fusion(\n",
+    "    ranked_lists: List[List[Tuple[str, float]]],\n",
+    "    k: int = 60\n",
+    ") -> List[Tuple[str, float]]:\n",
+    "    \"\"\"\n",
+    "    Merge multiple ranked lists using Reciprocal Rank Fusion.\n",
+    "    RRF score = sum(1 / (k + rank)) across all lists.\n",
+    "    k=60 is the standard default from the original RRF paper.\n",
+    "    \"\"\"\n",
+    "    rrf_scores: Dict[str, float] = {}\n",
+    "    for ranked in ranked_lists:\n",
+    "        for rank, (doc_id, _) in enumerate(ranked, start=1):\n",
+    "            rrf_scores[doc_id] = rrf_scores.get(doc_id, 0.0) + 1.0 / (k + rank)\n",
+    "    return sorted(rrf_scores.items(), key=lambda x: x[1], reverse=True)\n",
+    "\n",
+    "\n",
+    "def hybrid_retrieve(query: str, top_k: int = 5) -> List[Dict]:\n",
+    "    \"\"\"Full hybrid retrieval: BM25 + dense via ChromaDB, fused with RRF.\"\"\"\n",
+    "    dense_results = dense_retrieve(query, top_k=top_k)\n",
+    "    bm25_results = bm25_retrieve(query, top_k=top_k)\n",
+    "\n",
+    "    fused = reciprocal_rank_fusion([dense_results, bm25_results])\n",
+    "\n",
+    "    # Map back to documents\n",
+    "    id_to_doc = dict(zip(doc_ids, corpus))\n",
+    "    return [\n",
+    "        {\"id\": doc_id, \"score\": score, \"document\": id_to_doc[doc_id]}\n",
+    "        for doc_id, score in fused[:top_k]\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Run Example Queries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "queries = [\n",
+    "    \"How does hybrid search improve retrieval?\",\n",
+    "    \"What is BM25 and when should I use it?\",\n",
+    "    \"How do vector databases work with embeddings?\",\n",
+    "]\n",
+    "\n",
+    "for query in queries:\n",
+    "    print(f\"\\nQuery: {query}\")\n",
+    "    print(\"-\" * 60)\n",
+    "    results = hybrid_retrieve(query, top_k=3)\n",
+    "    for i, res in enumerate(results, 1):\n",
+    "        print(f\"  {i}. [score={res['score']:.4f}] {res['document']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Compare: Dense-Only vs BM25-Only vs Hybrid\n",
+    "\n",
+    "The table below illustrates how each retriever ranks results for a keyword-heavy query."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"BM25 keyword ranking function\"\n",
+    "print(f\"Query: '{query}'\\n\")\n",
+    "\n",
+    "print(\"Dense-only (ChromaDB):\")\n",
+    "for rank, (doc_id, score) in enumerate(dense_retrieve(query, top_k=3), 1):\n",
+    "    idx = doc_ids.index(doc_id)\n",
+    "    print(f\"  {rank}. {corpus[idx][:80]}...\")\n",
+    "\n",
+    "print(\"\\nBM25-only (sparse):\")\n",
+    "for rank, (doc_id, score) in enumerate(bm25_retrieve(query, top_k=3), 1):\n",
+    "    idx = doc_ids.index(doc_id)\n",
+    "    print(f\"  {rank}. {corpus[idx][:80]}...\")\n",
+    "\n",
+    "print(\"\\nHybrid (RRF fusion):\")\n",
+    "for rank, res in enumerate(hybrid_retrieve(query, top_k=3), 1):\n",
+    "    print(f\"  {rank}. {res['document'][:80]}...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Key Takeaways\n",
+    "\n",
+    "| Method | Strength | Weakness |\n",
+    "|---|---|---|\n",
+    "| BM25 (sparse) | Exact keyword matches, fast | Misses semantic similarity |\n",
+    "| Dense (ChromaDB) | Semantic understanding | Can miss exact terms |\n",
+    "| Hybrid (RRF) | Best of both worlds | Slightly more compute |\n",
+    "\n",
+    "**When to use hybrid retrieval:**\n",
+    "- Multi-hop QA where queries use specific entity names (BM25 helps)\n",
+    "- Domain-specific corpora with technical terminology\n",
+    "- Any production RAG system where recall matters\n",
+    "\n",
+    "**Further improvements:**\n",
+    "- Add a cross-encoder reranker on the fused top-k results\n",
+    "- Tune the RRF `k` parameter for your corpus\n",
+    "- Use ChromaDB's metadata filtering to pre-filter before retrieval"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Description of changes

Adds a self-contained Jupyter notebook demonstrating hybrid retrieval for RAG using ChromaDB.

The notebook combines BM25 sparse retrieval with ChromaDB dense semantic retrieval and uses Reciprocal Rank Fusion (RRF) to merge both ranked result sets.

- Improvements & Bug fixes
  - No bug fixes or changes to existing Chroma functionality.
  - No existing APIs or behavior are modified.

- New functionality
  - Adds `examples/advanced/hybrid_retrieval_rag.ipynb`.
  - Demonstrates BM25 sparse retrieval using `rank_bm25`.
  - Demonstrates dense semantic retrieval using ChromaDB with sentence-transformer embeddings.
  - Implements Reciprocal Rank Fusion (RRF) to combine sparse and dense ranked results.
  - Includes side-by-side retrieval examples to illustrate the behavior of sparse, dense, and hybrid retrieval.
  - Runs locally without requiring external API keys.

## Test plan

The notebook has been run and verified end-to-end.

The example verifies the complete workflow, including:

- Creating and indexing the example document corpus.
- BM25 sparse retrieval.
- ChromaDB dense semantic retrieval.
- Reciprocal Rank Fusion of the sparse and dense ranked result sets.
- Running example queries and comparing sparse, dense, and hybrid retrieval results.

The change is isolated to a new example notebook and does not modify the Chroma library, existing tests, or production code.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

The repository-wide test suites above are not applicable to this documentation/example-only addition and have therefore not been marked as completed.

## Migration Plan

No migrations or forwards/backwards compatibility changes are required.

This PR only adds a new standalone notebook under `examples/advanced/` and does not modify existing APIs, schemas, persisted data, configuration, or runtime behavior.

## Observability plan

No additional instrumentation or monitoring is required.

This change adds an educational example notebook only and does not introduce or modify production runtime behavior, services, telemetry, or operational infrastructure.

## Documentation Changes

This PR adds a self-contained Jupyter notebook at:

`examples/advanced/hybrid_retrieval_rag.ipynb`

The notebook serves as an advanced usage example demonstrating how ChromaDB dense retrieval can be combined with BM25 sparse retrieval using Reciprocal Rank Fusion (RRF).

The notebook includes the required setup, implementation, explanatory context, and example retrieval comparisons so that the hybrid retrieval workflow can be understood and run independently.

No existing user-facing APIs are changed, so no updates to the existing API documentation are required.