### PR TITLE
[BUG](python): Close HTTP client resources

### DIFF
--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -72,10 +72,11 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
         settings: Settings = Settings(),
+        *,
+        _system: Optional[System] = None,
     ) -> "AsyncClient":
         # Create an admin client for verifying that databases and tenants exist
-        self = cls(settings=settings)
-        SharedSystemClient._populate_data_from_system(self._system)
+        self = cls(settings=settings, _system=_system)
 
         self.tenant = tenant
         self.database = database
@@ -112,7 +113,12 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         database: str = DEFAULT_DATABASE,
     ) -> "AsyncClient":
         """Create a client from an existing system. This is useful for testing and debugging."""
-        return await AsyncClient.create(tenant, database, system.settings)
+        return await cls.create(
+            tenant,
+            database,
+            system.settings,
+            _system=system,
+        )
 
     @classmethod
     @override
@@ -667,8 +673,13 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
 class AsyncAdminClient(SharedSystemClient, AsyncAdminAPI):
     _server: AsyncServerAPI
 
-    def __init__(self, settings: Settings = Settings()) -> None:
-        super().__init__(settings)
+    def __init__(
+        self,
+        settings: Settings = Settings(),
+        *,
+        _system: Optional[System] = None,
+    ) -> None:
+        super().__init__(settings, _system=_system)
         self._server = self._system.instance(AsyncServerAPI)
 
     @override
@@ -708,6 +719,5 @@ class AsyncAdminClient(SharedSystemClient, AsyncAdminAPI):
         cls,
         system: System,
     ) -> "AsyncAdminClient":
-        SharedSystemClient._populate_data_from_system(system)
-        instance = cls(settings=system.settings)
+        instance = cls(settings=system.settings, _system=system)
         return instance

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -1,11 +1,14 @@
-import httpx
+import logging
 from typing import Optional, Sequence
 from uuid import UUID
+
+import httpx
 from overrides import override
 
 from chromadb.auth import UserIdentity
 from chromadb.auth.utils import maybe_set_tenant_and_database
 from chromadb.api import AsyncAdminAPI, AsyncClientAPI, AsyncServerAPI
+from chromadb.api.async_fastapi import AsyncFastAPI
 from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
     UpdateCollectionConfiguration,
@@ -38,6 +41,9 @@ from chromadb.api.types import (
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
 from chromadb.errors import ChromaError
 from chromadb.types import Database, Tenant, Where, WhereDocument
+
+
+logger = logging.getLogger(__name__)
 
 
 class AsyncClient(SharedSystemClient, AsyncClientAPI):
@@ -112,6 +118,13 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
                     getattr(self._admin_client, "_identifier")
                 )
             SharedSystemClient._release_system_on_error(self._identifier)
+            if hasattr(self, "_server") and isinstance(self._server, AsyncFastAPI):
+                try:
+                    await self._server._wait_for_cleanup()
+                except BaseException:
+                    logger.exception(
+                        "Failed to close async HTTP client during client rollback"
+                    )
             raise
 
     @classmethod

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -78,31 +78,41 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         # Create an admin client for verifying that databases and tenants exist
         self = cls(settings=settings, _system=_system)
 
-        self.tenant = tenant
-        self.database = database
+        try:
+            self.tenant = tenant
+            self.database = database
 
-        # Get the root system component we want to interact with
-        self._server = self._system.instance(AsyncServerAPI)
+            # Get the root system component we want to interact with
+            self._server = self._system.instance(AsyncServerAPI)
 
-        user_identity = await self.get_user_identity()
+            user_identity = await self.get_user_identity()
 
-        maybe_tenant, maybe_database = maybe_set_tenant_and_database(
-            user_identity,
-            overwrite_singleton_tenant_database_access_from_auth=settings.chroma_overwrite_singleton_tenant_database_access_from_auth,
-            user_provided_tenant=tenant,
-            user_provided_database=database,
-        )
-        if maybe_tenant:
-            self.tenant = maybe_tenant
-        if maybe_database:
-            self.database = maybe_database
+            maybe_tenant, maybe_database = maybe_set_tenant_and_database(
+                user_identity,
+                overwrite_singleton_tenant_database_access_from_auth=settings.chroma_overwrite_singleton_tenant_database_access_from_auth,
+                user_provided_tenant=tenant,
+                user_provided_database=database,
+            )
+            if maybe_tenant:
+                self.tenant = maybe_tenant
+            if maybe_database:
+                self.database = maybe_database
 
-        self._admin_client = AsyncAdminClient.from_system(self._system)
-        await self._validate_tenant_database(tenant=self.tenant, database=self.database)
+            self._admin_client = AsyncAdminClient.from_system(self._system)
+            await self._validate_tenant_database(
+                tenant=self.tenant, database=self.database
+            )
 
-        self._submit_client_start_event()
+            self._submit_client_start_event()
 
-        return self
+            return self
+        except Exception:
+            if hasattr(self, "_admin_client"):
+                SharedSystemClient._release_system_on_error(
+                    getattr(self._admin_client, "_identifier")
+                )
+            SharedSystemClient._release_system_on_error(self._identifier)
+            raise
 
     @classmethod
     # (we can't override and use from_system() because it's synchronous)
@@ -496,8 +506,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
     @override
     async def _begin_conditional_transaction(self) -> object:
         return await (
-            self._require_http_conditional_transactions()
-            ._begin_conditional_transaction()
+            self._require_http_conditional_transactions()._begin_conditional_transaction()
         )
 
     @override
@@ -680,7 +689,11 @@ class AsyncAdminClient(SharedSystemClient, AsyncAdminAPI):
         _system: Optional[System] = None,
     ) -> None:
         super().__init__(settings, _system=_system)
-        self._server = self._system.instance(AsyncServerAPI)
+        try:
+            self._server = self._system.instance(AsyncServerAPI)
+        except Exception:
+            SharedSystemClient._release_system_on_error(self._identifier)
+            raise
 
     @override
     async def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -106,7 +106,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
             self._submit_client_start_event()
 
             return self
