### PR TITLE
fix: respect settings.persist_directory when path not provided in PersistentClient

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -199,7 +199,7 @@ def EphemeralClient(
 
 
 def PersistentClient(
-    path: Union[str, Path] = "./chroma",
+    path: Optional[Union[str, Path]] = None,
     settings: Optional[Settings] = None,
     tenant: str = DEFAULT_TENANT,
     database: str = DEFAULT_DATABASE,
@@ -220,6 +220,8 @@ def PersistentClient(
     """
     if settings is None:
         settings = Settings()
+    if path is None:
+        path = getattr(settings, "persist_directory", None) or "./chroma"
     settings.persist_directory = str(path)
     settings.is_persistent = True
 

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -220,8 +220,16 @@ def PersistentClient(
     """
     if settings is None:
         settings = Settings()
+    settings_persist_dir = getattr(settings, "persist_directory", None)
     if path is None:
-        path = getattr(settings, "persist_directory", None) or "./chroma"
+        path = settings_persist_dir or "./chroma"
+    elif settings_persist_dir is not None and str(path) != str(settings_persist_dir):
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.warning(
+            "path='%s' overrides settings.persist_directory='%s'",
+            path, settings_persist_dir,
+        )
     settings.persist_directory = str(path)
     settings.is_persistent = True
 


### PR DESCRIPTION
## Problem

PersistentClient(settings=settings) silently ignores settings.persist_directory. Users who configure a custom directory lose data to ./chroma with no warning.

Root cause: path defaults to ./chroma and unconditionally overwrites settings.persist_directory.

## Fix

Changed path default from ./chroma to None, with priority: explicit path > settings.persist_directory > ./chroma fallback.

Fixes #7277