### PR TITLE
[FIX](client): Restore TLS verification in async HTTP client

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -138,12 +138,15 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
                 + " (https://github.com/chroma-core/chroma)"
             )
 
-            self._clients[loop_hash] = httpx.AsyncClient(
-                timeout=None,
-                headers=headers,
-                verify=self._settings.chroma_server_ssl_verify or False,
-                limits=self.http_limits,
-            )
+            kwargs = {
+                "timeout": None,
+                "headers": headers,
+                "limits": self.http_limits,
+            }
+            if self._settings.chroma_server_ssl_verify is not None:
+                kwargs["verify"] = self._settings.chroma_server_ssl_verify
+
+            self._clients[loop_hash] = httpx.AsyncClient(**kwargs)
 
         return self._clients[loop_hash]
 

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -6,6 +6,7 @@ from chromadb.config import Settings, System
 from chromadb.api import ClientAPI
 import chromadb.server.fastapi
 from chromadb.api.fastapi import FastAPI
+from chromadb.api.async_fastapi import AsyncFastAPI
 import pytest
 import tempfile
 import os
@@ -197,6 +198,57 @@ def test_fastapi_uses_http_limits_from_settings() -> None:
     assert limits.max_keepalive_connections == 16
     assert captured["timeout"] is None
     assert captured["verify"] is True
+
+
+def make_async_client_factory() -> Tuple[Callable[..., Any], Dict[str, Any]]:
+    captured: Dict[str, Any] = {}
+
+    # takes any positional args to match httpx.AsyncClient
+    def factory(*_: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        mock = MagicMock()
+
+        async def aclose() -> None:
+            pass
+
+        mock.aclose = aclose  # type: ignore[method-assign]
+        return mock
+
+    return factory, captured
+
+
+@pytest.mark.parametrize(
+    "ssl_verify,verify_kwarg_present",
+    [
+        # Default: no verify kwarg, so httpx verifies certificates.
+        (None, False),
+        (True, True),
+        (False, True),
+    ],
+)
+def test_async_fastapi_ssl_verify(
+    ssl_verify: Any, verify_kwarg_present: bool
+) -> None:
+    settings = Settings(
+        chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=9000,
+        chroma_server_ssl_verify=ssl_verify,
+    )
+    system = System(settings)
+
+    factory, captured = make_async_client_factory()
+
+    with patch.object(AsyncFastAPI, "require", return_value=MagicMock()):
+        with patch("chromadb.api.async_fastapi.httpx.AsyncClient", side_effect=factory):
+            api = AsyncFastAPI(system)
+            api._get_client()
+
+    api.stop()
+    assert captured["timeout"] is None
+    assert ("verify" in captured) == verify_kwarg_present
+    if "verify" in captured:
+        assert captured["verify"] == ssl_verify
 
 
 def test_persistent_client_close() -> None:


### PR DESCRIPTION
## Why

The async HTTP client passed `verify=self._settings.chroma_server_ssl_verify or False`. With the default `None`, `None or False` evaluates to `False`, so httpx skipped certificate chain and hostname verification. The sync client only sets `verify` when the setting is not None. This makes the async client behave like the sync client: certificates are verified by default.

## What changed

- async_fastapi.py: only pass the `verify` kwarg to httpx.AsyncClient when `chroma_server_ssl_verify` is explicitly set (True/False or a CA bundle path).
- test_client.py: parametrized test asserting the verify kwarg is absent by default and present (with the correct value) when explicitly configured.

## Validation

- pytest chromadb/test/test_client.py: 18 passed, including the new parametrized test.

Fixes #7511