-        except Exception:
+        except BaseException:
             if hasattr(self, "_admin_client"):
                 SharedSystemClient._release_system_on_error(
                     getattr(self._admin_client, "_identifier")

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -86,6 +86,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         self._opentelemetry_client = self.require(OpenTelemetryClient)
         self._product_telemetry_client = self.require(ProductTelemetryClient)
         self._settings = system.settings
+        self._cleanup_task: Optional[asyncio.Task[None]] = None
 
         self._api_url = AsyncFastAPI.resolve_url(
             chroma_server_host=str(system.settings.chroma_server_host),
@@ -110,11 +111,37 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     def stop(self) -> None:
         super().stop()
 
+        if not self._clients:
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None:
+            if self._cleanup_task is None or self._cleanup_task.done():
+                self._cleanup_task = loop.create_task(self._cleanup())
+            return
+
         @async_to_sync
         async def sync_cleanup() -> None:
             await self._cleanup()
 
         sync_cleanup()
+
+    async def _wait_for_cleanup(self) -> None:
+        cleanup_task = self._cleanup_task
+        if cleanup_task is None:
+            return
+
+        # Rollback must finish closing transports even if its caller is cancelled again.
+        while not cleanup_task.done():
+            try:
+                await asyncio.shield(cleanup_task)
+            except asyncio.CancelledError:
+                continue
+        await cleanup_task
 
     def _get_client(self) -> httpx.AsyncClient:
         # Ideally this would use anyio to be compatible with both

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -121,8 +121,10 @@ class Client(SharedSystemClient, ClientAPI):
             # to avoid a resource leak (the caller never receives the object to
             # call close() on it).
             if hasattr(self, "_admin_client"):
-                SharedSystemClient._release_system(self._admin_client._identifier)
-            SharedSystemClient._release_system(self._identifier)
+                SharedSystemClient._release_system_on_error(
+                    getattr(self._admin_client, "_identifier")
+                )
+            SharedSystemClient._release_system_on_error(self._identifier)
             raise
 
     @classmethod
@@ -551,8 +553,7 @@ class Client(SharedSystemClient, ClientAPI):
     @override
     def _begin_conditional_transaction(self) -> object:
         return (
-            self._require_http_conditional_transactions()
-            ._begin_conditional_transaction()
+            self._require_http_conditional_transactions()._begin_conditional_transaction()
         )
 
     @override
@@ -768,7 +769,9 @@ class Client(SharedSystemClient, ClientAPI):
         # Release the internal admin client's reference first, since it also
         # incremented the refcount for the shared system on creation.
         if hasattr(self, "_admin_client"):
-            SharedSystemClient._release_system(self._admin_client._identifier)
+            SharedSystemClient._release_system(
+                getattr(self._admin_client, "_identifier")
+            )
 
         # Release our own reference; stops system if this was the last client
         SharedSystemClient._release_system(self._identifier)
@@ -823,7 +826,11 @@ class AdminClient(SharedSystemClient, AdminAPI):
         _system: Optional[System] = None,
     ) -> None:
         super().__init__(settings, _system=_system)
-        self._server = self._system.instance(ServerAPI)
+        try:
+            self._server = self._system.instance(ServerAPI)
+        except Exception:
+            SharedSystemClient._release_system_on_error(self._identifier)
+            raise
 
     @override
     def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -74,8 +74,10 @@ class Client(SharedSystemClient, ClientAPI):
         tenant: Optional[str] = DEFAULT_TENANT,
         database: Optional[str] = DEFAULT_DATABASE,
         settings: Settings = Settings(),
+        *,
+        _system: Optional[System] = None,
     ) -> None:
-        super().__init__(settings=settings)
+        super().__init__(settings=settings, _system=_system)
         try:
             if tenant is not None:
                 self.tenant = tenant
@@ -131,8 +133,12 @@ class Client(SharedSystemClient, ClientAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> "Client":
-        SharedSystemClient._populate_data_from_system(system)
-        instance = cls(tenant=tenant, database=database, settings=system.settings)
+        instance = cls(
+            tenant=tenant,
+            database=database,
+            settings=system.settings,
+            _system=system,
+        )
         return instance
 
     # endregion
@@ -810,8 +816,13 @@ class AdminClient(SharedSystemClient, AdminAPI):
 
     _server: ServerAPI
 
-    def __init__(self, settings: Settings = Settings()) -> None:
-        super().__init__(settings)
+    def __init__(
+        self,
+        settings: Settings = Settings(),
+        *,
+        _system: Optional[System] = None,
+    ) -> None:
+        super().__init__(settings, _system=_system)
         self._server = self._system.instance(ServerAPI)
 
     @override
@@ -870,6 +881,5 @@ class AdminClient(SharedSystemClient, AdminAPI):
         cls,
         system: System,
     ) -> "AdminClient":
-        SharedSystemClient._populate_data_from_system(system)
-        instance = cls(settings=system.settings)
+        instance = cls(settings=system.settings, _system=system)
         return instance

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -96,22 +96,38 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         else:
             self._session = httpx.Client(timeout=None, limits=self.http_limits)
 
-        self._header = system.settings.chroma_server_headers or {}
-        self._header["Content-Type"] = "application/json"
-        self._header["User-Agent"] = (
-            "Chroma Python Client v"
-            + __version__
-            + " (https://github.com/chroma-core/chroma)"
-        )
+        try:
+            self._header = system.settings.chroma_server_headers or {}
+            self._header["Content-Type"] = "application/json"
+            self._header["User-Agent"] = (
+                "Chroma Python Client v"
+                + __version__
+                + " (https://github.com/chroma-core/chroma)"
+            )
 
-        if self._header is not None:
-            self._session.headers.update(self._header)
+            if self._header is not None:
+                self._session.headers.update(self._header)
 
-        if system.settings.chroma_client_auth_provider:
-            self._auth_provider = self.require(ClientAuthProvider)
-            _headers = self._auth_provider.authenticate()
-            for header, value in _headers.items():
-                self._session.headers[header] = value.get_secret_value()
+            if system.settings.chroma_client_auth_provider:
+                self._auth_provider = self.require(ClientAuthProvider)
+                _headers = self._auth_provider.authenticate()
+                for header, value in _headers.items():
+                    self._session.headers[header] = value.get_secret_value()
+        except Exception:
+            try:
+                self._session.close()
+            except Exception:
+                logger.exception(
+                    "Failed to close HTTP client after initialization error"
+                )
+            raise
+
+    @override
+    def stop(self) -> None:
+        try:
+            self._session.close()
+        finally:
+            super().stop()
 
     @override
     def get_request_headers(self) -> Mapping[str, str]:

--- a/chromadb/api/shared_system_client.py
+++ b/chromadb/api/shared_system_client.py
@@ -2,6 +2,7 @@ from typing import ClassVar, Dict, Optional
 import logging
 import threading
 import uuid
+from weakref import WeakSet
 from chromadb.api import ServerAPI
 from chromadb.api.base_http_client import BaseHTTPClient
 from chromadb.config import Settings, System
@@ -14,6 +15,7 @@ logger = logging.getLogger(__name__)
 class SharedSystemClient:
     _identifier_to_system: ClassVar[Dict[str, System]] = {}
     _identifier_to_refcount: ClassVar[Dict[str, int]] = {}
+    _released_systems: ClassVar[WeakSet[System]] = WeakSet()
     _refcount_lock: ClassVar[threading.Lock] = threading.Lock()
     _identifier: str
 
@@ -24,36 +26,43 @@ class SharedSystemClient:
         _system: Optional[System] = None,
     ) -> None:
         if _system is None:
-            self._identifier = SharedSystemClient._get_identifier_from_settings(
-                settings
-            )
-            SharedSystemClient._create_system_if_not_exists(self._identifier, settings)
-            SharedSystemClient._increment_refcount(self._identifier)
+            self._identifier = SharedSystemClient._create_and_retain_system(settings)
         else:
             self._identifier = SharedSystemClient._retain_system(_system)
 
     @classmethod
-    def _create_system_if_not_exists(
-        cls, identifier: str, settings: Settings
-    ) -> System:
-        if identifier not in cls._identifier_to_system:
-            new_system = System(settings)
-            cls._identifier_to_system[identifier] = new_system
+    def _create_and_retain_system(cls, settings: Settings) -> str:
+        """Create or reuse a system and retain it as one atomic operation."""
+        identifier = cls._get_identifier_from_settings(settings)
+        with cls._refcount_lock:
+            if identifier not in cls._identifier_to_system:
+                new_system = System(settings)
+                try:
+                    new_system.instance(ProductTelemetryClient)
+                    new_system.instance(ServerAPI)
+                    new_system.start()
+                except Exception:
+                    try:
+                        new_system.stop()
+                    except Exception:
+                        logger.exception(
+                            "Failed to stop Chroma system after initialization error"
+                        )
+                    raise
+                cls._identifier_to_system[identifier] = new_system
+            else:
+                previous_system = cls._identifier_to_system[identifier]
 
