### PR TITLE
[BUG](test): register fastapi fixtures with @pytest.fixture and fix sqlite fixture name (#7395)

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -387,19 +387,22 @@ def _fastapi_fixture(
         yield from run(args)
 
 
+@pytest.fixture(scope="function")
 def fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=False)
+    yield from _fastapi_fixture(is_persistent=False)
 
 
+@pytest.fixture(scope="function")
 def async_fastapi() -> Generator[System, None, None]:
-    return _fastapi_fixture(
+    yield from _fastapi_fixture(
         is_persistent=False,
         chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
     )
 
 
+@pytest.fixture(scope="function")
 def fastapi_persistent() -> Generator[System, None, None]:
-    return _fastapi_fixture(is_persistent=True)
+    yield from _fastapi_fixture(is_persistent=True)
 
 
 def fastapi_ssl() -> Generator[System, None, None]:
@@ -753,7 +756,7 @@ def filtered_fixture_names() -> List[str]:
         "fastapi",
         "async_fastapi",
         "fastapi_persistent",
-        "sqlite_fixture",
+        "sqlite",
         "sqlite_persistent",
     ]
 


### PR DESCRIPTION
Fixes #7395

## Root cause

Three generator functions — `fastapi`, `async_fastapi`, `fastapi_persistent` — were missing the `@pytest.fixture` decorator and used `return` instead of `yield from`. As a result, `request.getfixturevalue()` in the parameterised `system` fixture raised `fixture 'fastapi' not found` for any test that ran without integration-test environment variables set.

Additionally, `filtered_fixture_names()` referenced `"sqlite_fixture"` which does not exist; the correct name is `"sqlite"` (the parameterised fixture that wraps `python_sqlite_ephemeral`).

## What changed

- Added `@pytest.fixture(scope="function")` to `fastapi`, `async_fastapi`, and `fastapi_persistent`
- Changed `return _fastapi_fixture(...)` to `yield from _fastapi_fixture(...)` in all three so pytest can drive teardown
- Changed `"sqlite_fixture"` → `"sqlite"` in `filtered_fixture_names()`

## Test evidence

Before the fix, running `pytest chromadb/test/` locally without any `CHROMA_*` env vars set immediately fails at collection with `fixture 'fastapi' not found`. After the fix, collection succeeds and tests that require a running server are appropriately skipped or configured.

Verified by AST inspection that all three functions now carry the `@pytest.fixture` decorator and use `yield from` (not `return`).

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.