### PR TITLE
[BUG](py-client): Keep port for http hosts

### DIFF
--- a/chromadb/api/base_http_client.py
+++ b/chromadb/api/base_http_client.py
@@ -72,7 +72,10 @@ class BaseHTTPClient(Component):
         _skip_port = False
         _chroma_server_host = chroma_server_host
         BaseHTTPClient._validate_host(_chroma_server_host)
-        if _chroma_server_host.startswith("http"):
+        # Only an explicit scheme means the caller passed a full URL whose
+        # authority already carries the port. A bare hostname may legitimately
+        # start with "http" (e.g. "httpbin.org"), and must keep its port.
+        if _chroma_server_host.startswith(("http://", "https://")):
             logger.debug("Skipping port as the user is passing a full URL")
             _skip_port = True
         parsed = urlparse(_chroma_server_host)

--- a/chromadb/test/property/test_client_url.py
+++ b/chromadb/test/property/test_client_url.py
@@ -104,7 +104,7 @@ def test_url_resolve(
     assert (
         _url.startswith("https") if ssl_enabled else _url.startswith("http")
     ), f"Invalid URL: {_url} - SSL Enabled: {ssl_enabled}"
-    if hostname.startswith("http"):
+    if hostname.startswith(("http://", "https://")):
         assert ":" + str(port) not in _url, f"Port in URL not expected: {_url}"
     else:
         assert ":" + str(port) in _url, f"Port in URL expected: {_url}"
@@ -132,3 +132,22 @@ def test_resolve_invalid(
             default_api_path=default_api_path,
         )
     assert "Invalid URL" in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    ["httpbin.org", "httpd", "http-proxy.internal", "https-gw", "httpsomething.com"],
+)
+def test_resolve_url_keeps_port_for_http_prefixed_hostname(hostname: str) -> None:
+    """A bare hostname may legitimately start with "http" without being a URL.
+
+    Only an explicit http:// or https:// scheme means the caller supplied a
+    full URL whose authority already carries the port.
+    """
+    _url = FastAPI.resolve_url(
+        chroma_server_host=hostname,
+        chroma_server_http_port=8000,
+        chroma_server_ssl_enabled=False,
+        default_api_path="/api/v2",
+    )
+    assert _url == f"http://{hostname}:8000/api/v2"


### PR DESCRIPTION
## Description of changes

`resolve_url()` currently uses `startswith("http")` to decide whether a host is a full URL. Bare hostnames such as `httpbin.org`, `httpd`, and `https-gw` therefore skip `chroma_server_http_port` even though they have no URL scheme.

For example:

```python
FastAPI.resolve_url(
    chroma_server_host="httpbin.org",
    chroma_server_http_port=8000,
    chroma_server_ssl_enabled=False,
    default_api_path="/api/v2",
)
```

Before this change the result is `http://httpbin.org/api/v2`; after it, the configured port is preserved as `http://httpbin.org:8000/api/v2`.

The fix only treats explicit `http://` and `https://` schemes as full URLs. The property-test oracle is updated accordingly, with focused regression cases for affected hostname forms.

## Tests

- `python -m pytest chromadb/test/property/test_client_url.py -q` ? 7 passed
- `python -m black --check chromadb/api/base_http_client.py chromadb/test/property/test_client_url.py`
- `git diff --check upstream/main...HEAD`