-            new_system.instance(ProductTelemetryClient)
-            new_system.instance(ServerAPI)
+                # For now, the settings must match
+                if previous_system.settings != settings:
+                    raise ValueError(
+                        f"An instance of Chroma already exists for {identifier} with different settings"
+                    )
 
-            new_system.start()
-        else:
-            previous_system = cls._identifier_to_system[identifier]
-
-            # For now, the settings must match
-            if previous_system.settings != settings:
-                raise ValueError(
-                    f"An instance of Chroma already exists for {identifier} with different settings"
-                )
-
-        return cls._identifier_to_system[identifier]
+            cls._identifier_to_refcount[identifier] = (
+                cls._identifier_to_refcount.get(identifier, 0) + 1
+            )
+            return identifier
 
     @staticmethod
     def _get_identifier_from_settings(settings: Settings) -> str:
@@ -94,6 +103,11 @@ class SharedSystemClient:
     def _retain_system(cls, system: System) -> str:
         """Retain an exact System instance and return its cache identifier."""
         with cls._refcount_lock:
+            if system in cls._released_systems:
+                raise ValueError(
+                    "Cannot retain a Chroma System after its final reference was released"
+                )
+
             identifier = next(
                 (
                     identifier
@@ -104,36 +118,20 @@ class SharedSystemClient:
             )
             if identifier is None:
                 identifier = cls._get_identifier_from_settings(system.settings)
-                if identifier in cls._identifier_to_system:
-                    raise ValueError(
-                        f"Another Chroma system already exists for {identifier}"
-                    )
-                cls._identifier_to_system[identifier] = system
+                if identifier not in cls._identifier_to_system:
+                    cls._identifier_to_system[identifier] = system
+                elif system.settings.chroma_api_impl in [
+                    "chromadb.api.fastapi.FastAPI",
+                    "chromadb.api.async_fastapi.AsyncFastAPI",
+                ]:
+                    while identifier in cls._identifier_to_system:
+                        identifier = str(uuid.uuid4())
+                    cls._identifier_to_system[identifier] = system
 
             cls._identifier_to_refcount[identifier] = (
                 cls._identifier_to_refcount.get(identifier, 0) + 1
             )
             return identifier
-
-    @classmethod
-    def _increment_refcount(cls, identifier: str) -> None:
-        """Increment the reference count for a system identifier."""
-        with cls._refcount_lock:
-            if identifier not in cls._identifier_to_refcount:
-                cls._identifier_to_refcount[identifier] = 0
-            cls._identifier_to_refcount[identifier] += 1
-
-    @classmethod
-    def _decrement_refcount(cls, identifier: str) -> int:
-        """Decrement the reference count for a system identifier and return the new count."""
-        with cls._refcount_lock:
-            if identifier in cls._identifier_to_refcount:
-                cls._identifier_to_refcount[identifier] -= 1
-                count = cls._identifier_to_refcount[identifier]
-                if count <= 0:
-                    del cls._identifier_to_refcount[identifier]
-                return count
-            return 0
 
     @classmethod
     def _release_system(cls, identifier: str) -> None:
@@ -150,14 +148,26 @@ class SharedSystemClient:
             else:
                 cls._identifier_to_refcount.pop(identifier, None)
                 system = cls._identifier_to_system.pop(identifier, None)
+                if system is not None:
+                    cls._released_systems.add(system)
 
         if system is not None:
             system.stop()
 
+    @classmethod
+    def _release_system_on_error(cls, identifier: str) -> None:
+        """Release a system during rollback without masking the original error."""
+        try:
+            cls._release_system(identifier)
+        except Exception:
+            logger.exception("Failed to stop Chroma system during client rollback")
+
     @staticmethod
     def clear_system_cache() -> None:
-        SharedSystemClient._identifier_to_system = {}
-        SharedSystemClient._identifier_to_refcount = {}
+        with SharedSystemClient._refcount_lock:
+            SharedSystemClient._identifier_to_system = {}
+            SharedSystemClient._identifier_to_refcount = {}
+            SharedSystemClient._released_systems = WeakSet()
 
     @property
     def _system(self) -> System:

--- a/chromadb/api/shared_system_client.py
+++ b/chromadb/api/shared_system_client.py
@@ -35,6 +35,23 @@ class SharedSystemClient:
         """Create or reuse a system and retain it as one atomic operation."""
         identifier = cls._get_identifier_from_settings(settings)
         with cls._refcount_lock:
+            if settings.chroma_api_impl in [
+                "chromadb.api.segment.SegmentAPI",
+                "chromadb.api.rust.RustBindingsAPI",
+            ]:
+                # A retained local system may use a collision-safe alias.
+                # Reuse the latest matching system for settings-only clients.
+                identifier = next(
+                    (
+                        cached_identifier
+                        for cached_identifier, cached_system in reversed(
+                            cls._identifier_to_system.items()
+                        )
+                        if cached_system.settings == settings
+                    ),
+                    identifier,
+                )
+
             if identifier not in cls._identifier_to_system:
                 new_system = System(settings)
                 try:
@@ -118,15 +135,10 @@ class SharedSystemClient:
             )
             if identifier is None:
                 identifier = cls._get_identifier_from_settings(system.settings)
-                if identifier not in cls._identifier_to_system:
-                    cls._identifier_to_system[identifier] = system
-                elif system.settings.chroma_api_impl in [
-                    "chromadb.api.fastapi.FastAPI",
-                    "chromadb.api.async_fastapi.AsyncFastAPI",
-                ]:
+                if identifier in cls._identifier_to_system:
                     while identifier in cls._identifier_to_system:
                         identifier = str(uuid.uuid4())
