### PR TITLE
[BUG] Delete stale trajectory records when a trajectory is replaced

### DIFF
--- a/rust/foundation-api/src/trajectories/chroma_store.rs
+++ b/rust/foundation-api/src/trajectories/chroma_store.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use chroma::{
     types::{IncludeList, Key, Metadata, UpdateMetadata},
@@ -46,7 +46,7 @@ pub async fn chroma_load_generate_trajectory(
 
 /// Save one complete reasoning trajectory as finalized Chroma records.
 ///
-/// This operation upserts the records that represent `file`.
+/// This operation replaces all records that represent `file`.
 ///
 /// # Errors
 ///
@@ -60,7 +60,7 @@ pub async fn chroma_save_generate_trajectory(
 
     let mut records = Vec::new();
     collect_file_records(&mut records, file, WriteState::Finalized)?;
-    chroma_upsert_records(txn, records).await
+    chroma_replace_records(txn, [file.trajectory.id], records).await
 }
 
 /// Save many complete reasoning trajectories as finalized Chroma records.
@@ -80,7 +80,7 @@ pub async fn chroma_save_all_generate_trajectories(
         validate_file(file)?;
         collect_file_records(&mut records, file, WriteState::Finalized)?;
     }
-    chroma_upsert_records(txn, records).await
+    chroma_replace_records(txn, files.iter().map(|file| file.trajectory.id), records).await
 }
 
 /// Create an open trajectory that starts with zero committed entries.
@@ -243,7 +243,64 @@ pub async fn chroma_finalize_open_trajectory(
     let mut records = Vec::new();
     collect_finalization_records(&mut records, &mut header, file, &tid)?;
 
-    chroma_upsert_records(txn, records).await
+    chroma_replace_records(txn, [tid_uuid], records).await
+}
+
+/// Replace complete trajectory record sets, deleting ids omitted by the new sets.
+async fn chroma_replace_records<I>(
+    txn: &mut ConditionalCollectionTransaction,
+    tids: I,
+    records: Vec<ChromaRecord>,
+) -> Result<(), TrajectoryError>
+where
+    I: IntoIterator<Item = Uuid>,
+{
+    let mut stale_ids = BTreeSet::new();
+    for tid in tids.into_iter().collect::<BTreeSet<_>>() {
+        let prefix = format!("gt/{}/", uuid_to_tid(tid)?);
+        let replacement_ids = records
+            .iter()
+            .filter(|record| record.id.starts_with(&prefix))
+            .map(|record| record.id.clone())
+            .collect::<BTreeSet<_>>();
+        let existing_ids = chroma_record_ids_for_tid(txn, tid).await?;
+        stale_ids.extend(existing_ids.difference(&replacement_ids).cloned());
+    }
+
+    chroma_upsert_records(txn, records).await?;
+    chroma_delete_records(txn, stale_ids.into_iter().collect()).await
+}
+
+/// Load all Chroma record ids whose metadata belongs to one trajectory UUID.
+async fn chroma_record_ids_for_tid(
+    txn: &mut ConditionalCollectionTransaction,
+    tid_uuid: Uuid,
+) -> Result<BTreeSet<String>, TrajectoryError> {
+    let mut offset = 0u32;
+    let mut ids = BTreeSet::new();
+
+    loop {
+        let response = txn
+            .get(
+                None,
+                Some(Key::field("tid").eq(tid_uuid.to_string())),
+                Some(TRAJECTORY_FILTER_PAGE_LIMIT),
+                Some(offset),
+                Some(IncludeList::empty()),
+            )
+            .await?;
+        let count = u32::try_from(response.ids.len())?;
+        ids.extend(response.ids);
+
+        if count < TRAJECTORY_FILTER_PAGE_LIMIT {
+            break;
+        }
+        offset = offset.checked_add(count).ok_or_else(|| {
+            TrajectoryError::InvalidValue(format!("trajectory {tid_uuid} read offset overflowed"))
+        })?;
+    }
+
+    Ok(ids)
 }
 
 /// Load all Chroma documents whose metadata belongs to one trajectory UUID.
@@ -392,6 +449,18 @@ async fn chroma_upsert_records(
         Some(metadatas),
     )
     .await?;
+    Ok(())
+}
+
+/// Delete existing Chroma records by exact id.
+async fn chroma_delete_records(
+    txn: &mut ConditionalCollectionTransaction,
+    ids: Vec<String>,
+) -> Result<(), TrajectoryError> {
+    if ids.is_empty() {
+        return Ok(());
+    }
+    txn.delete(ids).await?;
     Ok(())
 }
 

