### PR TITLE
[TST] Use rejects.toBeInstanceOf instead of manual sentinel in admin test

### DIFF
--- a/clients/new-js/packages/chromadb/test/admin.test.ts
+++ b/clients/new-js/packages/chromadb/test/admin.test.ts
@@ -84,15 +84,11 @@ describe("AdminClient", () => {
     await adminClient.createDatabase({ name: dbName, tenant: tenantName });
 
     // Attempt to create it again, should fail
-    try {
-      await adminClient.createDatabase({
+    await expect(
+      adminClient.createDatabase({
         name: dbName,
         tenant: tenantName,
-      });
-      // If it reaches here, the test failed because no error was thrown
-      expect(true).toBe(false);
-    } catch (error) {
-      expect(error).toBeInstanceOf(Error);
-    }
+      }),
+    ).rejects.toBeInstanceOf(Error);
   });
 });


### PR DESCRIPTION
"it should throw well-formatted errors" used a try/catch with a manual `expect(true).toBe(false)` sentinel to fail the test if `createDatabase()` didn't throw:

```ts
try {
  await adminClient.createDatabase({ name: dbName, tenant: tenantName });
  expect(true).toBe(false);
} catch (error) {
  expect(error).toBeInstanceOf(Error);
}
```

Rewritten as `await expect(...).rejects.toBeInstanceOf(Error)`, matching the pattern the file already uses in "it should delete a database" and the fix #2135 proposed for this same test before the old `clients/js` client was replaced by `clients/new-js`.

Follows on from #7508 - same small-scope-per-file approach.

Addresses #2801