### PR TITLE
[BUG](api): Import IndexingStatus where annotated

### DIFF
--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -41,6 +41,7 @@ from chromadb.api.types import (
     IncludeMetadataDocuments,
     IncludeMetadataDocumentsDistances,
     IncludeMetadataDocumentsEmbeddings,
+    IndexingStatus,
     ReadLevel,
     Schema,
     SearchResult,

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -58,6 +58,7 @@ from chromadb.api.types import (
     IncludeMetadataDocumentsDistances,
     ConditionalCommitResult,
     DeleteResult,
+    IndexingStatus,
 )
 from chromadb.telemetry.product.events import (
     CollectionAddEvent,

--- a/chromadb/test/api/test_indexing_status.py
+++ b/chromadb/test/api/test_indexing_status.py
@@ -254,3 +254,24 @@ def test_indexing_status_concurrent_progress_variation(client: ClientAPI) -> Non
     )
 
     print(f"Unique progress values: {sorted(progress_values)}")
+
+
+def test_get_indexing_status_return_annotation_resolves() -> None:
+    """Every `_get_indexing_status` implementation must import `IndexingStatus`.
+
+    The return annotation is a string literal, so a missing import goes unnoticed
+    at import time and only surfaces when something resolves type hints -- e.g.
+    `typing.get_type_hints`, which raises `NameError` instead.
+    """
+    from typing import get_type_hints
+
+    from chromadb.api import ServerAPI
+    from chromadb.api.rust import RustBindingsAPI
+    from chromadb.api.segment import SegmentAPI
+
+    for cls in (ServerAPI, RustBindingsAPI, SegmentAPI):
+        hints = get_type_hints(cls._get_indexing_status)
+        assert hints["return"] is IndexingStatus, (
+            f"{cls.__name__}._get_indexing_status has an unresolvable return "
+            f"annotation; is IndexingStatus imported in its module?"
+        )


### PR DESCRIPTION
## Description of changes

`RustBindingsAPI._get_indexing_status` and `SegmentAPI._get_indexing_status` annotate their return type as the string literal `"IndexingStatus"`, but neither module imports that name.

Because the annotation is a string, the missing import is invisible at import time and only surfaces once something resolves type hints:

```python
>>> import typing
>>> from chromadb.api.rust import RustBindingsAPI
>>> typing.get_type_hints(RustBindingsAPI._get_indexing_status)
NameError: name 'IndexingStatus' is not defined
```

Same for `SegmentAPI`. Anything that resolves annotations at runtime hits this — `typing.get_type_hints()`, doc generation, and IDE/tooling that follows annotations.

The abstract declaration in `chromadb/api/__init__.py` resolves fine, but only because that module star-imports `chromadb.api.types`. That is why the gap went unnoticed: `flake8` reports it as `F405` there, but `F821 undefined name` in the two concrete implementations.

- Improvements & Bug fixes
  - Import `IndexingStatus` in `chromadb/api/rust.py` and `chromadb/api/segment.py`
  - Add a regression test resolving the annotation on all three classes
- New functionality
  - None

These were the only two `F821` occurrences in the repo; the count is now zero.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Added `test_get_indexing_status_return_annotation_resolves` to `chromadb/test/api/test_indexing_status.py`. It calls `typing.get_type_hints()` on `ServerAPI`, `RustBindingsAPI`, and `SegmentAPI` and asserts the return annotation resolves to `IndexingStatus`.

The test fails on `main` with `NameError: name 'IndexingStatus' is not defined` and passes with this change. Unlike the rest of that file it is not `@skip_if_not_cluster()`, since it needs no cluster and is a pure import-correctness guard.

`pytest chromadb/test/api/ chromadb/test/test_client.py`:

| | passed | skipped | errors |
|---|---|---|---|
| `main` | 111 | 86 | 375 |
| this branch | 112 | 86 | 375 |

The 375 errors are pre-existing (`fixture 'fastapi' not found`, see #7395) and unrelated to this change. `flake8` and `black` are clean on all three touched files.

## Migration plan

None. Adding a missing import is behaviour-preserving for any code path that was already working, and fixes the ones that were not.

## Observability plan

None needed — no runtime behaviour or instrumentation surface is changed.

## Documentation Changes

None. No user-facing API or docstring changes.
