### PR TITLE
[ENH](wqs): Persist function failure counts

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -6,6 +6,7 @@ for automatically processing collections.
 """
 
 import functools
+import io
 import json
 import pytest
 import time
@@ -118,6 +119,37 @@ def _wait_for_record_counter_count(
     pytest.fail(
         f"Timed out waiting for {output_collection_name} to contain total_count={expected_count}. "
         f"Last observed total_count={last_count!r}"
+    )
+
+
+def _wait_for_wqs_failure_count(
+    function_id: str,
+    input_collection_id: str,
+    expected_failure_count: int,
+    timeout_seconds: float = 180.0,
+) -> None:
+    parquet = pytest.importorskip("pyarrow.parquet")
+
+    deadline = time.monotonic() + timeout_seconds
+    last_failure_count = None
+    while time.monotonic() < deadline:
+        body = _minio_get_object(MINIO_BUCKET, "workqueue_state.parquet")
+        if body is not None:
+            rows = parquet.read_table(io.BytesIO(body)).to_pylist()
+            for row in rows:
+                if (
+                    row["fn_id"] == function_id
+                    and row["input_coll_id"] == input_collection_id
+                ):
+                    last_failure_count = row["failure_count"]
+                    if last_failure_count >= expected_failure_count:
+                        return
+        sleep(5)
+
+    pytest.fail(
+        "Timed out waiting for WQS failure count "
+        f"for function={function_id}, input_collection={input_collection_id}. "
+        f"Expected at least {expected_failure_count}, observed {last_failure_count!r}"
     )
 
 
@@ -677,6 +709,37 @@ def test_count_to_file_async_attached_function_counts_late_inputs(
     attached_fn_input_3 = attached_fn.add_input(input_collection_3.id)
     assert attached_fn_input_3 is not None
     _wait_for_minio_count(s3_path, 1200)
+
+
+def test_count_to_file_async_failure_is_dead_lettered(
+    basic_http_client: System,
+) -> None:
+    client = ClientCreator.from_system(basic_http_client)
+    client.reset()
+
+    collection = client.create_collection(name="async_count_dlq_input")
+    # The random bucket is intentionally never created, so every async invocation
+    # fails while writing its count and is reported back through WQS.
+    invalid_s3_path = f"s3://async-count-dlq-{uuid.uuid4()}/count.json"
+    attached_fn, created = collection.attach_function(
+        name="async_count_dlq",
+        function=COUNT_TO_FILE_ASYNC_FUNCTION,
+        output_collection="async_count_dlq_output",
+        params={"s3_path": invalid_s3_path},
+    )
+    assert attached_fn is not None
+    assert created is True
+
+    collection.add(
+        ids=[f"async_count_dlq_doc_{i}" for i in range(300)],
+        documents=["test document"] * 300,
+    )
+
+    _wait_for_wqs_failure_count(
+        str(attached_fn.id),
+        str(collection.id),
+        expected_failure_count=5,
+    )
 
 
 def test_record_counter_attached_late_counts_existing_and_new_inputs(

--- a/rust/worker/src/fn_consumer/config.rs
+++ b/rust/worker/src/fn_consumer/config.rs
@@ -51,6 +51,8 @@ pub struct FnConsumerConfig {
     pub get_work_batch_size: u32,
     #[serde(default = "FnConsumerConfig::default_job_expiry_seconds")]
     pub job_expiry_seconds: u64,
+    #[serde(default = "FnConsumerConfig::default_max_failure_count")]
+    pub max_failure_count: i32,
     #[serde(alias = "work_queue")]
     pub work_queue: GrpcWorkQueueConfig,
 }
@@ -68,6 +70,9 @@ impl FnConsumerConfig {
     fn default_job_expiry_seconds() -> u64 {
         3600
     }
+    fn default_max_failure_count() -> i32 {
+        5
+    }
 }
 
 impl Default for FnConsumerConfig {
@@ -77,6 +82,7 @@ impl Default for FnConsumerConfig {
             max_concurrent_workers: Self::default_max_concurrent_workers(),
             get_work_batch_size: Self::default_get_work_batch_size(),
             job_expiry_seconds: Self::default_job_expiry_seconds(),
+            max_failure_count: Self::default_max_failure_count(),
             work_queue: GrpcWorkQueueConfig::default(),
         }
     }

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -359,8 +359,8 @@ impl FnConsumerManager {
                         "Failed to process work batch"
                     );
                     for item in batch {
-                        let mut work_queue_client = self.work_queue_client.clone();
-                        if let Err(report_error) = work_queue_client
+                        if let Err(report_error) = self
+                            .work_queue_client
                             .fail_function(fn_id.to_string(), item.collection_id.to_string())
                             .await
                         {
@@ -416,3 +416,4 @@ impl Handler<ScheduledPollMessage> for FnConsumerManager {
         );
     }
 }
+rev

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -64,6 +64,7 @@ pub struct FnConsumerContext {
     pub max_concurrent_workers: usize,
     pub get_work_batch_size: u32,
     pub job_expiry_seconds: u64,
+    pub max_failure_count: i32,
     pub my_member_id: String,
     pub log: Log,
     pub sysdb: SysDb,
@@ -124,6 +125,7 @@ impl FnConsumerManager {
             max_concurrent_workers: config.max_concurrent_workers,
             get_work_batch_size: config.get_work_batch_size,
             job_expiry_seconds: config.job_expiry_seconds,
+            max_failure_count: config.max_failure_count,
             my_member_id,
             log,
             sysdb,
@@ -282,6 +284,48 @@ impl FnConsumerManager {
                 );
                 continue;
             };
+
+            // Match compaction's DLQ behavior: SysDB persists the counter, while
+            // the scheduler/consumer decides whether the work is dispatchable.
+            let attached_functions = match self
+                .context
+                .sysdb
+                .clone()
+                .list_attached_functions(input_coll_id)
+                .await
+            {
+                Ok(functions) => functions,
+                Err(error) => {
+                    tracing::error!(
+                        fn_id = %fn_id,
+                        input_coll_id = %input_coll_id,
+                        error = %error,
+                        "skipping work item: failed to fetch attached function"
+                    );
+                    continue;
+                }
+            };
+            let Some(attached_function) = attached_functions
+                .iter()
+                .find(|function| function.id == fn_id.to_string())
+            else {
+                tracing::info!(
+                    fn_id = %fn_id,
+                    input_coll_id = %input_coll_id,
+                    "skipping work item: attached function no longer exists"
+                );
+                continue;
+            };
+            if attached_function.failure_count >= self.context.max_failure_count {
+                tracing::info!(
+                    fn_id = %fn_id,
+                    input_coll_id = %input_coll_id,
+                    failure_count = attached_function.failure_count,
+                    max_failure_count = self.context.max_failure_count,
+                    "skipping dead-lettered attached function"
+                );
+                continue;
+            }
             work_items.push((fn_id, input_coll_id, compaction_offset));
         }
 
@@ -351,6 +395,20 @@ impl FnConsumerManager {
                         error = %e,
                         "Failed to process work batch"
                     );
+                    for item in batch {
+                        let mut work_queue_client = self.work_queue_client.clone();
+                        if let Err(report_error) = work_queue_client
+                            .fail_function(fn_id.to_string(), item.collection_id.to_string())
+                            .await
+                        {
+                            tracing::error!(
+                                fn_id = %fn_id,
+                                input_coll_id = %item.collection_id,
+                                error = %report_error,
+                                "Failed to report attached function execution failure"
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -416,4 +416,3 @@ impl Handler<ScheduledPollMessage> for FnConsumerManager {
         );
     }
 }
-rev

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -252,7 +252,11 @@ impl FnConsumerManager {
         let limit = self.context.get_work_batch_size;
         let resp = match self
             .work_queue_client
-            .get_work(self.context.my_member_id.clone(), limit)
+            .get_work_with_failure_limit(
+                self.context.my_member_id.clone(),
+                limit,
+                self.context.max_failure_count,
+            )
             .await
         {
             Ok(resp) => resp,
@@ -285,47 +289,6 @@ impl FnConsumerManager {
                 continue;
             };
 
-            // Match compaction's DLQ behavior: SysDB persists the counter, while
-            // the scheduler/consumer decides whether the work is dispatchable.
-            let attached_functions = match self
-                .context
-                .sysdb
-                .clone()
-                .list_attached_functions(input_coll_id)
-                .await
-            {
-                Ok(functions) => functions,
-                Err(error) => {
-                    tracing::error!(
-                        fn_id = %fn_id,
-                        input_coll_id = %input_coll_id,
-                        error = %error,
-                        "skipping work item: failed to fetch attached function"
-                    );
-                    continue;
-                }
-            };
-            let Some(attached_function) = attached_functions
-                .iter()
-                .find(|function| function.id == fn_id.to_string())
-            else {
-                tracing::info!(
-                    fn_id = %fn_id,
-                    input_coll_id = %input_coll_id,
-                    "skipping work item: attached function no longer exists"
-                );
-                continue;
-            };
-            if attached_function.failure_count >= self.context.max_failure_count {
-                tracing::info!(
-                    fn_id = %fn_id,
-                    input_coll_id = %input_coll_id,
-                    failure_count = attached_function.failure_count,
-                    max_failure_count = self.context.max_failure_count,
-                    "skipping dead-lettered attached function"
-                );
-                continue;
-            }
             work_items.push((fn_id, input_coll_id, compaction_offset));
         }
 


### PR DESCRIPTION
## Summary

Pass the fn-consumer DLQ threshold to WQS when fetching work. WQS applies it against its persisted, SysDB-mirrored failure count before enforcing the batch limit.

## Why

This keeps the threshold defined only in fn-consumer while preventing dead-lettered FIFO entries from starving later work.

## Testing

- Focused WQS queue-state tests cover pre-limit filtering, Parquet persistence, legacy-file hydration, and success reset behavior.