### PR TITLE
[CHORE](foundation): Add pod identity service account

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.91
+version: 0.1.92
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/foundation-service.yaml
+++ b/k8s/distributed-chroma/templates/foundation-service.yaml
@@ -1,6 +1,12 @@
 {{- if (and .Values.foundationService .Values.foundationService.enabled) -}}
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: foundation-service-serviceaccount
+  namespace: {{ .Values.namespace }}
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: foundation-server-config
@@ -25,6 +31,7 @@ spec:
       labels:
         app: foundation-server
     spec:
+      serviceAccountName: foundation-service-serviceaccount
       containers:
         - name: foundation-server
           image: "{{ .Values.foundationService.image.repository }}:{{ .Values.foundationService.image.tag }}"


### PR DESCRIPTION
## Summary
- create the Foundation ServiceAccount when the service is enabled
- run the Foundation pod under that account so EKS Pod Identity can inject AWS credentials and region

## Validation
- rendered the chart with Foundation enabled
- confirmed the Deployment references the emitted ServiceAccount