### PR TITLE
[BUG](hnsw): Lower result count log level

### DIFF
--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -141,7 +141,7 @@ class LocalHnswSegment(VectorReader):
         size = len(self._id_to_label)
 
         if k > size:
-            logger.warning(
+            logger.debug(
                 f"Number of requested results {k} is greater than number of elements in index {size}, updating n_results = {size}"
             )
             k = size

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -434,7 +434,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
         k = query["k"]
         if k > self.count(query["request_version_context"]):
             count = self.count(query["request_version_context"])
-            logger.warning(
+            logger.debug(
                 f"Number of requested results {k} is greater than number of elements in index {count}, updating n_results = {count}"
             )
             k = count

--- a/chromadb/test/segment/test_local_hnsw.py
+++ b/chromadb/test/segment/test_local_hnsw.py
@@ -1,0 +1,90 @@
+import logging
+from typing import Any, Optional, Sequence, Tuple, cast
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from chromadb.segment.impl.vector.batch import Batch
+from chromadb.segment.impl.vector.local_hnsw import LocalHnswSegment
+from chromadb.segment.impl.vector.local_persistent_hnsw import (
+    PersistentLocalHnswSegment,
+)
+from chromadb.types import Vector, VectorQuery
+from chromadb.utils.read_write_lock import ReadWriteLock
+
+
+class FakeHnswIndex:
+    def knn_query(
+        self, vectors: np.ndarray, k: int, filter: Optional[object] = None
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        return np.array([[1]]), np.array([[0.0]])
+
+
+class FakeBruteForceIndex:
+    def query(self, query: VectorQuery) -> Sequence[Sequence[Any]]:
+        return [[]]
+
+    def has_id(self, id: str) -> bool:
+        return False
+
+
+def make_query() -> VectorQuery:
+    vector = cast(Vector, np.array([0.0, 0.0, 0.0], dtype=np.float32))
+    return VectorQuery(
+        vectors=[vector],
+        k=10,
+        allowed_ids=None,
+        include_embeddings=False,
+        options=None,
+        request_version_context={"collection_version": 0, "log_position": 0},
+    )
+
+
+def test_query_with_fewer_elements_logs_at_debug(caplog: Any) -> None:
+    segment = object.__new__(LocalHnswSegment)
+    segment._index = FakeHnswIndex()
+    segment._id_to_label = {"one": 1}
+    segment._label_to_id = {1: "one"}
+    segment._lock = ReadWriteLock()
+
+    with caplog.at_level(
+        logging.DEBUG, logger="chromadb.segment.impl.vector.local_hnsw"
+    ):
+        results = segment.query_vectors(make_query())
+
+    assert results[0][0]["id"] == "one"
+    matching_records = [
+        record
+        for record in caplog.records
+        if "Number of requested results" in record.getMessage()
+    ]
+    assert len(matching_records) == 1
+    assert matching_records[0].levelno == logging.DEBUG
+
+
+def test_persistent_query_with_fewer_elements_logs_at_debug(
+    caplog: Any,
+) -> None:
+    segment = object.__new__(PersistentLocalHnswSegment)
+    segment._index = FakeHnswIndex()
+    segment._brute_force_index = MagicMock()
+    segment._brute_force_index.query.side_effect = FakeBruteForceIndex().query
+    segment._brute_force_index.has_id.return_value = False
+    segment._id_to_label = {"one": 1}
+    segment._label_to_id = {1: "one"}
+    segment._lock = ReadWriteLock()
+    segment._curr_batch = Batch()
+
+    with caplog.at_level(
+        logging.DEBUG, logger="chromadb.segment.impl.vector.local_persistent_hnsw"
+    ):
+        results = segment.query_vectors(make_query())
+
+    assert results[0][0]["id"] == "one"
+    matching_records = [
+        record
+        for record in caplog.records
+        if "Number of requested results" in record.getMessage()
+    ]
+    assert len(matching_records) == 1
+    assert matching_records[0].levelno == logging.DEBUG


### PR DESCRIPTION
## Description of changes

- Lower the routine result-count adjustment message from `WARNING` to `DEBUG` in both local HNSW query implementations.
- Add regression coverage for the in-memory and persistent HNSW paths. The tests verify that the query still returns the available result and that the adjustment is logged at `DEBUG`.

When a collection contains fewer elements than requested, the query already clamps the count and returns the available results. This is an expected implementation detail rather than a warning condition.

## Test plan

- `python -m pytest chromadb/test/segment/test_local_hnsw.py -q` — 2 passed
- `python -m pytest chromadb/test/segment/test_safe_unpickler.py -q` — 4 passed
- `python -m black --check chromadb/test/segment/test_local_hnsw.py`
- `python -m flake8 --extend-ignore=E203,E501,E503 --max-line-length=88 chromadb/test/segment/test_local_hnsw.py`
- `python -m mypy --strict --ignore-missing-imports --follow-imports=silent --disable-error-code=type-abstract --config-file=./pyproject.toml chromadb/test/segment/test_local_hnsw.py`
- `ruff format --check chromadb/test/segment/test_local_hnsw.py`
- `git diff --check`

The focused tests were run in an isolated environment with the repository dependencies. The broader repository test workflow still requires repository-side approval for this forked pull request.

## Migration plan

None. This changes the severity of a routine diagnostic log only; query results and control flow are unchanged.

## Observability plan

The adjustment remains available at `DEBUG` for users who need detailed HNSW diagnostics, while normal warning-level logs are no longer emitted for this expected condition.

## AI assistance disclosure

AI assistance was used to investigate the issue, draft the patch and regression tests, and review the resulting diff. I verified the behavior locally and am disclosing that assistance here.

Fixes #2834