### PR TITLE
[BUG]: validate the empty key before the single-member shortcut in assign()

### DIFF
--- a/chromadb/test/segment/distributed/test_rendezvous_hash.py
+++ b/chromadb/test/segment/distributed/test_rendezvous_hash.py
@@ -1,3 +1,5 @@
+import pytest
+
 from chromadb.utils.rendezvous_hash import assign, murmur3hasher
 from math import sqrt
 
@@ -62,3 +64,25 @@ def test_multi_assign_even_distribution() -> None:
     for node in nodes:
         # 3k keys expected for each node (10000 keys / 10 nodes * 3 replication)
         assert abs(key_distribution[node] - expected) < tolerance
+
+
+def test_empty_key_rejected_for_any_member_count() -> None:
+    """The empty-key guard used to sit after the single-member early return, so a
+    one-member list skipped it and got an assignment back."""
+    for members in (["a"], ["a", "b"], ["a", "b", "c"]):
+        with pytest.raises(ValueError, match="Cannot assign empty key"):
+            assign("", members, murmur3hasher, 1)
+
+
+def test_single_member_still_returns_that_member() -> None:
+    assert assign("key", ["a"], murmur3hasher, 1) == ["a"]
+
+
+def test_empty_memberlist_rejected() -> None:
+    with pytest.raises(ValueError, match="empty memberlist"):
+        assign("key", [], murmur3hasher, 0)
+
+
+def test_replication_above_member_count_rejected() -> None:
+    with pytest.raises(ValueError, match="Replication factor"):
+        assign("key", ["a", "b"], murmur3hasher, 3)

--- a/chromadb/utils/rendezvous_hash.py
+++ b/chromadb/utils/rendezvous_hash.py
@@ -28,11 +28,11 @@ def assign(
         )
     if len(members) == 0:
         raise ValueError("Cannot assign key to empty memberlist")
+    if key == "":
+        raise ValueError("Cannot assign empty key")
     if len(members) == 1:
         # Don't copy the input list for some safety
         return [members[0]]
-    if key == "":
-        raise ValueError("Cannot assign empty key")
 
     member_score_heap: List[Tuple[int, Member]] = []
     for member in members:


### PR DESCRIPTION
## Description of changes

`assign()` raises `ValueError("Cannot assign empty key")`, but that check sits below the `len(members) == 1` early return, so a single-member memberlist skips it:

```python
assign("", ["a"], murmur3hasher, 1)            # -> ["a"]
assign("", ["a", "b"], murmur3hasher, 1)       # -> ValueError: Cannot assign empty key
assign("", ["a", "b", "c"], murmur3hasher, 1)  # -> ValueError: Cannot assign empty key
```

Whether an empty key is an error depends on how many members happen to be in the ring, and a single-member ring is the ordinary state of a cluster that is starting up, rolling, or scaled down to one node — so the validation is weakest exactly when the caller is least likely to notice.

Moving the key check above the shortcut. `replication > len(members)` and the empty-memberlist check keep their current order.

*New functionality*
- Does it require a .md doc? No.

## Test plan

Four tests in `chromadb/test/segment/distributed/test_rendezvous_hash.py`:

- `test_empty_key_rejected_for_any_member_count` — 1, 2 and 3 members, all expected to raise
- `test_single_member_still_returns_that_member` — the shortcut itself, so this change can't silently disable it
- `test_empty_memberlist_rejected` and `test_replication_above_member_count_rejected` — the two guards whose order didn't change

Stashing only `rendezvous_hash.py` gives `1 failed, 6 passed`; with the change, `7 passed`. The two existing tests (`test_rendezvous_hash`, `test_even_distribution`) pass on both sides.

`black --check` clean on both files.

- [x] Tests pass locally with `pytest` for python

## Documentation Changes

None.