### PR TITLE
[BUG](foundation-api): Reject unknown source collections at init

### DIFF
--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -14,7 +14,13 @@ use chroma_types::{
     Collection, CollectionUuid, DatabaseName, ListAttachedFunctionsError, Metadata, MetadataValue,
     Schema, CHROMA_GROUP_CHUNK_SIBLINGS_KEY, SLACK_RAW_COLLECTION_NAME,
 };
-use frontend_core::{attached_function_ops, foundation::source_kind_for_collection_name};
+use frontend_core::{
+    attached_function_ops,
+    foundation::{
+        foundation_source_for_collection_name, source_kind_for_collection_name,
+        FoundationSourceKindError,
+    },
+};
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -76,6 +82,8 @@ pub async fn foundation_init(
     let foundation_cfg = &server.config.foundation;
     let db_name = DatabaseName::new(&foundation_cfg.database_name)
         .ok_or(FoundationInitError::DatabaseNameTooShort)?;
+    let indexed_sources =
+        indexed_source_descriptors(&foundation_cfg.indexed_source_collections)?;
 
     let mut sysdb = server.sysdb.clone();
     let database_id = ensure_database(&mut sysdb, db_name.clone(), tenant.clone()).await?;
@@ -212,20 +220,23 @@ pub async fn foundation_init(
     // inputs share one async attached function; extras are added via
     // `add_input()` below.
     let mut source_collection_ids = HashMap::new();
-    let mut indexed_source_collections = Vec::new();
-    for source_name in &foundation_cfg.indexed_source_collections {
+    let mut indexed_source_collection_ids = Vec::new();
+    for source_descriptor in indexed_sources {
         let source = ensure_collection(
             &mut sysdb,
             tenant.clone(),
             db_name.clone(),
-            source_name,
+            source_descriptor.collection_name,
             Some(group_chunk_siblings_metadata()),
-            source_dimension(source_name),
+            Some(source_descriptor.dimension),
             CollectionEmbeddingFunctions::default(),
         )
         .await?;
-        indexed_source_collections.push((source_name.clone(), source.collection_id));
-        source_collection_ids.insert(source_name.clone(), source.collection_id.to_string());
+        indexed_source_collection_ids.push(source.collection_id);
+        source_collection_ids.insert(
+            source_descriptor.collection_name.to_string(),
+            source.collection_id.to_string(),
+        );
     }
 
     // `slack_raw` is the attached function's *base* input, in place of the old
@@ -250,7 +261,7 @@ pub async fn foundation_init(
     // Add the indexed sources and the per-user coding-agent traces collection
     // as extra inputs to the same sources->wiki function, so they flow into the
     // shared wiki output alongside slack_raw.
-    for (_, source_collection_id) in &indexed_source_collections {
+    for source_collection_id in &indexed_source_collection_ids {
         attached_function_ops::add_attached_function_input(
             &mut sysdb,
             foundation_attached_function_name(),
@@ -292,18 +303,26 @@ pub async fn foundation_init(
     }))
 }
 
-/// Dense-index dimensionality to pin a source collection to.
-///
-/// Most sources (e.g. notion) carry 1024-dim vectors supplied by the
-/// writer. The Google Drive source instead carries no vectors of its own —
-/// the caller upserts records without embeddings — so it is pinned to a
-/// single dimension (with no embedding function, like currents /
-/// wiki_revisions) to keep the dense index trivially small.
-fn source_dimension(source_name: &str) -> Option<i32> {
-    match source_kind_for_collection_name(source_name) {
-        Ok("google_drive") => Some(1),
-        _ => Some(1024),
-    }
+struct IndexedSourceDescriptor<'a> {
+    collection_name: &'a str,
+    dimension: i32,
+}
+
+/// Validate all configured sources before `/init` makes any provisioning
+/// writes, and retain the source-specific collection settings for creation.
+fn indexed_source_descriptors(
+    source_names: &[String],
+) -> Result<Vec<IndexedSourceDescriptor<'_>>, FoundationSourceKindError> {
+    source_names
+        .iter()
+        .map(|collection_name| {
+            let source = foundation_source_for_collection_name(collection_name)?;
+            Ok(IndexedSourceDescriptor {
+                collection_name,
+                dimension: source.dimension(),
+            })
+        })
+        .collect()
 }
 
 /// Collection metadata that opts a source collection into chunk-sibling
@@ -556,15 +575,62 @@ async fn ensure_collection(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::FoundationApiConfig;
+    use chroma_sysdb::TestSysDb;
+    use chroma_system::System;
+    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]
-    fn gdrive_source_is_single_dimension_others_are_1024() {
-        assert_eq!(source_dimension("gdrive"), Some(1));
-        assert_eq!(source_dimension("gdrive_master"), Some(1));
-        assert_eq!(source_dimension("notion"), Some(1024));
-        // Unknown sources fall back to the default 1024 dims.
-        assert_eq!(source_dimension("unknown_source"), Some(1024));
+    fn init_source_descriptors_match_worker_source_mapping() {
+        let source_names = [
+            "slack_master",
+            "notion_master",
+            "gdrive_master",
+            "google_drive_master",
+            "coding_sessions",
+            "agent_sessions_user",
+            "granola_master",
+        ]
+        .map(str::to_string);
+        let descriptors = indexed_source_descriptors(&source_names).unwrap();
+
+        for descriptor in &descriptors {
+            assert!(source_kind_for_collection_name(descriptor.collection_name).is_ok());
+        }
+        assert_eq!(
+            descriptors
+                .iter()
+                .map(|descriptor| descriptor.dimension)
+                .collect::<Vec<_>>(),
+            vec![1024, 1024, 1, 1, 1024, 1024, 1024]
+        );
+    }
+
+    #[tokio::test]
+    async fn unsupported_source_fails_before_provisioning() {
+        let mut config = FoundationApiConfig::default();
+        config.foundation.indexed_source_collections = vec!["custom_docs".to_string()];
+        let server = FoundationApiServer::new(
+            config,
+            Arc::new(()),
+            SysDb::Test(TestSysDb::new()),
+            vec![],
+            System::new(),
+        );
+
+        // TestSysDb panics on database creation, so this error also proves
+        // source validation precedes the first provisioning write.
+        let error = match foundation_init(HeaderMap::new(), State(server)).await {
+            Ok(_) => panic!("unsupported source configuration should fail"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.0.code(), ErrorCodes::InvalidArgument);
+        assert_eq!(
+            error.to_string(),
+            "unknown foundation source collection: custom_docs"
+        );
     }
 
     /// `slack_raw` is the attached function's base input, so its source_kind

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -14,7 +14,13 @@ use chroma_types::{
     Collection, CollectionUuid, DatabaseName, ListAttachedFunctionsError, Metadata, MetadataValue,
     Schema, CHROMA_GROUP_CHUNK_SIBLINGS_KEY, SLACK_RAW_COLLECTION_NAME,
 };
-use frontend_core::{attached_function_ops, foundation::source_kind_for_collection_name};
+use frontend_core::{
+    attached_function_ops,
+    foundation::{
+        foundation_source_for_collection_name, source_kind_for_collection_name,
+        FoundationSourceKindError,
+    },
+};
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -76,6 +82,7 @@ pub async fn foundation_init(
     let foundation_cfg = &server.config.foundation;
     let db_name = DatabaseName::new(&foundation_cfg.database_name)
         .ok_or(FoundationInitError::DatabaseNameTooShort)?;
+    let indexed_sources = indexed_source_descriptors(&foundation_cfg.indexed_source_collections)?;
 
     let mut sysdb = server.sysdb.clone();
     let database_id = ensure_database(&mut sysdb, db_name.clone(), tenant.clone()).await?;
@@ -212,20 +219,23 @@ pub async fn foundation_init(
     // inputs share one async attached function; extras are added via
     // `add_input()` below.
     let mut source_collection_ids = HashMap::new();
-    let mut indexed_source_collections = Vec::new();
-    for source_name in &foundation_cfg.indexed_source_collections {
+    let mut indexed_source_collection_ids = Vec::new();
+    for source_descriptor in indexed_sources {
         let source = ensure_collection(
             &mut sysdb,
             tenant.clone(),
             db_name.clone(),
-            source_name,
+            source_descriptor.collection_name,
             Some(group_chunk_siblings_metadata()),
-            source_dimension(source_name),
+            Some(source_descriptor.dimension),
             CollectionEmbeddingFunctions::default(),
         )
         .await?;
-        indexed_source_collections.push((source_name.clone(), source.collection_id));
-        source_collection_ids.insert(source_name.clone(), source.collection_id.to_string());
+        indexed_source_collection_ids.push(source.collection_id);
+        source_collection_ids.insert(
+            source_descriptor.collection_name.to_string(),
+            source.collection_id.to_string(),
+        );
     }
 
     // `slack_raw` is the attached function's *base* input, in place of the old
@@ -250,7 +260,7 @@ pub async fn foundation_init(
     // Add the indexed sources and the per-user coding-agent traces collection
     // as extra inputs to the same sources->wiki function, so they flow into the
     // shared wiki output alongside slack_raw.
-    for (_, source_collection_id) in &indexed_source_collections {
+    for source_collection_id in &indexed_source_collection_ids {
         attached_function_ops::add_attached_function_input(
             &mut sysdb,
             foundation_attached_function_name(),
@@ -292,27 +302,27 @@ pub async fn foundation_init(
     }))
 }
 
-/// Dense-index dimensionality to pin a source collection to.
-///
-/// Sources split into two groups. Most of them — notion, and the per-user
-/// agent-session collections — carry real 1024-dim vectors that the writer
-/// computes and upserts. The backend-driven sources, Google Drive and
-/// Granola, carry no vectors of their own: their connectors run with
-/// embedding inference disabled and upsert a 1-element placeholder, because
-/// a Chroma record needs at least one dimension and these collections are
-/// read by the wiki's attached function rather than by vector search.
-///
-/// Pinning that second group to a single dimension is what lets their
-/// writes land at all. A collection pinned to 1024 rejects every
-/// placeholder upsert with a dimension mismatch, and because a
-/// collection's dimension is fixed at creation, the rejection is
-/// permanent. Add a source here whenever its connector is configured for
-/// no embedding (`DenseEmbeddingModel::NoEmbed`, in hosted-chroma).
-fn source_dimension(source_name: &str) -> Option<i32> {
-    match source_kind_for_collection_name(source_name) {
-        Ok("google_drive") | Ok("granola") => Some(1),
-        _ => Some(1024),
-    }
+struct IndexedSourceDescriptor<'a> {
+    collection_name: &'a str,
+    dimension: i32,
+}
+
+/// Resolve every configured source name before `/init` writes anything.
+/// An unknown name fails the whole list so a later bad entry cannot leave
+/// an earlier source collection behind.
+fn indexed_source_descriptors(
+    source_names: &[String],
+) -> Result<Vec<IndexedSourceDescriptor<'_>>, FoundationSourceKindError> {
+    source_names
+        .iter()
+        .map(|collection_name| {
+            let source = foundation_source_for_collection_name(collection_name)?;
+            Ok(IndexedSourceDescriptor {
+                collection_name,
+                dimension: source.dimension(),
+            })
+        })
+        .collect()
 }
 
 /// Collection metadata that opts a source collection into chunk-sibling
@@ -565,19 +575,77 @@ async fn ensure_collection(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::FoundationApiConfig;
+    use chroma_sysdb::TestSysDb;
+    use chroma_system::System;
+    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]
-    fn vectorless_sources_are_single_dimension_others_are_1024() {
-        // The Drive and Granola connectors upsert a 1-element placeholder
-        // vector, so their collections have to be pinned to one dimension.
-        assert_eq!(source_dimension("gdrive"), Some(1));
-        assert_eq!(source_dimension("gdrive_master"), Some(1));
-        assert_eq!(source_dimension("granola"), Some(1));
-        assert_eq!(source_dimension("granola_master"), Some(1));
-        assert_eq!(source_dimension("notion"), Some(1024));
-        // Unknown sources fall back to the default 1024 dims.
-        assert_eq!(source_dimension("unknown_source"), Some(1024));
+    fn init_source_descriptors_match_worker_source_mapping() {
+        let source_names = [
+            "slack_master",
+            "notion_master",
+            "gdrive_master",
+            "google_drive_master",
+            "coding_sessions",
+            "agent_sessions_user",
+            "granola_master",
+        ]
+        .map(str::to_string);
+        let descriptors = indexed_source_descriptors(&source_names).unwrap();
+
+        for descriptor in &descriptors {
+            assert!(source_kind_for_collection_name(descriptor.collection_name).is_ok());
+        }
+        assert_eq!(
+            descriptors
+                .iter()
+                .map(|descriptor| descriptor.dimension)
+                .collect::<Vec<_>>(),
+            vec![1024, 1024, 1, 1, 1024, 1024, 1]
+        );
+    }
+
+    #[test]
+    fn unknown_source_in_multi_source_list_fails_the_whole_list() {
+        let source_names = ["notion_master", "custom_docs", "gdrive_master"].map(str::to_string);
+        let error = match indexed_source_descriptors(&source_names) {
+            Ok(_) => panic!("a later unknown source must fail the whole list"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error.to_string(),
+            "unknown foundation source collection: custom_docs"
+        );
+    }
+
+    #[tokio::test]
+    async fn unsupported_source_fails_before_provisioning() {
+        let mut config = FoundationApiConfig::default();
+        config.foundation.indexed_source_collections =
+            vec!["notion_master".to_string(), "custom_docs".to_string()];
+        let server = FoundationApiServer::new(
+            config,
+            Arc::new(()),
+            SysDb::Test(TestSysDb::new()),
+            vec![],
+            System::new(),
+        );
+
+        // TestSysDb panics on database creation, so this error also proves
+        // source validation precedes the first provisioning write. A valid
+        // name before the unknown one must not create a partial collection.
+        let error = match foundation_init(HeaderMap::new(), State(server)).await {
+            Ok(_) => panic!("unsupported source configuration should fail"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.0.code(), ErrorCodes::InvalidArgument);
+        assert_eq!(
+            error.to_string(),
+            "unknown foundation source collection: custom_docs"
+        );
     }
 
     /// `slack_raw` is the attached function's base input, so its source_kind

--- a/rust/frontend-core/src/foundation.rs
+++ b/rust/frontend-core/src/foundation.rs
@@ -13,32 +13,67 @@ impl ChromaError for FoundationSourceKindError {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FoundationSource {
+    kind: &'static str,
+    dimension: i32,
+}
+
+impl FoundationSource {
+    pub const fn kind(self) -> &'static str {
+        self.kind
+    }
+
+    pub const fn dimension(self) -> i32 {
+        self.dimension
+    }
+}
+
+pub fn foundation_source_for_collection_name(
+    collection_name: &str,
+) -> Result<FoundationSource, FoundationSourceKindError> {
+    let source = if collection_name.contains("slack") {
+        FoundationSource {
+            kind: "slack",
+            dimension: 1024,
+        }
+    } else if collection_name.contains("notion") {
+        FoundationSource {
+            kind: "notion",
+            dimension: 1024,
+        }
+    } else if collection_name.contains("gdrive") || collection_name.contains("google_drive") {
+        FoundationSource {
+            kind: "google_drive",
+            dimension: 1,
+        }
+    } else if collection_name.contains("coding") || collection_name.contains("agent_sessions") {
+        FoundationSource {
+            kind: "coding_agent_session",
+            dimension: 1024,
+        }
+    } else if collection_name.contains("granola") {
+        FoundationSource {
+            kind: "granola",
+            dimension: 1024,
+        }
+    } else {
+        return Err(FoundationSourceKindError::UnknownSourceCollection(
+            collection_name.to_string(),
+        ));
+    };
+    Ok(source)
+}
+
 pub fn source_kind_for_collection_name(
     collection_name: &str,
 ) -> Result<&'static str, FoundationSourceKindError> {
-    if collection_name.contains("slack") {
-        return Ok("slack");
-    }
-    if collection_name.contains("notion") {
-        return Ok("notion");
-    }
-    if collection_name.contains("gdrive") || collection_name.contains("google_drive") {
-        return Ok("google_drive");
-    }
-    if collection_name.contains("coding") || collection_name.contains("agent_sessions") {
-        return Ok("coding_agent_session");
-    }
-    if collection_name.contains("granola") {
-        return Ok("granola");
-    }
-    Err(FoundationSourceKindError::UnknownSourceCollection(
-        collection_name.to_string(),
-    ))
+    foundation_source_for_collection_name(collection_name).map(FoundationSource::kind)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::source_kind_for_collection_name;
+    use super::{foundation_source_for_collection_name, source_kind_for_collection_name};
 
     #[test]
     fn detects_slack_source_kind() {
@@ -77,6 +112,22 @@ mod tests {
     #[test]
     fn rejects_unknown_source_kind() {
         assert!(source_kind_for_collection_name("unknown_source").is_err());
+    }
+
+    #[test]
+    fn carries_source_specific_dimensions() {
+        assert_eq!(
+            foundation_source_for_collection_name("gdrive_master")
+                .unwrap()
+                .dimension(),
+            1
+        );
+        assert_eq!(
+            foundation_source_for_collection_name("notion_master")
+                .unwrap()
+                .dimension(),
+            1024
+        );
     }
 
     #[test]

--- a/rust/frontend-core/src/foundation.rs
+++ b/rust/frontend-core/src/foundation.rs
@@ -13,32 +13,67 @@ impl ChromaError for FoundationSourceKindError {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FoundationSource {
+    kind: &'static str,
+    dimension: i32,
+}
+
+impl FoundationSource {
+    pub const fn kind(self) -> &'static str {
+        self.kind
+    }
+
+    pub const fn dimension(self) -> i32 {
+        self.dimension
+    }
+}
+
+pub fn foundation_source_for_collection_name(
+    collection_name: &str,
+) -> Result<FoundationSource, FoundationSourceKindError> {
+    let source = if collection_name.contains("slack") {
+        FoundationSource {
+            kind: "slack",
+            dimension: 1024,
+        }
+    } else if collection_name.contains("notion") {
+        FoundationSource {
+            kind: "notion",
+            dimension: 1024,
+        }
+    } else if collection_name.contains("gdrive") || collection_name.contains("google_drive") {
+        FoundationSource {
+            kind: "google_drive",
+            dimension: 1,
+        }
+    } else if collection_name.contains("coding") || collection_name.contains("agent_sessions") {
+        FoundationSource {
+            kind: "coding_agent_session",
+            dimension: 1024,
+        }
+    } else if collection_name.contains("granola") {
+        FoundationSource {
+            kind: "granola",
+            dimension: 1,
+        }
+    } else {
+        return Err(FoundationSourceKindError::UnknownSourceCollection(
+            collection_name.to_string(),
+        ));
+    };
+    Ok(source)
+}
+
 pub fn source_kind_for_collection_name(
     collection_name: &str,
 ) -> Result<&'static str, FoundationSourceKindError> {
-    if collection_name.contains("slack") {
-        return Ok("slack");
-    }
-    if collection_name.contains("notion") {
-        return Ok("notion");
-    }
-    if collection_name.contains("gdrive") || collection_name.contains("google_drive") {
-        return Ok("google_drive");
-    }
-    if collection_name.contains("coding") || collection_name.contains("agent_sessions") {
-        return Ok("coding_agent_session");
-    }
-    if collection_name.contains("granola") {
-        return Ok("granola");
-    }
-    Err(FoundationSourceKindError::UnknownSourceCollection(
-        collection_name.to_string(),
-    ))
+    foundation_source_for_collection_name(collection_name).map(FoundationSource::kind)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::source_kind_for_collection_name;
+    use super::{foundation_source_for_collection_name, source_kind_for_collection_name};
 
     #[test]
     fn detects_slack_source_kind() {
@@ -77,6 +112,28 @@ mod tests {
     #[test]
     fn rejects_unknown_source_kind() {
         assert!(source_kind_for_collection_name("unknown_source").is_err());
+    }
+
+    #[test]
+    fn carries_source_specific_dimensions() {
+        assert_eq!(
+            foundation_source_for_collection_name("gdrive_master")
+                .unwrap()
+                .dimension(),
+            1
+        );
+        assert_eq!(
+            foundation_source_for_collection_name("notion_master")
+                .unwrap()
+                .dimension(),
+            1024
+        );
+        assert_eq!(
+            foundation_source_for_collection_name("granola_master")
+                .unwrap()
+                .dimension(),
+            1
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`/api/init` creates and attaches every entry in
`indexed_source_collections` without checking that the worker can
resolve the name. `source_dimension` defaulted any unrecognized name to
1024 dimensions, so an unsupported source was provisioned and attached
to the sources-to-wiki function even though
`source_kind_for_collection_name` only matches a fixed set of
substrings.

The result is a silent failure. Init returns success and a collection
id, but every function invocation over that source aborts with
"unknown foundation source collection: <name>" before the generate
request is issued, so the work never reaches FinishWork and no wiki
output is ever produced.

## Reproduction

1. Configure `indexed_source_collections` as `["custom_docs"]`.
2. Call `/api/init`. It succeeds and returns a collection id.
3. Add a record to `custom_docs`.
4. fn-consumer reports "unknown foundation source collection:
   custom_docs" instead of calling /generate, and the work stays
   queued.

## Change

- Add `foundation_source_for_collection_name` in `frontend-core`. It
  returns the canonical source kind together with the dense-index
  dimensionality for that kind, and `source_kind_for_collection_name`
  now delegates to it, so init and the worker share one mapping.
- Resolve every configured source name in `foundation_init` before any
  provisioning write. An unsupported name fails with InvalidArgument
  instead of creating and attaching collections.
- Remove the 1024-dimension fallback for unknown names and build the
  source collections from the prevalidated descriptors.

Dimensionality is unchanged for all supported sources: Google Drive
stays at 1, everything else stays at 1024.

## Behavior change

A deployment that configures a source name outside the supported set
now fails init rather than partially provisioning. That configuration
could never produce wiki output, so failing at init surfaces the
misconfiguration where it can be fixed instead of leaving invocations
queued indefinitely.

## Tests

- `cargo test -p frontend-core foundation`
- `cargo test -p foundation-api routes::init::tests`
- `cargo test -p worker execution::functions::http_generate::tests`

New coverage: the descriptors init accepts are all accepted by the
worker mapping and carry the per-source dimensionality, and an
unsupported configuration fails before the first provisioning write.
