### PR TITLE
[TST] Fix vacuous-pass assertion in collection.config schema/EF conflict test

### DIFF
--- a/clients/new-js/packages/chromadb/test/collection.config.client.test.ts
+++ b/clients/new-js/packages/chromadb/test/collection.config.client.test.ts
@@ -611,15 +611,13 @@ describe("embedding function null vs undefined handling", () => {
     const schema = new Schema();
     const providedEf = new DefaultSpaceCustomEmbeddingFunction("i_want_l2", 5);
 
-    try {
-      const collection = await client.createCollection({
+    await expect(
+      client.createCollection({
         name: "test_provided_over_schema",
         schema,
         embeddingFunction: providedEf,
-      });
-    } catch (error) {
-      expect(error).toBeDefined();
-    }
+      }),
+    ).rejects.toBeDefined();
   });
   test("it should use provided embedding function if no schema", async () => {
     const providedEf = new DefaultSpaceCustomEmbeddingFunction("i_want_l2", 5);


### PR DESCRIPTION
"it should error if both schema and embedding function are provided" wrapped its assertion inside the catch block with no fallback:

```ts
try {
  const collection = await client.createCollection({ ... });
} catch (error) {
  expect(error).toBeDefined();
}
```

If `createCollection()` didn't throw, the catch body (and its `expect(error).toBeDefined()` check) never ran, and the test passed silently without ever exercising the assertion.

Rewritten as `await expect(...).rejects.toBeDefined()`, matching the pattern applied in #7508/#7509/#7525.

Flagged by review on #7525 pointing out this same shape recurs in a few places - this is the one instance not already covered by an open PR.

Addresses #2801