### PR TITLE
[CHORE](ci): Gate GCS storage tests behind an input flag

### DIFF
--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -2,6 +2,12 @@ name: Rust tests
 
 on:
   workflow_call:
+    inputs:
+      run_storage_gcs:
+        description: "Run GCS-backed storage tests"
+        required: false
+        type: boolean
+        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -46,6 +52,8 @@ jobs:
         run: cargo nextest run --profile ci_long_running
 
   test-storage-gcs:
+    # These tests require repository secrets that are unavailable to forked PRs.
+    if: inputs.run_storage_gcs
     runs-on: blacksmith-8vcpu-ubuntu-2404
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -70,6 +70,8 @@ jobs:
     name: Rust tests
     uses: ./.github/workflows/_rust-tests.yml
     secrets: inherit
+    with:
+      run_storage_gcs: ${{ github.ref == 'refs/heads/main' }}
 
   go-tests:
     name: Go tests


### PR DESCRIPTION
## Description of changes

The test-storage-gcs job requires repository secrets that are not
available to forked PRs, causing those runs to fail. Add a
run_storage_gcs boolean input to the reusable rust-tests workflow,
defaulting to false, and only execute the GCS job when it is set.

The release-chromadb workflow enables the job when running on main,
where the required secrets are present.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
