### PR TITLE
docs: fix broken docs link in pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -23,4 +23,4 @@ _What is the plan to instrument and monitor this change?_
 
 ## Documentation Changes
 
-_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
+_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/mintlify)?_


### PR DESCRIPTION
## What

The pull request template links to the docs section at `docs/docs.trychroma.com`, but the documentation was migrated to Mintlify and now lives under `docs/mintlify` (see `docs/mintlify/docs.json` and `docs/mintlify/README.md`). The current link 404s.

```diff
- [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)
+ [docs section](https://github.com/chroma-core/chroma/tree/main/docs/mintlify)
```

Since this link is in the PR template, every contributor sees it. Docs-only change.