### PR TITLE
[ENH](foundation-api): stamp optional author on page writes

### DIFF
--- a/rust/foundation-api/src/routes/apply_patch.rs
+++ b/rust/foundation-api/src/routes/apply_patch.rs
@@ -46,6 +46,11 @@ pub struct ApplyPatchRequest {
     /// `/api/upsert-page` but not persisted on the page.
     #[validate(length(max = 350, message = "reason must be at most 350 characters"))]
     pub reason: Option<String>,
+    /// Optional display label for revision history. Forwarded to
+    /// `/api/upsert-page` and stamped onto page and revision metadata.
+    #[serde(default)]
+    #[validate(length(min = 1, max = 256, message = "author must be 1 to 256 characters"))]
+    pub author: Option<String>,
     /// Identifier of the trajectory that produced this patch. Forwarded to
     /// `/api/upsert-page` and stamped onto page and revision metadata.
     #[validate(length(
@@ -150,6 +155,7 @@ pub(crate) async fn run_apply_patch(
         source_ids: patched.source_ids,
         categories: patched.categories,
         reason: request.reason.clone(),
+        author: request.author.clone(),
         last_written_by: request.last_written_by.clone(),
         expected_version: request.expected_version.unwrap_or(patched.base_version),
     };
@@ -252,6 +258,7 @@ mod tests {
             categories: vec!["product".to_string(), "infra".to_string()],
             expected_version: None,
             reason: None,
+            author: Some("Claude Sonnet 4.5".to_string()),
             last_written_by: "00000000-0000-0000-0000-000000000001".to_string(),
         }
     }
