### PR TITLE
[ENH](wqs): Report fn failures

### DIFF
--- a/idl/chromadb/proto/workqueue.proto
+++ b/idl/chromadb/proto/workqueue.proto
@@ -24,6 +24,12 @@ message FinishWorkRequest {
     int64 completion_offset = 3;
 }
 
+// Reports an execution failure for one queued attached-function invocation.
+message FailFunctionRequest {
+    string fn_id = 1;
+    string input_coll_id = 2;
+}
+
 message GetWorkRequest {
     string shard_id = 1;
     uint32 limit = 2;
@@ -43,5 +49,6 @@ message GetWorkResponse {
 service WorkQueueService {
     rpc PushWork(PushWorkRequest) returns (google.protobuf.Empty);
     rpc FinishWork(FinishWorkRequest) returns (google.protobuf.Empty);
+    rpc FailFunction(FailFunctionRequest) returns (google.protobuf.Empty);
     rpc GetWork(GetWorkRequest) returns (GetWorkResponse);
 }

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -147,6 +147,41 @@ mod tests {
         Ok(attached_function_id)
     }
 
+    #[tokio::test]
+    async fn test_k8s_integration_fail_function_increments_failure_count() {
+        with_work_queue_test(|mut ctx| async move {
+            let collection_id = CollectionUuid::new();
+            create_test_collection(
+                &mut ctx.sysdb,
+                collection_id,
+                &ctx.tenant_id,
+                &ctx.database_name,
+            )
+            .await
+            .expect("Failed to create collection");
+            let function_id = create_test_attached_function(&mut ctx.sysdb, collection_id)
+                .await
+                .expect("Failed to create attached function");
+
+            ctx.work_queue_client
+                .fail_function(function_id.to_string(), collection_id.to_string())
+                .await
+                .expect("Failed to report function failure");
+
+            let functions = ctx
+                .sysdb
+                .list_attached_functions(collection_id)
+                .await
+                .expect("Failed to fetch attached functions");
+            let function = functions
+                .iter()
+                .find(|function| function.id == function_id.to_string())
+                .expect("Attached function was not returned");
+            assert_eq!(function.failure_count, 1);
+        })
+        .await;
+    }
+
     // Note: In a real scenario, updating collection log position would be done
     // through the log service, not sysdb. For testing work queue repair logic,
     // we rely on the sysdb methods to simulate repair conditions.

--- a/rust/worker/src/work_queue/work_queue_client.rs
+++ b/rust/worker/src/work_queue/work_queue_client.rs
@@ -1,8 +1,8 @@
 use crate::fn_consumer::config::GrpcWorkQueueConfig;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::chroma_proto::{
-    work_queue_service_client::WorkQueueServiceClient, FinishWorkRequest, GetWorkRequest,
-    GetWorkResponse, PushWorkRequest,
+    work_queue_service_client::WorkQueueServiceClient, FailFunctionRequest, FinishWorkRequest,
+    GetWorkRequest, GetWorkResponse, PushWorkRequest,
 };
 use std::time::Duration;
 use tonic::transport::Endpoint;
@@ -104,6 +104,21 @@ impl WorkQueueClient {
             err
         })?;
 
+        Ok(())
+    }
+
+    pub async fn fail_function(
+        &mut self,
+        fn_id: String,
+        input_coll_id: String,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        self.client
+            .fail_function(Request::new(FailFunctionRequest {
+                fn_id,
+                input_coll_id,
+            }))
+            .await
+            .map_err(|e| Box::new(WorkQueueClientError::RequestError(e)) as Box<dyn ChromaError>)?;
         Ok(())
     }
 

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -6,8 +6,8 @@ use chroma_sysdb::SysDb;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     work_queue_service_server::{WorkQueueService, WorkQueueServiceServer},
-    FinalizeAsyncAttachedFunctionRepairRequest, FinishWorkRequest, GetWorkRequest, GetWorkResponse,
-    PushWorkRequest, WorkItemResult,
+    FailAttachedFunctionRequest, FailFunctionRequest, FinalizeAsyncAttachedFunctionRepairRequest,
+    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest, WorkItemResult,
 };
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use std::str::FromStr;
@@ -133,6 +133,28 @@ impl WorkQueueService for WorkQueueServer {
                 Ok(Response::new(()))
             }
         }
+    }
+
+    async fn fail_function(
+        &self,
+        request: Request<FailFunctionRequest>,
+    ) -> Result<Response<()>, Status> {
+        let req = request.into_inner();
+        let fn_id = AttachedFunctionUuid::from_str(&req.fn_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid fn_id: {}", e)))?;
+        let input_coll_id = CollectionUuid::from_str(&req.input_coll_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid collection_id: {}", e)))?;
+
+        let mut sysdb = self.sysdb.clone();
+        sysdb
+            .fail_attached_function(FailAttachedFunctionRequest {
+                attached_function_id: fn_id.to_string(),
+                collection_id: input_coll_id.to_string(),
+            })
+            .await
+            .map_err(|e| Status::internal(format!("Failed to record function failure: {}", e)))?;
+
+        Ok(Response::new(()))
     }
 
     async fn get_work(


### PR DESCRIPTION
## Summary

Adds the WQS failure-reporting boundary.

- Adds `FailFunction(fn_id, input_coll_id)` to the WQS API.
- Validates IDs and forwards failures to SysDB for durable count increments.
- Does not add WQS-specific DLQ persistence; queue records remain in WQS.
- Adds Kubernetes integration coverage for WQS → SysDB failure reporting.