### PR TITLE
fix: respect settings.persist_directory when path not explicitly passed to PersistentClient

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -199,7 +199,7 @@ def EphemeralClient(
 
 
 def PersistentClient(
-    path: Union[str, Path] = "./chroma",
+    path: Union[str, Path, None] = None,
     settings: Optional[Settings] = None,
     tenant: str = DEFAULT_TENANT,
     database: str = DEFAULT_DATABASE,
@@ -210,7 +210,8 @@ def PersistentClient(
     prefer a server-backed Chroma instance.
 
     Args:
-        path: Directory to store persisted data.
+        path: Directory to store persisted data. If None, uses settings.persist_directory
+            if configured, otherwise defaults to "./chroma".
         settings: Optional settings to override defaults.
         tenant: Tenant name to use for requests.
         database: Database name to use for requests.
@@ -220,7 +221,10 @@ def PersistentClient(
     """
     if settings is None:
         settings = Settings()
-    settings.persist_directory = str(path)
+    if path is not None:
+        settings.persist_directory = str(path)
+    elif settings.persist_directory is None:
+        settings.persist_directory = "./chroma"
     settings.is_persistent = True
 
     # Make sure paramaters are the correct types -- users can pass anything.

--- a/chromadb/api/configuration.py
+++ b/chromadb/api/configuration.py
@@ -231,25 +231,25 @@ class HNSWConfigurationInternal(ConfigurationInternal):
         ),
         "ef_construction": ConfigurationDefinition(
             name="ef_construction",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int) and not isinstance(value, bool) and value >= 1,
             is_static=True,
             default_value=100,
         ),
         "ef_search": ConfigurationDefinition(
             name="ef_search",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int) and not isinstance(value, bool) and value >= 1,
             is_static=False,
             default_value=100,
         ),
         "num_threads": ConfigurationDefinition(
             name="num_threads",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int) and not isinstance(value, bool) and value >= 1,
             is_static=False,
             default_value=cpu_count(),  # By default use all cores available
         ),
         "M": ConfigurationDefinition(
             name="M",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int) and not isinstance(value, bool) and value >= 1,
             is_static=True,
             default_value=16,
         ),
@@ -261,13 +261,13 @@ class HNSWConfigurationInternal(ConfigurationInternal):
         ),
         "batch_size": ConfigurationDefinition(
             name="batch_size",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int) and not isinstance(value, bool) and value >= 1,
             is_static=True,
             default_value=100,
         ),
         "sync_threshold": ConfigurationDefinition(
             name="sync_threshold",
-            validator=lambda value: isinstance(value, int) and value >= 1,
+            validator=lambda value: isinstance(value, int) and not isinstance(value, bool) and value >= 1,
             is_static=True,
             default_value=1000,
         ),

--- a/chromadb/cli/cli.py
+++ b/chromadb/cli/cli.py
@@ -47,7 +47,7 @@ def update():
 
 def app():
     args = sys.argv
-    if ["chroma", "update"] in args:
+    if args[1:2] == ["update"]:
         update()
         return
     try:


### PR DESCRIPTION
## Summary

Three bug fixes for ChromaDB.

### Fix 1: PersistentClient respects settings.persist_directory (#7277)
`PersistentClient(settings=Settings(persist_directory="/custom"))` silently ignored the configured directory. Changed `path` default to `None` with priority: explicit path > settings > default "./chroma".

### Fix 2: CLI update subcommand unreachable (#7286)
`["chroma", "update"] in args` checks for a list element in a list of strings — always False. Changed to `args[1:2] == ["update"]`.

### Fix 3: HNSW validators accept bool values (#7290)
`isinstance(True, int)` returns True in Python, so HNSW params like `ef_construction=True` pass validation. Added `not isinstance(value, bool)` guards to 6 int/float validators in `HNSWConfigurationInternal`.