### PR TITLE
[BUG](worker): Detach fn-consumer batches

### DIFF
--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -161,7 +161,12 @@ impl FnConsumerManager {
     }
 
     /// Runs the attached function workflow for the given function across a batch of input collections.
-    #[instrument(name = "FnConsumerManager::dispatch_batch", skip(self), err)]
+    #[instrument(
+        name = "FnConsumerManager::dispatch_batch",
+        parent = None,
+        skip(self),
+        err
+    )]
     async fn dispatch_batch(
         &self,
         fn_id: AttachedFunctionUuid,


### PR DESCRIPTION
## Summary

Detach each `FnConsumerManager::dispatch_batch` span from the scheduled poll trace.

## Why

A scheduled poll can run multiple batches concurrently via `join_all`, so keeping those spans under the poll conflates independent attached-function executions in one trace. Each batch is now its own trace root, while the scheduled-poll trace retains polling and `GetWork` visibility.

## Impact

Function-batch traces can be inspected independently in Honeycomb. This changes trace topology only; it does not change function execution behavior or span volume.

## Validation

- `git diff --check`
- `cargo fmt --check`
- `cargo test -p worker fn_consumer --lib`