### PR TITLE
[BUG] js-client: prevent TOCTOU race on tenant/database init in _path()

### DIFF
--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -81,6 +81,7 @@ export interface ChromaClientArgs {
 export class ChromaClient {
   private _tenant: string | undefined;
   private _database: string | undefined;
+  private _identityPromise: Promise<void> | null = null;
   private _preflightChecks: ChecklistResponse | undefined;
   private _headers: Record<string, string> | undefined;
   private readonly apiClient: ReturnType<typeof createClient>;
@@ -189,22 +190,39 @@ export class ChromaClient {
   /** @ignore */
   public async _path(): Promise<{ tenant: string; database: string }> {
     if (!this._tenant || !this._database) {
-      const { tenant, databases } = await this.getUserIdentity();
-      const uniqueDBs = [...new Set(databases)];
-      this._tenant = tenant;
-      if (uniqueDBs.length === 0) {
-        throw new ChromaUnauthorizedError(
-          `Your API key does not have access to any DBs for tenant ${this.tenant}`,
-        );
+      if (!this._identityPromise) {
+        this._identityPromise = this._resolveIdentity().catch((error) => {
+          // Clear the memoized promise on failure so subsequent calls retry.
+          this._identityPromise = null;
+          throw error;
+        });
       }
-      if (uniqueDBs.length > 1 || uniqueDBs[0] === "*") {
-        throw new ChromaValueError(
-          "Your API key is scoped to more than 1 DB. Please provide a DB name to the CloudClient constructor",
-        );
-      }
-      this._database = uniqueDBs[0];
+      await this._identityPromise;
     }
-    return { tenant: this._tenant, database: this._database };
+    return { tenant: this._tenant!, database: this._database! };
+  }
+
+  /**
+   * Resolves tenant and database from the user's identity. Only one
+   * resolution is ever in flight at a time; concurrent `_path()` callers
+   * await the same promise so they cannot race on `_tenant`/`_database`
+   * initialization.
+   */
+  private async _resolveIdentity(): Promise<void> {
+    const { tenant, databases } = await this.getUserIdentity();
+    const uniqueDBs = [...new Set(databases)];
+    this._tenant = tenant;
+    if (uniqueDBs.length === 0) {
+      throw new ChromaUnauthorizedError(
+        `Your API key does not have access to any DBs for tenant ${this.tenant}`,
+      );
+    }
+    if (uniqueDBs.length > 1 || uniqueDBs[0] === "*") {
+      throw new ChromaValueError(
+        "Your API key is scoped to more than 1 DB. Please provide a DB name to the CloudClient constructor",
+      );
+    }
+    this._database = uniqueDBs[0];
   }
 
   /**

--- a/clients/new-js/packages/chromadb/test/path-race.test.ts
+++ b/clients/new-js/packages/chromadb/test/path-race.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { CloudClient } from "../src";
+import type { UserIdentity } from "../src/types";
+
+describe("_path() tenant/database initialization", () => {
+  beforeEach(() => {
+    // Ensure tenant/database are unset so _path() must resolve identity.
+    delete process.env.CHROMA_TENANT;
+    delete process.env.CHROMA_DATABASE;
+  });
+
+  const makeClient = () => new CloudClient({ apiKey: "test-api-key" });
+
+  test("concurrent callers share a single identity resolution and get the same path", async () => {
+    const chroma = makeClient();
+    const resolvers: Array<(identity: UserIdentity) => void> = [];
+    const identitySpy = jest
+      .spyOn(chroma, "getUserIdentity")
+      .mockImplementation(
+        () =>
+          new Promise<UserIdentity>((resolve) => {
+            resolvers.push(resolve);
+          }),
+      );
+
+    // Both callers enter _path() before identity resolution has completed.
+    const firstPath = chroma._path();
+    const secondPath = chroma._path();
+
+    // Resolve every in-flight identity request with a distinct tenant. If the
+    // client fired more than one request, the last writer would win on
+    // _tenant/_database and the two callers would see inconsistent paths.
+    resolvers.forEach((resolve, i) =>
+      resolve({
+        tenant: `tenant-${i}`,
+        databases: [`database-${i}`],
+        user_id: "test-user",
+      }),
+    );
+
+    const [first, second] = await Promise.all([firstPath, secondPath]);
+
+    expect(identitySpy).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ tenant: "tenant-0", database: "database-0" });
+    expect(second).toEqual(first);
+    expect(chroma.tenant).toBe("tenant-0");
+    expect(chroma.database).toBe("database-0");
+  });
+
+  test("does not re-fetch identity once tenant and database are resolved", async () => {
+    const chroma = makeClient();
+    const identitySpy = jest
+      .spyOn(chroma, "getUserIdentity")
+      .mockResolvedValue({
+        tenant: "tenant-a",
+        databases: ["database-a"],
+        user_id: "test-user",
+      });
+
+    await expect(chroma._path()).resolves.toEqual({
+      tenant: "tenant-a",
+      database: "database-a",
+    });
+    await expect(chroma._path()).resolves.toEqual({
+      tenant: "tenant-a",
+      database: "database-a",
+    });
+
+    expect(identitySpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failed identity resolution is retried on the next call", async () => {
+    const chroma = makeClient();
+    const identitySpy = jest
+      .spyOn(chroma, "getUserIdentity")
+      .mockRejectedValueOnce(new Error("identity fetch failed"))
+      .mockResolvedValueOnce({
+        tenant: "tenant-a",
+        databases: ["database-a"],
+        user_id: "test-user",
+      });
+
+    await expect(chroma._path()).rejects.toThrow("identity fetch failed");
+    await expect(chroma._path()).resolves.toEqual({
+      tenant: "tenant-a",
+      database: "database-a",
+    });
+
+    expect(identitySpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Fixes #7513

## What

`ChromaClient._path()` had a check-then-await-then-write race: concurrent callers during lazy tenant/database resolution each fired `getUserIdentity()` and could observe inconsistent tenant/database values (last writer wins), so concurrent callers got wrong paths.

This memoizes the in-flight identity resolution as a single shared promise (async single-flight); all concurrent callers await the same resolution. The promise is cleared on rejection so later calls retry, preserving the existing retry semantics. API, error types, and error messages are unchanged.

## Tests

New `test/path-race.test.ts` with a mocked `getUserIdentity`:

- two concurrent `_path()` calls resolve with exactly 1 identity fetch and identical paths (fails on main: 2 fetches, divergent paths)
- no refetch after successful init
- a failed resolution is retried on the next call

Ran with the package's jest config minus the Docker-based globalSetup (no Docker available in my environment); validation and schema suites pass alongside (70/70).

Credit to @tsushanth for the report in #7513.
