### PR TITLE
[TST] Fix vacuous-pass assertions in add.collections tests (rejects.toThrow)

### DIFF
--- a/clients/new-js/packages/chromadb/test/add.collections.test.ts
+++ b/clients/new-js/packages/chromadb/test/add.collections.test.ts
@@ -69,9 +69,9 @@ describe("add collections", () => {
     const ids = IDS.concat(["test1"]);
     const embeddings = EMBEDDINGS.concat([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]);
     const metadatas = METADATAS.concat([{ test: "test1", float_value: 0.1 }]);
-    await expect(async () => {
-      await collection.add({ ids, embeddings, metadatas });
-    }).rejects.toThrow("duplicates");
+    await expect(
+      collection.add({ ids, embeddings, metadatas }),
+    ).rejects.toThrow("duplicates");
   });
 
   test("should error on empty embedding", async () => {
@@ -79,9 +79,9 @@ describe("add collections", () => {
     const ids = ["id1"];
     const embeddings = [[]];
     const metadatas = [{ test: "test1", float_value: 0.1 }];
-    await expect(async () => {
-      await collection.add({ ids, embeddings, metadatas });
-    }).rejects.toThrow(
+    await expect(
+      collection.add({ ids, embeddings, metadatas }),
+    ).rejects.toThrow(
       "Expected each embedding to be a non-empty array of numbers",
     );
   });

--- a/clients/new-js/packages/chromadb/test/add.collections.test.ts
+++ b/clients/new-js/packages/chromadb/test/add.collections.test.ts
@@ -69,11 +69,9 @@ describe("add collections", () => {
     const ids = IDS.concat(["test1"]);
     const embeddings = EMBEDDINGS.concat([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]);
     const metadatas = METADATAS.concat([{ test: "test1", float_value: 0.1 }]);
-    try {
+    await expect(async () => {
       await collection.add({ ids, embeddings, metadatas });
-    } catch (e: any) {
-      expect(e.message).toMatch("duplicates");
-    }
+    }).rejects.toThrow("duplicates");
   });
 
   test("should error on empty embedding", async () => {
@@ -81,12 +79,10 @@ describe("add collections", () => {
     const ids = ["id1"];
     const embeddings = [[]];
     const metadatas = [{ test: "test1", float_value: 0.1 }];
-    try {
+    await expect(async () => {
       await collection.add({ ids, embeddings, metadatas });
-    } catch (e: any) {
-      expect(e.message).toMatch(
-        "Expected each embedding to be a non-empty array of numbers",
-      );
-    }
+    }).rejects.toThrow(
+      "Expected each embedding to be a non-empty array of numbers",
+    );
   });
 });


### PR DESCRIPTION
Two tests in `add.collections.test.ts` wrapped the assertion inside the catch block:

```ts
try {
  await collection.add({ ids, embeddings, metadatas });
} catch (e: any) {
  expect(e.message).toMatch("duplicates");
}
```

If `collection.add()` didn't throw, the catch body (and its `expect()`) never ran and the test passed vacuously instead of failing - not just a style issue, a real gap in coverage.

Rewritten as `await expect(...).rejects.toThrow(...)`, matching the pattern the file already uses two tests above ("should error on non existing collection") and the fix #2135 proposed for the old `clients/js` client before it was replaced by `clients/new-js`.

Scoped to this one file rather than the full sweep in #2135, which was closed for being too large to review - happy to follow up with more files in separate PRs if this pattern is welcome.

Addresses #2801