### PR TITLE
[TST] Fix vacuous-pass assertion in get.collection "wrong code" test

### DIFF
--- a/clients/new-js/packages/chromadb/test/get.collection.test.ts
+++ b/clients/new-js/packages/chromadb/test/get.collection.test.ts
@@ -43,19 +43,16 @@ describe("get collections", () => {
       embeddings: EMBEDDINGS,
       metadatas: METADATAS,
     });
-    try {
-      await collection.get({
+    await expect(
+      collection.get({
         where: {
           //@ts-ignore supposed to fail
           test: { $invalid: "hello" },
         },
-      });
-    } catch (error: any) {
-      expect(error).toBeDefined();
-      expect(error.message).toMatchInlineSnapshot(
-        `"Expected operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, $contains, $not_contains, but got $invalid"`,
-      );
-    }
+      }),
+    ).rejects.toThrow(
+      "Expected operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, $contains, $not_contains, but got $invalid",
+    );
   });
 
   test("it should get embedding with matching documents", async () => {


### PR DESCRIPTION
"wrong code returns an error" wrapped its assertions inside the catch block:

```ts
try {
  await collection.get({ where: { test: { $invalid: "hello" } } });
} catch (error: any) {
  expect(error).toBeDefined();
  expect(error.message).toMatchInlineSnapshot(...);
}
```

If `collection.get()` didn't throw, the catch body (and its `error.message` check) never ran and the test passed vacuously instead of failing.

Rewritten as `await expect(...).rejects.toThrow(message)`, matching the pattern already used elsewhere in this file ("should error on non existing collection") and applied in #7508/#7509.

Addresses #2801