### PR TITLE
[BUG] Use UTF-8 for Python reference output

### DIFF
--- a/docs/scripts/generate_python_reference.py
+++ b/docs/scripts/generate_python_reference.py
@@ -812,7 +812,7 @@ Example:
     out_dir.mkdir(parents=True, exist_ok=True)
     for filename, content in generate_documentation_per_file().items():
         fpath = out_dir / filename
-        fpath.write_text(content)
+        fpath.write_text(content, encoding="utf-8")
         print(f"Generated: {fpath}")
 
 


### PR DESCRIPTION
## Summary
- write generated Python reference docs with explicit UTF-8 encoding

## Problem
`Path.write_text()` uses the platform default encoding if none is specified. The generated reference content can include non-ASCII text, so this docs generator can behave differently on Windows or other non-UTF-8 locales.

## Before / After
Before: generated `.mdx` reference files were written with the process default encoding.

After: generated reference files are always written as UTF-8.

## Verification
- `python -m py_compile docs/scripts/generate_python_reference.py`