### PR TITLE
fix: honor settings.persist_directory in PersistentClient when path is not passed

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -199,7 +199,7 @@ def EphemeralClient(
 
 
 def PersistentClient(
-    path: Union[str, Path] = "./chroma",
+    path: Optional[Union[str, Path]] = None,
     settings: Optional[Settings] = None,
     tenant: str = DEFAULT_TENANT,
     database: str = DEFAULT_DATABASE,
@@ -210,7 +210,9 @@ def PersistentClient(
     prefer a server-backed Chroma instance.
 
     Args:
-        path: Directory to store persisted data.
+        path: Directory to store persisted data. If not provided, the
+            ``persist_directory`` from ``settings`` is used (falling back to
+            ``"./chroma"`` when neither is set).
         settings: Optional settings to override defaults.
         tenant: Tenant name to use for requests.
         database: Database name to use for requests.
@@ -220,7 +222,16 @@ def PersistentClient(
     """
     if settings is None:
         settings = Settings()
-    settings.persist_directory = str(path)
+    # Resolve the persist directory with a clear precedence: an explicit `path`
+    # argument wins, otherwise honor `settings.persist_directory`, and only fall
+    # back to the default when neither is set. Previously `path` defaulted to
+    # "./chroma" and unconditionally overwrote `settings.persist_directory`, so
+    # `PersistentClient(settings=settings)` silently ignored a configured
+    # persist_directory. See #7277.
+    if path is not None:
+        settings.persist_directory = str(path)
+    elif not settings.persist_directory:
+        settings.persist_directory = "./chroma"
     settings.is_persistent = True
 
     # Make sure paramaters are the correct types -- users can pass anything.

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -343,3 +343,48 @@ def test_rust_bindings_api_stop_closes_bindings() -> None:
     bindings.close.assert_called_once_with()
     assert hasattr(api, "bindings") is False
     assert api._running is False
+
+
+def test_persistent_client_honors_settings_persist_directory() -> None:
+    """PersistentClient must not silently overwrite a configured
+    ``settings.persist_directory``. Resolution precedence: an explicit ``path``
+    argument wins, otherwise ``settings.persist_directory`` is honored, and only
+    when neither is set does it fall back to "./chroma". Regression for #7277,
+    where ``path`` defaulted to "./chroma" and always clobbered the setting.
+
+    ClientCreator is mocked so the resolution logic is exercised without
+    standing up a backend.
+    """
+    # 1. settings.persist_directory is honored when no path is passed.
+    settings = Settings()
+    settings.persist_directory = "/custom/path/to/chroma"
+    with patch("chromadb.ClientCreator") as mock_creator:
+        chromadb.PersistentClient(settings=settings)
+    assert (
+        mock_creator.call_args.kwargs["settings"].persist_directory
+        == "/custom/path/to/chroma"
+    )
+
+    # 2. An explicit path takes precedence over settings.persist_directory.
+    settings = Settings()
+    settings.persist_directory = "/custom/path/to/chroma"
+    with patch("chromadb.ClientCreator") as mock_creator:
+        chromadb.PersistentClient(path="/explicit/path", settings=settings)
+    assert (
+        mock_creator.call_args.kwargs["settings"].persist_directory
+        == "/explicit/path"
+    )
+
+    # 3. With neither path nor a configured setting, it falls back to "./chroma".
+    with patch("chromadb.ClientCreator") as mock_creator:
+        chromadb.PersistentClient()
+    resolved = mock_creator.call_args.kwargs["settings"]
+    assert resolved.persist_directory == "./chroma"
+    assert resolved.is_persistent is True
+
+    # 4. A path passed without settings is still respected (legacy behavior).
+    with patch("chromadb.ClientCreator") as mock_creator:
+        chromadb.PersistentClient(path="/only/path")
+    assert (
+        mock_creator.call_args.kwargs["settings"].persist_directory == "/only/path"
+    )


### PR DESCRIPTION
## Description of changes

Fixes #7277.

`PersistentClient`'s `path` parameter defaulted to `"./chroma"` and then unconditionally overwrote `settings.persist_directory`:

```python
def PersistentClient(path: Union[str, Path] = "./chroma", settings=None, ...):
    if settings is None:
        settings = Settings()
    settings.persist_directory = str(path)   # always wins, even the default
```

So `PersistentClient(settings=settings)` with a configured `persist_directory` silently stored data under `"./chroma"` instead of the requested directory, with no error or warning. The `persist_directory` setting looked supported while being a no-op unless you also passed `path`.

### Fix

Default `path` to `None` and resolve with a clear precedence: an explicit `path` wins, otherwise `settings.persist_directory` is honored, and only when neither is set does it fall back to `"./chroma"`:

```python
if path is not None:
    settings.persist_directory = str(path)
elif not settings.persist_directory:
    settings.persist_directory = "./chroma"
```

This is backward compatible. `PersistentClient()` and `PersistentClient(path=...)` behave exactly as before, since `Settings` already defaults `persist_directory` to `"./chroma"`; only the previously ignored settings-driven case changes.

## Test plan

Added `test_persistent_client_honors_settings_persist_directory` to `chromadb/test/test_client.py`. It mocks `ClientCreator` and inspects the settings it receives, covering all four combinations plus that `is_persistent` stays set:

```
settings-only custom dir -> honored (was: overwritten with "./chroma")
explicit path + settings -> explicit path wins
neither                  -> "./chroma"
path only                -> path (legacy behavior)
```

I confirmed it fails on the pre-fix source and passes with the change (reverted only `chromadb/__init__.py` and the test went red; restored it and it passed).

Note: `test_persistent_client_close` in the same file fails in my sandbox with a `chromadb/api/rust.py` `TypeError`, but it fails identically on unmodified `main` (it constructs a real backend-backed client, which this environment can't stand up). It's unrelated to this change, which only touches the pre-backend path-resolution logic and uses mocks in its own test.

- [x] Tests pass locally with my changes (the new test; pre-existing backend-dependent failures are environment-only)

## Documentation Changes

Updated the `path` argument's docstring to describe the new precedence. No other docs needed.
