### PR TITLE
[BUG](segment): Fix local hnsw panic when k is 0

### DIFF
--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -348,10 +348,7 @@ impl LocalHnswSegmentReader {
                                         offset_id: *curr_id as u32,
                                         measure: curr_distance,
                                     });
-                                } else {
-                                    // SAFETY(hammadb): We are sure that the heap has at least one element
-                                    // because we insert until we have k elements.
-                                    let top = max_heap.peek().unwrap();
+                                } else if let Some(top) = max_heap.peek() {
                                     if top.measure > curr_distance {
                                         max_heap.pop();
                                         max_heap.push(RecordMeasure {
@@ -981,5 +978,80 @@ mod tests {
             42
         );
         assert_eq!(reader.index.inner.read().await.last_seen_seq_id, 42);
+    }
+
+    #[tokio::test]
+    async fn query_embedding_returns_nothing_for_zero_k() {
+        let sqlite = get_new_sqlite_db().await;
+        let persist_dir = tempfile::tempdir().expect("persist dir");
+        let persist_path = persist_dir.path().to_str().expect("utf-8 path").to_string();
+
+        let mut collection = Collection::test_collection(3);
+        collection.schema = Some(Schema::new_default(KnnIndex::Hnsw));
+
+        let vector_segment = Segment {
+            id: SegmentUuid::new(),
+            r#type: SegmentType::HnswLocalPersisted,
+            scope: SegmentScope::VECTOR,
+            collection: collection.collection_id,
+            metadata: None,
+            file_path: Default::default(),
+        };
+
+        let mut writer = LocalHnswSegmentWriter::from_segment(
+            &collection,
+            &vector_segment,
+            3,
+            Some(persist_path),
+            sqlite,
+        )
+        .await
+        .expect("writer");
+
+        let record = |log_offset: i64, id: i64, operation: Operation| LogRecord {
+            log_offset,
+            record: OperationRecord {
+                id: format!("id-{id}"),
+                embedding: matches!(operation, Operation::Add)
+                    .then(|| vec![id as f32, id as f32, id as f32]),
+                encoding: None,
+                metadata: None,
+                document: None,
+                operation,
+            },
+        };
+
+        writer
+            .apply_log_chunk(Chunk::new(
+                (1..=5).map(|i| record(i, i, Operation::Add)).collect(),
+            ))
+            .await
+            .expect("apply adds");
+
+        // Deleting 2 of 5 records puts the index over the 20% deleted
+        // threshold, so queries take the brute force branch.
+        writer
+            .apply_log_chunk(Chunk::new(
+                (4..=5)
+                    .map(|i| record(i + 5, i, Operation::Delete))
+                    .collect(),
+            ))
+            .await
+            .expect("apply deletes");
+
+        let reader = LocalHnswSegmentReader::from_index(writer.index.clone());
+
+        let results = reader
+            .query_embedding(&[], vec![1.0, 1.0, 1.0], 0)
+            .await
+            .expect("query with k = 0");
+        assert!(results.is_empty());
+
+        // A regular k still returns results on the same index.
+        let results = reader
+            .query_embedding(&[], vec![1.0, 1.0, 1.0], 2)
+            .await
+            .expect("query with k = 2");
+        assert_eq!(results.len(), 2);
     }
 }


### PR DESCRIPTION
## Description of changes

`LocalHnswSegmentReader::query_embedding` brute forces the search when the index is
small and more than 20% of its records are deleted (`rust/segment/src/local_hnsw.rs:320`).
That branch pushes into a max heap until it holds `k` entries, then switches to
`max_heap.peek().unwrap()`:

```rust
if max_heap.len() < k as usize {
    max_heap.push(RecordMeasure { ... });
} else {
    // SAFETY(hammadb): We are sure that the heap has at least one element
    // because we insert until we have k elements.
    let top = max_heap.peek().unwrap();
```

The stated invariant does not hold for `k == 0`: `0 < 0` is false on the very first
candidate, so the `else` runs with an empty heap and the unwrap panics.

`n_results` reaches this as `k` unchanged. `QueryRequest` has no validator on the field
(`rust/types/src/api_types.rs:2217`), `payload.n_results.unwrap_or(10)` keeps `Some(0)`
as `0` (`rust/frontend/src/server.rs:3436`), and the default `impl QuotaEnforcer for ()`
returns no override. So `n_results: 0` sent over raw HTTP, from the JS client or from
the Rust client reaches `query_embedding(.., 0)` on a single node deployment. The
Python client rejects the value before sending, which is why this has not surfaced
there.

The other branch of the same function returns no results for `k == 0`, so the two
branches disagreed on the same input depending only on how many records had been
deleted.

The fix is the `peek` guard that `rust/worker/src/execution/operators/knn_log.rs:130`
already uses for the identical heap pattern. The brute force branch now also returns
no results.

I did not add validation for `n_results`, since which layer should reject `0` (if any)
is a separate decision, and today both non-degraded paths accept it and return nothing.

- Improvements & Bug fixes
  - A local query with `n_results = 0` returns no results instead of panicking once
    the vector index is past the 20% deleted threshold.
- New functionality
  - None.

## Test plan

New unit test `query_embedding_returns_nothing_for_zero_k` in
`rust/segment/src/local_hnsw.rs`. It adds 5 records, deletes 2 so the reader takes the
brute force branch, then queries with `k = 0` and with `k = 2`.

Before the fix:

```
running 1 test
test local_hnsw::tests::query_embedding_returns_nothing_for_zero_k ... FAILED

failures:

---- local_hnsw::tests::query_embedding_returns_nothing_for_zero_k stdout ----

thread 'local_hnsw::tests::query_embedding_returns_nothing_for_zero_k' panicked at rust/segment/src/local_hnsw.rs:354:63:
called `Option::unwrap()` on a `None` value

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 83 filtered out; finished in 0.02s
```

After the fix:

```
running 2 tests
test local_hnsw::tests::query_embedding_returns_nothing_for_zero_k ... ok
test local_hnsw::tests::reader_migrates_legacy_max_seq_id ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 82 filtered out; finished in 0.03s
```

Whole crate, `cargo test -p chroma-segment`:

```
test result: ok. 84 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 20.11s
```

I also confirmed the path end to end with a throwaway test in
`rust/frontend/src/executor/local.rs` that drives the real `Frontend` over
`FrontendConfig::sqlite_in_memory()`: add 5 records, delete 2, then
`QueryRequest::try_new(.., n_results = 0, ..)`. On `main` that test panics at
`local_hnsw.rs:354`; with this change it returns 0 ids. That test is not part of the
diff, since the unit test above covers the same regression in the crate that owns the
code.

`cargo fmt -- --check` and
`cargo clippy -p chroma-segment --all-targets --all-features --keep-going -- -D warnings -D clippy::large_futures -D clippy::all`
are both clean. The three `test_k8s_integration_*` failures in `chroma-frontend` are
pre-existing on `main` and need a running Tilt environment.

## Migration plan

None. No format, schema or API change. The only behaviour change is that an input that
used to panic now returns an empty result, which is what the non-degraded branch
already did.

## Observability plan

None. This removes a panic on a request path; no new metrics or spans are needed.

## Documentation Changes

None. `n_results = 0` is not documented as an error, and this change makes the
documented behaviour (return the nearest `n_results` records) consistent across both
branches.
