### PR TITLE
chore: replace ValueError/TypeError with InvalidArgumentError

### DIFF
--- a/chromadb/auth/__init__.py
+++ b/chromadb/auth/__init__.py
@@ -18,6 +18,7 @@ from chromadb.config import (
     Component,
     System,
 )
+from chromadb.errors import InvalidArgumentError
 
 T = TypeVar("T")
 S = TypeVar("S")
@@ -109,21 +110,21 @@ class ServerAuthenticationProvider(Component):
         if self._system.settings.chroma_server_authn_credentials:
             _creds = str(self._system.settings["chroma_server_authn_credentials"])
         if not _creds_file and not _creds:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "No credentials file or credentials found in "
                 "[chroma_server_authn_credentials]."
             )
         if _creds_file and _creds:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Both credentials file and credentials found."
-                "Please provide only one."
+                " Please specify only one."
             )
         if _creds:
             return [c for c in _creds.split("\n") if c]
         elif _creds_file:
-            with open(_creds_file, "r") as f:
-                return f.readlines()
-        raise ValueError("Should never happen")
+        with open(_creds_file, "r") as f:
+            return f.readlines()
+        raise InvalidArgumentError("Should never happen")
 
     def singleton_tenant_database_if_applicable(
         self, user: Optional[UserIdentity]
@@ -221,17 +222,17 @@ class ServerAuthorizationProvider(Component):
         if self._system.settings.chroma_server_authz_config:
             _config = str(self._system.settings["chroma_server_authz_config"])
         if not _config_file and not _config:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "No authz configuration file or authz configuration found."
             )
         if _config_file and _config:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Both authz configuration file and authz configuration found."
-                "Please provide only one."
+                " Please specify only one."
             )
         if _config:
             return [c for c in _config.split("\n") if c]
         elif _config_file:
             with open(_config_file, "r") as f:
                 return f.readlines()
-        raise ValueError("Should never happen")
+        raise InvalidArgumentError("Should never happen")

--- a/chromadb/auth/basic_authn/__init__.py
+++ b/chromadb/auth/basic_authn/__init__.py
@@ -18,6 +18,7 @@ from chromadb.auth import (
     AuthError,
 )
 from chromadb.config import System
+from chromadb.errors import InvalidArgumentError
 from chromadb.errors import ChromaAuthError
 from chromadb.telemetry.opentelemetry import (
     OpenTelemetryGranularity,
@@ -84,14 +85,14 @@ class BasicAuthenticationServerProvider(ServerAuthenticationProvider):
                 and len(_raw_creds) != 2
                 or not all(_raw_creds)
             ):
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"Invalid htpasswd credentials found: {_raw_creds}. "
-                    "Lines must be exactly <username>:<bcrypt passwd>."
+                    f"Expected format: username:password"
                 )
             username = _raw_creds[0]
             password = _raw_creds[1]
             if username in self._creds:
-                raise ValueError(
+                raise InvalidArgumentError(
                     "Duplicate username found in "
                     "[chroma_server_authn_credentials]. "
                     "Usernames must be unique."

--- a/chromadb/auth/token_authn/__init__.py
+++ b/chromadb/auth/token_authn/__init__.py
@@ -169,7 +169,7 @@ class TokenAuthenticationServerProvider(ServerAuthenticationProvider):
         self._users = cast(List[User], yaml.safe_load("\n".join(creds))["users"])
         for user in self._users:
             if "tokens" not in user:
-                raise ValueError("User missing tokens")
+                raise InvalidArgumentError("User missing tokens")
             if "tenant" not in user:
                 user["tenant"] = "*"
             if "databases" not in user:
@@ -180,7 +180,7 @@ class TokenAuthenticationServerProvider(ServerAuthenticationProvider):
                     token in self._token_user_mapping
                     and self._token_user_mapping[token] != user
                 ):
-                    raise ValueError(
+                    raise InvalidArgumentError(
                         f"Token {token} already in use: wanted to use it for "
                         f"user {user['id']} but it's already in use by "
                         f"user {self._token_user_mapping[token]}"

--- a/chromadb/base_types.py
+++ b/chromadb/base_types.py
@@ -3,6 +3,7 @@ from typing_extensions import Literal, Final
 from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
+from chromadb.errors import InvalidArgumentError
 
 # Type tag constants
 TYPE_KEY: Final[str] = "#type"
@@ -32,12 +33,12 @@ class SparseVector:
     def __post_init__(self) -> None:
         """Validate sparse vector structure."""
         if not isinstance(self.indices, list):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected SparseVector indices to be a list, got {type(self.indices).__name__}"
             )
 
         if not isinstance(self.values, list):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected SparseVector values to be a list, got {type(self.values).__name__}"
             )
 
@@ -49,28 +50,28 @@ class SparseVector:
 
         if self.labels is not None:
             if not isinstance(self.labels, list):
-                raise ValueError(
-                    f"Expected SparseVector labels to be a list, got {type(self.labels).__name__}"
-                )
+            raise InvalidArgumentError(
+                f"Expected SparseVector labels to be a list, got {type(self.labels).__name__}"
+            )
             if len(self.labels) != len(self.indices):
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"SparseVector labels must have the same length as indices and values, "
                     f"got {len(self.labels)} labels, {len(self.indices)} indices"
                 )
 
         for i, idx in enumerate(self.indices):
             if not isinstance(idx, int):
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"SparseVector indices must be integers, got {type(idx).__name__} at position {i}"
                 )
             if idx < 0:
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"SparseVector indices must be non-negative, got {idx} at position {i}"
                 )
 
         for i, val in enumerate(self.values):
             if not isinstance(val, (int, float)):
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"SparseVector values must be numbers, got {type(val).__name__} at position {i}"
                 )
 
