### PR TITLE
[BUG](ci): Run all pre-commit hooks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -269,19 +269,10 @@ jobs:
           github-token: ${{ github.token }}
       - name: Run pre-commit
         shell: bash
+        env:
+          SKIP: mypy
         run: |
-          pre-commit run --all-files trailing-whitespace
-          pre-commit run --all-files mixed-line-ending
-          pre-commit run --all-files end-of-file-fixer
-          pre-commit run --all-files requirements-txt-fixer
-          pre-commit run --all-files check-xml
-          pre-commit run --all-files check-merge-conflict
-          pre-commit run --all-files check-case-conflict
-          pre-commit run --all-files check-docstring-first
-          pre-commit run --all-files black
-          pre-commit run --all-files flake8
-          pre-commit run --all-files prettier
-          pre-commit run --all-files check-yaml
+          pre-commit run --all-files --show-diff-on-failure
         continue-on-error: true
       - name: Cargo fmt check
         shell: bash


### PR DESCRIPTION
## Description of changes

The lint job currently invokes each pre-commit hook as a separate command.
Because the workflow shell exits on the first failed hook, later hooks are
skipped, and the manually maintained list can drift from
`.pre-commit-config.yaml`.

- Improvements & Bug fixes
  - Replace the hand-written hook list with one `pre-commit` invocation so
    configured hooks are discovered and run together.
  - Keep `mypy` skipped to preserve the current CI scope.
  - Leave `continue-on-error: true` unchanged. Making lint blocking and
    addressing the existing formatting backlog should be a separate change.
- New functionality
  - None.

Fixes #7560

## Test plan

- [x] `pre-commit validate-config`
- [x] `SKIP=mypy pre-commit run --files .github/workflows/pr.yml --show-diff-on-failure`
      (all applicable hooks passed; `mypy` was skipped and `prettier` had no
      matching files)
- [x] `git diff --check`
- [x] Confirmed the single invocation covers the hook IDs currently declared
      in `.pre-commit-config.yaml`, with `mypy` excluded explicitly.

## Migration plan

None. This changes only how the existing lint step invokes pre-commit.

## Observability plan

The existing CI lint output will now report every configured hook in one run,
including the diff for hooks that fail. There is no runtime behavior change.

## Documentation Changes

No user-facing documentation or API changes are needed.

## AI assistance

An AI coding assistant helped inspect the repository, review the workflow
behavior, and set up the validation commands. I reviewed the one-file diff and
ran the checks listed above.
