### PR TITLE
[BUG](foundation-api): Make /init tolerate an existing attachment

### DIFF
--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -11,8 +11,8 @@ use axum::{extract::State, http::HeaderMap, Json};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_sysdb::SysDb;
 use chroma_types::{
-    Collection, CollectionUuid, DatabaseName, Metadata, MetadataValue, Schema,
-    CHROMA_GROUP_CHUNK_SIBLINGS_KEY, SLACK_RAW_COLLECTION_NAME,
+    Collection, CollectionUuid, DatabaseName, ListAttachedFunctionsError, Metadata, MetadataValue,
+    Schema, CHROMA_GROUP_CHUNK_SIBLINGS_KEY, SLACK_RAW_COLLECTION_NAME,
 };
 use frontend_core::{attached_function_ops, foundation::source_kind_for_collection_name};
 use serde::Serialize;
@@ -327,8 +327,9 @@ impl ChromaError for MissingFunctionEndpointUrl {
 /// `add_input()`. Params carry the modal endpoint and the base source kind,
 /// matching the existing Foundation function contract.
 ///
-/// `/init` is safe to call repeatedly — the shared helper treats an
-/// already-existing function as a no-op (`created = false`).
+/// `/init` is safe to call repeatedly: an attachment that is already there is
+/// left alone. Checking here is what makes that true — see
+/// [`foundation_function_already_attached`] for why the layer below cannot.
 async fn ensure_attached_function(
     sysdb: &mut SysDb,
     tenant: String,
@@ -336,6 +337,15 @@ async fn ensure_attached_function(
     base_source_name: &str,
     cfg: &FoundationConfig,
 ) -> Result<(), ServerError> {
+    if foundation_function_already_attached(sysdb, input_collection_id).await? {
+        tracing::info!(
+            attached_function = %foundation_attached_function_name(),
+            %input_collection_id,
+            "foundation function is already attached; leaving it as it is"
+        );
+        return Ok(());
+    }
+
     let endpoint_url = cfg
         .function_endpoint_url
         .as_ref()
@@ -361,6 +371,38 @@ async fn ensure_attached_function(
     )
     .await?;
     Ok(())
+}
+
+/// Whether the foundation function is already attached to `collection_id`.
+///
+/// Attaching cannot be left to fail harmlessly. sysdb decides whether a create
+/// is a repeat by comparing the *attached-function id*, and `/init` mints a
+/// fresh one on every call, so a second `/init` never matches. It falls through
+/// to the execution-mode check instead and is refused with `AlreadyExists`:
+///
+/// ```text
+/// collection already has an attached function with the same execution mode:
+/// name=foundation_sources_to_wiki, function=http_generate, output_collection=wiki
+/// ```
+///
+/// That reaches a user as a flat "the Chroma API rejected the sync request",
+/// and it means onboarding can never finish for a workspace that was set up
+/// before — which is every returning user. Looking the attachment up by name
+/// first is what actually delivers the idempotency `/init` advertises.
+///
+/// A backend that cannot list attachments answers `false`, so this reduces to
+/// the previous behaviour rather than failing: the sqlite backend used for
+/// local development does not implement the call.
+async fn foundation_function_already_attached(
+    sysdb: &mut SysDb,
+    collection_id: CollectionUuid,
+) -> Result<bool, ServerError> {
+    let name = foundation_attached_function_name();
+    match sysdb.list_attached_functions(collection_id).await {
+        Ok(attached) => Ok(attached.iter().any(|function| function.name == name)),
+        Err(ListAttachedFunctionsError::NotImplemented) => Ok(false),
+        Err(error) => Err(ServerError::from(Box::new(error) as Box<dyn ChromaError>)),
+    }
 }
 
 fn foundation_attached_function_name() -> String {
@@ -500,6 +542,7 @@ async fn ensure_collection(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::SystemTime;
 
     #[test]
     fn gdrive_source_is_single_dimension_others_are_1024() {
@@ -519,6 +562,84 @@ mod tests {
         assert_eq!(
             source_kind_for_collection_name(SLACK_RAW_COLLECTION_NAME).unwrap(),
             "slack"
+        );
+    }
+
+    fn attached_function(
+        name: &str,
+        input_collection_id: CollectionUuid,
+    ) -> chroma_types::AttachedFunction {
+        chroma_types::AttachedFunction {
+            id: chroma_types::AttachedFunctionUuid::new(),
+            name: name.to_string(),
+            function_id: uuid::Uuid::new_v4(),
+            input_collection_id,
+            output_collection_name: "wiki".to_string(),
+            output_collection_id: None,
+            params: None,
+            tenant_id: "tenant".to_string(),
+            database_id: "database".to_string(),
+            last_run: None,
+            completion_offset: 0,
+            min_records_for_invocation: 1,
+            is_deleted: false,
+            is_async: true,
+            created_at: SystemTime::now(),
+            updated_at: SystemTime::now(),
+        }
+    }
+
+    fn sysdb_with(functions: Vec<chroma_types::AttachedFunction>) -> (SysDb, CollectionUuid) {
+        let collection_id = CollectionUuid::new();
+        let mut test = chroma_sysdb::TestSysDb::new();
+        test.set_attached_functions(HashMap::from([(
+            collection_id,
+            functions
+                .into_iter()
+                .map(|function| chroma_types::AttachedFunction {
+                    input_collection_id: collection_id,
+                    ..function
+                })
+                .collect(),
+        )]));
+        (SysDb::Test(test), collection_id)
+    }
+
+    /// `ServerError` carries no `Debug`, so `unwrap` is unavailable here.
+    async fn already_attached(sysdb: &mut SysDb, collection_id: CollectionUuid) -> bool {
+        match foundation_function_already_attached(sysdb, collection_id).await {
+            Ok(found) => found,
+            Err(_) => panic!("listing attached functions should succeed against the test sysdb"),
+        }
+    }
+
+    /// The case that broke onboarding: a workspace set up earlier already has
+    /// the function, and `/init` must leave it alone rather than attempting an
+    /// attach that sysdb refuses with `AlreadyExists`.
+    #[tokio::test]
+    async fn an_existing_attachment_is_recognized() {
+        let (mut sysdb, collection_id) = sysdb_with(vec![attached_function(
+            &foundation_attached_function_name(),
+            CollectionUuid::new(),
+        )]);
+
+        assert!(already_attached(&mut sysdb, collection_id).await);
+    }
+
+    /// A first-time workspace, and a collection carrying somebody else's
+    /// function, both still need the attach to run.
+    #[tokio::test]
+    async fn anything_else_still_needs_attaching() {
+        let (mut sysdb, empty) = sysdb_with(vec![]);
+        assert!(!already_attached(&mut sysdb, empty).await);
+
+        let (mut sysdb, other) = sysdb_with(vec![attached_function(
+            "revision_history",
+            CollectionUuid::new(),
+        )]);
+        assert!(
+            !already_attached(&mut sysdb, other).await,
+            "matching on name only — a different function must not be mistaken for ours"
         );
     }
 }

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -35,6 +35,15 @@ pub struct FoundationInitResponse {
     /// downstream. Wired as the attached function's base input in place of
     /// the old indexed `slack` source.
     pub slack_raw_collection_id: String,
+    /// Whether this workspace had already been set up before the call.
+    ///
+    /// True when the shared foundation function was already attached, which
+    /// only happens on a workspace a previous `/init` completed. Everything
+    /// `/init` does is get-or-create, so a caller cannot otherwise tell a
+    /// first-time setup from a repeat, and the two deserve different words:
+    /// "workspace ready" reads wrong to someone who just created one, and
+    /// "created your workspace" reads wrong to everyone else.
+    pub already_initialized: bool,
     /// Name -> id for each ensured INDEXED source collection
     /// (notion, gdrive, …). Each carries the chunk-sibling grouping flag.
     pub source_collection_ids: std::collections::HashMap<String, String>,
@@ -229,7 +238,7 @@ pub async fn foundation_init(
     //    changes, keeping repeated `/init` calls idempotent.
     // Its source_kind resolves to `slack`, so the generation contract is
     // unchanged from the old `slack` base.
-    ensure_attached_function(
+    let already_initialized = ensure_attached_function(
         &mut sysdb,
         tenant.clone(),
         slack_raw.collection_id,
@@ -278,6 +287,7 @@ pub async fn foundation_init(
         file_uploads_collection_id: file_uploads.collection_id.to_string(),
         agent_sessions_collection_id: agent_sessions.collection_id.to_string(),
         slack_raw_collection_id: slack_raw.collection_id.to_string(),
+        already_initialized,
         source_collection_ids,
     }))
 }
@@ -330,20 +340,23 @@ impl ChromaError for MissingFunctionEndpointUrl {
 /// `/init` is safe to call repeatedly: an attachment that is already there is
 /// left alone. Checking here is what makes that true — see
 /// [`foundation_function_already_attached`] for why the layer below cannot.
+///
+/// Returns whether the attachment was already present, which is what tells the
+/// caller this workspace had been set up before.
 async fn ensure_attached_function(
     sysdb: &mut SysDb,
     tenant: String,
     input_collection_id: CollectionUuid,
     base_source_name: &str,
     cfg: &FoundationConfig,
-) -> Result<(), ServerError> {
+) -> Result<bool, ServerError> {
     if foundation_function_already_attached(sysdb, input_collection_id).await? {
         tracing::info!(
             attached_function = %foundation_attached_function_name(),
             %input_collection_id,
             "foundation function is already attached; leaving it as it is"
         );
-        return Ok(());
+        return Ok(true);
     }
 
     let endpoint_url = cfg
@@ -370,7 +383,7 @@ async fn ensure_attached_function(
         output_schema,
     )
     .await?;
-    Ok(())
+    Ok(false)
 }
 
 /// Whether the foundation function is already attached to `collection_id`.


### PR DESCRIPTION
## The bug

`POST /api/init` cannot finish for any workspace that was set up before. Attaching the shared foundation function is refused, and the whole call fails:

```
API error 409: collection already has an attached function with the same
execution mode: name=foundation_sources_to_wiki, function=http_generate,
output_collection=wiki
```

**This is the Mac app's entire onboarding path.** Reconnecting an existing workspace runs `/init`, so every returning user hits it — and the FFI reduces it to a flat *"The Chroma API rejected the sync request"* with no detail.

## Why the existing idempotency does not cover it

There are two layers, and both look like they handle a repeat call.

`attached_function_ops::create_attached_function` handles `created = false` and returns cleanly. But it never gets that answer, because sysdb decides whether a create is a repeat by comparing the **attached-function id**:

```go
if attachedFunction.ID == spec.AttachedFunctionID {
    return !attachedFunction.IsReady, nil        // the repeat path
}
...
if existingFunction.IsAsync == requestedFunction.IsAsync {
    return false, status.Errorf(codes.AlreadyExists, ...)
}
```

`/init` mints a fresh id on every call, so it never matches that first branch. It falls through to the execution-mode check and is refused.

The route's own doc comment already promised the behaviour we do not have — *"`/init` is safe to call repeatedly"*, resting on a `created = false` path it cannot reach.

## The change

Look the attachment up by name before attaching, and skip when it is already there. That is what actually delivers the documented contract, and it keeps the fix in the route that makes the claim rather than changing shared attach semantics for every caller.

Deliberately matched on **name only**. An attachment with a different name is somebody else's function and must not be mistaken for ours.

A backend that cannot list attachments answers `false`, so this reduces to the previous behaviour rather than failing — the sqlite backend used for local development does not implement the call.

## Testing

Two tests against the test sysdb, both verified against their own revert (stubbing the lookup to `false` fails the first):

- an existing `foundation_sources_to_wiki` on the collection is recognised, so the attach is skipped
- an empty collection, and one carrying a differently-named function, both still need the attach

## Not addressed here

**The generic error text.** Every non-2xx from this route reaches the app as one fixed sentence, because the FFI sanitizes on the way out. That is deliberate and correct — but until [foundation#321](https://github.com/chroma-core/foundation/pull/321) the app installed no Rust log either, so the detail had nowhere to go and was destroyed rather than kept. This 409 was unreadable for three attempts before that landed.

**Whether a partially-migrated workspace can produce a duplicate attachment.** The case here is refused cleanly, so nothing is created. But a workspace whose function sits on a *different* input collection — one predating the `slack_raw` cutover, say — would not match this check either, and its attach may succeed and leave two writers on one collection. That has happened before and needed hand repair. It deserves its own look; this change neither causes nor fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: the response now says whether the workspace already existed

Everything `/init` does is get-or-create, so a caller cannot tell a first-time setup from a repeat and has to pick one set of words for both. "Workspace ready" reads wrong to someone who just created one; "created your workspace" reads wrong to everyone else.

The fix above already computes the answer — it checks whether the shared foundation function is attached before attaching it, and that is only true on a workspace an earlier `/init` completed. This returns it rather than discarding it:

```json
{ "tenant": "...", "database": "FOUNDATION", "already_initialized": true, ... }
```

**Additive and optional to consume.** The response type carries no `deny_unknown_fields`, and the CLI's copy already omits several fields the server sends (`user_id`, `currents_collection_id`, and others), so existing clients ignore it until someone wants it.

There is a reason to want it beyond wording. The two clients currently disagree about what an `/init` failure means — the CLI prints a warning and carries on, the Mac app treats it as fatal and blocks onboarding — and neither is unreasonable given that "already set up" and "genuinely broken" arrive as the same error. With this field, "already set up" stops being an error at all, and a client can narrow its catch-all to failures that really are failures.

### On the naming

`already_initialized` describes what a caller wants to know, but what is actually observed is narrower: the shared function was already attached. Those come apart for a workspace initialised before a later collection was added to the config — it would report `already_initialized: true` while still having had something created on this call. The field is documented in those terms rather than promising more than it checks.

### Testing

The value comes straight from `foundation_function_already_attached`, which the two tests above cover in both directions. The wiring from there into the response is not covered — `foundation-api` has no handler-level test harness, and standing one up for a boolean is out of proportion to this change.
