### PR TITLE
Replace unmaintained rust-stemmers with frostem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,6 +1554,7 @@ dependencies = [
  "chroma-types",
  "dotenvy",
  "failsafe",
+ "frostem",
  "futures-util",
  "httpmock",
  "murmur3",
@@ -1561,7 +1562,6 @@ dependencies = [
  "parking_lot",
  "proptest",
  "reqwest 0.13.2",
- "rust-stemmers",
  "serde",
  "serde_json",
  "test-log",
@@ -3837,6 +3837,12 @@ dependencies = [
  "tracing",
  "utoipa",
 ]
+
+[[package]]
+name = "frostem"
+version = "1.20260804.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0ae10cfccbae085dd8612669ccc116fe88bd5dfe39d202a8fa68c24c1e546f"
 
 [[package]]
 name = "fs4"
@@ -7193,7 +7199,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",

--- a/rust/chroma/Cargo.toml
+++ b/rust/chroma/Cargo.toml
@@ -14,7 +14,7 @@ murmur3.workspace = true
 opentelemetry = { version = ">=0.27,<0.32", optional = true }
 parking_lot.workspace = true
 reqwest = { version = ">=0.13.0,<0.14.0", features = ["json", "charset", "system-proxy", "http2", "query"], default-features = false }
-rust-stemmers = "1.2"
+frostem = { version = "1.20260804.0", default-features = false, features = ["english"] }
 serde.workspace = true
 serde_json.workspace = true
 tokio = { version = ">=1,<2", features = ["sync"] }

--- a/rust/chroma/src/embed/bm25_tokenizer.rs
+++ b/rust/chroma/src/embed/bm25_tokenizer.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
-use rust_stemmers::{Algorithm, Stemmer};
+use frostem::{Algorithm, Stemmer};
 
 use crate::embed::Tokenizer;
 
@@ -217,7 +217,7 @@ pub struct Bm25Tokenizer {
 impl Default for Bm25Tokenizer {
     fn default() -> Self {
         Self {
-            stemmer: Stemmer::create(Algorithm::English),
+            stemmer: Stemmer::new(Algorithm::English),
             stopwords: DEFAULT_ENGLISH_STOPWORDS.clone(),
             token_max_length: 40,
         }


### PR DESCRIPTION
## Why

`rust-stemmers` is effectively unmaintained: it still ships old Snowball algorithms and does not track upstream ([CurrySoftware/rust-stemmers#27](https://github.com/CurrySoftware/rust-stemmers/issues/27)). Staying on that crate means this project inherits known stemmer bugs and cannot pick up algorithm fixes without a manual dependency swap.

A concrete example is the Greek multibyte-suffix panic fixed in [lance-format/lance#8183](https://github.com/lance-format/lance/pull/8183): `rust-stemmers` 1.2.0 can keep stale UTF-8 byte offsets after shortening a Greek word and then panic while slicing. Current upstream Snowball (and therefore current generated stemmers) handle that input correctly.

## Change

Switch BM25 tokenizer stemming from `rust-stemmers` to [`frostem`](https://github.com/Xuanwo/frostem).

`frostem` is a pre-built Snowball facade that:

- **Automatically tracks upstream** [`snowballstem/snowball`](https://github.com/snowballstem/snowball) `main`
- **Automatically regenerates and publishes** the latest algorithm sources (no Snowball compiler at consumer build time)
- Keeps a small, stable Rust API (`Algorithm` / `Stemmer`) close to what Chroma already uses

Only the English algorithm is enabled (the only language Chroma's BM25 tokenizer uses).

Same dependency swap as [quickwit-oss/tantivy#3028](https://github.com/quickwit-oss/tantivy/pull/3028).
