### PR TITLE
[BUG](client): Refresh stale System after dir swap

### DIFF
--- a/chromadb/api/shared_system_client.py
+++ b/chromadb/api/shared_system_client.py
@@ -1,5 +1,6 @@
-from typing import ClassVar, Dict, Optional
+from typing import ClassVar, Dict, Optional, Tuple
 import logging
+import os
 import threading
 import uuid
 from chromadb.api import ServerAPI
@@ -14,6 +15,7 @@ logger = logging.getLogger(__name__)
 class SharedSystemClient:
     _identifier_to_system: ClassVar[Dict[str, System]] = {}
     _identifier_to_refcount: ClassVar[Dict[str, int]] = {}
+    _identifier_to_dir_identity: ClassVar[Dict[str, Optional[Tuple[int, int]]]] = {}
     _refcount_lock: ClassVar[threading.Lock] = threading.Lock()
     _identifier: str
 
@@ -25,10 +27,33 @@ class SharedSystemClient:
         SharedSystemClient._create_system_if_not_exists(self._identifier, settings)
         SharedSystemClient._increment_refcount(self._identifier)
 
+    @staticmethod
+    def _persist_directory_identity(
+        persist_directory: str,
+    ) -> Optional[Tuple[int, int]]:
+        try:
+            stat = os.stat(persist_directory)
+        except OSError:
+            return None
+        return (stat.st_dev, stat.st_ino)
+
     @classmethod
     def _create_system_if_not_exists(
         cls, identifier: str, settings: Settings
     ) -> System:
+        if identifier in cls._identifier_to_system and settings.is_persistent:
+            # identifier is the persist_directory for local persistent clients.
+            # If a caller removed and recreated that directory without closing
+            # the client that made it (e.g. deleting it on disk directly), the
+            # cached System still holds a connection to storage that no longer
+            # exists. Reusing it can only fail (e.g. sqlite "readonly database"
+            # errors), so start a new System instead of returning the stale one.
+            if cls._persist_directory_identity(
+                identifier
+            ) != cls._identifier_to_dir_identity.get(identifier):
+                cls._identifier_to_system.pop(identifier).stop()
+                cls._identifier_to_dir_identity.pop(identifier, None)
+
         if identifier not in cls._identifier_to_system:
             new_system = System(settings)
             cls._identifier_to_system[identifier] = new_system
@@ -37,6 +62,11 @@ class SharedSystemClient:
             new_system.instance(ServerAPI)
 
             new_system.start()
+
+            if settings.is_persistent:
+                cls._identifier_to_dir_identity[
+                    identifier
+                ] = cls._persist_directory_identity(identifier)
         else:
             previous_system = cls._identifier_to_system[identifier]
 
@@ -80,6 +110,10 @@ class SharedSystemClient:
     def _populate_data_from_system(system: System) -> str:
         identifier = SharedSystemClient._get_identifier_from_settings(system.settings)
         SharedSystemClient._identifier_to_system[identifier] = system
+        if system.settings.is_persistent:
+            SharedSystemClient._identifier_to_dir_identity[
+                identifier
+            ] = SharedSystemClient._persist_directory_identity(identifier)
         return identifier
 
     @classmethod
@@ -120,6 +154,7 @@ class SharedSystemClient:
         refcount = cls._decrement_refcount(identifier)
         if refcount <= 0:
             system = cls._identifier_to_system.pop(identifier, None)
+            cls._identifier_to_dir_identity.pop(identifier, None)
             if system is not None:
                 system.stop()
 
@@ -127,6 +162,7 @@ class SharedSystemClient:
     def clear_system_cache() -> None:
         SharedSystemClient._identifier_to_system = {}
         SharedSystemClient._identifier_to_refcount = {}
+        SharedSystemClient._identifier_to_dir_identity = {}
 
     @property
     def _system(self) -> System:

--- a/chromadb/test/api/test_shared_system_client.py
+++ b/chromadb/test/api/test_shared_system_client.py
@@ -1,8 +1,12 @@
+import os
+import shutil
+
 import pytest
 from unittest.mock import MagicMock
+from chromadb.api.client import Client
 from chromadb.api.shared_system_client import SharedSystemClient
 from chromadb.api.base_http_client import BaseHTTPClient
-from chromadb.config import System
+from chromadb.config import Settings, System
 from typing import Optional, Dict, Generator
 
 
