### PR TITLE
[BUG] Remove subprocess pip install at import time

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -139,24 +139,11 @@ if not is_client:
     import sqlite3
 
     if sqlite3.sqlite_version_info < (3, 35, 0):
-        if IN_COLAB:
-            # In Colab, hotswap to pysqlite-binary if it's too old
-            import subprocess
-            import sys
-
-            subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", "pysqlite3-binary"]
-            )
-            __import__("pysqlite3")
-            sys.modules["sqlite3"] = sys.modules.pop("pysqlite3")
-        else:
-            raise RuntimeError(
-                "\033[91mYour system has an unsupported version of sqlite3. Chroma \
-                    requires sqlite3 >= 3.35.0.\033[0m\n"
-                "\033[94mPlease visit \
-                    https://docs.trychroma.com/troubleshooting#sqlite to learn how \
-                    to upgrade.\033[0m"
-            )
+        raise RuntimeError(
+            "[91mYour system has an unsupported version of sqlite3. Chroma                 requires sqlite3 >= 3.35.0.[0m
+"
+            "[94mPlease visit                 https://docs.trychroma.com/troubleshooting#sqlite to learn how                 to upgrade.[0m"
+        )
 
 
 def configure(**kwargs) -> None:  # type: ignore


### PR DESCRIPTION
## Problem

Fixes #7402

When importing  in Google Colab (or any environment with SQLite < 3.35.0), the module silently executes  at import time. This:

1. **Violates import side-effect principles** - importing a library should not modify the user's environment
2. **Fails on non-standard architectures** -  has no prebuilt wheels for ppc64, s390x, etc., causing import to fail with a pip error instead of a clear version mismatch message
3. **Bypasses package management** - silently running pip can conflict with virtual environments, air-gapped systems, and production deployments
4. **Creates security concerns** - auto-installing packages without user consent is an anti-pattern

## Solution

Removed the Colab-specific  branch entirely. Now all environments with old SQLite receive the same clear  directing users to the troubleshooting documentation.

### Before


### After


The  function and  constant remain available for telemetry use (they are used in ).

### Why this approach

Users on Colab who need a newer SQLite can follow the same troubleshooting guide as everyone else. If  is needed as a dependency, it should be declared in build requirements, not installed imperatively at runtime.