### PR TITLE
[BUG]: reject LRUCache capacities below 1 instead of raising KeyError

### DIFF
--- a/chromadb/test/utils/test_lru_cache.py
+++ b/chromadb/test/utils/test_lru_cache.py
@@ -1,0 +1,57 @@
+import pytest
+
+from chromadb.utils.lru_cache import LRUCache
+
+
+def test_evicts_least_recently_used() -> None:
+    cache: LRUCache[str, int] = LRUCache(2)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.get("a")  # "a" becomes the most recently used
+    cache.set("c", 3)
+
+    assert cache.get("a") == 1
+    assert cache.get("b") is None
+    assert cache.get("c") == 3
+
+
+def test_eviction_invokes_callback() -> None:
+    evicted: list[tuple[str, int]] = []
+    cache: LRUCache[str, int] = LRUCache(
+        1, callback=lambda k, v: evicted.append((k, v))
+    )
+    cache.set("a", 1)
+    cache.set("b", 2)
+
+    assert evicted == [("a", 1)]
+
+
+def test_overwriting_a_key_does_not_evict() -> None:
+    evicted: list[str] = []
+    cache: LRUCache[str, int] = LRUCache(1, callback=lambda k, _: evicted.append(k))
+    cache.set("a", 1)
+    cache.set("a", 2)
+
+    assert cache.get("a") == 2
+    assert evicted == []
+
+
+@pytest.mark.parametrize("capacity", [0, -1])
+def test_capacity_below_one_is_rejected(capacity: int) -> None:
+    """A zero capacity used to raise KeyError on the first set(), a negative one never evicted.
+
+    LocalSegmentManager derives the capacity from
+    RLIMIT_NOFILE // PersistentLocalHnswSegment.get_file_handle_count(), which floors to 0 when
+    the file-descriptor limit is lower than the per-segment handle count.
+    """
+    with pytest.raises(ValueError, match="capacity must be at least 1"):
+        LRUCache(capacity)
+
+
+def test_capacity_one_holds_a_single_entry() -> None:
+    cache: LRUCache[str, int] = LRUCache(1)
+    cache.set("a", 1)
+    cache.set("b", 2)
+
+    assert cache.get("a") is None
+    assert cache.get("b") == 2

--- a/chromadb/utils/lru_cache.py
+++ b/chromadb/utils/lru_cache.py
@@ -11,6 +11,8 @@ class LRUCache(Generic[K, V]):
     for a callback to be invoked when an item is evicted from the cache."""
 
     def __init__(self, capacity: int, callback: Optional[Callable[[K, V], Any]] = None):
+        if capacity < 1:
+            raise ValueError(f"LRUCache capacity must be at least 1, got {capacity}")
         self.capacity = capacity
         self.cache: OrderedDict[K, V] = OrderedDict()
         self.callback = callback
@@ -25,7 +27,7 @@ class LRUCache(Generic[K, V]):
     def set(self, key: K, value: V) -> None:
         if key in self.cache:
             self.cache.pop(key)
-        elif len(self.cache) == self.capacity:
+        elif len(self.cache) >= self.capacity:
             evicted_key, evicted_value = self.cache.popitem(last=False)
             if self.callback:
                 self.callback(evicted_key, evicted_value)


### PR DESCRIPTION
## Description of changes

`LRUCache.set` evicts on `len(self.cache) == self.capacity`. Two capacities break that:

```python
LRUCache(0).set("a", 1)    # KeyError: 'dictionary is empty'
LRUCache(-1)               # equality never matches -> grows without bound
```

With capacity `0` the first `set()` matches on an empty `OrderedDict` and `popitem(last=False)` raises. With a negative capacity nothing is ever evicted, which is the opposite of what the argument asks for.

Capacity 0 isn't hypothetical. `LocalSegmentManager` derives it:

```python
segment_limit = self._max_file_handles // PersistentLocalHnswSegment.get_file_handle_count()
self._vector_instances_file_handle_cache = LRUCache(segment_limit, callback=...)
```

`_max_file_handles` is `RLIMIT_NOFILE`, and `get_file_handle_count()` is `hnswlib.Index.file_handle_count + 1`. A container started with a low `ulimit -n` floors that division to 0, and the failure then surfaces as a `KeyError` from inside a cache rather than as a configuration error anyone can act on.

Validate in `__init__`, and use `>=` for the eviction check so the bound holds even if the cache is ever populated by another path.

*New functionality*
- Does it require a .md doc? No — internal utility, behaviour is unchanged for every valid capacity.

## Test plan

`chromadb/test/utils/test_lru_cache.py`, six tests: eviction order, the eviction callback, overwriting an existing key not evicting, capacity 1 holding a single entry, and `0` / `-1` raising.

The four behaviour tests pass on both sides — they're there so the `==` → `>=` change is pinned rather than taken on trust. Stashing only `lru_cache.py` gives `2 failed, 4 passed`; with the change, `6 passed`.

`black --check` clean on both files. `ruff check` reports the same 4 findings before and after (all `I001` import sorting, pre-existing); the repo runs `black` in pre-commit and has no ruff config, so I left those alone.

- [x] Tests pass locally with `pytest` for python

## Documentation Changes

None.