### PR TITLE
fix(test): register fastapi fixtures and correct sqlite fixture name

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -387,19 +387,22 @@ def _fastapi_fixture(
         yield from run(args)
 
 
+@pytest.fixture()
 def fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=False)
+    yield from _fastapi_fixture(is_persistent=False)
 
 
+@pytest.fixture()
 def async_fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(
+    yield from _fastapi_fixture(
         is_persistent=False,
         chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
     )
 
 
+@pytest.fixture()
 def fastapi_persistent() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=True)
+    yield from _fastapi_fixture(is_persistent=True)
 
 
 def fastapi_ssl() -> Generator[System, None, None]:
@@ -753,7 +756,7 @@ def filtered_fixture_names() -> List[str]:
         "fastapi",
         "async_fastapi",
         "fastapi_persistent",
-        "sqlite_fixture",
+        "sqlite",
         "sqlite_persistent",
     ]
 


### PR DESCRIPTION
## Summary

Three related bugs in `chromadb/test/conftest.py` that prevent FastAPI fixtures from being discovered and cleaned up by pytest:

- `fastapi`, `async_fastapi`, and `fastapi_persistent` were plain functions with no `@pytest.fixture()` decorator, so `request.getfixturevalue()` could not find them at runtime.
- All three used `return _fastapi_fixture(...)` instead of `yield from _fastapi_fixture(...)`, meaning the generator's teardown code never executed after each test.
- `filtered_fixture_names()` listed `"sqlite_fixture"` which does not exist; the correct name is `"sqlite"`.

## Changes

- Added `@pytest.fixture()` to `fastapi`, `async_fastapi`, and `fastapi_persistent`.
- Changed `return` to `yield from` in all three so teardown (server shutdown) runs after each test.
- Corrected `"sqlite_fixture"` → `"sqlite"` in `filtered_fixture_names()`.

## Test plan

- [ ] Run existing FastAPI integration tests — fixtures are now discoverable via `request.getfixturevalue("fastapi")` etc.
- [ ] Confirm server teardown executes after each test (no dangling processes).
- [ ] Confirm `"sqlite"` fixture resolves correctly in the filtered fixture list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)