### PR TITLE
[DOC](storage): Document custom_endpoint on Explicit S3 credentials

### DIFF
--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -38,6 +38,12 @@ pub enum S3CredentialsConfig {
     /// Explicit credentials for customer buckets or S3-compatible services.
     /// Use this when you need to connect to arbitrary S3 buckets with specific
     /// credentials, rather than using the default AWS credential chain.
+    ///
+    /// Setting `custom_endpoint` points the client at a service other than
+    /// Amazon S3 (for example Backblaze B2, Cloudflare R2, or MinIO), such
+    /// as `https://s3.example-region.example.com`, and switches the client
+    /// to path-style addressing. `region` is part of the request signature,
+    /// so it must match what the service expects.
     Explicit {
         access_key_id: String,
         #[serde(skip_serializing)]


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Expand the rustdoc on `S3CredentialsConfig::Explicit` to cover its two least obvious fields. Setting `custom_endpoint` also flips the client to path-style addressing (`rust/storage/src/s3.rs`), and `region` is still part of the request signature, so it has to match what the endpoint expects. Both are easy to get wrong when pointing the storage layer at an S3-compatible endpoint, and neither was written down next to the fields.
- New functionality
  - None, comment-only change.

## Test plan

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Comment-only change with no behavior change, so no new tests. `pre-commit run --files rust/storage/src/config.rs` passes. No Rust code and no doctest were added, so `cargo fmt -- --check` and `cargo test --doc` are unaffected.

## Migration plan

None, documentation only.

## Observability plan

None, documentation only.

## Documentation Changes

This is the docstring change. Nothing under `docs/` needs updating: `custom_endpoint` is a distributed storage config field, not part of a public client API.