-                    cls._identifier_to_system[identifier] = system
+                cls._identifier_to_system[identifier] = system
 
             cls._identifier_to_refcount[identifier] = (
                 cls._identifier_to_refcount.get(identifier, 0) + 1
@@ -159,7 +171,7 @@ class SharedSystemClient:
         """Release a system during rollback without masking the original error."""
         try:
             cls._release_system(identifier)
-        except Exception:
+        except BaseException:
             logger.exception("Failed to stop Chroma system during client rollback")
 
     @staticmethod

--- a/chromadb/api/shared_system_client.py
+++ b/chromadb/api/shared_system_client.py
@@ -20,10 +20,17 @@ class SharedSystemClient:
     def __init__(
         self,
         settings: Settings = Settings(),
+        *,
+        _system: Optional[System] = None,
     ) -> None:
-        self._identifier = SharedSystemClient._get_identifier_from_settings(settings)
-        SharedSystemClient._create_system_if_not_exists(self._identifier, settings)
-        SharedSystemClient._increment_refcount(self._identifier)
+        if _system is None:
+            self._identifier = SharedSystemClient._get_identifier_from_settings(
+                settings
+            )
+            SharedSystemClient._create_system_if_not_exists(self._identifier, settings)
+            SharedSystemClient._increment_refcount(self._identifier)
+        else:
+            self._identifier = SharedSystemClient._retain_system(_system)
 
     @classmethod
     def _create_system_if_not_exists(
@@ -76,19 +83,37 @@ class SharedSystemClient:
 
         return identifier
 
-    @staticmethod
-    def _populate_data_from_system(system: System) -> str:
-        identifier = SharedSystemClient._get_identifier_from_settings(system.settings)
-        SharedSystemClient._identifier_to_system[identifier] = system
-        return identifier
-
     @classmethod
     def from_system(cls, system: System) -> "SharedSystemClient":
         """Create a client from an existing system. This is useful for testing and debugging."""
 
-        SharedSystemClient._populate_data_from_system(system)
-        instance = cls(system.settings)
+        instance = cls(system.settings, _system=system)
         return instance
+
+    @classmethod
+    def _retain_system(cls, system: System) -> str:
+        """Retain an exact System instance and return its cache identifier."""
+        with cls._refcount_lock:
+            identifier = next(
+                (
+                    identifier
+                    for identifier, cached_system in cls._identifier_to_system.items()
+                    if cached_system is system
+                ),
+                None,
+            )
+            if identifier is None:
+                identifier = cls._get_identifier_from_settings(system.settings)
+                if identifier in cls._identifier_to_system:
+                    raise ValueError(
+                        f"Another Chroma system already exists for {identifier}"
+                    )
+                cls._identifier_to_system[identifier] = system
+
+            cls._identifier_to_refcount[identifier] = (
+                cls._identifier_to_refcount.get(identifier, 0) + 1
+            )
+            return identifier
 
     @classmethod
     def _increment_refcount(cls, identifier: str) -> None:
@@ -117,11 +142,17 @@ class SharedSystemClient:
         This consolidates the "decrement + conditional stop" pattern used in
         both Client.close() and the Client.__init__ exception handler.
         """
-        refcount = cls._decrement_refcount(identifier)
-        if refcount <= 0:
-            system = cls._identifier_to_system.pop(identifier, None)
-            if system is not None:
-                system.stop()
+        system = None
+        with cls._refcount_lock:
+            refcount = cls._identifier_to_refcount.get(identifier, 0) - 1
+            if refcount > 0:
+                cls._identifier_to_refcount[identifier] = refcount
+            else:
+                cls._identifier_to_refcount.pop(identifier, None)
+                system = cls._identifier_to_system.pop(identifier, None)
+
+        if system is not None:
+            system.stop()
 
     @staticmethod
     def clear_system_cache() -> None:

--- a/chromadb/test/api/test_shared_system_client.py
+++ b/chromadb/test/api/test_shared_system_client.py
@@ -227,7 +227,7 @@ def test_retain_system_registers_untracked_system_once() -> None:
     assert SharedSystemClient._identifier_to_refcount == {}
 
 
-def test_retain_system_reuses_canonical_local_identifier() -> None:
+def test_retain_system_registers_local_collision_separately() -> None:
     settings = Settings(is_persistent=False)
     existing_system = MagicMock(spec=System)
     existing_system.settings = settings
@@ -238,15 +238,29 @@ def test_retain_system_reuses_canonical_local_identifier() -> None:
 
     identifier = SharedSystemClient._retain_system(retained_system)
 
-    assert identifier == "ephemeral"
+    assert identifier != "ephemeral"
     assert SharedSystemClient._identifier_to_system["ephemeral"] is existing_system
-    assert SharedSystemClient._identifier_to_refcount == {"ephemeral": 2}
+    assert SharedSystemClient._identifier_to_system[identifier] is retained_system
+    assert SharedSystemClient._identifier_to_refcount == {
+        "ephemeral": 1,
+        identifier: 1,
+    }
 
+    settings_identifier = SharedSystemClient._create_and_retain_system(settings)
+
+    assert settings_identifier == identifier
+    assert SharedSystemClient._identifier_to_refcount == {
+        "ephemeral": 1,
+        identifier: 2,
+    }
+
+    SharedSystemClient._release_system(settings_identifier)
     SharedSystemClient._release_system(identifier)
 
-    retained_system.stop.assert_not_called()
+    retained_system.stop.assert_called_once_with()
     existing_system.stop.assert_not_called()
     assert SharedSystemClient._identifier_to_system == {"ephemeral": existing_system}
+    assert SharedSystemClient._identifier_to_refcount == {"ephemeral": 1}
 
 
 def test_retain_system_during_final_release_cannot_revive_system() -> None:

--- a/chromadb/test/api/test_shared_system_client.py
+++ b/chromadb/test/api/test_shared_system_client.py
@@ -1,4 +1,5 @@
 import pytest
+import threading
 from unittest.mock import MagicMock
 from chromadb.api.shared_system_client import SharedSystemClient
 from chromadb.api.base_http_client import BaseHTTPClient
@@ -222,5 +223,77 @@ def test_retain_system_registers_untracked_system_once() -> None:
     SharedSystemClient._release_system(retained_identifier)
 
     system.stop.assert_called_once_with()
+    assert SharedSystemClient._identifier_to_system == {}
+    assert SharedSystemClient._identifier_to_refcount == {}
+
+
+def test_retain_system_reuses_canonical_local_identifier() -> None:
+    settings = Settings(is_persistent=False)
+    existing_system = MagicMock(spec=System)
+    existing_system.settings = settings
+    retained_system = MagicMock(spec=System)
+    retained_system.settings = settings
+    SharedSystemClient._identifier_to_system["ephemeral"] = existing_system
+    SharedSystemClient._identifier_to_refcount["ephemeral"] = 1
+
+    identifier = SharedSystemClient._retain_system(retained_system)
+
+    assert identifier == "ephemeral"
+    assert SharedSystemClient._identifier_to_system["ephemeral"] is existing_system
+    assert SharedSystemClient._identifier_to_refcount == {"ephemeral": 2}
+
+    SharedSystemClient._release_system(identifier)
+
+    retained_system.stop.assert_not_called()
+    existing_system.stop.assert_not_called()
+    assert SharedSystemClient._identifier_to_system == {"ephemeral": existing_system}
+
+
+def test_retain_system_during_final_release_cannot_revive_system() -> None:
+    system = MagicMock(spec=System)
+    system.settings = Settings(
+        chroma_api_impl="chromadb.api.fastapi.FastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=8000,
+    )
+    SharedSystemClient._identifier_to_system["existing"] = system
+    SharedSystemClient._identifier_to_refcount["existing"] = 1
+    stop_started = threading.Event()
+    allow_stop = threading.Event()
+    retain_errors: list[Exception] = []
+
+    def blocking_stop() -> None:
+        stop_started.set()
+        assert allow_stop.wait(timeout=5)
+
+    def retain_system() -> None:
+        try:
+            SharedSystemClient._retain_system(system)
+        except Exception as error:
+            retain_errors.append(error)
+
+    system.stop.side_effect = blocking_stop
+    release_thread = threading.Thread(
+        target=SharedSystemClient._release_system,
+        args=("existing",),
+    )
+    retain_thread = threading.Thread(target=retain_system)
+
+    release_thread.start()
+    assert stop_started.wait(timeout=5)
+    try:
+        retain_thread.start()
+        retain_thread.join(timeout=5)
+
+        assert not retain_thread.is_alive()
+        assert len(retain_errors) == 1
+        assert isinstance(retain_errors[0], ValueError)
+        assert "final reference" in str(retain_errors[0])
+    finally:
+        allow_stop.set()
+        release_thread.join(timeout=5)
+        retain_thread.join(timeout=5)
+
+    assert not release_thread.is_alive()
     assert SharedSystemClient._identifier_to_system == {}
     assert SharedSystemClient._identifier_to_refcount == {}

--- a/chromadb/test/api/test_shared_system_client.py
+++ b/chromadb/test/api/test_shared_system_client.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 from chromadb.api.shared_system_client import SharedSystemClient
 from chromadb.api.base_http_client import BaseHTTPClient
-from chromadb.config import System
+from chromadb.config import Settings, System
 from typing import Optional, Dict, Generator
 
 
@@ -178,3 +178,49 @@ def test_multiple_clients_returns_one_key() -> None:
     api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
 
     assert api_key in ["key-1", "key-2"]
+
+
+def test_retain_system_reuses_existing_identifier() -> None:
+    system = MagicMock(spec=System)
+    system.settings = Settings(
+        chroma_api_impl="chromadb.api.fastapi.FastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=8000,
+    )
+    SharedSystemClient._identifier_to_system["existing"] = system
+
+    identifier = SharedSystemClient._retain_system(system)
+
+    assert identifier == "existing"
+    assert SharedSystemClient._identifier_to_system == {"existing": system}
+    assert SharedSystemClient._identifier_to_refcount == {"existing": 1}
+
+    SharedSystemClient._release_system(identifier)
+
+    system.stop.assert_called_once_with()
+    assert SharedSystemClient._identifier_to_system == {}
+    assert SharedSystemClient._identifier_to_refcount == {}
+
+
+def test_retain_system_registers_untracked_system_once() -> None:
+    system = MagicMock(spec=System)
+    system.settings = Settings(
+        chroma_api_impl="chromadb.api.fastapi.FastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=8000,
+    )
+
+    identifier = SharedSystemClient._retain_system(system)
+    retained_identifier = SharedSystemClient._retain_system(system)
+
+    assert retained_identifier == identifier
+    assert SharedSystemClient._identifier_to_system == {identifier: system}
+    assert SharedSystemClient._identifier_to_refcount == {identifier: 2}
+
+    SharedSystemClient._release_system(identifier)
+    system.stop.assert_not_called()
+    SharedSystemClient._release_system(retained_identifier)
+
+    system.stop.assert_called_once_with()
+    assert SharedSystemClient._identifier_to_system == {}
+    assert SharedSystemClient._identifier_to_refcount == {}

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -170,6 +170,7 @@ def make_sync_client_factory() -> Tuple[Callable[..., Any], Dict[str, Any]]:
         captured.update(kwargs)
         session = MagicMock()
         session.headers = {}
+        captured["session"] = session
         return session
 
     return factory, captured
@@ -200,6 +201,47 @@ def test_fastapi_uses_http_limits_from_settings() -> None:
     assert limits.max_keepalive_connections == 16
     assert captured["timeout"] is None
     assert captured["verify"] is True
+    captured["session"].close.assert_called_once_with()
+    assert api._running is False
+
+
+def test_fastapi_stop_marks_component_stopped_when_close_fails() -> None:
+    api = FastAPI.__new__(FastAPI)
+    api._session = MagicMock()
+    api._session.close.side_effect = RuntimeError("close failed")
+    api._running = True
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        api.stop()
+
+    assert api._running is False
+
+
+def test_fastapi_closes_session_when_initialization_fails() -> None:
+    settings = Settings(
+        chroma_api_impl="chromadb.api.fastapi.FastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=9000,
+        chroma_client_auth_provider=(
+            "chromadb.auth.basic_authn.BasicAuthClientProvider"
+        ),
+    )
+    system = System(settings)
+    session = MagicMock()
+    session.headers = {}
+
+    with (
+        patch.object(
+            FastAPI,
+            "require",
+            side_effect=[MagicMock(), MagicMock(), RuntimeError("auth setup failed")],
+        ),
+        patch("chromadb.api.fastapi.httpx.Client", return_value=session),
+        pytest.raises(RuntimeError, match="auth setup failed"),
+    ):
+        FastAPI(system)
+
+    session.close.assert_called_once_with()
 
 
 def test_http_client_close_releases_transport_and_system() -> None:

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -3,7 +3,10 @@ from typing import Any, Awaitable, Callable, Generator, cast, Dict, Tuple
 from unittest.mock import MagicMock, patch
 import chromadb
 from chromadb.config import Settings, System
-from chromadb.api import ClientAPI
+from chromadb.api import ClientAPI, ServerAPI
+from chromadb.api.client import Client
+from chromadb.api.shared_system_client import SharedSystemClient
+from chromadb.auth import UserIdentity
 import chromadb.server.fastapi
 from chromadb.api.fastapi import FastAPI
 import pytest
@@ -197,6 +200,56 @@ def test_fastapi_uses_http_limits_from_settings() -> None:
     assert limits.max_keepalive_connections == 16
     assert captured["timeout"] is None
     assert captured["verify"] is True
+
+
+def test_http_client_close_releases_transport_and_system() -> None:
+    SharedSystemClient.clear_system_cache()
+    identity = UserIdentity(
+        user_id="test",
+        tenant="tenant",
+        databases=["database"],
+    )
+    client = None
+    sessions = []
+
+    try:
+        with (
+            patch.object(Client, "get_user_identity", return_value=identity),
+            patch.object(Client, "_validate_tenant_database", return_value=None),
+        ):
+            client = chromadb.CloudClient(
+                api_key="not-a-real-key",
+                tenant="tenant",
+                database="database",
+                settings=Settings(anonymized_telemetry=False),
+                cloud_host="127.0.0.1",
+                cloud_port=9,
+                enable_ssl=False,
+            )
+
+        systems = dict(SharedSystemClient._identifier_to_system)
+        unique_systems = list({id(system): system for system in systems.values()}.values())
+        for system in unique_systems:
+            session = getattr(system.instance(ServerAPI), "_session", None)
+            if session is not None:
+                sessions.append(session)
+
+        assert len(unique_systems) == 1
+        assert len(sessions) == 1
+        assert set(systems) == set(SharedSystemClient._identifier_to_refcount)
+
+        client.close()
+
+        assert sessions[0].is_closed
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        if client is not None:
+            client.close()
+        for session in sessions:
+            if not session.is_closed:
+                session.close()
+        SharedSystemClient.clear_system_cache()
 
 
 def test_persistent_client_close() -> None:

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import Any, Awaitable, Callable, Generator, cast, Dict, Tuple
 from unittest.mock import AsyncMock, MagicMock, patch
 import chromadb
+import httpx
 from chromadb.config import Settings, System
 from chromadb.api import ClientAPI, ServerAPI
 from chromadb.api.async_client import AsyncClient
@@ -382,6 +383,93 @@ def test_async_from_system_reuses_supplied_system() -> None:
         unique_systems[id(system)] = system
         for cached_system in unique_systems.values():
             cached_system.stop()
+        SharedSystemClient.clear_system_cache()
+
+
+def test_http_client_initialization_rollback_closes_resources() -> None:
+    SharedSystemClient.clear_system_cache()
+    identity = UserIdentity(
+        user_id="test",
+        tenant="tenant",
+        databases=["database"],
+    )
+    initialization_error = RuntimeError("validation failed")
+    created_sessions = []
+    httpx_client = httpx.Client
+
+    def create_session(*args: Any, **kwargs: Any) -> httpx.Client:
+        session = httpx_client(*args, **kwargs)
+        created_sessions.append(session)
+        return session
+
+    try:
+        with (
+            patch.object(Client, "get_user_identity", return_value=identity),
+            patch.object(
+                Client,
+                "_validate_tenant_database",
+                side_effect=initialization_error,
+            ),
+            patch("chromadb.api.fastapi.httpx.Client", side_effect=create_session),
+            pytest.raises(RuntimeError, match="validation failed") as exc_info,
+        ):
+            chromadb.CloudClient(
+                api_key="not-a-real-key",
+                tenant="tenant",
+                database="database",
+                settings=Settings(anonymized_telemetry=False),
+                cloud_host="127.0.0.1",
+                cloud_port=9,
+                enable_ssl=False,
+            )
+
+        assert exc_info.value is initialization_error
+        assert created_sessions
+        assert all(session.is_closed for session in created_sessions)
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        for session in created_sessions:
+            if not session.is_closed:
+                session.close()
+        SharedSystemClient.clear_system_cache()
+
+
+def test_http_client_context_manager_closes_resources() -> None:
+    SharedSystemClient.clear_system_cache()
+    session = None
+
+    try:
+        with create_no_network_cloud_client() as client:
+            session = client._server._session
+            assert session.is_closed is False
+
+        assert session.is_closed
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        if session is not None and not session.is_closed:
+            session.close()
+        SharedSystemClient.clear_system_cache()
+
+
+def test_http_client_close_is_idempotent() -> None:
+    SharedSystemClient.clear_system_cache()
+    client = create_no_network_cloud_client()
+    session = client._server._session
+
+    try:
+        client.close()
+        client.close()
+        client.close()
+
+        assert session.is_closed
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        client.close()
+        if not session.is_closed:
+            session.close()
         SharedSystemClient.clear_system_cache()
 
 

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import chromadb
 import httpx
 from chromadb.config import Settings, System
-from chromadb.api import ClientAPI, ServerAPI
+from chromadb.api import AsyncServerAPI, ClientAPI, ServerAPI
 from chromadb.api.async_client import AsyncAdminClient, AsyncClient
+from chromadb.api.async_fastapi import AsyncFastAPI
 from chromadb.api.client import AdminClient, Client
 from chromadb.api.shared_system_client import SharedSystemClient
 from chromadb.auth import UserIdentity
@@ -577,6 +578,118 @@ def test_async_cancellation_releases_system(cancel_during_validation: bool) -> N
         assert SharedSystemClient._identifier_to_system == {}
         assert SharedSystemClient._identifier_to_refcount == {}
     finally:
+        SharedSystemClient.clear_system_cache()
+
+
+@pytest.mark.parametrize(
+    "initialization_error",
+    [RuntimeError("identity failed"), asyncio.CancelledError()],
+)
+async def test_async_rollback_awaits_transport_cleanup(
+    initialization_error: BaseException,
+) -> None:
+    SharedSystemClient.clear_system_cache()
+    AsyncFastAPI._clients = {}
+    system = System(
+        Settings(
+            chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+            chroma_server_host="localhost",
+            chroma_server_http_port=8000,
+            anonymized_telemetry=False,
+        )
+    )
+    api = system.instance(AsyncServerAPI)
+    system.start()
+    session = MagicMock()
+    session.aclose = AsyncMock()
+
+    try:
+        with patch(
+            "chromadb.api.async_fastapi.httpx.AsyncClient", return_value=session
+        ):
+            cast(AsyncFastAPI, api)._get_client()
+
+        with (
+            patch.object(
+                AsyncClient,
+                "get_user_identity",
+                new=AsyncMock(side_effect=initialization_error),
+            ),
+            pytest.raises(type(initialization_error)) as exc_info,
+        ):
+            await AsyncClient.from_system_async(system)
+
+        assert exc_info.value is initialization_error
+        session.aclose.assert_awaited_once_with()
+        assert cast(AsyncFastAPI, api)._clients == {}
+        assert system._running is False
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        if cast(AsyncFastAPI, api)._clients:
+            await cast(AsyncFastAPI, api)._cleanup()
+        AsyncFastAPI._clients = {}
+        SharedSystemClient.clear_system_cache()
+
+
+async def test_async_rollback_cleanup_survives_cancellation() -> None:
+    SharedSystemClient.clear_system_cache()
+    AsyncFastAPI._clients = {}
+    system = System(
+        Settings(
+            chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+            chroma_server_host="localhost",
+            chroma_server_http_port=8000,
+            anonymized_telemetry=False,
+        )
+    )
+    api = system.instance(AsyncServerAPI)
+    system.start()
+    initialization_error = RuntimeError("identity failed")
+    cleanup_started = asyncio.Event()
+    allow_cleanup = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+
+    async def blocking_aclose() -> None:
+        cleanup_started.set()
+        await allow_cleanup.wait()
+        cleanup_finished.set()
+
+    session = MagicMock()
+    session.aclose = AsyncMock(side_effect=blocking_aclose)
+
+    try:
+        with patch(
+            "chromadb.api.async_fastapi.httpx.AsyncClient", return_value=session
+        ):
+            cast(AsyncFastAPI, api)._get_client()
+
+        with patch.object(
+            AsyncClient,
+            "get_user_identity",
+            new=AsyncMock(side_effect=initialization_error),
+        ):
+            rollback_task = asyncio.create_task(AsyncClient.from_system_async(system))
+            await cleanup_started.wait()
+            rollback_task.cancel()
+            await asyncio.sleep(0)
+            allow_cleanup.set()
+
+            with pytest.raises(RuntimeError) as exc_info:
+                await rollback_task
+
+        assert exc_info.value is initialization_error
+        session.aclose.assert_awaited_once_with()
+        assert cleanup_finished.is_set()
+        assert cast(AsyncFastAPI, api)._clients == {}
+        assert system._running is False
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        allow_cleanup.set()
+        if cast(AsyncFastAPI, api)._clients:
+            await cast(AsyncFastAPI, api)._cleanup()
+        AsyncFastAPI._clients = {}
         SharedSystemClient.clear_system_cache()
 
 

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -527,6 +527,59 @@ def test_async_initialization_failure_releases_system() -> None:
         SharedSystemClient.clear_system_cache()
 
 
+@pytest.mark.parametrize("cancel_during_validation", [False, True])
+def test_async_cancellation_releases_system(cancel_during_validation: bool) -> None:
+    SharedSystemClient.clear_system_cache()
+    system = MagicMock(spec=System)
+    system.settings = Settings(
+        chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=8000,
+        anonymized_telemetry=False,
+    )
+    system.instance.return_value = MagicMock()
+    identity = UserIdentity(
+        user_id="test",
+        tenant="tenant",
+        databases=["database"],
+    )
+    cancellation = asyncio.CancelledError()
+
+    try:
+        with (
+            patch.object(
+                AsyncClient,
+                "get_user_identity",
+                new=AsyncMock(
+                    return_value=identity,
+                    side_effect=cancellation if not cancel_during_validation else None,
+                ),
+            ),
+            patch.object(
+                AsyncClient,
+                "_validate_tenant_database",
+                new=AsyncMock(
+                    side_effect=cancellation if cancel_during_validation else None
+                ),
+            ),
+            pytest.raises(asyncio.CancelledError) as exc_info,
+        ):
+            _run_async(
+                AsyncClient.from_system_async(
+                    system,
+                    tenant="tenant",
+                    database="database",
+                )
+            )
+
+        assert exc_info.value is cancellation
+        system.stop.assert_called_once_with()
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        SharedSystemClient.clear_system_cache()
+
+
 def test_http_client_initialization_rollback_closes_resources() -> None:
     SharedSystemClient.clear_system_cache()
     identity = UserIdentity(

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -1,9 +1,10 @@
 import asyncio
 from typing import Any, Awaitable, Callable, Generator, cast, Dict, Tuple
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import chromadb
 from chromadb.config import Settings, System
 from chromadb.api import ClientAPI, ServerAPI
+from chromadb.api.async_client import AsyncClient
 from chromadb.api.client import Client
 from chromadb.api.shared_system_client import SharedSystemClient
 from chromadb.auth import UserIdentity
@@ -244,22 +245,19 @@ def test_fastapi_closes_session_when_initialization_fails() -> None:
     session.close.assert_called_once_with()
 
 
-def test_http_client_close_releases_transport_and_system() -> None:
-    SharedSystemClient.clear_system_cache()
+def create_no_network_cloud_client() -> Client:
     identity = UserIdentity(
         user_id="test",
         tenant="tenant",
         databases=["database"],
     )
-    client = None
-    sessions = []
-
-    try:
-        with (
-            patch.object(Client, "get_user_identity", return_value=identity),
-            patch.object(Client, "_validate_tenant_database", return_value=None),
-        ):
-            client = chromadb.CloudClient(
+    with (
+        patch.object(Client, "get_user_identity", return_value=identity),
+        patch.object(Client, "_validate_tenant_database", return_value=None),
+    ):
+        return cast(
+            Client,
+            chromadb.CloudClient(
                 api_key="not-a-real-key",
                 tenant="tenant",
                 database="database",
@@ -267,7 +265,17 @@ def test_http_client_close_releases_transport_and_system() -> None:
                 cloud_host="127.0.0.1",
                 cloud_port=9,
                 enable_ssl=False,
-            )
+            ),
+        )
+
+
+def test_http_client_close_releases_transport_and_system() -> None:
+    SharedSystemClient.clear_system_cache()
+    client = None
+    sessions = []
+
+    try:
+        client = create_no_network_cloud_client()
 
         systems = dict(SharedSystemClient._identifier_to_system)
         unique_systems = list({id(system): system for system in systems.values()}.values())
@@ -279,6 +287,8 @@ def test_http_client_close_releases_transport_and_system() -> None:
         assert len(unique_systems) == 1
         assert len(sessions) == 1
         assert set(systems) == set(SharedSystemClient._identifier_to_refcount)
+        assert client._admin_client._system is client._system
+        assert client._admin_client._server is client._server
 
         client.close()
 
@@ -291,6 +301,87 @@ def test_http_client_close_releases_transport_and_system() -> None:
         for session in sessions:
             if not session.is_closed:
                 session.close()
+        SharedSystemClient.clear_system_cache()
+
+
+def test_repeated_http_client_close_does_not_grow_cache() -> None:
+    SharedSystemClient.clear_system_cache()
+    sessions = []
+
+    try:
+        for _ in range(25):
+            client = create_no_network_cloud_client()
+            session = client._server._session
+            sessions.append(session)
+
+            client.close()
+
+            assert session.is_closed
+            assert SharedSystemClient._identifier_to_system == {}
+            assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        for session in sessions:
+            if not session.is_closed:
+                session.close()
+        SharedSystemClient.clear_system_cache()
+
+
+def test_async_from_system_reuses_supplied_system() -> None:
+    SharedSystemClient.clear_system_cache()
+    identity = UserIdentity(
+        user_id="test",
+        tenant="tenant",
+        databases=["database"],
+    )
+    system = System(
+        Settings(
+            chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+            chroma_server_host="localhost",
+            chroma_server_http_port=8000,
+            anonymized_telemetry=False,
+        )
+    )
+    system.start()
+
+    try:
+        with (
+            patch.object(
+                AsyncClient,
+                "get_user_identity",
+                new=AsyncMock(return_value=identity),
+            ),
+            patch.object(
+                AsyncClient,
+                "_validate_tenant_database",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            client = cast(
+                AsyncClient,
+                _run_async(
+                    AsyncClient.from_system_async(
+                        system,
+                        tenant="tenant",
+                        database="database",
+                    )
+                ),
+            )
+
+        assert client._system is system
+        assert client._admin_client._system is system
+        assert client._admin_client._server is client._server
+        assert len(SharedSystemClient._identifier_to_system) == 1
+        assert set(SharedSystemClient._identifier_to_system) == set(
+            SharedSystemClient._identifier_to_refcount
+        )
+    finally:
+        unique_systems = {
+            id(cached_system): cached_system
+            for cached_system in SharedSystemClient._identifier_to_system.values()
+        }
+        unique_systems[id(system)] = system
+        for cached_system in unique_systems.values():
+            cached_system.stop()
         SharedSystemClient.clear_system_cache()
 
 

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -5,8 +5,8 @@ import chromadb
 import httpx
 from chromadb.config import Settings, System
 from chromadb.api import ClientAPI, ServerAPI
-from chromadb.api.async_client import AsyncClient
-from chromadb.api.client import Client
+from chromadb.api.async_client import AsyncAdminClient, AsyncClient
+from chromadb.api.client import AdminClient, Client
 from chromadb.api.shared_system_client import SharedSystemClient
 from chromadb.auth import UserIdentity
 import chromadb.server.fastapi
@@ -246,6 +246,109 @@ def test_fastapi_closes_session_when_initialization_fails() -> None:
     session.close.assert_called_once_with()
 
 
+def test_client_component_failure_removes_unretained_system() -> None:
+    SharedSystemClient.clear_system_cache()
+    settings = Settings(
+        chroma_api_impl="chromadb.api.fastapi.FastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=9000,
+        chroma_client_auth_provider=(
+            "chromadb.auth.basic_authn.BasicAuthClientProvider"
+        ),
+        anonymized_telemetry=False,
+    )
+    session = MagicMock()
+    session.headers = {}
+    initialization_error = RuntimeError("auth setup failed")
+
+    try:
+        with (
+            patch.object(
+                FastAPI,
+                "require",
+                side_effect=[MagicMock(), MagicMock(), initialization_error],
+            ),
+            patch("chromadb.api.fastapi.httpx.Client", return_value=session),
+            pytest.raises(RuntimeError, match="auth setup failed") as exc_info,
+        ):
+            Client(settings=settings)
+
+        assert exc_info.value is initialization_error
+        session.close.assert_called_once_with()
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        SharedSystemClient.clear_system_cache()
+
+
+def test_client_rollback_preserves_error_when_transport_close_fails() -> None:
+    SharedSystemClient.clear_system_cache()
+    settings = Settings(
+        chroma_api_impl="chromadb.api.fastapi.FastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=9000,
+        anonymized_telemetry=False,
+    )
+    identity = UserIdentity(
+        user_id="test",
+        tenant="tenant",
+        databases=["database"],
+    )
+    initialization_error = ValueError("validation failed")
+    session = MagicMock()
+    session.headers = {}
+    session.close.side_effect = RuntimeError("cleanup failed")
+
+    try:
+        with (
+            patch.object(FastAPI, "require", side_effect=[MagicMock(), MagicMock()]),
+            patch("chromadb.api.fastapi.httpx.Client", return_value=session),
+            patch.object(Client, "get_user_identity", return_value=identity),
+            patch.object(
+                Client,
+                "_validate_tenant_database",
+                side_effect=initialization_error,
+            ),
+            pytest.raises(ValueError, match="validation failed") as exc_info,
+        ):
+            Client(
+                tenant="tenant",
+                database="database",
+                settings=settings,
+            )
+
+        assert exc_info.value is initialization_error
+        session.close.assert_called_once_with()
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        SharedSystemClient.clear_system_cache()
+
+
+@pytest.mark.parametrize("admin_cls", [AdminClient, AsyncAdminClient])
+def test_retained_admin_failure_releases_system(admin_cls: Any) -> None:
+    SharedSystemClient.clear_system_cache()
+    system = MagicMock(spec=System)
+    system.settings = Settings(
+        chroma_api_impl="chromadb.api.fastapi.FastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=9000,
+    )
+    initialization_error = RuntimeError("server setup failed")
+    system.instance.side_effect = initialization_error
+
+    try:
+        with pytest.raises(RuntimeError, match="server setup failed") as exc_info:
+            admin_cls(settings=system.settings, _system=system)
+
+        assert exc_info.value is initialization_error
+        system.stop.assert_called_once_with()
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
+        SharedSystemClient.clear_system_cache()
+
+
 def create_no_network_cloud_client() -> Client:
     identity = UserIdentity(
         user_id="test",
@@ -279,7 +382,9 @@ def test_http_client_close_releases_transport_and_system() -> None:
         client = create_no_network_cloud_client()
 
         systems = dict(SharedSystemClient._identifier_to_system)
-        unique_systems = list({id(system): system for system in systems.values()}.values())
+        unique_systems = list(
+            {id(system): system for system in systems.values()}.values()
+        )
         for system in unique_systems:
             session = getattr(system.instance(ServerAPI), "_session", None)
             if session is not None:
@@ -288,8 +393,9 @@ def test_http_client_close_releases_transport_and_system() -> None:
         assert len(unique_systems) == 1
         assert len(sessions) == 1
         assert set(systems) == set(SharedSystemClient._identifier_to_refcount)
-        assert client._admin_client._system is client._system
-        assert client._admin_client._server is client._server
+        admin_client = cast(AdminClient, client._admin_client)
+        assert admin_client._system is client._system
+        assert admin_client._server is client._server
 
         client.close()
 
@@ -312,7 +418,7 @@ def test_repeated_http_client_close_does_not_grow_cache() -> None:
     try:
         for _ in range(25):
             client = create_no_network_cloud_client()
-            session = client._server._session
+            session = cast(FastAPI, client._server)._session
             sessions.append(session)
 
             client.close()
@@ -369,20 +475,55 @@ def test_async_from_system_reuses_supplied_system() -> None:
             )
 
         assert client._system is system
-        assert client._admin_client._system is system
-        assert client._admin_client._server is client._server
+        admin_client = cast(AsyncAdminClient, client._admin_client)
+        assert admin_client._system is system
+        assert admin_client._server is client._server
         assert len(SharedSystemClient._identifier_to_system) == 1
         assert set(SharedSystemClient._identifier_to_system) == set(
             SharedSystemClient._identifier_to_refcount
         )
+        assert SharedSystemClient._identifier_to_refcount[client._identifier] == 2
+
+        SharedSystemClient._release_system(cast(Any, client._admin_client)._identifier)
+        SharedSystemClient._release_system(client._identifier)
+
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+        assert system._running is False
     finally:
-        unique_systems = {
-            id(cached_system): cached_system
-            for cached_system in SharedSystemClient._identifier_to_system.values()
-        }
-        unique_systems[id(system)] = system
-        for cached_system in unique_systems.values():
-            cached_system.stop()
+        if system._running:
+            system.stop()
+        SharedSystemClient.clear_system_cache()
+
+
+def test_async_initialization_failure_releases_system() -> None:
+    SharedSystemClient.clear_system_cache()
+    system = MagicMock(spec=System)
+    system.settings = Settings(
+        chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=8000,
+        anonymized_telemetry=False,
+    )
+    system.instance.return_value = MagicMock()
+    initialization_error = RuntimeError("identity failed")
+
+    try:
+        with (
+            patch.object(
+                AsyncClient,
+                "get_user_identity",
+                new=AsyncMock(side_effect=initialization_error),
+            ),
+            pytest.raises(RuntimeError, match="identity failed") as exc_info,
+        ):
+            _run_async(AsyncClient.from_system_async(system))
+
+        assert exc_info.value is initialization_error
+        system.stop.assert_called_once_with()
+        assert SharedSystemClient._identifier_to_system == {}
+        assert SharedSystemClient._identifier_to_refcount == {}
+    finally:
         SharedSystemClient.clear_system_cache()
 
 
@@ -441,7 +582,7 @@ def test_http_client_context_manager_closes_resources() -> None:
 
     try:
         with create_no_network_cloud_client() as client:
-            session = client._server._session
+            session = cast(FastAPI, client._server)._session
             assert session.is_closed is False
 
         assert session.is_closed
@@ -456,7 +597,7 @@ def test_http_client_context_manager_closes_resources() -> None:
 def test_http_client_close_is_idempotent() -> None:
     SharedSystemClient.clear_system_cache()
     client = create_no_network_cloud_client()
-    session = client._server._session
+    session = cast(FastAPI, client._server)._session
 
     try:
         client.close()


### PR DESCRIPTION
## Summary

Fixes #2702.

The synchronous Python HTTP API allocates an `httpx.Client`, but inherited component shutdown only marked the component stopped. `Client.close()` could therefore release its Chroma systems while leaving the underlying connection pools open.

The internal admin `from_system()` path also generated an unrefcounted cache alias and constructed a second HTTP system because HTTP identifiers are random. PR #6373 exposed `Client.close()`, but synchronous component shutdown still did not close its transport.

## Changes

- Close the synchronous `httpx.Client` from `FastAPI.stop()`.
- Close sessions allocated by failed HTTP component construction.
- Retain the exact supplied `System` for client/admin `from_system()` paths without creating a second HTTP transport.
- Make create/retain/release bookkeeping atomic and balance references during close, initialization rollback, and async cancellation.
- Preserve the initiating exception when rollback cleanup also fails.
- Await async HTTP transport cleanup during rollback, including caller cancellation while cleanup is in flight.
- Prevent a final release racing with re-retention of the same system.
- Add no-network regression tests for explicit close, context manager exit, repeated clients, initialization failure, retained-system collisions, and cancellation.

## Evidence

In a long-running Linux worker, the affected behavior accumulated 1,009 `CLOSE_WAIT` sockets. Explicit transport and cache cleanup reduced the idle worker to zero `CLOSE_WAIT` sockets.

The deterministic unit reproduction previously left one cache alias, zero refcounts, and two open sessions after `Client.close()`. The fixed path leaves no owned cache entries and closes its single shared HTTP session.

## Non-goals

This PR does not change request timeouts, retries, cancellation of in-flight requests, or connection-pool limits.

## Test Plan

- `python -m pytest -x chromadb/test/test_client.py chromadb/test/api/test_shared_system_client.py -v` — 49 passed
- `CHROMA_RUST_BINDINGS_TEST_ONLY=1 python -m pytest -x chromadb/test/test_client.py chromadb/test/api -q` — 210 passed, 108 skipped
- Changed-file Black and Flake8 hooks — passed
- `git diff origin/main --check` — passed

The changed-file mypy hook reports 24 existing errors in these files; the same command on `origin/main` reports 26 errors. This PR introduces no new mypy diagnostics. A repository-wide pre-commit run also encounters unrelated existing formatting/lint debt outside this change.