@@ -314,5 +321,27 @@ mod tests {
         let mut missing_writer = request("Old", "New");
         missing_writer.last_written_by.clear();
         assert!(missing_writer.validate().is_err());
+    }
+
+    #[test]
+    fn request_deserialize_defaults_missing_author() {
+        let req: ApplyPatchRequest = serde_json::from_value(serde_json::json!({
+            "slug": "alpha",
+            "old_str": "Old",
+            "new_str": "New",
+            "last_written_by": "00000000-0000-0000-0000-000000000001"
+        }))
+        .unwrap();
+
+        assert_eq!(req.author, None);
+        req.validate().unwrap();
+    }
+
+    #[test]
+    fn request_validate_rejects_empty_author() {
+        let mut req = request("Old", "New");
+        req.author = Some(String::new());
+
+        assert!(req.validate().is_err());
     }
 }

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -83,6 +83,11 @@ pub struct UpsertPageRequest {
     /// context.
     #[validate(length(max = 350, message = "reason must be at most 350 characters"))]
     pub reason: Option<String>,
+    /// Optional display label for revision history. Stamped on every chunk as
+    /// `author` when non-empty after trimming and copied into revision history.
+    #[serde(default)]
+    #[validate(length(min = 1, max = 256, message = "author must be 1 to 256 characters"))]
+    pub author: Option<String>,
     /// Identifier of the trajectory that produced this page write. Stamped on
     /// every chunk as `last_written_by` and copied into revision history.
     #[validate(length(
@@ -209,6 +214,7 @@ pub(crate) async fn run_upsert_page(
     categories: &[String],
 ) -> Result<UpsertPageResponse, UpsertPageError> {
     let slug = request.slug.as_str();
+    let author = normalize_author(request.author.as_deref());
     let wiki_client = server
         .foundation_chroma_client
         .as_ref()
@@ -366,6 +372,7 @@ pub(crate) async fn run_upsert_page(
         i64::from(version),
         categories,
         &request.source_ids,
+        author,
         &request.last_written_by,
     );
 
@@ -578,6 +585,10 @@ pub(crate) fn normalize_categories(categories: &[String]) -> Vec<String> {
         .collect()
 }
 
+fn normalize_author(author: Option<&str>) -> Option<&str> {
+    author.map(str::trim).filter(|author| !author.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -603,6 +614,7 @@ mod tests {
             source_ids: source_ids.iter().map(|s| s.to_string()).collect(),
             categories: categories.iter().map(|s| s.to_string()).collect(),
             reason: None,
+            author: Some("Claude Sonnet 4.5".to_string()),
             last_written_by: "00000000-0000-0000-0000-000000000001".to_string(),
             expected_version: 0,
         }
@@ -729,6 +741,16 @@ mod tests {
             vec!["a".to_string(), "b".to_string()]
         );
         assert_eq!(normalize_categories(&[]), Vec::<String>::new());
+    }
+
+    #[test]
+    fn normalize_author_trims_and_omits_blank_labels() {
+        assert_eq!(
+            normalize_author(Some("  Claude Sonnet 4.5  ")),
+            Some("Claude Sonnet 4.5")
+        );
+        assert_eq!(normalize_author(Some("   ")), None);
+        assert_eq!(normalize_author(None), None);
     }
 
     #[test]
@@ -954,12 +976,41 @@ mod tests {
     }
 
     #[test]
+    fn request_deserialize_defaults_missing_author() {
+        let req: UpsertPageRequest = serde_json::from_value(json!({
+            "slug": "foo",
+            "content": "# Title\n\nBody",
+            "source_ids": ["slack_master:abc"],
+            "categories": ["z", "a"],
+            "last_written_by": "00000000-0000-0000-0000-000000000001",
+            "expected_version": 0
+        }))
+        .unwrap();
+
+        assert_eq!(req.author, None);
+        req.validate().unwrap();
+    }
+
+    #[test]
     fn request_validate_bounds_reason_length() {
         let mut req = request("foo", "body", &[], &[]);
         req.reason = Some("a".repeat(350));
         req.validate().unwrap();
 
         req.reason = Some("a".repeat(351));
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn request_validate_bounds_author_length() {
+        let mut req = request("foo", "body", &[], &[]);
+        req.author = Some("a".repeat(256));
+        req.validate().unwrap();
+
+        req.author = Some("a".repeat(257));
+        assert!(req.validate().is_err());
+
+        req.author = Some(String::new());
         assert!(req.validate().is_err());
     }
 

--- a/rust/foundation-api/src/wiki/page.rs
+++ b/rust/foundation-api/src/wiki/page.rs
@@ -32,6 +32,7 @@ pub(crate) fn build_metadatas(
     version: i64,
     categories: &[String],
     source_ids: &[String],
+    author: Option<&str>,
     last_written_by: &str,
 ) -> Vec<Metadata> {
     chunks
@@ -72,6 +73,9 @@ pub(crate) fn build_metadatas(
                     "source_ids".to_string(),
                     MetadataValue::StringArray(source_ids.to_vec()),
                 );
+            }
+            if let Some(author) = author {
+                meta.insert("author".to_string(), MetadataValue::Str(author.to_string()));
             }
             meta
         })
@@ -147,6 +151,7 @@ mod tests {
             3,
             &["a".to_string()],
             &["slack_master:abc".to_string()],
+            Some("Claude Sonnet 4.5"),
             "00000000-0000-0000-0000-000000000001",
         );
 
@@ -168,6 +173,10 @@ mod tests {
             Some(&MetadataValue::Str(
                 "00000000-0000-0000-0000-000000000001".to_string()
             ))
+        );
+        assert_eq!(
+            first.get("author"),
+            Some(&MetadataValue::Str("Claude Sonnet 4.5".to_string()))
         );
         assert_eq!(
             first.get("categories"),
@@ -199,11 +208,13 @@ mod tests {
             1,
             &[],
             &[],
+            None,
             "00000000-0000-0000-0000-000000000001",
         );
 
         assert!(!metas[0].contains_key("categories"));
         assert!(!metas[0].contains_key("source_ids"));
+        assert!(!metas[0].contains_key("author"));
         assert!(metas[0].contains_key(SPARSE_KEY));
     }
 }


### PR DESCRIPTION
## Description of changes

Add an optional `author` display label to the upsert-page and
apply-patch request bodies, forwarding it through to page and
revision metadata. The label is trimmed and omitted when blank so
empty values never reach the store.

- Validate author length (1 to 256 characters) on both routes
- Normalize author by trimming and dropping empty labels in upsert
- Thread author into build_metadatas, stamping it per chunk
- Forward author from apply-patch through to upsert-page

## Test plan

CI

## Migration plan

Backwards-compatible.

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
