### PR TITLE
[ENH](fn-consumer): Dead-letter fn work

### DIFF
--- a/idl/chromadb/proto/workqueue.proto
+++ b/idl/chromadb/proto/workqueue.proto
@@ -33,6 +33,7 @@ message FailFunctionRequest {
 message GetWorkRequest {
     string shard_id = 1;
     uint32 limit = 2;
+    int32 max_failure_count = 3;
 }
 
 message WorkItemResult {

--- a/rust/worker/src/bin/work_queue_cli.rs
+++ b/rust/worker/src/bin/work_queue_cli.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         Commands::Get { shard_id, limit } => {
-            let response = client.get_work(shard_id, limit).await?;
+            let response = client.get_work(shard_id, limit, i32::MAX).await?;
 
             if response.items.is_empty() {
                 println!("No work items available");

--- a/rust/worker/src/bin/work_queue_cli.rs
+++ b/rust/worker/src/bin/work_queue_cli.rs
@@ -81,7 +81,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         Commands::Get { shard_id, limit } => {
-            let response = client.get_work(shard_id, limit, i32::MAX).await?;
+            let response = client
+                .get_work_with_failure_limit(shard_id, limit, i32::MAX)
+                .await?;
 
             if response.items.is_empty() {
                 println!("No work items available");

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -374,14 +374,23 @@ impl QueueState {
         &self,
         limit: usize,
         max_failure_count: i32,
-    ) -> Vec<WorkQueueRecord> {
-        self.pending_work
+    ) -> (Vec<WorkQueueRecord>, usize) {
+        let mut work = Vec::with_capacity(limit);
+        let mut failure_count_filtered = 0;
+
+        for item in self
+            .pending_work
             .iter()
             .filter(|item| self.contains_entry(&item.fn_id, &item.input_coll_id))
-            .filter(|item| item.failure_count < max_failure_count)
-            .take(limit)
-            .cloned()
-            .collect()
+        {
+            if item.failure_count >= max_failure_count {
+                failure_count_filtered += 1;
+            } else if work.len() < limit {
+                work.push(item.clone());
+            }
+        }
+
+        (work, failure_count_filtered)
     }
 
     pub fn update_failure_count(

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -1,5 +1,5 @@
 use crate::work_queue::types::{WorkQueueError, WorkQueueRecord};
-use arrow::array::{Array, Int64Array, StringArray, UInt64Array};
+use arrow::array::{Array, Int32Array, Int64Array, StringArray, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use bytes::Bytes;
@@ -59,6 +59,7 @@ impl QueueState {
             Field::new("completion_offset", DataType::Int64, false),
             Field::new("compaction_offset", DataType::Int64, false),
             Field::new("insertion_order", DataType::UInt64, false),
+            Field::new("failure_count", DataType::Int32, false),
         ]));
 
         let mut buffer = Vec::new();
@@ -91,6 +92,8 @@ impl QueueState {
                 .iter()
                 .map(|r| r.compaction_offset)
                 .collect();
+            let failure_counts: Vec<_> =
+                self.pending_work.iter().map(|r| r.failure_count).collect();
 
             let batch = RecordBatch::try_new(
                 schema,
@@ -100,6 +103,7 @@ impl QueueState {
                     Arc::new(Int64Array::from(completion_offsets)),
                     Arc::new(Int64Array::from(compaction_offsets)),
                     Arc::new(UInt64Array::from(orders)),
+                    Arc::new(Int32Array::from(failure_counts)),
                 ],
             )
             .map_err(|e| WorkQueueError::Serialization(e.to_string()))?;
@@ -162,6 +166,7 @@ impl QueueState {
             let compaction_offsets_idx = schema
                 .column_with_name("compaction_offset")
                 .map(|(idx, _)| idx);
+            let failure_counts_idx = schema.column_with_name("failure_count").map(|(idx, _)| idx);
 
             let fn_ids = batch
                 .column(fn_ids_idx)
@@ -208,6 +213,19 @@ impl QueueState {
                         })
                 })
                 .transpose()?;
+            let failure_counts = failure_counts_idx
+                .map(|idx| {
+                    batch
+                        .column(idx)
+                        .as_any()
+                        .downcast_ref::<Int32Array>()
+                        .ok_or_else(|| {
+                            WorkQueueError::Serialization(
+                                "Failed to downcast failure_count".to_string(),
+                            )
+                        })
+                })
+                .transpose()?;
 
             for i in 0..batch.num_rows() {
                 let fn_id = AttachedFunctionUuid::from_str(fn_ids.value(i))
@@ -243,6 +261,15 @@ impl QueueState {
                     completion_offset: completion_offset.unwrap_or(compaction_offset),
                     compaction_offset,
                     insertion_order: orders.value(i),
+                    failure_count: failure_counts
+                        .map(|failure_counts| {
+                            if failure_counts.is_valid(i) {
+                                failure_counts.value(i)
+                            } else {
+                                0
+                            }
+                        })
+                        .unwrap_or(0),
                 };
 
                 let key = (fn_id, input_coll_id);
@@ -307,6 +334,12 @@ impl QueueState {
             }
         }
 
+        let failure_count = self
+            .pending_work
+            .iter()
+            .find(|record| record.fn_id == fn_id && record.input_coll_id == input_coll_id)
+            .map_or(0, |record| record.failure_count);
+
         // We eagerly drop the older queue row here for simplicity; we could
         // remove this retain later if get_work learns to skip stale rows lazily.
         self.pending_work
@@ -318,6 +351,7 @@ impl QueueState {
             completion_offset,
             compaction_offset,
             insertion_order: self.next_insertion_order,
+            failure_count,
         };
 
         self.next_insertion_order += 1;
@@ -334,6 +368,43 @@ impl QueueState {
         input_coll_id: &CollectionUuid,
     ) -> bool {
         self.dedup_index.contains_key(&(*fn_id, *input_coll_id))
+    }
+
+    pub(crate) fn get_live_work(
+        &self,
+        limit: usize,
+        max_failure_count: i32,
+    ) -> Vec<WorkQueueRecord> {
+        self.pending_work
+            .iter()
+            .filter(|item| self.contains_entry(&item.fn_id, &item.input_coll_id))
+            .filter(|item| item.failure_count < max_failure_count)
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
+    pub fn update_failure_count(
+        &mut self,
+        fn_id: &AttachedFunctionUuid,
+        input_coll_id: &CollectionUuid,
+        failure_count: i32,
+    ) -> bool {
+        let Some(record) = self
+            .pending_work
+            .iter_mut()
+            .find(|record| record.fn_id == *fn_id && record.input_coll_id == *input_coll_id)
+        else {
+            return false;
+        };
+
+        if record.failure_count == failure_count {
+            return false;
+        }
+
+        record.failure_count = failure_count;
+        self.dirty = true;
+        true
     }
 
     /// Mark work as successfully completed.
@@ -356,6 +427,15 @@ impl QueueState {
                 // Remove from dedup index
                 self.dedup_index.remove(&key);
                 self.dirty = true;
+            } else if let Some(record) = self
+                .pending_work
+                .iter_mut()
+                .find(|record| record.fn_id == *fn_id && record.input_coll_id == *input_coll_id)
+            {
+                if record.failure_count != 0 {
+                    record.failure_count = 0;
+                    self.dirty = true;
+                }
             }
         }
     }
@@ -376,6 +456,7 @@ mod tests {
             completion_offset: 100,
             compaction_offset: 140,
             insertion_order: 0,
+            failure_count: 0,
         };
 
         let record2 = WorkQueueRecord {
@@ -384,6 +465,7 @@ mod tests {
             completion_offset: 200,
             compaction_offset: 240,
             insertion_order: 1,
+            failure_count: 5,
         };
 
         let record3 = WorkQueueRecord {
@@ -392,6 +474,7 @@ mod tests {
             completion_offset: 300,
             compaction_offset: 360,
             insertion_order: 2,
+            failure_count: 0,
         };
 
         state.pending_work.push_back(record1.clone());
@@ -426,6 +509,7 @@ mod tests {
         assert_eq!(restored.pending_work[0].compaction_offset, 140);
         assert_eq!(restored.pending_work[1].completion_offset, 200);
         assert_eq!(restored.pending_work[1].compaction_offset, 240);
+        assert_eq!(restored.pending_work[1].failure_count, 5);
         assert_eq!(restored.pending_work[2].completion_offset, 300);
         assert_eq!(restored.pending_work[2].compaction_offset, 360);
         assert_eq!(restored.dedup_index.len(), 3);
@@ -466,6 +550,35 @@ mod tests {
         assert_eq!(restored.pending_work.len(), 1);
         assert_eq!(restored.pending_work[0].completion_offset, 100);
         assert_eq!(restored.pending_work[0].compaction_offset, 100);
+        assert_eq!(restored.pending_work[0].failure_count, 0);
+    }
+
+    #[test]
+    fn test_dlq_state_survives_a_newer_queue_frontier() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+
+        assert!(state.push_work(fn_id, coll_id, 10, 10));
+        assert!(state.update_failure_count(&fn_id, &coll_id, 5));
+
+        assert!(state.push_work(fn_id, coll_id, 20, 20));
+        assert_eq!(state.pending_work[0].failure_count, 5);
+    }
+
+    #[test]
+    fn test_success_clears_dlq_when_work_remains() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+
+        assert!(state.push_work(fn_id, coll_id, 10, 20));
+        assert!(state.update_failure_count(&fn_id, &coll_id, 5));
+
+        state.finish_work_success(&fn_id, &coll_id, 10);
+
+        assert_eq!(state.pending_work.len(), 1);
+        assert_eq!(state.pending_work[0].failure_count, 0);
     }
 
     #[test]

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -211,7 +211,7 @@ mod tests {
             // Get work
             let work_items = ctx
                 .work_queue_client
-                .get_work("test_shard".to_string(), 10)
+                .get_work("test_shard".to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work");
 
@@ -242,7 +242,7 @@ mod tests {
             // Get work again - should not contain our function
             let work_items = ctx
                 .work_queue_client
-                .get_work("test_shard".to_string(), 10)
+                .get_work("test_shard".to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work after finish");
 
@@ -293,7 +293,7 @@ mod tests {
             // Get work - should return in FIFO order
             let retrieved = ctx
                 .work_queue_client
-                .get_work("test_shard".to_string(), 10)
+                .get_work("test_shard".to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work");
 
@@ -342,7 +342,7 @@ mod tests {
             // Get work again - should filter out completed items
             let filtered = ctx
                 .work_queue_client
-                .get_work("test_shard".to_string(), 10)
+                .get_work("test_shard".to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get filtered work");
 
@@ -437,7 +437,7 @@ mod tests {
             // Get work - this branch still re-enqueues repair work into the queue.
             let work_items = ctx
                 .work_queue_client
-                .get_work("test_shard".to_string(), 10)
+                .get_work("test_shard".to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work after repair");
 

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -211,7 +211,7 @@ mod tests {
             // Get work
             let work_items = ctx
                 .work_queue_client
-                .get_work("test_shard".to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit("test_shard".to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work");
 
@@ -242,7 +242,7 @@ mod tests {
             // Get work again - should not contain our function
             let work_items = ctx
                 .work_queue_client
-                .get_work("test_shard".to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit("test_shard".to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work after finish");
 
@@ -293,7 +293,7 @@ mod tests {
             // Get work - should return in FIFO order
             let retrieved = ctx
                 .work_queue_client
-                .get_work("test_shard".to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit("test_shard".to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work");
 
@@ -342,7 +342,7 @@ mod tests {
             // Get work again - should filter out completed items
             let filtered = ctx
                 .work_queue_client
-                .get_work("test_shard".to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit("test_shard".to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get filtered work");
 
@@ -437,7 +437,7 @@ mod tests {
             // Get work - this branch still re-enqueues repair work into the queue.
             let work_items = ctx
                 .work_queue_client
-                .get_work("test_shard".to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit("test_shard".to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work after repair");
 

--- a/rust/worker/src/work_queue/types.rs
+++ b/rust/worker/src/work_queue/types.rs
@@ -10,6 +10,7 @@ pub struct WorkQueueRecord {
     pub completion_offset: i64,
     pub compaction_offset: i64,
     pub insertion_order: u64,
+    pub failure_count: i32,
 }
 
 #[derive(Error, Debug, Clone)]

--- a/rust/worker/src/work_queue/work_queue_client.rs
+++ b/rust/worker/src/work_queue/work_queue_client.rs
@@ -127,7 +127,21 @@ impl WorkQueueClient {
         shard_id: String,
         limit: u32,
     ) -> Result<GetWorkResponse, Box<dyn ChromaError>> {
-        let request = Request::new(GetWorkRequest { shard_id, limit });
+        self.get_work_with_failure_limit(shard_id, limit, i32::MAX)
+            .await
+    }
+
+    pub async fn get_work_with_failure_limit(
+        &mut self,
+        shard_id: String,
+        limit: u32,
+        max_failure_count: i32,
+    ) -> Result<GetWorkResponse, Box<dyn ChromaError>> {
+        let request = Request::new(GetWorkRequest {
+            shard_id,
+            limit,
+            max_failure_count,
+        });
 
         let response =
             self.client.get_work(request).await.map_err(|e| {

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -40,7 +40,16 @@ pub struct GetWorkMessage {
     #[allow(dead_code)]
     pub shard_id: String,
     pub limit: usize,
+    pub max_failure_count: i32,
     pub response_tx: oneshot::Sender<Result<Vec<WorkQueueRecord>, WorkQueueError>>,
+}
+
+#[derive(Debug)]
+pub struct UpdateFunctionFailureCountMessage {
+    pub fn_id: AttachedFunctionUuid,
+    pub input_coll_id: CollectionUuid,
+    pub failure_count: i32,
+    pub response_tx: oneshot::Sender<()>,
 }
 
 #[derive(Debug)]
@@ -384,18 +393,30 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
     async fn handle(&mut self, msg: GetWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
         // With eager stale-row removal on push, the queue's dedup index is the
         // source of truth for whether a row is still live.
-        let filtered: Vec<_> = self
-            .state
-            .pending_work
-            .iter()
-            .filter(|item| self.state.contains_entry(&item.fn_id, &item.input_coll_id))
-            .take(msg.limit)
-            .cloned()
-            .collect();
+        let filtered = self.state.get_live_work(msg.limit, msg.max_failure_count);
         tracing::info!("Returning {} items from get work response", filtered.len());
 
         if msg.response_tx.send(Ok(filtered)).is_err() {
             tracing::warn!("Failed to send get work response - receiver dropped");
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<UpdateFunctionFailureCountMessage> for WorkQueueManager {
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        msg: UpdateFunctionFailureCountMessage,
+        _ctx: &ComponentContext<WorkQueueManager>,
+    ) {
+        self.state
+            .update_failure_count(&msg.fn_id, &msg.input_coll_id, msg.failure_count);
+        if msg.response_tx.send(()).is_err() {
+            tracing::warn!(
+                "Failed to acknowledge function failure count update - receiver dropped"
+            );
         }
     }
 }
@@ -532,6 +553,7 @@ mod tests {
             completion_offset: 999,
             compaction_offset: 999,
             insertion_order: 999,
+            failure_count: 0,
         });
 
         // Test filtering logic (simulating what get_work does)
@@ -550,6 +572,24 @@ mod tests {
         for (i, item) in filtered.iter().enumerate().take(3) {
             assert_eq!(item.completion_offset, (i as i64) * 100);
         }
+    }
+
+    #[test]
+    fn test_get_work_skips_dlq_items_before_applying_limit() {
+        let mut state = QueueState::new();
+        let dlq_fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let dlq_coll_id = CollectionUuid(Uuid::new_v4());
+        let live_fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let live_coll_id = CollectionUuid(Uuid::new_v4());
+
+        state.push_work(dlq_fn_id, dlq_coll_id, 10, 10);
+        state.push_work(live_fn_id, live_coll_id, 20, 20);
+        assert!(state.update_failure_count(&dlq_fn_id, &dlq_coll_id, 3));
+
+        let work = state.get_live_work(1, 3);
+
+        assert_eq!(work.len(), 1);
+        assert_eq!(work[0].fn_id, live_fn_id);
     }
 
     #[tokio::test]

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -393,8 +393,14 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
     async fn handle(&mut self, msg: GetWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
         // With eager stale-row removal on push, the queue's dedup index is the
         // source of truth for whether a row is still live.
-        let filtered = self.state.get_live_work(msg.limit, msg.max_failure_count);
-        tracing::info!("Returning {} items from get work response", filtered.len());
+        let (filtered, failure_count_filtered) =
+            self.state.get_live_work(msg.limit, msg.max_failure_count);
+        tracing::info!(
+            returned_items = filtered.len(),
+            failure_count_filtered,
+            max_failure_count = msg.max_failure_count,
+            "Returning work from get work response"
+        );
 
         if msg.response_tx.send(Ok(filtered)).is_err() {
             tracing::warn!("Failed to send get work response - receiver dropped");
@@ -586,10 +592,11 @@ mod tests {
         state.push_work(live_fn_id, live_coll_id, 20, 20);
         assert!(state.update_failure_count(&dlq_fn_id, &dlq_coll_id, 3));
 
-        let work = state.get_live_work(1, 3);
+        let (work, failure_count_filtered) = state.get_live_work(1, 3);
 
         assert_eq!(work.len(), 1);
         assert_eq!(work[0].fn_id, live_fn_id);
+        assert_eq!(failure_count_filtered, 1);
     }
 
     #[tokio::test]

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -1,6 +1,7 @@
 use crate::work_queue::types::{FinishResult, WorkQueueError};
 use crate::work_queue::work_queue_manager::{
-    FinishWorkMessage, GetWorkMessage, PushWorkMessage, WorkQueueManager,
+    FinishWorkMessage, GetWorkMessage, PushWorkMessage, UpdateFunctionFailureCountMessage,
+    WorkQueueManager,
 };
 use chroma_sysdb::SysDb;
 use chroma_system::ComponentHandle;
@@ -146,13 +147,33 @@ impl WorkQueueService for WorkQueueServer {
             .map_err(|e| Status::invalid_argument(format!("Invalid collection_id: {}", e)))?;
 
         let mut sysdb = self.sysdb.clone();
-        sysdb
+        let failure_count = sysdb
             .fail_attached_function(FailAttachedFunctionRequest {
                 attached_function_id: fn_id.to_string(),
                 collection_id: input_coll_id.to_string(),
             })
             .await
             .map_err(|e| Status::internal(format!("Failed to record function failure: {}", e)))?;
+
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        self.manager
+            .receiver()
+            .send(
+                UpdateFunctionFailureCountMessage {
+                    fn_id,
+                    input_coll_id,
+                    failure_count,
+                    response_tx,
+                },
+                None,
+            )
+            .await
+            .map_err(|e| {
+                Status::internal(format!("Failed to update function failure count: {}", e))
+            })?;
+        response_rx.await.map_err(|e| {
+            Status::internal(format!("Failed to receive failure count update: {}", e))
+        })?;
 
         Ok(Response::new(()))
     }
@@ -167,6 +188,7 @@ impl WorkQueueService for WorkQueueServer {
         let msg = GetWorkMessage {
             shard_id: req.shard_id,
             limit: req.limit as usize,
+            max_failure_count: req.max_failure_count,
             response_tx,
         };
 


### PR DESCRIPTION
## Summary

Adds fn-consumer DLQ behavior for attached-function work.

- Reports a failed function batch to WQS for each input collection.
- Before dispatch, reads the attached function from SysDB.
- Logs and skips functions whose failure count has reached the configurable threshold (default: 5).
- Leaves skipped queue records in WQS, per the current design.