### PR TITLE
[BUG](sysdb): Make concurrent AttachFunction idempotent by field match

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -2316,6 +2316,208 @@ func (suite *APIsTestSuite) TestDeleteOutputCollectionDeletesAttachedFunction() 
 	suite.Equal(int64(1), count)
 }
 
+// TestConcurrentAttachFunction_IdempotentSuccess covers CHR-527: two callers
+// race AttachFunction with freshly minted ids. Both must succeed and share one
+// attached-function id — the loser must not get AlreadyExists.
+func (suite *APIsTestSuite) TestConcurrentAttachFunction_IdempotentSuccess() {
+	ctx := context.Background()
+
+	inputCollectionID := types.NewUniqueID()
+	_, _, err := suite.coordinator.CreateCollection(ctx, &model.CreateCollection{
+		ID:           inputCollectionID,
+		Name:         "concurrent_attach_input",
+		TenantID:     suite.tenantName,
+		DatabaseName: suite.databaseName,
+	})
+	suite.NoError(err)
+
+	const n = 8
+	type result struct {
+		resp *coordinatorpb.AttachFunctionResponse
+		err  error
+	}
+	results := make([]result, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i].resp, results[i].err = suite.coordinator.AttachFunction(ctx, &coordinatorpb.AttachFunctionRequest{
+				Name:                    "concurrent_attach_fn",
+				InputCollectionId:       inputCollectionID.String(),
+				OutputCollectionName:    "concurrent_attach_output",
+				FunctionName:            dbmodel.FunctionNameRecordCounter,
+				TenantId:                suite.tenantName,
+				Database:                suite.databaseName,
+				MinRecordsForInvocation: 100,
+				Params:                  &structpb.Struct{Fields: map[string]*structpb.Value{}},
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	var sharedID string
+	for i, r := range results {
+		suite.NoError(r.err, "caller %d", i)
+		suite.NotNil(r.resp, "caller %d", i)
+		suite.NotEmpty(r.resp.AttachedFunction.Id, "caller %d", i)
+		if sharedID == "" {
+			sharedID = r.resp.AttachedFunction.Id
+		} else {
+			suite.Equal(sharedID, r.resp.AttachedFunction.Id, "caller %d", i)
+		}
+	}
+
+	var count int64
+	suite.db.Model(&dbmodel.AttachedFunction{}).
+		Where("input_collection_id = ? AND is_deleted = ?", inputCollectionID.String(), false).
+		Count(&count)
+	suite.Equal(int64(1), count)
+}
+
+// TestSequentialAddAttachedFunctionInput_BothInputsPresent asserts that two
+// different per-user input collections both end up wired to the same async
+// attached function — the silent half of the /init race when attach fails
+// before add-input.
+func (suite *APIsTestSuite) TestSequentialAddAttachedFunctionInput_BothInputsPresent() {
+	ctx := context.Background()
+
+	baseInputID := types.NewUniqueID()
+	userAInputID := types.NewUniqueID()
+	userBInputID := types.NewUniqueID()
+	for _, collection := range []struct {
+		id   types.UniqueID
+		name string
+	}{
+		{baseInputID, "sequential_add_input_base"},
+		{userAInputID, "sequential_add_input_user_a"},
+		{userBInputID, "sequential_add_input_user_b"},
+	} {
+		_, _, err := suite.coordinator.CreateCollection(ctx, &model.CreateCollection{
+			ID:           collection.id,
+			Name:         collection.name,
+			TenantID:     suite.tenantName,
+			DatabaseName: suite.databaseName,
+		})
+		suite.NoError(err)
+	}
+
+	attachRes, err := suite.coordinator.AttachFunction(ctx, &coordinatorpb.AttachFunctionRequest{
+		Name:                    "sequential_add_fn",
+		InputCollectionId:       baseInputID.String(),
+		OutputCollectionName:    "sequential_add_output",
+		FunctionName:            dbmodel.FunctionNameDummyAsync,
+		TenantId:                suite.tenantName,
+		Database:                suite.databaseName,
+		MinRecordsForInvocation: 100,
+		Params:                  &structpb.Struct{Fields: map[string]*structpb.Value{}},
+	})
+	suite.NoError(err)
+	attachedFunctionID := attachRes.AttachedFunction.Id
+
+	for _, inputID := range []types.UniqueID{userAInputID, userBInputID} {
+		resp, err := suite.coordinator.AddAttachedFunctionInput(ctx, &coordinatorpb.AddAttachedFunctionInputRequest{
+			AttachedFunctionId: attachedFunctionID,
+			InputCollectionId:  inputID.String(),
+		})
+		suite.NoError(err)
+		suite.True(resp.Created)
+		suite.Equal(attachedFunctionID, resp.AttachedFunction.Id)
+	}
+
+	var inputCollectionIDs []string
+	err = suite.db.Model(&dbmodel.AttachedFunction{}).
+		Where("id = ? AND is_deleted = ?", attachedFunctionID, false).
+		Pluck("input_collection_id", &inputCollectionIDs).Error
+	suite.NoError(err)
+	suite.ElementsMatch(
+		[]string{baseInputID.String(), userAInputID.String(), userBInputID.String()},
+		inputCollectionIDs,
+	)
+}
+
+// TestConcurrentAddAttachedFunctionInput_DifferentCollections pins the
+// property that concurrent add-input for distinct per-user collections both
+// succeed — already true today, and must stay true after the attach race fix.
+func (suite *APIsTestSuite) TestConcurrentAddAttachedFunctionInput_DifferentCollections() {
+	ctx := context.Background()
+
+	baseInputID := types.NewUniqueID()
+	userAInputID := types.NewUniqueID()
+	userBInputID := types.NewUniqueID()
+	for _, collection := range []struct {
+		id   types.UniqueID
+		name string
+	}{
+		{baseInputID, "concurrent_add_input_base"},
+		{userAInputID, "concurrent_add_input_user_a"},
+		{userBInputID, "concurrent_add_input_user_b"},
+	} {
+		_, _, err := suite.coordinator.CreateCollection(ctx, &model.CreateCollection{
+			ID:           collection.id,
+			Name:         collection.name,
+			TenantID:     suite.tenantName,
+			DatabaseName: suite.databaseName,
+		})
+		suite.NoError(err)
+	}
+
+	attachRes, err := suite.coordinator.AttachFunction(ctx, &coordinatorpb.AttachFunctionRequest{
+		Name:                    "concurrent_add_fn",
+		InputCollectionId:       baseInputID.String(),
+		OutputCollectionName:    "concurrent_add_output",
+		FunctionName:            dbmodel.FunctionNameDummyAsync,
+		TenantId:                suite.tenantName,
+		Database:                suite.databaseName,
+		MinRecordsForInvocation: 100,
+		Params:                  &structpb.Struct{Fields: map[string]*structpb.Value{}},
+	})
+	suite.NoError(err)
+	attachedFunctionID := attachRes.AttachedFunction.Id
+
+	inputs := []types.UniqueID{userAInputID, userBInputID}
+	type result struct {
+		resp *coordinatorpb.AddAttachedFunctionInputResponse
+		err  error
+	}
+	results := make([]result, len(inputs))
+	var wg sync.WaitGroup
+	wg.Add(len(inputs))
+	start := make(chan struct{})
+	for i, inputID := range inputs {
+		go func(i int, inputID types.UniqueID) {
+			defer wg.Done()
+			<-start
+			results[i].resp, results[i].err = suite.coordinator.AddAttachedFunctionInput(ctx, &coordinatorpb.AddAttachedFunctionInputRequest{
+				AttachedFunctionId: attachedFunctionID,
+				InputCollectionId:  inputID.String(),
+			})
+		}(i, inputID)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, r := range results {
+		suite.NoError(r.err, "caller %d", i)
+		suite.NotNil(r.resp, "caller %d", i)
+		suite.True(r.resp.Created, "caller %d", i)
+		suite.Equal(attachedFunctionID, r.resp.AttachedFunction.Id, "caller %d", i)
+	}
+
+	var inputCollectionIDs []string
+	err = suite.db.Model(&dbmodel.AttachedFunction{}).
+		Where("id = ? AND is_deleted = ?", attachedFunctionID, false).
+		Pluck("input_collection_id", &inputCollectionIDs).Error
+	suite.NoError(err)
+	suite.ElementsMatch(
+		[]string{baseInputID.String(), userAInputID.String(), userBInputID.String()},
+		inputCollectionIDs,
+	)
+}
+
 func TestAPIsTestSuite(t *testing.T) {
 	testSuite := new(APIsTestSuite)
 	suite.Run(t, testSuite)

--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -486,11 +486,12 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_AllowsAsyncAndSyncFunct
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
 		Return([]*dbmodel.AttachedFunction{existingAsyncAttachedFunction}, nil).Twice()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(4)
+	// GetByName + pre-lock GetByIDs + post-lock GetByIDs + insert GetByID + insert GetByIDs
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(5)
 	suite.mockFunctionDb.On("GetByName", "record_counter").
 		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
 	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{existingAsyncFunctionID}).
-		Return([]*dbmodel.Function{{ID: existingAsyncFunctionID, Name: "dummy_async", IsAsync: true}}, nil).Twice()
+		Return([]*dbmodel.Function{{ID: existingAsyncFunctionID, Name: "dummy_async", IsAsync: true}}, nil).Times(3)
 	suite.mockFunctionDb.On("GetByID", newSyncFunctionID).
 		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
 
@@ -943,6 +944,99 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_NotReadySameModeBlocksD
 	suite.mockMetaDomain.AssertExpectations(suite.T())
 	suite.mockAttachedFunctionDb.AssertExpectations(suite.T())
 	suite.mockFunctionDb.AssertExpectations(suite.T())
+}
+
+func (suite *AttachFunctionTestSuite) TestAttachFunction_PostLockRaceReturnsExistingId() {
+	ctx := context.Background()
+
+	// Simulates CHR-527: both callers passed the pre-lock empty check; the
+	// winner inserted under the graph lock; the loser re-reads and must treat
+	// the winner's row as an idempotent success even though the ids differ.
+	existingAttachedFunctionID := uuid.New()
+	attachedFunctionName := "foundation_sources_to_wiki"
+	inputCollectionID := "input-collection-id"
+	outputCollectionName := "wiki"
+	functionName := "record_counter"
+	tenantID := "test-tenant"
+	databaseName := "test-database"
+	databaseID := "database-uuid"
+	functionID := dbmodel.FunctionRecordCounter
+	minRecordsForInvocation := uint64(100)
+	now := time.Now()
+
+	request := &coordinatorpb.AttachFunctionRequest{
+		Name:                    attachedFunctionName,
+		InputCollectionId:       inputCollectionID,
+		OutputCollectionName:    outputCollectionName,
+		FunctionName:            functionName,
+		TenantId:                tenantID,
+		Database:                databaseName,
+		MinRecordsForInvocation: minRecordsForInvocation,
+	}
+
+	existingAttachedFunction := &dbmodel.AttachedFunction{
+		ID:                      existingAttachedFunctionID,
+		Name:                    attachedFunctionName,
+		TenantID:                tenantID,
+		DatabaseID:              databaseID,
+		InputCollectionID:       inputCollectionID,
+		OutputCollectionName:    outputCollectionName,
+		FunctionID:              functionID,
+		MinRecordsForInvocation: int64(minRecordsForInvocation),
+		IsReady:                 true,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(2)
+	suite.mockFunctionDb.On("GetByName", functionName).
+		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
+	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{functionID}).
+		Return([]*dbmodel.Function{{ID: functionID, Name: functionName, IsAsync: false}}, nil).Once()
+
+	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Twice()
+	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
+		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Twice()
+
+	suite.mockMetaDomain.On("CollectionDb", mock.Anything).Return(suite.mockCollectionDb).Maybe()
+	suite.mockCollectionDb.On("GetCollections",
+		[]string{inputCollectionID}, (*string)(nil), tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
+		Return([]*dbmodel.CollectionAndMetadata{{Collection: &dbmodel.Collection{ID: inputCollectionID}}}, nil).Once()
+	suite.mockCollectionDb.On("GetCollections",
+		[]string(nil), matchStringPtr(outputCollectionName), tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
+		Return([]*dbmodel.CollectionAndMetadata{}, nil).Once()
+	suite.mockCollectionDb.On("LockCollection", mock.AnythingOfType("string")).Return((*bool)(nil), nil).Maybe()
+
+	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Maybe()
+	// Pre-lock: empty (both racers saw this). Post-lock: winner's row.
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
+		Return([]*dbmodel.AttachedFunction{}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
+		Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
+	// Graph materialization looks for upstream writers of the input collection.
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), (*string)(nil), matchStringPtr(inputCollectionID), []uuid.UUID(nil), false).
+		Return([]*dbmodel.AttachedFunction{}, nil).Twice()
+
+	suite.mockTxImpl.On("Transaction", ctx, mock.AnythingOfType("func(context.Context) error")).
+		Run(func(args mock.Arguments) {
+			txFunc := args.Get(1).(func(context.Context) error)
+			err := txFunc(context.Background())
+			suite.NoError(err)
+		}).Return(nil).Once()
+
+	response, err := suite.coordinator.AttachFunction(ctx, request)
+
+	suite.NoError(err)
+	suite.NotNil(response)
+	suite.Equal(existingAttachedFunctionID.String(), response.AttachedFunction.Id)
+	suite.False(response.Created)
+	suite.mockAttachedFunctionDb.AssertNotCalled(suite.T(), "Insert")
+
+	suite.mockMetaDomain.AssertExpectations(suite.T())
+	suite.mockAttachedFunctionDb.AssertExpectations(suite.T())
+	suite.mockFunctionDb.AssertExpectations(suite.T())
+	suite.mockDatabaseDb.AssertExpectations(suite.T())
+	suite.mockTxImpl.AssertExpectations(suite.T())
 }
 
 func TestAttachFunctionTestSuite(t *testing.T) {

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -405,6 +405,19 @@ type attachedFunctionInsertSpec struct {
 	MinRecordsForInvocation int64
 }
 
+// attachedFunctionMatchesInsertSpec reports whether an existing row is the same
+// attach request as spec, ignoring attached-function id. Callers mint a fresh id
+// on every AttachFunction; under a race the winner's row must still count as a
+// match for the loser so the attach stays idempotent.
+func attachedFunctionMatchesInsertSpec(attachedFunction *dbmodel.AttachedFunction, spec attachedFunctionInsertSpec) bool {
+	return attachedFunction.Name == spec.Name &&
+		attachedFunction.TenantID == spec.TenantID &&
+		attachedFunction.DatabaseID == spec.DatabaseID &&
+		attachedFunction.OutputCollectionName == spec.OutputCollectionName &&
+		attachedFunction.FunctionID == spec.FunctionID &&
+		attachedFunction.MinRecordsForInvocation == spec.MinRecordsForInvocation
+}
+
 // attached functions are stored per input collection, so async functions with
 // multiple inputs can produce several rows that reference the same function ID.
 func uniqueFunctionIDs(attachedFunctions []*dbmodel.AttachedFunction) []uuid.UUID {
@@ -441,44 +454,51 @@ func (s *Coordinator) loadFunctionsForAttachedFunctions(ctx context.Context, att
 // lock for spec.InputCollectionID. AttachFunction takes that lock as part of the
 // full graph lock, while AddAttachedFunctionInput locks the new input collection
 // directly before calling this helper.
+//
+// Returns (created, attachedFunctionID, err). When an existing row matches the
+// request by fields (not only by id), attachedFunctionID is the existing row's
+// id and created is false — the same contract a serial repeat call gets.
 func (s *Coordinator) insertAttachedFunctionForInputCollection(
 	ctx context.Context,
 	spec attachedFunctionInsertSpec,
 	existingAttachedFunctions []*dbmodel.AttachedFunction,
-) (bool, error) {
+) (bool, uuid.UUID, error) {
 	if existingAttachedFunctions == nil {
 		var err error
 		existingAttachedFunctions, err = s.catalog.metaDomain.AttachedFunctionDb(ctx).GetAttachedFunctions(nil, nil, &spec.InputCollectionID, nil, nil, false)
 		if err != nil {
-			return false, err
+			return false, uuid.Nil, err
 		}
 	}
 
 	requestedFunction, err := s.catalog.metaDomain.FunctionDb(ctx).GetByID(spec.FunctionID)
 	if err != nil {
-		return false, err
+		return false, uuid.Nil, err
 	}
 	if requestedFunction == nil {
-		return false, common.ErrFunctionNotFound
+		return false, uuid.Nil, common.ErrFunctionNotFound
 	}
 
 	existingFunctionsByID, err := s.loadFunctionsForAttachedFunctions(ctx, existingAttachedFunctions)
 	if err != nil {
-		return false, err
+		return false, uuid.Nil, err
 	}
 
 	for _, attachedFunction := range existingAttachedFunctions {
-		if attachedFunction.ID == spec.AttachedFunctionID {
-			return !attachedFunction.IsReady, nil
+		// Match by request fields, not only by id. Concurrent AttachFunction
+		// callers each mint a fresh id; the loser must still treat the winner's
+		// row as an idempotent success rather than an execution-mode conflict.
+		if attachedFunctionMatchesInsertSpec(attachedFunction, spec) {
+			return !attachedFunction.IsReady, attachedFunction.ID, nil
 		}
 
 		existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
 		if !ok {
-			return false, common.ErrFunctionNotFound
+			return false, uuid.Nil, common.ErrFunctionNotFound
 		}
 
 		if existingFunction.IsAsync == requestedFunction.IsAsync {
-			return false, status.Errorf(codes.AlreadyExists,
+			return false, uuid.Nil, status.Errorf(codes.AlreadyExists,
 				"collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s",
 				attachedFunction.Name,
 				existingFunction.Name,
@@ -496,10 +516,10 @@ func (s *Coordinator) insertAttachedFunctionForInputCollection(
 		false,
 	)
 	if err != nil {
-		return false, err
+		return false, uuid.Nil, err
 	}
 	if len(collections) == 0 {
-		return false, common.ErrCollectionNotFound
+		return false, uuid.Nil, common.ErrCollectionNotFound
 	}
 
 	now := time.Now()
@@ -524,10 +544,10 @@ func (s *Coordinator) insertAttachedFunctionForInputCollection(
 	}
 
 	if err := s.catalog.metaDomain.AttachedFunctionDb(ctx).Insert(attachedFunction); err != nil {
-		return false, err
+		return false, uuid.Nil, err
 	}
 
-	return true, nil
+	return true, spec.AttachedFunctionID, nil
 }
 
 // AttachFunction creates an output collection and attached function in a single transaction
@@ -663,6 +683,46 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 			log.Error("AttachFunction: failed to check for existing attached function under graph lock", zap.Error(err))
 			return err
 		}
+		existingFunctionsByID, err = s.loadFunctionsForAttachedFunctions(txCtx, existingAttachedFunctions)
+		if err != nil {
+			log.Error("AttachFunction: failed to load existing functions for input collection validation under graph lock", zap.Error(err))
+			return err
+		}
+
+		// Re-run the full field-by-field comparison under the lock. Concurrent
+		// callers mint different attached-function ids, so an id-only check
+		// would miss the winner's row and fall through to AlreadyExists.
+		for _, attachedFunction := range existingAttachedFunctions {
+			matches, err := s.validateAttachedFunctionMatchesRequest(txCtx, attachedFunction, req)
+			if err != nil {
+				return err
+			}
+			if matches {
+				attachedFunctionID = attachedFunction.ID
+				created = !attachedFunction.IsReady
+				return nil
+			}
+
+			existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
+			if !ok {
+				log.Error("AttachFunction: unknown function ID on existing attached function under graph lock",
+					zap.Stringer("function_id", attachedFunction.FunctionID))
+				return common.ErrFunctionNotFound
+			}
+			if existingFunction.IsAsync == function.IsAsync {
+				log.Error("AttachFunction: collection already has an attached function with the same execution mode under graph lock",
+					zap.String("name", attachedFunction.Name),
+					zap.String("existing_function", existingFunction.Name),
+					zap.String("requested_function", function.Name),
+					zap.Bool("is_async", function.IsAsync),
+					zap.Bool("is_ready", attachedFunction.IsReady))
+				return status.Errorf(codes.AlreadyExists,
+					"collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s",
+					attachedFunction.Name,
+					existingFunction.Name,
+					attachedFunction.OutputCollectionName)
+			}
+		}
 
 		// Validate that the input collection can accept another upstream edge.
 		inputCollectionIDStr := req.InputCollectionId
@@ -753,7 +813,7 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 			paramsJSON = "{}"
 		}
 
-		created, err = s.insertAttachedFunctionForInputCollection(txCtx, attachedFunctionInsertSpec{
+		created, attachedFunctionID, err = s.insertAttachedFunctionForInputCollection(txCtx, attachedFunctionInsertSpec{
 			AttachedFunctionID:      attachedFunctionID,
 			Name:                    req.Name,
 			TenantID:                req.TenantId,
@@ -843,7 +903,7 @@ func (s *Coordinator) AddAttachedFunctionInput(ctx context.Context, req *coordin
 			return err
 		}
 
-		created, err = s.insertAttachedFunctionForInputCollection(txCtx, attachedFunctionInsertSpec{
+		created, attachedFunctionID, err = s.insertAttachedFunctionForInputCollection(txCtx, attachedFunctionInsertSpec{
 			AttachedFunctionID:      attachedFunctionID,
 			Name:                    baseAttachedFunction.Name,
 			TenantID:                baseAttachedFunction.TenantID,


### PR DESCRIPTION
## Summary
- Concurrent `AttachFunction` callers each mint a fresh attached-function id. After taking the graph lock, sysdb only compared ids, so the loser hit `AlreadyExists` instead of an idempotent success (CHR-527 / `/api/init` race).
- Re-run the full field-by-field comparison under the lock (and in `insertAttachedFunctionForInputCollection`) and return the existing id with `created = false` when the request matches.
- Add unit coverage for the post-lock race, plus DB tests for concurrent attach, sequential multi-input wiring, and concurrent add-input.

## Test plan
- [x] `CGO_ENABLED=0 go test ./pkg/sysdb/coordinator/ -run TestAttachFunctionTestSuite`
- [ ] CI: `TestAPIsTestSuite/TestConcurrentAttachFunction_IdempotentSuccess`
- [ ] CI: `TestAPIsTestSuite/TestSequentialAddAttachedFunctionInput_BothInputsPresent`
- [ ] CI: `TestAPIsTestSuite/TestConcurrentAddAttachedFunctionInput_DifferentCollections`

Fixes CHR-527