### PR TITLE
[CLN] Ban relative imports via flake8-tidy-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,15 @@ repos:
     hooks:
       - id: flake8
         args:
-          - "--extend-ignore=E203,E501,E503"
+          # I250/I251 (flake8-tidy-imports' import-alias and banned-module
+          # checks) are ignored here since this only opts into the
+          # ban-relative-imports rule (I252); enabling the plugin turns on
+          # all of its checks by default.
+          - "--extend-ignore=E203,E501,E503,I250,I251"
           - "--max-line-length=88"
+          - "--ban-relative-imports=true"
+        additional_dependencies:
+          - "flake8-tidy-imports==4.12.0"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -8,7 +8,7 @@ It can be used to get information about available schemas and their versions.
 from typing import Dict, List, Set
 import os
 import json
-from .schema_utils import SCHEMAS_DIR
+from chromadb.utils.embedding_functions.schemas.schema_utils import SCHEMAS_DIR
 
 
 def get_available_schemas() -> List[str]:


### PR DESCRIPTION
Adds `flake8-tidy-imports` as a flake8 dependency and enables `--ban-relative-imports=true` (rule I252), per the request in #2334.

`flake8-tidy-imports` also ships two other checks (I250 unnecessary-alias, I251 banned-import) that turn on by default once the plugin is installed - those are explicitly ignored here to keep this change scoped to only what the issue asks for.

Fixed the one existing relative import this rule catches: `chromadb/utils/embedding_functions/schemas/registry.py`.

Verified locally: ran flake8 with the exact new args against the whole repo - zero I252 violations remain.

Fixes #2334