### PR TITLE
[BLD](idl): Make proto_go work from a clean checkout

### DIFF
--- a/idl/makefile
+++ b/idl/makefile
@@ -1,7 +1,12 @@
 .PHONY: proto
 
-PROTOC_GEN_GO_BIN_PATH := $(if $(shell which protoc-gen-go),$(shell which protoc-gen-go),"${GOPATH}/bin/protoc-gen-go")
-PROTOC_GEN_GO_GRPC_BIN_PATH := $(if $(shell which protoc-gen-go-grpc),$(shell which protoc-gen-go-grpc),"${GOPATH}/bin/protoc-gen-go-grpc")
+# Fall back to the Go bin directory when the plugins are not on PATH. Ask the
+# toolchain for it rather than reading the shell's ${GOPATH}: that variable is
+# unset on most machines, which silently made the fallback "/bin/protoc-gen-go".
+GO_BIN_DIR := $(shell go env GOPATH)/bin
+
+PROTOC_GEN_GO_BIN_PATH := $(if $(shell which protoc-gen-go),$(shell which protoc-gen-go),$(GO_BIN_DIR)/protoc-gen-go)
+PROTOC_GEN_GO_GRPC_BIN_PATH := $(if $(shell which protoc-gen-go-grpc),$(shell which protoc-gen-go-grpc),$(GO_BIN_DIR)/protoc-gen-go-grpc)
 
 proto_python:
 	@echo "Generating gRPC code for python..."
@@ -17,6 +22,9 @@ proto_python:
 
 proto_go:
 	@echo "Generating gRPC code for golang..."
+	@# `go/pkg/proto/` is gitignored in full, so on a fresh clone these
+	@# directories do not exist and protoc fails before generating anything.
+	@mkdir -p ../go/pkg/proto/coordinatorpb ../go/pkg/proto/logservicepb
 	@protoc \
 		--go_out=../go/pkg/proto/coordinatorpb \
 		--go_opt paths=source_relative \
@@ -26,7 +34,8 @@ proto_go:
     	--plugin protoc-gen-go-grpc="${PROTOC_GEN_GO_GRPC_BIN_PATH}" \
 			chromadb/proto/chroma.proto \
 			chromadb/proto/coordinator.proto \
-			chromadb/proto/logservice.proto
+			chromadb/proto/logservice.proto \
+			chromadb/proto/heapservice.proto
 	@mv ../go/pkg/proto/coordinatorpb/chromadb/proto/logservice*.go ../go/pkg/proto/logservicepb/
 	@mv ../go/pkg/proto/coordinatorpb/chromadb/proto/*.go ../go/pkg/proto/coordinatorpb/
 	@rm -rf ../go/pkg/proto/coordinatorpb/chromadb


### PR DESCRIPTION
## Why

`make proto_go` is the documented way to generate the Go protobuf bindings, and **it cannot produce a buildable tree from a fresh clone.** This surfaced while removing an unrelated field: `pkg/sysdb/coordinator` would not build, and the bindings had to be generated by hand to get any work done.

Three separate defects, all in `idl/makefile`.

**The output directories are never created.** `go/pkg/proto/` is gitignored in its entirety and nothing under it is committed, so on a fresh clone those directories do not exist. Git does not track empty directories, so there is nothing to restore them. `protoc` exits with `No such file or directory` before generating a single file.

**`heapservice.proto` is missing from the target.** `proto_python` generates it; `proto_go` does not — while `pkg/sysdb/coordinator`, `pkg/sysdb/grpc` and `cmd/coordinator` all reference its symbols. It needs no new `mv` rule, because its `go_package` is already `coordinatorpb` and the existing catch-all move handles it.

**The plugin fallback reads the shell's `${GOPATH}`.** That variable is unset on most machines, so the fallback silently resolved to `/bin/protoc-gen-go`. It now asks the toolchain with `go env GOPATH`, which is the supported way to read it.

## Verification

From a worktree at `origin/main` with the plugins installed:

- `make proto_go` succeeds and emits `heapservice.pb.go` and `heapservice_grpc.pb.go`
- `go build ./pkg/sysdb/...` then passes

To confirm the heapservice omission was load-bearing rather than cosmetic, I moved just those two generated files aside and rebuilt — **8 errors**. Restored, it builds clean.

## Not fixed here

A related problem is **not** repo-fixable and is called out so the next person does not chase it. On at least one machine the user-level Go environment pins `GOBIN` and `GOPATH` to a home directory that does not exist, so `go install` fails and `go build` cannot create its module cache:

```
go: could not create module cache: mkdir /Users/lyon: permission denied
```

That lives in the developer's own `go/env` file, not in this repository. The `go env GOPATH` change above makes the makefile robust to `${GOPATH}` being *unset*, which is the part a repo change can address; it cannot help a value that is set and wrong. The fix there is `go env -w GOPATH=... GOBIN=...` on the affected machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