--- a/rust/foundation-api/src/trajectories/tests.rs
+++ b/rust/foundation-api/src/trajectories/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::io;
 
@@ -12,7 +12,7 @@ use super::ids::{
 use super::limits::{
     CALL_INDEX_WIDTH, CHUNK_INDEX_WIDTH, ENTRY_INDEX_WIDTH, ITEM_ID_WIDTH, TID_WIDTH,
 };
-use super::metadata::metadata_for_key;
+use super::metadata::{metadata_for_key, update_metadata_from_metadata};
 use super::record_format::{
     collect_entry_records, collect_file_records, collect_finalization_records,
     load_one_from_documents, read_trajectory_header, trajectory_header_key, ChromaRecord,
@@ -1193,8 +1193,23 @@ async fn save_generate_trajectory_returns_complete_write_response() -> TestResul
     let server = MockServer::start_async().await;
     let collection = mocked_collection(&server);
     let file = sample_file(Uuid::parse_str("00000000-0000-0000-0000-00000000000e")?);
+    let get_path = collection_path(&collection, "conditional/get");
     let commit_path = collection_path(&collection, "conditional/commit");
 
+    let get_mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path(get_path);
+            then.status(200).json_body(json!({
+                "ids": [],
+                "embeddings": null,
+                "documents": null,
+                "uris": null,
+                "metadatas": null,
+                "include": [],
+                "read_token": 42,
+            }));
+        })
+        .await;
     let commit_mock = server
         .mock_async(|when, then| {
             when.method("POST").path(commit_path);
@@ -1215,7 +1230,114 @@ async fn save_generate_trajectory_returns_complete_write_response() -> TestResul
             first_inserted_record_offset: Some(23),
         }
     );
+    assert_eq!(get_mock.calls(), 1);
     assert_eq!(commit_mock.calls(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+/// Verifies replacement deletes removed citations and entries in the same commit.
+async fn replacing_trajectory_deletes_records_absent_from_new_file() -> TestResult {
+    let server = MockServer::start_async().await;
+    let collection = mocked_collection(&server);
+    let id = Uuid::parse_str("00000000-0000-0000-0000-000000000019")?;
+    let mut old_file = ReasoningTrajectoryFile {
+        citations: Some(Citations {
+            input_ids: vec!["a".to_string(), "b".to_string()],
+            surfaced_page_ids: Vec::new(),
+            read_page_ids: Vec::new(),
+            final_citations: BTreeMap::new(),
+        }),
+        trajectory: ReasoningTrajectory {
+            id,
+            entries: vec![
+                reasoning_entry(Some("first".to_string()), &[]),
+                reasoning_entry(Some("second".to_string()), &[]),
+            ],
+        },
+    };
+    let old_records = records_for_file(&old_file, WriteState::Finalized)?;
+    old_file
+        .citations
+        .as_mut()
+        .ok_or_else(|| test_error("missing citations"))?
+        .input_ids
+        .truncate(1);
+    old_file.trajectory.entries.truncate(1);
+    let replacement = old_file;
+    let replacement_records = records_for_file(&replacement, WriteState::Finalized)?;
+
+    let replacement_ids = replacement_records
+        .iter()
+        .map(|record| record.id.clone())
+        .collect::<BTreeSet<_>>();
+    let stale_ids = old_records
+        .iter()
+        .map(|record| record.id.clone())
+        .filter(|id| !replacement_ids.contains(id))
+        .collect::<BTreeSet<_>>();
+    let tid = uuid_to_tid(id)?;
+    let removed_citation = format!("gt/{tid}/citations/input_ids/{}", sha256_base36(b"b")?);
+    assert!(stale_ids.iter().any(|id| id.starts_with(&removed_citation)));
+    assert!(stale_ids
+        .iter()
+        .any(|id| id.starts_with(&format!("gt/{tid}/entries/000001/"))));
+
+    let old_ids = old_records
+        .iter()
+        .map(|record| record.id.clone())
+        .collect::<Vec<_>>();
+    let get_path = collection_path(&collection, "conditional/get");
+    let commit_path = collection_path(&collection, "conditional/commit");
+    let get_mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path(get_path).json_body(json!({
+                "ids": null,
+                "where": {"tid": {"$eq": id.to_string()}},
+                "where_document": null,
+                "limit": 300,
+                "offset": 0,
+                "include": [],
+                "read_token": null,
+            }));
+            then.status(200).json_body(json!({
+                "ids": old_ids,
+                "embeddings": null,
+                "documents": null,
+                "uris": null,
+                "metadatas": null,
+                "include": [],
+                "read_token": 42,
+            }));
+        })
+        .await;
+    let commit_body = replacement_commit_body(&replacement_records, &stale_ids, 42);
+    let commit_mock = server
+        .mock_async(|when, then| {
+            when.method("POST").path(commit_path).json_body(commit_body);
+            then.status(200).json_body(json!({
+                "first_inserted_record_offset": 31,
+                "record_count": replacement_records.len() + stale_ids.len(),
+            }));
+        })
+        .await;
+
+    let mut txn = collection.conditional();
+    chroma_save_generate_trajectory(&mut txn, &replacement).await?;
+    txn.commit().await?;
+
+    assert_eq!(get_mock.calls(), 1);
+    assert_eq!(commit_mock.calls(), 1);
+    let mut documents = documents_from_records(&old_records);
+    insert_documents(&mut documents, replacement_records);
+    assert_eq!(
+        load_one_from_documents(&documents, id, true).map_err(|error| error.to_string()),
+        Err("invalid value: citations count mismatch for input_ids: expected 1, got 2".to_string())
+    );
+    for id in stale_ids {
+        documents.remove(&id);
+    }
+    assert_eq!(load_one_from_documents(&documents, id, true)?, replacement);
     Ok(())
 }
 
