### PR TITLE
fix(PersistentClient): respect settings.persist_directory when path not passed (#7277)

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -199,7 +199,7 @@ def EphemeralClient(
 
 
 def PersistentClient(
-    path: Union[str, Path] = "./chroma",
+    path: Optional[Union[str, Path]] = None,
     settings: Optional[Settings] = None,
     tenant: str = DEFAULT_TENANT,
     database: str = DEFAULT_DATABASE,
@@ -210,7 +210,8 @@ def PersistentClient(
     prefer a server-backed Chroma instance.
 
     Args:
-        path: Directory to store persisted data.
+        path: Directory to store persisted data. Defaults to
+            ``settings.persist_directory`` if set, otherwise ``"./chroma"``.
         settings: Optional settings to override defaults.
         tenant: Tenant name to use for requests.
         database: Database name to use for requests.
@@ -220,7 +221,13 @@ def PersistentClient(
     """
     if settings is None:
         settings = Settings()
-    settings.persist_directory = str(path)
+
+    # Priority: explicit path > settings.persist_directory > default
+    if path is not None:
+        settings.persist_directory = str(path)
+    elif settings.persist_directory is None:
+        settings.persist_directory = "./chroma"
+
     settings.is_persistent = True
 
     # Make sure paramaters are the correct types -- users can pass anything.

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -222,10 +222,12 @@ def PersistentClient(
     if settings is None:
         settings = Settings()
 
-    # Priority: explicit path > settings.persist_directory > default
+    # Priority: explicit path > settings.persist_directory > default.
+    # Use a falsy check so an empty-string persist_directory also falls back
+    # to "./chroma" (consistent with #7280/#7464/#7505 on issue #7277).
     if path is not None:
         settings.persist_directory = str(path)
-    elif settings.persist_directory is None:
+    elif not settings.persist_directory:
         settings.persist_directory = "./chroma"
 
     settings.is_persistent = True

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -236,6 +236,47 @@ def test_persistent_client_close() -> None:
         client2.clear_system_cache()
 
 
+def test_persistent_client_persist_directory_priority() -> None:
+    """persist_directory resolution: explicit path > settings.persist_directory > default.
+
+    An empty-string ``persist_directory`` must fall back to "./chroma" (the
+    falsy check used across the #7277 fixes), not be kept as-is.
+    """
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY"):
+        pytest.skip("Integration test only")
+
+    clients: list = []
+
+    def make(**kwargs: Any) -> "ClientAPI":
+        client = chromadb.PersistentClient(**kwargs)
+        clients.append(client)
+        return client
+
+    try:
+        # Explicit path wins over a configured settings.persist_directory.
+        c1 = make(
+            path="/tmp/explicit_path",
+            settings=Settings(persist_directory="/tmp/from_settings"),
+        )
+        assert c1.get_settings().persist_directory == "/tmp/explicit_path"
+        assert c1.get_settings().is_persistent is True
+
+        # Non-empty settings.persist_directory is respected when path is omitted.
+        c2 = make(settings=Settings(persist_directory="/tmp/from_settings"))
+        assert c2.get_settings().persist_directory == "/tmp/from_settings"
+
+        # Empty-string settings.persist_directory falls back to the default.
+        c3 = make(settings=Settings(persist_directory=""))
+        assert c3.get_settings().persist_directory == "./chroma"
+
+        # No path and no settings falls back to the default.
+        c4 = make()
+        assert c4.get_settings().persist_directory == "./chroma"
+    finally:
+        for c in clients:
+            c.clear_system_cache()
+
+
 def test_persistent_client_context_manager() -> None:
     """Test that PersistentClient works as a context manager."""
     if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY"):


### PR DESCRIPTION
## Description

`PersistentClient` silently ignored `Settings.persist_directory` when the `path` parameter was not explicitly passed, because the default value `"./chroma"` unconditionally overwrote it:

```python
def PersistentClient(path: Union[str, Path] = "./chroma", ...):
    settings.persist_directory = str(path)  # always "./chroma" if not passed
```

This meant users who configured `settings.persist_directory` and called `PersistentClient(settings=settings)` without `path=` would get `./chroma` instead of their configured directory.

## Fix

Change the `path` default from `"./chroma"` to `None` and implement a priority chain:

```python
def PersistentClient(path: Optional[Union[str, Path]] = None, ...):
    if path is not None:
        settings.persist_directory = str(path)         # explicit wins
    elif not settings.persist_directory:
        settings.persist_directory = "./chroma"        # fallback default
```

The fallback is a falsy check rather than `is None` (thanks @ErenAta16) because `persist_directory` is typed `str` and defaults to `"./chroma"`, so it is never `None` in practice. The two forms differ on an empty string — `Settings(persist_directory=os.environ.get("CHROMA_DIR", ""))` is a normal way to write that and produces one when the env var is unset. Under `is None` the empty value would survive, and since `os.path.abspath("")` resolves to the working directory, the client would silently persist into wherever the process happened to be running.

## Second bug this closes: `path=None` created a directory named `None`

On `main`, `str(path)` runs unconditionally (`chromadb/__init__.py:223`), so the explicit `path=None` argument that the current signature invites — and that the new signature legalizes — produced a directory literally named `None`:

| call | `main` | this PR |
| --- | --- | --- |
| `PersistentClient("/tmp/explicit", Settings(persist_directory="/tmp/from_settings"))` | `/tmp/explicit` | `/tmp/explicit` |
| `PersistentClient(settings=Settings(persist_directory="/tmp/from_settings"))` | `./chroma` | `/tmp/from_settings` |
| `PersistentClient(settings=Settings(persist_directory=""))` | `./chroma` | `./chroma` |
| `PersistentClient()` | `./chroma` | `./chroma` |
| `PersistentClient(path=None)` | `'None'` | `./chroma` |

## Upgrade note: this can change the directory an existing process reads

Worth carrying into the release notes. `Settings` is a `BaseSettings` with `model_config = {"env_file": ".env", ...}` and **no `env_prefix`** (`chromadb/config.py:320`), and the field is declared `persist_directory: str = "./chroma"` (`chromadb/config.py:160`). Pydantic-settings therefore populates it from a bare `PERSIST_DIRECTORY`:

```
PERSIST_DIRECTORY=/tmp/ENVSET        -> Settings().persist_directory = '/tmp/ENVSET'
CHROMA_PERSIST_DIRECTORY=/tmp/ENVSET -> Settings().persist_directory = './chroma'
```

So anyone who has `PERSIST_DIRECTORY` exported, or a `.env` in the working directory carrying it, and calls `PersistentClient()` with no arguments will start reading and writing a different directory than before — silently, and with no error. That is the fix working as intended, but it is a data-location change on upgrade rather than a pure bugfix, and the unprefixed variable name makes an accidental hit likelier than it looks.

## Related Issue

Closes #7277
