### PR TITLE
[ENH] Add Fusion Embedding function (fusion-embedding-2)

### DIFF
--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -48,6 +48,7 @@ def test_get_builtins_holds() -> None:
         "OpenCLIPEmbeddingFunction",
         "RoboflowEmbeddingFunction",
         "SentenceTransformerEmbeddingFunction",
+        "FusionEmbeddingFunction",
         "Text2VecEmbeddingFunction",
         "ChromaLangchainEmbeddingFunction",
         "TogetherAIEmbeddingFunction",

--- a/chromadb/test/ef/test_fusion_embedding_ef.py
+++ b/chromadb/test/ef/test_fusion_embedding_ef.py
@@ -1,0 +1,41 @@
+import pytest
+
+from chromadb.utils.embedding_functions.fusion_embedding_function import (
+    FusionEmbeddingFunction,
+)
+
+
+def test_name() -> None:
+    assert FusionEmbeddingFunction.name() == "fusion_embedding"
+
+
+def test_spaces() -> None:
+    # default/supported spaces do not touch the model
+    ef = object.__new__(FusionEmbeddingFunction)
+    assert ef.default_space() == "cosine"
+    assert set(ef.supported_spaces()) == {"cosine", "l2", "ip"}
+
+
+def test_get_config_and_validate() -> None:
+    ef = object.__new__(FusionEmbeddingFunction)
+    ef.model_name = "EximiusLabs/fusion-embedding-2-2b-preview"
+    ef.device = "cpu"
+    ef.dim = 512
+    config = ef.get_config()
+    assert config == {
+        "model_name": "EximiusLabs/fusion-embedding-2-2b-preview",
+        "device": "cpu",
+        "dim": 512,
+    }
+    FusionEmbeddingFunction.validate_config(config)
+
+
+def test_validate_config_rejects_missing_required() -> None:
+    with pytest.raises(Exception):
+        FusionEmbeddingFunction.validate_config({"device": "cpu"})  # missing model_name
+
+
+def test_encode_roundtrip() -> None:
+    # Loading instantiates a ~2B model; only run where the package and weights are present.
+    pytest.importorskip("fusion_embedding")
+    pytest.skip("requires the fusion-embedding model weights (~2B); run manually")

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -22,6 +22,9 @@ from chromadb.utils.embedding_functions.huggingface_embedding_function import (
 from chromadb.utils.embedding_functions.sentence_transformer_embedding_function import (
     SentenceTransformerEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.fusion_embedding_function import (
+    FusionEmbeddingFunction,
+)
 from chromadb.utils.embedding_functions.google_embedding_function import (
     GooglePalmEmbeddingFunction,
     GoogleGenerativeAiEmbeddingFunction,
@@ -107,6 +110,7 @@ _all_classes: Set[str] = {
     "HuggingFaceEmbeddingFunction",
     "HuggingFaceEmbeddingServer",
     "SentenceTransformerEmbeddingFunction",
+    "FusionEmbeddingFunction",
     "GooglePalmEmbeddingFunction",
     "GoogleGenerativeAiEmbeddingFunction",
     "GoogleVertexEmbeddingFunction",
@@ -150,6 +154,7 @@ known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignor
     "huggingface": HuggingFaceEmbeddingFunction,
     "huggingface_server": HuggingFaceEmbeddingServer,
     "sentence_transformer": SentenceTransformerEmbeddingFunction,
+    "fusion_embedding": FusionEmbeddingFunction,
     "google_palm": GooglePalmEmbeddingFunction,
     "google_generative_ai": GoogleGenerativeAiEmbeddingFunction,
     "google_vertex": GoogleVertexEmbeddingFunction,
@@ -277,6 +282,7 @@ __all__ = [
     "HuggingFaceEmbeddingFunction",
     "HuggingFaceEmbeddingServer",
     "SentenceTransformerEmbeddingFunction",
+    "FusionEmbeddingFunction",
     "GooglePalmEmbeddingFunction",
     "GoogleGenerativeAiEmbeddingFunction",
     "GoogleVertexEmbeddingFunction",

--- a/chromadb/utils/embedding_functions/fusion_embedding_function.py
+++ b/chromadb/utils/embedding_functions/fusion_embedding_function.py
@@ -1,0 +1,80 @@
+from chromadb.api.types import EmbeddingFunction, Space, Embeddings, Documents
+from typing import List, Dict, Any, Optional
+import numpy as np
+from chromadb.utils.embedding_functions.schemas import validate_config_schema
+
+
+class FusionEmbeddingFunction(EmbeddingFunction[Documents]):
+    """Text embeddings from Eximius Labs' open-weight Fusion Embedding models
+    (e.g. ``EximiusLabs/fusion-embedding-2-2b-preview``).
+
+    Loads locally through the ``fusion-embedding`` package's text-only path (the frozen
+    base plus the trained connector head, without the audio tower). Install the model
+    package with::
+
+        pip install git+https://github.com/Eximius-Labs/fusion-embedding
+    """
+
+    # Cache loaded models across instances (dynamic import -> typed Any).
+    models: Dict[str, Any] = {}
+
+    def __init__(
+        self,
+        model_name: str = "EximiusLabs/fusion-embedding-2-2b-preview",
+        device: str = "cpu",
+        dim: Optional[int] = None,
+    ):
+        try:
+            from fusion_embedding import FusionTextEmbedder
+        except ImportError:
+            raise ValueError(
+                "The fusion-embedding package is not installed. Install it with "
+                "`pip install git+https://github.com/Eximius-Labs/fusion-embedding`"
+            )
+
+        self.model_name = model_name
+        self.device = device
+        self.dim = dim
+
+        cache_key = f"{model_name}@{device}"
+        if cache_key not in self.models:
+            self.models[cache_key] = FusionTextEmbedder.from_pretrained(
+                model_name, device=device
+            )
+        self._model = self.models[cache_key]
+
+    def __call__(self, input: Documents) -> Embeddings:
+        vectors = self._model.encode(list(input), dim=self.dim)  # np.ndarray [N, D]
+        return [np.asarray(vector, dtype=np.float32) for vector in vectors]
+
+    @staticmethod
+    def name() -> str:
+        return "fusion_embedding"
+
+    def default_space(self) -> Space:
+        return "cosine"
+
+    def supported_spaces(self) -> List[Space]:
+        return ["cosine", "l2", "ip"]
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+        model_name = config.get("model_name")
+        device = config.get("device")
+        if model_name is None or device is None:
+            assert False, "This code should not be reached"
+        return FusionEmbeddingFunction(
+            model_name=model_name, device=device, dim=config.get("dim")
+        )
+
+    def get_config(self) -> Dict[str, Any]:
+        return {"model_name": self.model_name, "device": self.device, "dim": self.dim}
+
+    def validate_config_update(
+        self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+    ) -> None:
+        return
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        validate_config_schema(config, "fusion_embedding")

--- a/schemas/embedding_functions/fusion_embedding.json
+++ b/schemas/embedding_functions/fusion_embedding.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Fusion Embedding Function Schema",
+    "description": "Configuration schema for the Fusion Embedding function",
+    "version": "1.0.0",
+    "type": "object",
+    "properties": {
+        "model_name": {
+            "type": "string",
+            "description": "Hugging Face id of the Fusion Embedding model"
+        },
+        "device": {
+            "type": "string",
+            "description": "Device used for computation (e.g. cpu or cuda)"
+        },
+        "dim": {
+            "type": ["integer", "null"],
+            "description": "Optional MRL truncation dimension for the returned vectors"
+        }
+    },
+    "required": ["model_name", "device"],
+    "additionalProperties": false
+}


### PR DESCRIPTION
### Description of changes

Adds `FusionEmbeddingFunction`, a native embedding function for [Fusion Embedding 2](https://huggingface.co/EximiusLabs/fusion-embedding-2-2b-preview), an open-weight multimodal embedding model from Eximius Labs. For text documents and queries it returns text embeddings, loaded locally through the model's `fusion-embedding` package (text-only path, no audio tower). It mirrors the existing `SentenceTransformerEmbeddingFunction`: lazy import, class-level model cache, config round-trip, and JSON-schema validation.

Added:
- `chromadb/utils/embedding_functions/fusion_embedding_function.py`
- `schemas/embedding_functions/fusion_embedding.json`
- `chromadb/test/ef/test_fusion_embedding_ef.py`

Registered in `chromadb/utils/embedding_functions/__init__.py` (`known_embedding_functions["fusion_embedding"]`, `_all_classes`, `__all__`) and added to `expected_builtins` in `chromadb/test/ef/test_ef.py`.

The model package is imported lazily inside `__init__`, so `import chromadb` and the import/builtins tests never pull the model or its heavy dependencies.

This PR is Python-only; happy to add the JS embedding package for parity if you'd like.

### Test plan

`pytest chromadb/test/ef/test_ef.py chromadb/test/ef/test_fusion_embedding_ef.py`

Static tests (name, spaces, config validation and round-trip) run in CI. The encode test is skipped unless the model weights (~2B) are present locally.