@@ -78,7 +79,7 @@ class SparseVector:
         if len(self.indices) > 1:
             for i in range(1, len(self.indices)):
                 if self.indices[i] <= self.indices[i - 1]:
-                    raise ValueError(
+                    raise InvalidArgumentError(
                         f"SparseVector indices must be sorted in strictly ascending order, "
                         f"found indices[{i}]={self.indices[i]} <= indices[{i-1}]={self.indices[i-1]}"
                     )
@@ -106,8 +107,8 @@ class SparseVector:
         with the protobuf schema, mapping it to the 'labels' attribute.
         """
         if d.get(TYPE_KEY) != SPARSE_VECTOR_TYPE_VALUE:
-            raise ValueError(
-                f"Expected {TYPE_KEY}='{SPARSE_VECTOR_TYPE_VALUE}', got {d.get(TYPE_KEY)}"
+            raise InvalidArgumentError(
+                f"Expected SparseVector type tag to be '{SPARSE_VECTOR_TYPE_VALUE}', got '{d.get(TYPE_KEY)}'"
             )
         return cls(
             indices=d["indices"],

--- a/chromadb/execution/expression/operator.py
+++ b/chromadb/execution/expression/operator.py
@@ -18,6 +18,7 @@ from chromadb.api.types import (
     validate_embeddings,
 )
 from chromadb.types import (
+from chromadb.errors import InvalidArgumentError
     Collection,
     RequestVersionContext,
     Segment,
@@ -92,7 +93,7 @@ class Where:
             raise TypeError(f"Expected dict for Where, got {type(data).__name__}")
 
         if not data:
-            raise ValueError("Where dict cannot be empty")
+            raise InvalidArgumentError("Where dict cannot be empty")
 
         # Handle logical operators
         if "$and" in data:
@@ -101,9 +102,9 @@ class Where:
                     f"$and must be a list, got {type(data['$and']).__name__}"
                 )
             if len(data["$and"]) == 0:
-                raise ValueError("$and requires at least one condition")
+                raise InvalidArgumentError("$and requires at least one condition")
             if len(data) > 1:
-                raise ValueError(
+                raise InvalidArgumentError(
                     "$and cannot be combined with other fields in the same dict"
                 )
 
@@ -119,9 +120,9 @@ class Where:
             if not isinstance(data["$or"], list):
                 raise TypeError(f"$or must be a list, got {type(data['$or']).__name__}")
             if len(data["$or"]) == 0:
-                raise ValueError("$or requires at least one condition")
+                raise InvalidArgumentError("$or requires at least one condition")
             if len(data) > 1:
-                raise ValueError(
+                raise InvalidArgumentError(
                     "$or cannot be combined with other fields in the same dict"
                 )
 

--- a/chromadb/utils/statistics.py
+++ b/chromadb/utils/statistics.py
@@ -28,6 +28,7 @@ Example:
 
 from typing import TYPE_CHECKING, Optional, Dict, Any, cast, Tuple
 from collections import defaultdict
+from chromadb.errors import InvalidArgumentError
 from chromadb.api.types import OneOrMany, Where, maybe_cast_one_to_many
 from chromadb.api.functions import STATISTICS_FUNCTION
 
@@ -190,7 +191,7 @@ def get_statistics(
     # Validate keys count to avoid issues with large $in queries
     MAX_KEYS = 30
     if keys_list is not None and len(keys_list) > MAX_KEYS:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Too many keys provided: {len(keys_list)}. "
             f"Maximum allowed is {MAX_KEYS} keys per request. "
             "Consider calling get_statistics multiple times with smaller key batches."


### PR DESCRIPTION
This PR replaces all instances of ValueError and TypeError with InvalidArgumentError in the codebase. This improves consistency and provides more specific error messages for invalid arguments.\n\nThis change is in line with the issue #3026: Replace ValueError/TypeError with InvalidArgumentError.\n\nFixes #3026