### PR TITLE
[ENH] project wiki_add_backlink writes to source slug

### DIFF
--- a/rust/foundation-api/src/trajectories/model.rs
+++ b/rust/foundation-api/src/trajectories/model.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-const WIKI_WRITE_TOOLS: [&str; 2] = ["wiki_apply_patch", "wiki_upsert_file"];
+const WIKI_WRITE_TOOLS: [&str; 3] = ["wiki_add_backlink", "wiki_apply_patch", "wiki_upsert_file"];
 
 /// Represents the pruned trajectory data shown through reasoning views.
 ///

--- a/rust/foundation-api/src/trajectories/tests.rs
+++ b/rust/foundation-api/src/trajectories/tests.rs
@@ -299,6 +299,90 @@ fn generated_json_deserializes_to_reasoning_projection() -> TestResult {
 }
 
 #[test]
+/// Verifies backlink writes are projected against the mutated source page only.
+fn generated_json_projects_add_backlink_write_to_source_slug() -> TestResult {
+    let id = Uuid::parse_str("00000000-0000-0000-0000-000000000024")?;
+    let file: ReasoningTrajectoryFile = serde_json::from_value(json!({
+        "trajectory": {
+            "id": id,
+            "actions_and_observations": [
+                {
+                    "tools": [{
+                        "tool_schema": {
+                            "name": "wiki_add_backlink",
+                            "description": "append backlink",
+                            "parameters": {"type": "object"},
+                            "required": ["slug", "target_slug"]
+                        }
+                    }],
+                    "params": [{
+                        "slug": "source-page",
+                        "target_slug": "target-page"
+                    }],
+                    "sources": ["agent"],
+                    "reasoning": "link source to target"
+                },
+                {
+                    "observations": ["ok"],
+                    "sources": ["wiki"],
+                    "tool_metadata": [{
+                        "slug": "source-page",
+                        "target_slug": "target-page",
+                        "skipped_due_to_handoff": false
+                    }]
+                },
+                {
+                    "tools": [{
+                        "tool_schema": {
+                            "name": "wiki_add_backlink",
+                            "description": "append backlink",
+                            "parameters": {"type": "object"},
+                            "required": ["slug", "target_slug"]
+                        }
+                    }],
+                    "params": [{
+                        "slug": "skipped-source-page",
+                        "target_slug": "skipped-target-page"
+                    }],
+                    "sources": ["agent"],
+                    "reasoning": "skipped backlink"
+                },
+                {
+                    "observations": ["skipped"],
+                    "sources": ["wiki"],
+                    "tool_metadata": [{
+                        "slug": "skipped-source-page",
+                        "target_slug": "skipped-target-page",
+                        "skipped_due_to_handoff": true
+                    }]
+                }
+            ]
+        }
+    }))?;
+
+    assert_eq!(
+        file,
+        ReasoningTrajectoryFile {
+            citations: None,
+            trajectory: ReasoningTrajectory {
+                id,
+                entries: vec![
+                    reasoning_entry(Some("link source to target".to_string()), &["source-page"]),
+                    reasoning_entry(Some("skipped backlink".to_string()), &[]),
+                ],
+            },
+        }
+    );
+    assert!(!file
+        .trajectory
+        .entries
+        .iter()
+        .flat_map(|entry| entry.writes.iter())
+        .any(|write| write.slug == "target-page"));
+    Ok(())
+}
+
+#[test]
 /// Verifies empty raw observations are projection inputs, not stored entries.
 fn generated_json_drops_empty_initial_observation() -> TestResult {
     let id = Uuid::parse_str("00000000-0000-0000-0000-000000000023")?;


### PR DESCRIPTION
## Description of changes

Add wiki_add_backlink to WIKI_WRITE_TOOLS so backlink writes are
recognized as wiki mutations and projected against the mutated
source page in reasoning views.

Cover the behavior with a test asserting the write is attributed to
the source slug only, that handoff-skipped writes drop their slugs,
and that the target slug is never treated as a write target.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
