### PR TITLE
[FIX](api): Reject documents containing NUL bytes

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1453,6 +1453,11 @@ def validate_documents(documents: Documents, nullable: bool = False) -> None:
             continue
         if not is_document(document):
             raise ValueError(f"Expected document to be a str, got {document}")
+        if "\x00" in document:
+            raise ValueError(
+                "Expected document to not contain NUL characters (\\x00). "
+                "Embedded NUL bytes corrupt the full-text search index."
+            )
 
 
 def validate_images(images: Images) -> None:

--- a/chromadb/test/api/test_types.py
+++ b/chromadb/test/api/test_types.py
@@ -1,6 +1,12 @@
 import pytest
 from typing import List, cast, Dict, Any
-from chromadb.api.types import Documents, Image, Document, Embeddings
+from chromadb.api.types import (
+    Documents,
+    Image,
+    Document,
+    Embeddings,
+    validate_documents,
+)
 from chromadb.utils.embedding_functions import (
     EmbeddingFunction,
     register_embedding_function,
@@ -103,3 +109,19 @@ def test_embedding_function_results_format_when_response_is_invalid() -> None:
         from chromadb.api.types import normalize_embeddings
 
         normalize_embeddings(result)
+
+
+def test_validate_documents_rejects_nul_byte() -> None:
+    # Regression test: an embedded NUL byte in a document corrupts the FTS5
+    # inverted index for the whole collection. It must be rejected up front.
+    valid_documents = ["hello world", "another doc"]
+    validate_documents(valid_documents)
+
+    nul_document = "before-nuls " + ("\x00" * 100) + " after-nuls"
+    with pytest.raises(ValueError, match="NUL"):
+        validate_documents([nul_document])
+
+    # A NUL in any document in the batch is rejected, even if others are fine.
+    with pytest.raises(ValueError, match="NUL"):
+        validate_documents([nul_document, "valid"])
+


### PR DESCRIPTION
## Why

A document string containing an embedded NUL byte (U+0000) passed to add/upsert/update corrupts the FTS5 inverted index for the whole collection, not just that document. PRAGMA quick_check then reports a malformed inverted index. This is valid Python input, so nothing rejected it before it reached SQLite/FTS5.

## What changed

- validate_documents: raise a ValueError when any document contains a NUL byte, so a single malformed document cannot poison the full-text index.

## Validation

- New unit test in test_types.py covering a standalone NUL document and a NUL mixed into a larger batch.
- End-to-end: after a rejected NUL write, the collection stays usable and PRAGMA quick_check returns ok.

Fixes #7388