### PR TITLE
[TST](work-queue): Avoid completed test work

### DIFF
--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -243,12 +243,16 @@ mod tests {
                     .await
                     .expect("Failed to create async attached function");
 
+                // A new attached function begins at completion offset zero.
+                // Keep every queued frontier ahead of it so fn-consumer does
+                // not acknowledge the item as already complete.
+                let offset = (i + 1) * 100;
                 ctx.work_queue_client
-                    .push_work(fn_id.to_string(), coll_id.to_string(), i * 100, i * 100)
+                    .push_work(fn_id.to_string(), coll_id.to_string(), offset, offset)
                     .await
                     .expect("Failed to push work");
 
-                work_items.push((fn_id, coll_id, i * 100));
+                work_items.push((fn_id, coll_id, offset));
             }
 
             // Get work - should return in FIFO order
@@ -280,9 +284,9 @@ mod tests {
 
             // Check FIFO order by completion offset (assuming same order as pushed)
             for (i, item) in our_retrieved.iter().enumerate() {
-                let expected_offset = i * 100;
+                let expected_offset = work_items[i].2;
                 assert_eq!(
-                    item.completion_offset, expected_offset as i64,
+                    item.completion_offset, expected_offset,
                     "Expected offset {} for item {}",
                     expected_offset, i
                 );


### PR DESCRIPTION
## Summary

Update the Work Queue FIFO integration test to queue all three test items past a newly created attached function’s completion frontier.

The fn-consumer now correctly acknowledges any item whose queued frontier is already complete. The prior zero-offset item (`0, 0`) was therefore removed before the test read the queue, causing the `2 == 3` failure.

## Validation

- `cargo fmt --check --package worker`
- `cargo test --package worker work_queue::tests::integration::tests::test_k8s_integration_work_queue_fifo_and_filtering --no-run`