### PR TITLE
[DOC] Fix vacuum CLI command (chroma utils vacuum -> chroma vacuum)

### DIFF
--- a/docs/mintlify/docs/cli/vacuum.mdx
+++ b/docs/mintlify/docs/cli/vacuum.mdx
@@ -14,7 +14,7 @@ Vacuuming blocks all reads and writes to your database while it's running, so we
 To vacuum your database, run:
 
 ```bash
-chroma utils vacuum --path <your-data-directory>
+chroma vacuum --path <your-data-directory>
 ```
 
 For large databases, expect this to take up to a few minutes.

--- a/docs/mintlify/docs/overview/migration.mdx
+++ b/docs/mintlify/docs/overview/migration.mdx
@@ -150,7 +150,7 @@ Finally, the embeddings returned from `collection.get()`, `collection.query()`, 
 
 Chroma internally uses a write-ahead log. In all versions prior to v0.5.6, this log was never pruned. This resulted in the data directory being much larger than it needed to be, as well as the directory size not decreasing by the expected amount after deleting a collection.
 
-In v0.5.6 the write-ahead log is pruned automatically. However, this is not enabled by default for existing databases. After upgrading, you should run `chroma utils vacuum` once to reduce your database size and enable continuous pruning. See the [CLI reference](/docs/cli/vacuum) for more details.
+In v0.5.6 the write-ahead log is pruned automatically. However, this is not enabled by default for existing databases. After upgrading, you should run `chroma vacuum` once to reduce your database size and enable continuous pruning. See the [CLI reference](/docs/cli/vacuum) for more details.
 
 This does not need to be run regularly and does not need to be run on new databases created with v0.5.6 or later.
 


### PR DESCRIPTION
The vacuum docs tell users to run `chroma utils vacuum`, but the CLI has no `utils` subcommand, so the command fails.

`vacuum` is a **top-level** command. In `rust/cli/src/lib.rs` the `Command` enum has no `Utils` variant — `Vacuum(VacuumArgs)` is dispatched directly as `chroma vacuum`. Running the documented form errors with `unrecognized subcommand 'utils'` and exits non-zero.

`--path` is unchanged (defined in `VacuumArgs`, `rust/cli/src/commands/vacuum.rs`).

Fixes two occurrences:
- `docs/mintlify/docs/cli/vacuum.mdx:17`
- `docs/mintlify/docs/overview/migration.mdx:153`

Docs-only, no functional change.

_FYI (left out to keep this docs-only): the runtime warning in `chromadb/db/impl/sqlite.py` likewise points at `chromadb utils vacuum --help`, another leftover of the removed `utils` namespace — happy to fix in a follow-up if you'd like._