@@ -1392,6 +1514,49 @@ fn insert_documents(documents: &mut BTreeMap<String, String>, records: Vec<Chrom
     for record in records {
         documents.insert(record.id, record.document);
     }
+}
+
+/// Build the expected conditional commit for a complete trajectory replacement.
+fn replacement_commit_body(
+    records: &[ChromaRecord],
+    stale_ids: &BTreeSet<String>,
+    read_token: u64,
+) -> Value {
+    json!({
+        "read_token": read_token,
+        "read_ids": records
+            .iter()
+            .map(|record| record.id.clone())
+            .chain(stale_ids.iter().cloned())
+            .collect::<BTreeSet<_>>(),
+        "operations": [
+            {
+                "operation": "upsert",
+                "payload": {
+                    "ids": records.iter().map(|record| record.id.clone()).collect::<Vec<_>>(),
+                    "embeddings": vec![vec![0.0]; records.len()],
+                    "documents": records
+                        .iter()
+                        .map(|record| Some(record.document.clone()))
+                        .collect::<Vec<_>>(),
+                    "uris": null,
+                    "metadatas": records
+                        .iter()
+                        .map(|record| Some(update_metadata_from_metadata(record.metadata.clone())))
+                        .collect::<Vec<_>>(),
+                },
+            },
+            {
+                "operation": "delete",
+                "payload": {
+                    "ids": stale_ids,
+                    "limit": null,
+                    "where": null,
+                    "where_document": null,
+                },
+            },
+        ],
+    })
 }
 
 /// Rename every document key under one prefix to another prefix.


### PR DESCRIPTION
## Description of changes

Saving a finalized trajectory only upserted the record ids produced by the new file. Ids that already existed under the same trajectory UUID but are absent from the new file were never deleted. Loading fetches every record carrying the trajectory's `tid` metadata, and the citation reader scans all stored citation chunk sets before requiring their count to equal the header count, so a single removed citation deterministically breaks reads for that trajectory.

Reproduction: save a finalized trajectory with `input_ids ["a", "b"]`, then save the same UUID with `input_ids ["a"]`. Loading now fails with `citations count mismatch for input_ids: expected 1, got 2` instead of returning the second file. The same happens when reprocessing produces fewer entries, and obsolete records keep accumulating for any reused UUID, so backfills and reprocessing can leave trajectories permanently unreadable.

- Improvements & Bug fixes
  - Add a `chroma_replace_records` helper that reads the existing record ids for each trajectory UUID, diffs them against the new record set, and buffers the deletion of the leftovers alongside the upserts so the whole replacement lands in one conditional commit.
  - Use the helper for single saves, bulk saves, and open-trajectory finalization, so all three write paths have replace semantics instead of upsert-only semantics.
  - Update the save doc comment to describe replacement.
- New functionality
  - None.

## Test plan

- `cargo test -p foundation-api trajectories` (47 passed, 0 failed).
- New mocked-transaction regression `replacing_trajectory_deletes_records_absent_from_new_file` covers both a removed citation and a shortened entry list. It asserts the conditional commit carries the upsert plus a delete of exactly the stale ids, and that loading the merged document set reproduces the count mismatch before those ids are removed and returns the new file after.
- Existing open-trajectory create, append, and finalize tests still pass unchanged.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

None required; no user-facing API surface changes. Only internal doc comments were adjusted to match the new replacement semantics.
