### PR TITLE
[BUG](sysdb): Take write lock in delete_collection

### DIFF
--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -604,6 +604,12 @@ impl SqliteSysDb {
             .begin()
             .await
             .map_err(|e| DeleteCollectionError::Internal(e.into()))?;
+        // Match create_collection: a deferred transaction lets a concurrent
+        // create/delete on the same name lose updates.
+        self.db
+            .begin_immediate(&mut *tx)
+            .await
+            .map_err(|e| DeleteCollectionError::Internal(e.into()))?;
 
         let was_found = self
             .delete_collection_with_conn(&mut *tx, tenant, database, collection_id, segment_ids)


### PR DESCRIPTION
`SqliteSysDb::delete_collection` opens its transaction with `begin()`, which starts a *deferred* SQLite transaction — the write lock isn't taken until the first actual write. In that window another connection can open its own transaction on the same collection name and interleave, so a concurrent create/delete pair can both report success and lose an update. `create_collection` already guards against this by following `begin()` with `begin_immediate()`; `delete_collection` did not. Credit to **@roli-lpci** for reporting #7375 and pinning down that asymmetry — the diagnosis in the issue is exactly right.

This adds the same `begin_immediate()` call so the write lock is acquired up front and the two paths behave consistently.

```rust
let mut tx = self.db.get_conn().begin().await?;
// now also in delete_collection, matching create_collection:
self.db.begin_immediate(&mut *tx).await?;
```

Verified with `cargo test -p chroma-sysdb sqlite::` (15 passed), `cargo fmt --check`, and `cargo clippy -p chroma-sysdb --lib -- -D warnings`, on a branch merged with current `main`.

Closes #7375

🤖 Generated with Claude Code
