### PR TITLE
[BUG](metadata): sanitize NUL bytes in chroma:document before FTS5 insert

### DIFF
--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -344,6 +344,8 @@ class SqliteMetadataSegment(MetadataReader):
         )
         for key, value in metadata.items():
             if isinstance(value, str):
+                # Embedded NUL bytes corrupt the FTS5 inverted index (gh#7388).
+                value = value.replace("\x00", "")
                 q = q.insert(
                     ParameterValue(id),
                     ParameterValue(key),
@@ -390,13 +392,17 @@ class SqliteMetadataSegment(MetadataReader):
             t = Table("embedding_fulltext_search")
 
             def insert_into_fulltext_search() -> None:
+                doc = metadata["chroma:document"]
+                # Embedded NUL bytes corrupt the FTS5 inverted index (gh#7388).
+                if isinstance(doc, str) and "\x00" in doc:
+                    doc = doc.replace("\x00", "")
                 q = (
                     self._db.querybuilder()
                     .into(t)
                     .columns(t.rowid, t.string_value)
                     .insert(
                         ParameterValue(id),
-                        ParameterValue(metadata["chroma:document"]),
+                        ParameterValue(doc),
                     )
                 )
                 sql, params = get_sql(q)

--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -390,13 +390,19 @@ class SqliteMetadataSegment(MetadataReader):
             t = Table("embedding_fulltext_search")
 
             def insert_into_fulltext_search() -> None:
+                doc = metadata["chroma:document"]
+                # Embedded NUL bytes corrupt the FTS5 inverted index (gh#7388).
+                # Replace with a space (not the empty string) so tokenization is
+                # preserved: "before\x00after" still matches both "before" and "after".
+                if isinstance(doc, str) and "\x00" in doc:
+                    doc = doc.replace("\x00", " ")
                 q = (
                     self._db.querybuilder()
                     .into(t)
                     .columns(t.rowid, t.string_value)
                     .insert(
                         ParameterValue(id),
-                        ParameterValue(metadata["chroma:document"]),
+                        ParameterValue(doc),
                     )
                 )
                 sql, params = get_sql(q)

--- a/chromadb/test/segment/test_sqlite_metadata.py
+++ b/chromadb/test/segment/test_sqlite_metadata.py
@@ -1,0 +1,130 @@
+from uuid import uuid4
+
+from chromadb.config import Settings, System
+from chromadb.db.impl.sqlite import SqliteDB
+from chromadb.segment.impl.metadata.sqlite import SqliteMetadataSegment
+
+
+def test_large_nul_run_does_not_corrupt_fts5_index() -> None:
+    """Regression test for gh#7388.
+
+    A large run of embedded NUL bytes in ``chroma:document`` corrupts the FTS5
+    inverted index for the entire collection.  The fix sanitizes the document
+    *before* it reaches the FTS table, replacing NUL bytes with spaces so that
+    tokenization is preserved.
+
+    The reporter in #7388 observed that a single NUL byte does **not** trigger
+    the corruption — only a run of ~10 k bytes does — so this test reproduces the
+    original payload rather than a single ``\\x00``.
+    """
+    system = System(
+        Settings(
+            chroma_api_impl="chromadb.api.segment.SegmentAPI",
+            chroma_sysdb_impl="chromadb.db.impl.sqlite.SqliteDB",
+            chroma_producer_impl="chromadb.db.impl.sqlite.SqliteDB",
+            chroma_consumer_impl="chromadb.db.impl.sqlite.SqliteDB",
+            is_persistent=False,
+            allow_reset=True,
+        )
+    )
+    system.start()
+
+    try:
+        db = system.instance(SqliteDB)
+        segment_id = uuid4()
+        metadata_segment = SqliteMetadataSegment(
+            system,
+            {
+                "id": segment_id,
+                "type": "urn:chroma:segment/metadata/sqlite",
+                "scope": "METADATA",
+                "topic": "test",
+                "collection": uuid4(),
+            },
+        )
+
+        # Reproduce the payload from #7388: a ~10 k NUL run between two tokens.
+        document = "before-nuls " + "\x00" * 10291 + " after-nuls"
+
+        with db.tx() as cur:
+            cur.execute(
+                "INSERT INTO embeddings (segment_id, embedding_id, seq_id) "
+                "VALUES (?, ?, ?)",
+                (str(segment_id), "id", 1),
+            )
+            metadata_segment._insert_metadata(cur, 1, {"chroma:document": document})
+
+        with db.tx() as cur:
+            # The FTS5 index must remain intact (the core of #7388).
+            integrity = cur.execute("PRAGMA quick_check").fetchone()
+            assert integrity[0] == "ok"
+
+            # The document must be present in the FTS table without NUL bytes.
+            row = cur.execute(
+                "SELECT string_value FROM embedding_fulltext_search "
+                "WHERE rowid = ?",
+                (1,),
+            ).fetchone()
+            assert row is not None
+            assert "\x00" not in row[0]
+    finally:
+        system.stop()
+
+
+def test_nul_replaced_with_space_preserves_tokenization() -> None:
+    """Pin the decision to replace NUL with a space, not the empty string.
+
+    gh#7388's large-NUL payload has spaces on both sides of the NUL run, so it
+    cannot tell a space replacement from an empty-string replacement apart. A
+    single ``\\x00`` between two tokens can: replacing with a space keeps
+    ``prefix`` and ``suffix`` independently searchable, whereas the empty string
+    would collapse them into ``prefixsuffix`` (matching neither half).
+    """
+    system = System(
+        Settings(
+            chroma_api_impl="chromadb.api.segment.SegmentAPI",
+            chroma_sysdb_impl="chromadb.db.impl.sqlite.SqliteDB",
+            chroma_producer_impl="chromadb.db.impl.sqlite.SqliteDB",
+            chroma_consumer_impl="chromadb.db.impl.sqlite.SqliteDB",
+            is_persistent=False,
+            allow_reset=True,
+        )
+    )
+    system.start()
+
+    try:
+        db = system.instance(SqliteDB)
+        segment_id = uuid4()
+        metadata_segment = SqliteMetadataSegment(
+            system,
+            {
+                "id": segment_id,
+                "type": "urn:chroma:segment/metadata/sqlite",
+                "scope": "METADATA",
+                "topic": "test",
+                "collection": uuid4(),
+            },
+        )
+
+        with db.tx() as cur:
+            cur.execute(
+                "INSERT INTO embeddings (segment_id, embedding_id, seq_id) "
+                "VALUES (?, ?, ?)",
+                (str(segment_id), "id", 1),
+            )
+            metadata_segment._insert_metadata(
+                cur, 1, {"chroma:document": "prefix\x00suffix"}
+            )
+
+        with db.tx() as cur:
+            # Both halves must remain independently searchable after the NUL is
+            # replaced with a space ("prefix suffix" still matches "prefix").
+            hits = cur.execute(
+                "SELECT count(*) FROM embedding_fulltext_search "
+                "WHERE embedding_fulltext_search MATCH ?",
+                ('"prefix"',),
+            ).fetchone()[0]
+            assert hits == 1
+    finally:
+        system.stop()
+


### PR DESCRIPTION
## Summary

Fixes #7388. A large run of embedded NUL bytes in a document corrupts the FTS5 inverted index for the whole collection.

This PR sanitizes `chroma:document` **before** it reaches the FTS5 table, replacing embedded NUL bytes with spaces so that tokenization is preserved (e.g. `"before\x00after"` still matches both `before` and `after`).

## Changes

- `chromadb/segment/impl/metadata/sqlite.py`: sanitize `chroma:document` in `insert_into_fulltext_search` before the FTS insert.
  - Scoped strictly to the FTS-derived value. General string metadata is left untouched — SQLite `TEXT` columns store NUL bytes transparently, so stripping them there would silently alter what the user gets back from `get()`.
  - Replaces NUL with a space (not the empty string) so surrounding tokens remain separately searchable.
- `chromadb/test/segment/test_sqlite_metadata.py`: regression test guarding #7388.
  - Uses the actual reporter payload: a ~10 k NUL run (`"before-nuls " + "\x00" * 10291 + " after-nuls"`). A short run does **not** reproduce the corruption, so the test mirrors the real trigger.
  - Asserts `PRAGMA quick_check` is clean and that no NUL bytes reach the FTS table.

## Addressing review feedback

- Removed the earlier blanket stripping in the `for key, value in metadata.items()` loop (writing to `embedding_metadata`); that would have silently shortened user metadata values. Only `chroma:document` (which reaches FTS5) is now sanitized.
- Switched the replacement from `""` to `" "` so `"prefix\x00suffix"` still matches both `prefix` and `suffix` rather than neither.
- Made the test actually guard the reported corruption by using the large NUL run + `PRAGMA quick_check`.

## Test Plan

```
python -m pytest chromadb/test/segment/test_sqlite_metadata.py -v
```
