### PR TITLE
[BUG](tracing): Rename the tracing field `error` to `error_message`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -288,6 +288,11 @@ jobs:
         run: cargo fmt -- --check
       - name: Clippy
         run: cargo clippy --all-targets --all-features --keep-going -- -D warnings -D clippy::large_futures -D clippy::all
+      # Its own step rather than a line in the pre-commit block above, which is
+      # `continue-on-error` and so cannot fail the build.
+      - name: Check for a tracing field named `error`
+        shell: bash
+        run: bin/check_tracing_error_field.sh
 
   # This job exists for our branch protection rule.
   # We want to require status checks to pass before merging, but the set of

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,16 @@ repos:
         exclude: "^clients/(js|new-js)/src/generated/.+|.*\\.gen\\.ts$"
         additional_dependencies:
           - prettier@2.8.7
+
+  - repo: local
+    hooks:
+      # A tracing field named `error` is silently discarded by Honeycomb. Clippy
+      # cannot see it — the field name lives inside a macro — so it needs its own
+      # check. CI runs this as its own step in the lint job, because the
+      # pre-commit step there is advisory.
+      - id: rust-tracing-error-field
+        name: rust-tracing-error-field
+        language: system
+        types: [file, rust]
+        entry: bin/check_tracing_error_field.sh
+        pass_filenames: false

--- a/bin/check_tracing_error_field.sh
+++ b/bin/check_tracing_error_field.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Reject a tracing field literally named `error`.
+#
+# Honeycomb assigns a column its type on first write and keeps it forever. Its
+# OTLP ingest derives a *boolean* `error` from OpenTelemetry span status, so in
+# any service with a busy error path that boolean lands first and in volume, and
+# `error` becomes a boolean column. Every string written to it afterwards is
+# coerced to `false` — the message is destroyed, silently, and cannot be
+# recovered later because it was never stored.
+#
+# The failure is invisible from the code: the same `error = %e` keeps its text in
+# a dataset whose column happened to type as a string, and loses it in one that
+# typed as boolean. `error` is boolean in every dataset the data plane reports
+# into.
+#
+# Write `error_message` instead. It never collides with the derived boolean.
+#
+#   tracing::error!(error = %e, "upload failed");            // dropped
+#   tracing::error!(error_message = %e, "upload failed");    // kept
+#
+# A more specific name is fine and often better — `storage_error`, `manifest_error`
+# all pass. The only banned spelling is the bare `error`.
+#
+# Clippy cannot catch this: the field name lives inside a macro, where no lint can
+# see it.
+
+set -euo pipefail
+
+# Directories this check covers.
+ROOTS=(rust)
+
+# A field named `error` has four spellings, and all four have to be caught.
+
+# 1. Sigil form. `%` and `?` are the tracing sigils for Display and Debug.
+#    Tolerate the spacing, because `error =% err` is as common here as
+#    `error = %err`.
+P_SIGIL='\berror[[:space:]]*=[[:space:]]*[%?]'
+
+# 2. Shorthand. `warn!(%error, …)` names the field after the local variable, so a
+#    binding called `error` produces a column called `error` with no `=` on the
+#    line at all. A key of its own names the column, so `error_message = %error`
+#    is fine and is filtered back out below.
+P_SHORTHAND='[%?]error\b'
+
+# 3. A value that is already a `String` needs no sigil: `error = last_err,`. An
+#    assignment ends in `;`, so requiring a trailing comma is what separates a
+#    macro field from ordinary Rust such as `let error = ...;`.
+P_ARG_LINE='^[[:space:]]*error[[:space:]]*=[[:space:]]*[^;]*,[[:space:]]*$'
+
+# 4. The same, written inline. Naming the macros and refusing to cross an opening
+#    quote keeps message text such as `println!("… error={err}")` out of the
+#    results.
+P_ARG_INLINE='\b(tracing::)?(error|warn|info|debug|trace|event)!\([^"]*\berror[[:space:]]*=[[:space:]]*[^=%?]'
+
+hits=$(
+    {
+        grep -rnE "$P_SIGIL" --include='*.rs' "${ROOTS[@]}" 2>/dev/null || true
+        { grep -rnE "$P_SHORTHAND" --include='*.rs' "${ROOTS[@]}" 2>/dev/null || true; } \
+            | { grep -vE '=[[:space:]]*[%?]error\b' || true; }
+        grep -rnE "$P_ARG_LINE" --include='*.rs' "${ROOTS[@]}" 2>/dev/null || true
+        grep -rnE "$P_ARG_INLINE" --include='*.rs' "${ROOTS[@]}" 2>/dev/null || true
+    } | sort -u -t: -k1,1 -k2,2n
+)
+
+if [[ -n "$hits" ]]; then
+    echo "error: tracing field named \`error\` — Honeycomb will discard the message." >&2
+    echo >&2
+    echo "$hits" >&2
+    echo >&2
+    echo "Rename it to \`error_message\` (or something more specific, like" >&2
+    echo "\`storage_error\`). See the comment at the top of $0 for why." >&2
+    exit 1
+fi

