### PR TITLE
[FIX](segment): Correct int/float bound comparison in metadata filters

### DIFF
--- a/rust/segment/src/sqlite_metadata.rs
+++ b/rust/segment/src/sqlite_metadata.rs
@@ -562,18 +562,28 @@ impl IntoSqliteExpr for Where {
                         }
                     }
                     MetadataComparison::Set(op, MetadataSetValue::Float(fs)) => {
-                        let alt = MetadataExpression {
-                            key: expr.key.clone(),
-                            comparison: MetadataComparison::Set(
-                                op.clone(),
-                                MetadataSetValue::Int(
-                                    fs.iter().cloned().map(|f| f as i64).collect(),
+                        // A non-integral float bound (e.g. 2.5) can never match
+                        // an integer-stored value, so only keep integral floats
+                        // (e.g. 2.0) in the int-side alternation.
+                        let integral_ints: Vec<i64> = fs
+                            .iter()
+                            .filter(|f| f.fract() == 0.0)
+                            .map(|f| *f as i64)
+                            .collect();
+                        if integral_ints.is_empty() {
+                            expr.eval()
+                        } else {
+                            let alt = MetadataExpression {
+                                key: expr.key.clone(),
+                                comparison: MetadataComparison::Set(
+                                    op.clone(),
+                                    MetadataSetValue::Int(integral_ints),
                                 ),
-                            ),
-                        };
-                        match op {
-                            SetOperator::In => expr.eval().or(alt.eval()),
-                            SetOperator::NotIn => expr.eval().and(alt.eval()),
+                            };
+                            match op {
+                                SetOperator::In => expr.eval().or(alt.eval()),
+                                SetOperator::NotIn => expr.eval().and(alt.eval()),
+                            }
                         }
                     }
                     // since the metadata expr eval handles the union in case of int and float, we can just pass through
@@ -619,6 +629,37 @@ fn create_union_subquery_for_int_float_ops(
 
     let int_col = Expr::col((EmbeddingMetadata::Table, EmbeddingMetadata::IntValue));
     let float_col = Expr::col((EmbeddingMetadata::Table, EmbeddingMetadata::FloatValue));
+
+    // A non-integral float bound (e.g. 2.5) can never equal an integer-stored
+    // value, so truncating it (2.5 -> 2) would match the wrong rows. Skip the
+    // int column for equality/inequality and round outward for range operators:
+    // `>= 2.5` means `int_col >= 3`, `<= 2.5` means `int_col <= 2`.
+    if matches!(val, MetadataValue::Float(v) if v.fract() != 0.0) {
+        match op {
+            PrimitiveOperator::Equal | PrimitiveOperator::NotEqual => {
+                subq2.and_where(float_col.eq(f));
+                return subq2;
+            }
+            PrimitiveOperator::GreaterThan => {
+                subq1.and_where(int_col.gte(f.ceil() as i64));
+                subq2.and_where(float_col.gt(f));
+            }
+            PrimitiveOperator::GreaterThanOrEqual => {
+                subq1.and_where(int_col.gte(f.ceil() as i64));
+                subq2.and_where(float_col.gte(f));
+            }
+            PrimitiveOperator::LessThan => {
+                subq1.and_where(int_col.lte(f.floor() as i64));
+                subq2.and_where(float_col.lt(f));
+            }
+            PrimitiveOperator::LessThanOrEqual => {
+                subq1.and_where(int_col.lte(f.floor() as i64));
+                subq2.and_where(float_col.lte(f));
+            }
+        }
+        subq1.union(sea_query::UnionType::Distinct, subq2);
+        return subq1;
+    }
 
     match op {
         PrimitiveOperator::Equal => {
@@ -1163,8 +1204,8 @@ mod tests {
         plan::{Count, Get, ReadLevel},
         strategies::{any_collection_data_and_where_filter, TestCollectionData},
         Chunk, CollectionAndSegments, ContainsOperator, DocumentOperator, LogRecord,
-        MetadataComparison, MetadataExpression, MetadataValue, Operation, OperationRecord,
-        PrimitiveOperator, UpdateMetadataValue, Where,
+        MetadataComparison, MetadataExpression, MetadataSetValue, MetadataValue, Operation,
+        OperationRecord, PrimitiveOperator, SetOperator, UpdateMetadataValue, Where,
     };
     use proptest::prelude::*;
     use std::collections::HashMap;
@@ -1411,6 +1452,236 @@ mod tests {
         assert_eq!(ref_get2.result.records.len(), 2);
         assert_eq!(ref_get2.result.records[0].id, "id1");
         assert_eq!(ref_get2.result.records[1].id, "id2");
+    }
+
+    #[tokio::test]
+    async fn test_int_float_mixed_primitive_filters() {
+        // Regression test for the int/float union filter truncating float
+        // bounds against integer-stored values. Metadata: n=2 (int), n=2.5
+        // (float), n=3 (int). A bound of 2.5 must never behave as 2.
+        let mut ref_seg = TestReferenceSegment::default();
+        let sqlite_seg_writer = SqliteMetadataWriter {
+            db: get_new_sqlite_db().await,
+        };
+
+        let mut logs = Vec::new();
+        let mut metadata2 = HashMap::new();
+        metadata2.insert("n".to_string(), UpdateMetadataValue::Int(2));
+        let mut metadata25 = HashMap::new();
+        metadata25.insert("n".to_string(), UpdateMetadataValue::Float(2.5));
+        let mut metadata3 = HashMap::new();
+        metadata3.insert("n".to_string(), UpdateMetadataValue::Int(3));
+
+        for (log_offset, (id, metadata)) in [
+            ("int2", metadata2),
+            ("float2_5", metadata25),
+            ("int3", metadata3),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            logs.push(LogRecord {
+                log_offset: log_offset as i64,
+                record: OperationRecord {
+                    id: id.to_string(),
+                    metadata: Some(metadata),
+                    document: None,
+                    operation: Operation::Add,
+                    embedding: None,
+                    encoding: None,
+                },
+            });
+        }
+
+        let collection_and_segments = CollectionAndSegments::test(3);
+        let metadata_seg_id = collection_and_segments.metadata_segment.id;
+
+        ref_seg.apply_logs(logs.clone(), metadata_seg_id);
+        let mut tx = sqlite_seg_writer
+            .begin()
+            .await
+            .expect("Should be able to start transaction");
+        let data: Chunk<LogRecord> = Chunk::new(logs.into());
+        sqlite_seg_writer
+            .apply_logs(
+                data,
+                metadata_seg_id,
+                collection_and_segments.collection.schema.clone(),
+                &mut *tx,
+            )
+            .await
+            .expect("Should be able to apply logs");
+        tx.commit().await.expect("Should be able to commit log");
+
+        let sqlite_seg_reader = SqliteMetadataReader {
+            db: sqlite_seg_writer.db,
+        };
+
+        // (operator, expected ids) against float bound 2.5
+        let cases: [(PrimitiveOperator, &[&str]); 6] = [
+            (PrimitiveOperator::Equal, &["float2_5"]),
+            (PrimitiveOperator::NotEqual, &["int2", "int3"]),
+            (PrimitiveOperator::GreaterThan, &["int3"]),
+            (PrimitiveOperator::GreaterThanOrEqual, &["float2_5", "int3"]),
+            (PrimitiveOperator::LessThan, &["int2"]),
+            (PrimitiveOperator::LessThanOrEqual, &["float2_5", "int2"]),
+        ];
+
+        for (op, expected) in cases {
+            let where_clause = Where::Metadata(MetadataExpression {
+                key: "n".to_string(),
+                comparison: MetadataComparison::Primitive(op.clone(), MetadataValue::Float(2.5)),
+            });
+            let plan = Get {
+                scan: Scan {
+                    collection_and_segments: collection_and_segments.clone(),
+                    shard_index: 0,
+                    num_shards: 1,
+                    log_upper_bound_offset: 0,
+                },
+                filter: Filter {
+                    query_ids: None,
+                    where_clause: Some(where_clause),
+                },
+                limit: Limit {
+                    offset: 0,
+                    limit: None,
+                },
+                proj: Projection {
+                    document: false,
+                    embedding: false,
+                    metadata: true,
+                },
+            };
+            let ref_get = ref_seg.get(plan.clone()).expect("Get should not fail");
+            let sqlite_get = sqlite_seg_reader
+                .get(plan)
+                .await
+                .expect("Get should not fail");
+            assert_eq!(sqlite_get, ref_get);
+            let mut got: Vec<String> = sqlite_get
+                .result
+                .records
+                .into_iter()
+                .map(|r| r.id)
+                .collect();
+            got.sort();
+            assert_eq!(got, expected, "operator {:?} returned wrong ids", op);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_int_float_mixed_set_filters() {
+        // Same mixed int/float handling for $in / $nin set membership.
+        let mut ref_seg = TestReferenceSegment::default();
+        let sqlite_seg_writer = SqliteMetadataWriter {
+            db: get_new_sqlite_db().await,
+        };
+
+        let mut logs = Vec::new();
+        let mut metadata2 = HashMap::new();
+        metadata2.insert("n".to_string(), UpdateMetadataValue::Int(2));
+        let mut metadata25 = HashMap::new();
+        metadata25.insert("n".to_string(), UpdateMetadataValue::Float(2.5));
+        let mut metadata3 = HashMap::new();
+        metadata3.insert("n".to_string(), UpdateMetadataValue::Int(3));
+
+        for (log_offset, (id, metadata)) in [
+            ("int2", metadata2),
+            ("float2_5", metadata25),
+            ("int3", metadata3),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            logs.push(LogRecord {
+                log_offset: log_offset as i64,
+                record: OperationRecord {
+                    id: id.to_string(),
+                    metadata: Some(metadata),
+                    document: None,
+                    operation: Operation::Add,
+                    embedding: None,
+                    encoding: None,
+                },
+            });
+        }
+
+        let collection_and_segments = CollectionAndSegments::test(3);
+        let metadata_seg_id = collection_and_segments.metadata_segment.id;
+
+        ref_seg.apply_logs(logs.clone(), metadata_seg_id);
+        let mut tx = sqlite_seg_writer
+            .begin()
+            .await
+            .expect("Should be able to start transaction");
+        let data: Chunk<LogRecord> = Chunk::new(logs.into());
+        sqlite_seg_writer
+            .apply_logs(
+                data,
+                metadata_seg_id,
+                collection_and_segments.collection.schema.clone(),
+                &mut *tx,
+            )
+            .await
+            .expect("Should be able to apply logs");
+        tx.commit().await.expect("Should be able to commit log");
+
+        let sqlite_seg_reader = SqliteMetadataReader {
+            db: sqlite_seg_writer.db,
+        };
+
+        // (set values, operator, expected ids)
+        let cases: [(Vec<f64>, SetOperator, &[&str]); 3] = [
+            (vec![2.5], SetOperator::In, &["float2_5"]),
+            (vec![2.5], SetOperator::NotIn, &["int2", "int3"]),
+            (vec![2.0, 2.5], SetOperator::In, &["float2_5", "int2"]),
+        ];
+
+        for (vals, op, expected) in cases {
+            let where_clause = Where::Metadata(MetadataExpression {
+                key: "n".to_string(),
+                comparison: MetadataComparison::Set(
+                    op.clone(),
+                    MetadataSetValue::Float(vals.clone()),
+                ),
+            });
+            let plan = Get {
+                scan: Scan {
+                    collection_and_segments: collection_and_segments.clone(),
+                    shard_index: 0,
+                    num_shards: 1,
+                    log_upper_bound_offset: 0,
+                },
+                filter: Filter {
+                    query_ids: None,
+                    where_clause: Some(where_clause),
+                },
+                limit: Limit {
+                    offset: 0,
+                    limit: None,
+                },
+                proj: Projection {
+                    document: false,
+                    embedding: false,
+                    metadata: true,
+                },
+            };
+            let ref_get = ref_seg.get(plan.clone()).expect("Get should not fail");
+            let sqlite_get = sqlite_seg_reader
+                .get(plan)
+                .await
+                .expect("Get should not fail");
+            assert_eq!(sqlite_get, ref_get);
+            let mut got: Vec<String> = sqlite_get
+                .result
+                .records
+                .into_iter()
+                .map(|r| r.id)
+                .collect();
+            got.sort();
+            assert_eq!(got, expected, "set {:?} {:?} returned wrong ids", vals, op);
+        }
     }
 
     #[tokio::test]

--- a/rust/segment/src/test.rs
+++ b/rust/segment/src/test.rs
@@ -556,50 +556,53 @@ impl CheckRecord for MetadataExpression {
         let stored = record.metadata.as_ref().and_then(|m| m.get(&self.key));
         match &self.comparison {
             MetadataComparison::Primitive(primitive_operator, metadata_value) => {
-                // Convert int to float to make comparisons easier
-                let metadata_value = match metadata_value {
-                    MetadataValue::Int(i) => {
-                        if matches!(stored, Some(MetadataValue::Float(_))) {
-                            MetadataValue::Float(*i as f64)
-                        } else {
-                            metadata_value.clone()
-                        }
+                // Promote numeric comparisons to f64 so that non-integral float
+                // bounds compare correctly against integer-stored values: an int
+                // never equals 2.5, 2 < 2.5, 2 >= 2.5 is false, etc.
+                let numeric_pair = match (stored, metadata_value) {
+                    (Some(MetadataValue::Int(v)), MetadataValue::Int(i)) => {
+                        Some((*v as f64, *i as f64))
                     }
-                    MetadataValue::Float(f) => {
-                        if matches!(stored, Some(MetadataValue::Int(_))) {
-                            MetadataValue::Int(*f as i64)
-                        } else {
-                            metadata_value.clone()
-                        }
-                    }
-                    v => v.clone(),
+                    (Some(MetadataValue::Int(v)), MetadataValue::Float(f)) => Some((*v as f64, *f)),
+                    (Some(MetadataValue::Float(v)), MetadataValue::Int(i)) => Some((*v, *i as f64)),
+                    (Some(MetadataValue::Float(v)), MetadataValue::Float(f)) => Some((*v, *f)),
+                    _ => None,
                 };
+
+                if let Some((stored_f, bound_f)) = numeric_pair {
+                    return match primitive_operator {
+                        PrimitiveOperator::Equal => stored_f == bound_f,
+                        PrimitiveOperator::NotEqual => stored_f != bound_f,
+                        PrimitiveOperator::GreaterThan => stored_f > bound_f,
+                        PrimitiveOperator::GreaterThanOrEqual => stored_f >= bound_f,
+                        PrimitiveOperator::LessThan => stored_f < bound_f,
+                        PrimitiveOperator::LessThanOrEqual => stored_f <= bound_f,
+                    };
+                }
 
                 let match_type = matches!(
                     (&stored, &metadata_value),
                     (Some(MetadataValue::Bool(_)), MetadataValue::Bool(_))
-                        | (Some(MetadataValue::Int(_)), MetadataValue::Int(_))
-                        | (Some(MetadataValue::Float(_)), MetadataValue::Float(_))
                         | (Some(MetadataValue::Str(_)), MetadataValue::Str(_))
                 );
                 match primitive_operator {
                     PrimitiveOperator::Equal => {
-                        match_type && stored.is_some_and(|v| *v == metadata_value)
+                        match_type && stored.is_some_and(|v| *v == *metadata_value)
                     }
                     PrimitiveOperator::NotEqual => {
-                        !match_type || stored.is_some_and(|v| *v != metadata_value)
+                        !match_type || stored.is_some_and(|v| *v != *metadata_value)
                     }
                     PrimitiveOperator::GreaterThan => {
-                        match_type && stored.is_some_and(|v| *v > metadata_value)
+                        match_type && stored.is_some_and(|v| *v > *metadata_value)
                     }
                     PrimitiveOperator::GreaterThanOrEqual => {
-                        match_type && stored.is_some_and(|v| *v >= metadata_value)
+                        match_type && stored.is_some_and(|v| *v >= *metadata_value)
                     }
                     PrimitiveOperator::LessThan => {
-                        match_type && stored.is_some_and(|v| *v < metadata_value)
+                        match_type && stored.is_some_and(|v| *v < *metadata_value)
                     }
                     PrimitiveOperator::LessThanOrEqual => {
-                        match_type && stored.is_some_and(|v| *v <= metadata_value)
+                        match_type && stored.is_some_and(|v| *v <= *metadata_value)
                     }
                 }
             }
@@ -616,6 +619,14 @@ impl CheckRecord for MetadataExpression {
                     }
                     (Some(MetadataValue::Str(val)), MetadataSetValue::Str(vec)) => {
                         vec.contains(val)
+                    }
+                    // Mixed int/float set membership: an int matches an integral
+                    // float element (e.g. int 2 matches float 2.0) and vice versa.
+                    (Some(MetadataValue::Int(val)), MetadataSetValue::Float(vec)) => {
+                        vec.iter().any(|f| *f == *val as f64)
+                    }
+                    (Some(MetadataValue::Float(val)), MetadataSetValue::Int(vec)) => {
+                        vec.iter().any(|i| *val == *i as f64)
                     }
                     _ => false,
                 };


### PR DESCRIPTION
## Why

The sqlite metadata int/float union filter truncated a non-integral float bound (e.g. 2.5 -> 2) before comparing against integer-stored values. Every comparison operator then returned wrong results: $eq 2.5 matched an int 2, $gte 2.5 included 2, $lt 2.5 excluded 2, and $ne 2.5 excluded 2. The same truncation existed in the $in/$nin set path.

## What changed

- create_union_subquery_for_int_float_ops: for a non-integral float bound, skip the int column for equality/inequality (an int can never equal 2.5) and round outward for range operators (>= 2.5 -> int_col >= 3, <= 2.5 -> int_col <= 2).
- Where::eval set path: only integral floats (e.g. 2.0) participate in the int-side alternation.
- Reference segment used by proptests: promote numeric comparisons to f64 so the reference matches the corrected sqlite semantics.

## Validation

- cargo test -p chroma-segment --lib sqlite_metadata: 23 passed, including two new regression tests covering the full operator matrix for primitive and set filters against int/float mixed metadata.

Fixes #7491