@@ -178,3 +182,56 @@ def test_multiple_clients_returns_one_key() -> None:
     api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
 
     assert api_key in ["key-1", "key-2"]
+
+
+def _persistent_settings(path: str) -> Settings:
+    return Settings(
+        chroma_api_impl="chromadb.api.rust.RustBindingsAPI",
+        is_persistent=True,
+        persist_directory=path,
+    )
+
+
+def test_reuses_system_for_untouched_persist_directory(tmp_path: str) -> None:
+    """A second client for the same, unmodified persist_directory should
+    share the already-running System rather than starting a new one."""
+    path = str(tmp_path)
+    client1 = Client(settings=_persistent_settings(path))
+    system1 = SharedSystemClient._identifier_to_system[path]
+
+    client2 = Client(settings=_persistent_settings(path))
+    system2 = SharedSystemClient._identifier_to_system[path]
+
+    assert system1 is system2
+    client1.close()
+    client2.close()
+
+
+def test_recreates_system_when_persist_directory_is_replaced(
+    tmp_path: str,
+) -> None:
+    """If a persist_directory is deleted and recreated without the owning
+    client being closed (e.g. abandoned/garbage collected), a new client
+    for that path must get a fresh System instead of reusing one whose
+    connection points at storage that no longer exists (see #6499)."""
+    path = str(tmp_path)
+
+    client1 = Client(settings=_persistent_settings(path))
+    collection = client1.create_collection("test")
+    collection.add(ids=["1"], embeddings=[[1.0, 2.0, 3.0]])
+    assert collection.count() == 1
+    stale_system = SharedSystemClient._identifier_to_system[path]
+    # client1 is intentionally never closed here, simulating a client that
+    # goes out of scope without an explicit close().
+
+    shutil.rmtree(path)
+    os.makedirs(path)
+
+    client2 = Client(settings=_persistent_settings(path))
+    collection2 = client2.create_collection("test")
+    collection2.add(ids=["1"], embeddings=[[1.0, 2.0, 3.0]])
+    assert collection2.count() == 1
+
+    fresh_system = SharedSystemClient._identifier_to_system[path]
+    assert fresh_system is not stale_system
+    client2.close()


### PR DESCRIPTION
## The bug

`PersistentClient` (and `Client`/`SharedSystemClient` in general) caches a `System` per `persist_directory` and only tears it down when the client that created it is explicitly closed. If a client is abandoned without `close()` and its `persist_directory` is deleted and recreated on disk in the meantime, the next `PersistentClient` for that same path reuses the stale cached `System` instead of building a new one.

That stale `System` still holds a connection to storage that no longer exists, so any operation on it fails in confusing ways unrelated to what the caller actually did:

```python
client = chromadb.PersistentClient(path=d)
col = client.create_collection("test")
col.add(ids=["1"], embeddings=[[1, 2, 3]])
client.delete_collection("test")
client = None  # never closed

shutil.rmtree(d)
os.makedirs(d)

client2 = chromadb.PersistentClient(path=d)
client2.create_collection("test")
# chromadb.errors.InternalError: Database error: error returned from
# database: (code: 1032) attempt to write a readonly database
```

The only workaround was reaching into `SharedSystemClient._identifier_to_system` and deleting the cache entry by hand, which isn't a supported API. Reported in #6499.

## The fix

`SharedSystemClient` now records the `(st_dev, st_ino)` of a persistent client's directory alongside the `System` it created for it. When a new client asks for a `System` at an identifier that's already cached, it re-stats the directory: if the identity changed (or the directory is gone), the old `System` is stopped and discarded, and a fresh one is created in its place. Directories that haven't been touched are unaffected — the existing `System` is reused exactly as before.

`from_system()` (used by tests/tooling to attach a client to an already-running `System`) records the directory identity at the time it's populated, so simulated "restarts" that hand the same directory to a new `System` object continue to work as before.

## Testing

Added `test_recreates_system_when_persist_directory_is_replaced` and `test_reuses_system_for_untouched_persist_directory` to `test_shared_system_client.py`, covering both the regression and the common case. Confirmed the new regression test fails with the old code and passes with the fix.

Also ran `test_client.py`, the persistence property tests (`test_persist.py`, `test_restart_persist.py`), and the full `test_shared_system_client.py` suite locally — all green.