--- a/rust/foundation-api/src/lib.rs
+++ b/rust/foundation-api/src/lib.rs
@@ -124,7 +124,7 @@ pub async fn foundation_service_entrypoint_with_config_system_registry(
         Ok(sysdb) => sysdb,
         Err(e) => {
             tracing::error!(
-                error = %e,
+                error_message = %e,
                 "foundation-api startup failed: could not construct SysDb client from config",
             );
             return;
@@ -135,7 +135,7 @@ pub async fn foundation_service_entrypoint_with_config_system_registry(
         Ok(rules) => rules,
         Err(e) => {
             tracing::error!(
-                error = %e,
+                error_message = %e,
                 "foundation-api startup failed: invalid scorecard rule pattern",
             );
             return;

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -387,7 +387,7 @@ async fn submit_search_agent_usage_events(
         .await
         {
             tracing::warn!(
-                error = %error,
+                error_message = %error,
                 tenant,
                 database,
                 model = usage.model,

--- a/rust/foundation-api/src/server.rs
+++ b/rust/foundation-api/src/server.rs
@@ -88,7 +88,7 @@ impl FoundationApiServer {
             }
             Err(err) => {
                 tracing::error!(
-                    error = %err,
+                    error_message = %err,
                     "invalid foundation frontend_ingress_url; record-I/O routes disabled",
                 );
                 None

--- a/rust/frontend-core/src/retry.rs
+++ b/rust/frontend-core/src/retry.rs
@@ -70,7 +70,7 @@ where
         .when(|err: &E| is_transient(err.code()))
         .notify(|err: &E, delay: Duration| {
             tracing::warn!(
-                error = %err,
+                error_message = %err,
                 retry_after_ms = delay.as_millis() as u64,
                 "retrying transient sysdb failure",
             );

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -597,7 +597,7 @@ impl Handler<ManualGarbageCollectionRequest> for GarbageCollector {
             .manual_garbage_collection_request(req.collection_id)
             .await
         {
-            tracing::event!(Level::ERROR, name = "manual collection failed", error =? err);
+            tracing::event!(Level::ERROR, name = "manual collection failed", error_message =? err);
         }
     }
 }
@@ -719,7 +719,7 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
                         Level::ERROR,
                         name = "cannot perform manual collection",
                         collection_id = collection_id.to_string(),
-                        error = err.to_string(),
+                        error_message = err.to_string(),
                     );
                 }
             }

--- a/rust/garbage_collector/src/mcmr.rs
+++ b/rust/garbage_collector/src/mcmr.rs
@@ -115,7 +115,7 @@ pub async fn instantiate_regions_and_topologies(
                     SpannerConfig::Gcp(_) => {
                         let mut config = SpannerClientConfig::default().with_auth().await.map_err(
                             |err| -> Box<dyn ChromaError> {
-                                tracing::event!(Level::ERROR, name = "auth error", error = ?err);
+                                tracing::event!(Level::ERROR, name = "auth error", error_message = ?err);
                                 Box::new(RegionsAndTopologiesError::from(err)) as _
                             },
                         )?;

--- a/rust/garbage_collector/src/operators/compute_unused_between_versions.rs
+++ b/rust/garbage_collector/src/operators/compute_unused_between_versions.rs
@@ -47,7 +47,7 @@ impl ComputeUnusedBetweenVersionsOperator {
                 }
                 Err(e) => {
                     tracing::error!(
-                        error = %e,
+                        error_message = %e,
                         file_path = %file_path,
                         "Failed to parse UUID from file path"
                     );
@@ -71,7 +71,7 @@ impl ComputeUnusedBetweenVersionsOperator {
                 }
                 Err(e) => {
                     tracing::error!(
-                        error = %e,
+                        error_message = %e,
                         uuid = %id,
                         "Failed to get block IDs"
                     );
@@ -239,7 +239,7 @@ impl Operator<ComputeUnusedBetweenVersionsInput, ComputeUnusedBetweenVersionsOut
                 .await
                 .map_err(|e| {
                     tracing::error!(
-                        error = %e,
+                        error_message = %e,
                         version = older_version,
                         "Failed to extract S3 files from older version"
                     );
@@ -250,7 +250,7 @@ impl Operator<ComputeUnusedBetweenVersionsInput, ComputeUnusedBetweenVersionsOut
                 .await
                 .map_err(|e| {
                     tracing::error!(
-                        error = %e,
+                        error_message = %e,
                         version = newer_version,
                         "Failed to extract S3 files from newer version"
                     );
@@ -290,7 +290,7 @@ impl Operator<ComputeUnusedBetweenVersionsInput, ComputeUnusedBetweenVersionsOut
                 .await
                 .map_err(|e| {
                     tracing::error!(
-                        error = %e,
+                        error_message = %e,
                         version = last_version,
                         "Failed to extract S3 files from last version"
                     );
@@ -301,7 +301,7 @@ impl Operator<ComputeUnusedBetweenVersionsInput, ComputeUnusedBetweenVersionsOut
                 .await
                 .map_err(|e| {
                     tracing::error!(
-                        error = %e,
+                        error_message = %e,
                         version = input.oldest_version_to_keep,
                         "Failed to extract S3 files from version to keep"
                     );

--- a/rust/garbage_collector/src/operators/compute_unused_files.rs
+++ b/rust/garbage_collector/src/operators/compute_unused_files.rs
@@ -89,7 +89,7 @@ impl ComputeUnusedFilesOperator {
                     for file_path in file_paths.paths.iter() {
                         let (prefix, hnsw_uuid) = Segment::extract_prefix_and_id(file_path)
                             .map_err(|e| {
-                                tracing::error!(error = %e, "Failed to extract prefix and ID");
+                                tracing::error!(error_message = %e, "Failed to extract prefix and ID");
                                 ComputeUnusedFilesError::InvalidUuid(e, file_path.to_string())
                             })?;
                         for file in FILES.iter() {
@@ -113,7 +113,7 @@ impl ComputeUnusedFilesOperator {
                     for file_path in file_paths.paths.iter() {
                         let (prefix, id) =
                             Segment::extract_prefix_and_id(file_path).map_err(|e| {
-                                tracing::error!(error = %e, "Failed to extract prefix and ID");
+                                tracing::error!(error_message = %e, "Failed to extract prefix and ID");
                                 ComputeUnusedFilesError::InvalidUuid(e, file_path.to_string())
                             })?;
                         let s3_key =
@@ -202,14 +202,14 @@ impl ComputeUnusedFilesOperator {
 
         for si_path in si_ids {
             let (prefix, si_id) = Segment::extract_prefix_and_id(&si_path).map_err(|e| {
-                tracing::error!(error = %e, "Failed to parse UUID");
+                tracing::error!(error_message = %e, "Failed to parse UUID");
                 ComputeUnusedFilesError::InvalidUuid(e, si_path.to_string())
             })?;
 
             let block_ids = match self.root_manager.get_all_block_ids(&si_id, prefix).await {
                 Ok(ids) => ids,
                 Err(e) => {
-                    tracing::error!(error = %e, "Failed to get block IDs");
+                    tracing::error!(error_message = %e, "Failed to get block IDs");
                     return Err(ComputeUnusedFilesError::FailedToFetchBlockIDs(e));
                 }
             };

--- a/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
@@ -104,7 +104,7 @@ impl DeleteVersionsAtSysDbOperator {
         for result in results {
             if let Err((path, error)) = result {
                 tracing::warn!(
-                    error = %error,
+                    error_message = %error,
                     path = %path,
                     "Failed to delete version file {}, continuing since it could have been deleted already",
                     path
@@ -170,7 +170,7 @@ impl Operator<DeleteVersionsAtSysDbInput, DeleteVersionsAtSysDbOutput>
                 }
                 Err(e) => {
                     tracing::error!(
-                        error = %e,
+                        error_message = %e,
                         versions = ?input.versions_to_delete.versions,
                         "Failed to delete versions from SysDB"
                     );

--- a/rust/garbage_collector/src/operators/fetch_version_file.rs
+++ b/rust/garbage_collector/src/operators/fetch_version_file.rs
@@ -105,7 +105,7 @@ impl Operator<FetchVersionFileInput, FetchVersionFileOutput> for FetchVersionFil
             .await
             .map_err(|e| {
                 tracing::error!(
-                    error = ?e,
+                    error_message = ?e,
                     path = %input.version_file_path,
                     "Failed to fetch version file"
                 );

--- a/rust/index/src/sparse/maxscore.rs
+++ b/rust/index/src/sparse/maxscore.rs
@@ -579,7 +579,7 @@ impl<'me> MaxScoreReader<'me> {
                 tracing::error!(
                     dimension = encoded_dim,
                     part_count,
-                    error = %err,
+                    error_message = %err,
                     "corrupt sparse posting directory: parts exist on disk \
                      but could not be reconstructed; dimension will be skipped"
                 );

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -324,7 +324,7 @@ async fn connect_spanner(spanner: &SpannerConfig) -> Result<SpannerClient, Error
                 .with_auth()
                 .await
                 .map_err(|e| {
-                    tracing::event!(Level::ERROR, name = "auth error", error =? e);
+                    tracing::event!(Level::ERROR, name = "auth error", error_message =? e);
                     Error::from(e)
                 })?;
             config.session_config = session_config;
@@ -1908,7 +1908,7 @@ impl LogServer {
                 Ok(())
             }
             Err(err) => {
-                tracing::event!(Level::ERROR, name = "could not roll dirty log for local", error =? err);
+                tracing::event!(Level::ERROR, name = "could not roll dirty log for local", error_message =? err);
                 Err(err)
             }
         }
@@ -1943,7 +1943,7 @@ impl LogServer {
                     }
                 }
                 Err(err) => {
-                    tracing::event!(Level::ERROR, name = "could not roll dirty log for topology", error =? err);
+                    tracing::event!(Level::ERROR, name = "could not roll dirty log for topology", error_message =? err);
                 }
             }
         }
@@ -2306,7 +2306,7 @@ impl LogServer {
         let mut buffered = stream.buffer_unordered(self.config.rollup_concurrency.max(1));
         while let Some(res) = buffered.next().await {
             if let Err(err) = res {
-                tracing::error!(error = ?err);
+                tracing::error!(error_message = ?err);
             }
         }
         self.metrics

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -514,11 +514,11 @@ impl GrpcLog {
             .await
             .map_err(|err| match backoff_reason_from_status(&err) {
                 Some("compaction") => {
-                    tracing::event!(Level::INFO, name = "backoff", reason = "compaction", error =? err);
+                    tracing::event!(Level::INFO, name = "backoff", reason = "compaction", error_message =? err);
                     GrpcPushLogsError::BackoffCompaction
                 }
                 Some(reason) => {
-                    tracing::event!(Level::INFO, name = "backoff", reason, error =? err);
+                    tracing::event!(Level::INFO, name = "backoff", reason, error_message =? err);
                     GrpcPushLogsError::Backoff
                 }
                 None => err.into(),

--- a/rust/rust-sysdb/src/server.rs
+++ b/rust/rust-sysdb/src/server.rs
@@ -634,7 +634,7 @@ impl SysDb for SysdbService {
                 Err(e) => {
                     tracing::error!(
                         collection_id = %collection_id_str,
-                        error = ?e,
+                        error_message = ?e,
                         "Failed to mark versions for deletion after retries"
                     );
                     false
@@ -677,7 +677,7 @@ impl SysDb for SysdbService {
                 Err(e) => {
                     tracing::error!(
                         collection_id = %collection_id_str,
-                        error = ?e,
+                        error_message = ?e,
                         "Failed to delete versions for collection"
                     );
                     false
@@ -1160,7 +1160,7 @@ impl SysdbService {
             let mut version_file = version_file_manager.fetch(&collection).await.map_err(|e| {
                 tracing::error!(
                     collection_id = %collection_id,
-                    error = ?e,
+                    error_message = ?e,
                     "Failed to fetch version file for {}",
                     operation.name()
                 );
@@ -1268,7 +1268,7 @@ impl SysdbService {
                 .map_err(|e| {
                     tracing::error!(
                         collection_id = %collection_id,
-                        error = ?e,
+                        error_message = ?e,
                         "Failed to upload {} version file",
                         operation.name()
                     );
@@ -1299,7 +1299,7 @@ impl SysdbService {
                 .map_err(|e| {
                     tracing::error!(
                         collection_id = %collection_id,
-                        error = ?e,
+                        error_message = ?e,
                         "Failed to update version related fields"
                     );
                     e

--- a/rust/rust-sysdb/src/spanner.rs
+++ b/rust/rust-sysdb/src/spanner.rs
@@ -285,7 +285,7 @@ impl SpannerBackend {
             let file_paths_json: String = serde_json::to_string(&file_paths).map_err(|e| {
                 tracing::error!(
                     segment_id = %flush_segment_compaction.segment_id,
-                    error = %e,
+                    error_message = %e,
                     "Failed to serialize file paths to JSON"
                 );
                 SysDbError::InvalidSchemaJson(e)
@@ -436,7 +436,7 @@ impl SpannerBackend {
             tracing::warn!(
                 database_name = %db_name_for_log,
                 delay_ms = dur.as_millis(),
-                error = %e,
+                error_message = %e,
                 "Spanner aborted or cancelled create database transaction; retrying"
             );
         })
@@ -1072,7 +1072,7 @@ impl SpannerBackend {
                 collection_name = ?filter.name,
                 ids_count = ?filter.ids.as_ref().map(Vec::len),
                 delay_ms = dur.as_millis(),
-                error = %e,
+                error_message = %e,
                 "Spanner aborted or cancelled get_collections query; retrying"
             );
         })
@@ -2083,7 +2083,7 @@ impl SpannerBackend {
             tracing::warn!(
                 collection_id = %collection_id,
                 delay_ms = dur.as_millis(),
-                error = %e,
+                error_message = %e,
                 "Spanner aborted or cancelled flush collection compaction transaction; retrying"
             );
         })

--- a/rust/rust-sysdb/src/types.rs
+++ b/rust/rust-sysdb/src/types.rs
@@ -1861,7 +1861,7 @@ impl Runnable for ListCollectionsToGcRequest {
                 Ok(resp) => all_collections.extend(resp.collections),
                 Err(e) => {
                     tracing::warn!(
-                        error = %e,
+                        error_message = %e,
                         "Failed to list collections to gc from backend, continuing with other backends"
                     );
                 }

--- a/rust/segment/src/version_file.rs
+++ b/rust/segment/src/version_file.rs
@@ -89,7 +89,7 @@ impl VersionFileManager {
             .await
             .map_err(|e| {
                 tracing::error!(
-                    error = ?e,
+                    error_message = ?e,
                     path = %version_file_path,
                     "Failed to fetch version file"
                 );
@@ -157,7 +157,7 @@ impl VersionFileManager {
             .await
             .map_err(|e| {
                 tracing::error!(
-                    error = ?e,
+                    error_message = ?e,
                     path = %version_file_path,
                     size = content_size,
                     "Failed to upload version file"

--- a/rust/storage/src/local.rs
+++ b/rust/storage/src/local.rs
@@ -175,7 +175,7 @@ impl LocalStorage {
         // Create parent directory for destination if it doesn't exist
         if let Some(parent) = std::path::Path::new(&dst_path).parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
-                tracing::error!(error = %e, path = %parent.display(), "Failed to create parent directory");
+                tracing::error!(error_message = %e, path = %parent.display(), "Failed to create parent directory");
                 return Err(StorageError::Generic {
                     source: Arc::new(e),
                 });
@@ -197,7 +197,7 @@ impl LocalStorage {
         // Create parent directory for destination if it doesn't exist
         if let Some(parent) = std::path::Path::new(&dst_path).parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
-                tracing::error!(error = %e, path = %parent.display(), "Failed to create parent directory");
+                tracing::error!(error_message = %e, path = %parent.display(), "Failed to create parent directory");
                 return Err(StorageError::Generic {
                     source: Arc::new(e),
                 });

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -1030,7 +1030,7 @@ impl S3Storage {
                         }),
                         Some("SlowDown") => Err(StorageError::Backoff),
                         _ => {
-                            tracing::error!(error = %inner, key = %key, "Failed to delete object from S3");
+                            tracing::error!(error_message = %inner, key = %key, "Failed to delete object from S3");
                             Err(StorageError::Generic {
                                 source: Arc::new(inner),
                             })
@@ -1137,7 +1137,7 @@ impl S3Storage {
                 Ok(())
             }
             Err(e) => {
-                tracing::error!(error = %e, src = %src_key, "Failed to delete source object after copy");
+                tracing::error!(error_message = %e, src = %src_key, "Failed to delete source object after copy");
                 Err(e)
             }
         }
@@ -1164,7 +1164,7 @@ impl S3Storage {
             Ok(_) => Ok(()),
             Err(e) => {
                 let inner = e.into_service_error();
-                tracing::error!(error = %inner, src = %src_key, dst = %dst_key, "Failed to copy object");
+                tracing::error!(error_message = %inner, src = %src_key, dst = %dst_key, "Failed to copy object");
                 if inner.meta().code() == Some("NoSuchKey") {
                     Err(StorageError::NotFound {
                         path: src_key.to_string(),

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -1683,7 +1683,7 @@ impl GrpcSysDb {
                 }
                 Err(e) => {
                     tracing::error!(
-                        error = ?e,
+                        error_message = ?e,
                         "Failed to get collections from mcmr_client - collections from mcmr sysdb will be missing from GC list"
                     );
                     // Intentionally continue
@@ -1957,7 +1957,7 @@ impl GrpcSysDb {
                     // Log the error but continue with other clients
                     // This allows partial results when tenants are distributed across backends
                     tracing::warn!(
-                        error = %e,
+                        error_message = %e,
                         "Failed to get last compaction time from one client, continuing with other clients"
                     );
                 }
@@ -2282,7 +2282,7 @@ impl GrpcSysDb {
             uuid::Uuid::parse_str(&attached_function.id).map_err(|e| {
                 tracing::error!(
                     attached_function_id = %attached_function.id,
-                    error = %e,
+                    error_message = %e,
                     "Server returned invalid attached_function_id UUID - attached function was created but response is corrupt"
                 );
                 AttachFunctionError::ServerReturnedInvalidData
@@ -2327,7 +2327,7 @@ impl GrpcSysDb {
             uuid::Uuid::parse_str(&attached_function.id).map_err(|e| {
                 tracing::error!(
                     attached_function_id = %attached_function.id,
-                    error = %e,
+                    error_message = %e,
                     "Server returned invalid attached_function_id UUID - attached function input was added but response is corrupt"
                 );
                 AttachFunctionError::ServerReturnedInvalidData
@@ -2347,7 +2347,7 @@ impl GrpcSysDb {
             uuid::Uuid::parse_str(&attached_function.id).map_err(|e| {
                 tracing::error!(
                     attached_function_id = %attached_function.id,
-                    error = %e,
+                    error_message = %e,
                     "Server returned invalid attached_function_id UUID"
                 );
                 GetAttachedFunctionError::ServerReturnedInvalidData
@@ -2359,7 +2359,7 @@ impl GrpcSysDb {
             uuid::Uuid::parse_str(&attached_function.input_collection_id).map_err(|e| {
                 tracing::error!(
                     input_collection_id = %attached_function.input_collection_id,
-                    error = %e,
+                    error_message = %e,
                     "Server returned invalid input_collection_id UUID"
                 );
                 GetAttachedFunctionError::ServerReturnedInvalidData
@@ -2382,7 +2382,7 @@ impl GrpcSysDb {
                         uuid::Uuid::parse_str(id_str).map_err(|e| {
                             tracing::error!(
                                 output_collection_id = %id_str,
-                                error = %e,
+                                error_message = %e,
                                 "Server returned invalid output_collection_id UUID"
                             );
                             GetAttachedFunctionError::ServerReturnedInvalidData
@@ -2397,7 +2397,7 @@ impl GrpcSysDb {
         let function_id = uuid::Uuid::parse_str(&attached_function.function_id).map_err(|e| {
             tracing::error!(
                 function_id = %attached_function.function_id,
-                error = %e,
+                error_message = %e,
                 "Server returned invalid function_id UUID"
             );
             GetAttachedFunctionError::ServerReturnedInvalidData
@@ -2542,7 +2542,7 @@ impl GrpcSysDb {
                     .map_err(|e| {
                         tracing::error!(
                             attached_function_id = %af.id,
-                            error = %e,
+                            error_message = %e,
                             "Server returned invalid attached_function_id UUID"
                         );
                         GetAttachedFunctionsToGcError::ServerReturnedInvalidData

--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -467,7 +467,7 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
                 Ok(())
             }
             Err(err) => {
-                tracing::error!(error =% err, "could not write garbage");
+                tracing::error!(error_message =% err, "could not write garbage");
                 Err(err)
             }
         }

--- a/rust/wal3/src/interfaces/repl/fragment_manager.rs
+++ b/rust/wal3/src/interfaces/repl/fragment_manager.rs
@@ -393,7 +393,7 @@ impl FragmentUploader<FragmentUuid> for ReplicatedFragmentUploader {
                     tracing::event!(
                         Level::ERROR,
                         name = "quorum write failed because of error",
-                        error =? **err
+                        error_message =? **err
                     );
                 }
                 Err(Error::ReplicationError)
@@ -499,7 +499,7 @@ impl FragmentReader {
                             tracing::info!("read repair successful");
                         }
                         Err(e) => {
-                            tracing::warn!(error = ?e, "read repair failed");
+                            tracing::warn!(error_message = ?e, "read repair failed");
                         }
                     }
                 }

--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -205,7 +205,7 @@ impl ManifestManager {
         }
         if let Some(last_err) = last_err {
             tracing::warn!(
-                error = last_err,
+                error_message = last_err,
                 "set_ignore_dirty transaction exhausted retries",
             );
         }
@@ -823,7 +823,7 @@ impl ManifestManager {
         }
         if let Some(last_err) = last_err {
             tracing::warn!(
-                error = last_err,
+                error_message = last_err,
                 "set_ignore_dirty transaction exhausted retries",
             );
         }
@@ -1205,7 +1205,7 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
         }
         if let Some(last_err) = last_err {
             tracing::warn!(
-                error = last_err,
+                error_message = last_err,
                 "apply_garbage transaction exhausted retries",
             );
         }
@@ -1463,7 +1463,10 @@ impl ManifestPublisher<FragmentUuid> for ManifestManager {
             }
         }
         if let Some(last_err) = last_err {
-            tracing::warn!(error = last_err, "destroy transaction exhausted retries",);
+            tracing::warn!(
+                error_message = last_err,
+                "destroy transaction exhausted retries",
+            );
         }
         Err(Error::Backoff)
     }
@@ -1603,7 +1606,7 @@ impl ManifestConsumer<FragmentUuid> for ManifestManager {
         }
         if let Some(last_err) = last_err {
             tracing::warn!(
-                error = last_err,
+                error_message = last_err,
                 "set_intrinsic_cursor transaction exhausted retries",
             );
         }

--- a/rust/wal3/src/interfaces/s3/mod.rs
+++ b/rust/wal3/src/interfaces/s3/mod.rs
@@ -176,7 +176,7 @@ async fn snapshot_load(
             // pass
         }
         Err(err) => {
-            tracing::event!(Level::ERROR, name = "cache error", error =? err);
+            tracing::event!(Level::ERROR, name = "cache error", error_message =? err);
         }
     };
     if let Some(res) = uncached_snapshot_load(throttle, storage, prefix, pointer).await? {

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -673,7 +673,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 }
                 Ok(None) => {}
                 Err(err) => {
-                    tracing::error!(error = %err, "batch manager failed");
+                    tracing::error!(error_message = %err, "batch manager failed");
                 }
             }
             let span = tracing::info_span!("wait_for_durability");
@@ -862,7 +862,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 }
                 Ok(None) => None,
                 Err(err) => {
-                    tracing::error!(error =% err, "could not install garbage");
+                    tracing::error!(error_message =% err, "could not install garbage");
                     return Err(err);
                 }
             };
@@ -900,7 +900,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                 | Err(Error::LogContentionRetry)
                 | Err(Error::LogContentionDurable) => {}
                 Err(err) => {
-                    tracing::error!(error =% err, "could not install garbage");
+                    tracing::error!(error_message =% err, "could not install garbage");
                     return Err(err);
                 }
             };
@@ -931,7 +931,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
         if !garbage.is_empty() {
             self.manifest_manager.apply_garbage(garbage.clone()).await.inspect_err(|err| {
                 if let Error::GarbageCollectionPrecondition(err) = err {
-                    tracing::event!(Level::ERROR, name = "garbage collection precondition failed", error =? err, garbage =? garbage);
+                    tracing::event!(Level::ERROR, name = "garbage collection precondition failed", error_message =? err, garbage =? garbage);
                 }
             })?;
         }
@@ -1002,7 +1002,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
                     match storage.delete_many(&paths).await {
                         Ok(mut deleted_objects) => {
                             for err in deleted_objects.errors.iter() {
-                                tracing::error!(error = ?err, "could not clean up");
+                                tracing::error!(error_message = ?err, "could not clean up");
                             }
                             if let Some(err) = deleted_objects.errors.pop() {
                                 return Err::<(), Error>(Arc::new(err).into());

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -251,7 +251,7 @@ impl CompactionManager {
             {
                 tracing::error!(
                     collection_id = ?job.collection_id,
-                    error = ?e,
+                    error_message = ?e,
                     "Failed to send start scheduled compaction task"
                 );
             }

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -155,7 +155,7 @@ impl Scheduler {
                 Ok(collections) => collections,
                 Err(e) => {
                     tracing::error!(
-                        error = ?e,
+                        error_message = ?e,
                         "Error fetching one-off collections from sysdb"
                     );
                     self.pending_oneoff_ids.extend(batch.iter().copied());

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -1119,7 +1119,7 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for LogFetchOrchestrator
                 let collection_info = match self.context.get_collection_info() {
                     Ok(info) => info,
                     Err(err) => {
-                        tracing::warn!(error =? err, "No logs were pulled from the log service, and get_collection_info returned an error.");
+                        tracing::warn!(error_message =? err, "No logs were pulled from the log service, and get_collection_info returned an error.");
                         self.terminate_with_result(Err(err.into()), ctx).await;
                         return;
                     }

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -348,7 +348,7 @@ impl FnConsumerManager {
                     tracing::warn!(
                         fn_id = %fn_id,
                         batch_size = batch.len(),
-                        error = %e,
+                        error_message = %e,
                         "Failed to process work batch"
                     );
                 }


### PR DESCRIPTION
## What this is about

When these crates log an error, they attach the message as a field called `error`. Honeycomb throws that message away on arrival — the field is recorded as `false`, and the text is gone. This is the data-plane half of a fix that has already landed in hosted-chroma ([#8035](https://github.com/chroma-core/hosted-chroma/pull/8035), [#8051](https://github.com/chroma-core/hosted-chroma/pull/8051)).

## Why

Honeycomb assigns a column its type on first write and keeps it forever. Its OTLP ingest derives a **boolean** `error` from OpenTelemetry span status, so in a service with a busy error path that boolean lands first and in volume — and `error` becomes a boolean column. Every string written to it afterwards is coerced to `false`. The message is destroyed at ingest and cannot be recovered later, because it was never stored.

You cannot tell from the source whether a given call site is affected, which is why this went unnoticed. The same `error = %e` keeps its text in a dataset whose column happened to type as a string and loses it in one that typed as boolean.

Here, all of them lose it. `error` is a boolean column in every dataset these crates report into — `query-service`, `compaction-service`, `sysdb-service`, `garbage-collector`, `rust-log-service`, `rust-frontend-service`, and `foundation-service` — each confirmed individually against production. The shared crates (`storage`, `wal3`, `segment`, `index`, `log`, `sysdb`) are linked into all of those binaries, so their sites emit into whichever host dataset is running them and are lost in every one.

## The change

**Rename all 72 sites.** Only field keys change; values, messages, and levels are untouched.

| crate | sites | crate | sites |
| --- | --- | --- | --- |
| `garbage_collector` | 16 | `log-service` | 4 |
| `wal3` | 14 | `foundation-api` | 4 |
| `rust-sysdb` | 10 | `segment` | 2 |
| `sysdb` | 9 | `log` | 2 |
| `storage` | 5 | `index` | 1 |
| `worker` | 4 | `frontend-core` | 1 |

Three spellings are in use here and all are covered:

- the sigil after the equals sign — `error = %err`
- the sigil attached to it — `error =% err`, which is the prevailing style in `wal3` and `log-service`
- a `String` value carrying no sigil at all — `error = last_err`

**Add a check, wired in as a pre-commit hook and as its own CI step.** Clippy cannot catch this: the field name lives inside a macro, where no lint can see it. And a guard matters more than the rename does — `error` is the obvious thing to type, so it comes back. It was reintroduced twice during the investigation that found it, once by the person who had diagnosed it an hour earlier.

The check is a separate step rather than a line in the lint job's pre-commit block, because that block is `continue-on-error` and so cannot fail the build.

Two guards keep ordinary Rust out of the results. An assignment ends in `;` where a macro field ends in `,`, which is what separates a field from `let error = ...;`. And the inline pattern names the tracing macros and refuses to cross an opening quote — without that, a `println!` in `rust/faults` whose message contains `error={err}` trips the check.

## Testing

`cargo check --all-targets` and `cargo clippy -D warnings -D clippy::large_futures` clean on all twelve crates, `cargo fmt --check` clean.

Verified in both directions: the check passes on this branch, and each of the four spellings fails it with the file and line when reintroduced.

## Notes for review

**A rename is needed even where the column is a string.** `error` holding the literal `"true"` from the derived boolean, mixed with the occasional real message, is not a column you can filter or group on.

**The boolean columns should be left alone.** Once nothing writes strings into `error`, it becomes purely the derived boolean, consistently typed everywhere, which is what keeps `EXISTS` filters and refinery sampling working. Converting the column would break that without recovering any history — the lost messages were never stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)