### PR TITLE
[BUG](api): Normalize Knn key before comparison

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -830,7 +830,15 @@ class CollectionCommon(Generic[ClientT]):
             return knn
 
         query_text = knn.query
+
+        # Convert Key to string if provided. Key overloads __eq__ to build an Eq
+        # expression, which is always truthy, so comparing a Key directly would
+        # take the main-embedding branch for every key.
+        from chromadb.execution.expression.operator import Key as KeyType
+
         key = knn.key
+        if isinstance(key, KeyType):
+            key = key.name
 
         # Handle main embedding field
         if key == EMBEDDING_KEY:

--- a/chromadb/test/api/test_knn_key.py
+++ b/chromadb/test/api/test_knn_key.py
@@ -1,0 +1,49 @@
+"""Regression tests for Knn key handling in _embed_knn_string_queries."""
+
+from typing import Any, List
+
+import pytest
+
+from chromadb.api.models.CollectionCommon import CollectionCommon
+from chromadb.execution.expression.operator import Key, Knn
+
+
+class _StubCollection:
+    """Minimal stand-in exposing only what _embed_knn_string_queries touches."""
+
+    schema = None
+
+    def __init__(self) -> None:
+        self.embed_calls: List[Any] = []
+
+    def _embed(self, input: Any, is_query: bool = False) -> Any:
+        self.embed_calls.append(input)
+        return [[0.0, 1.0, 2.0]]
+
+
+def _embed_knn(stub: _StubCollection, knn: Knn) -> Any:
+    return CollectionCommon._embed_knn_string_queries(stub, knn)  # type: ignore[arg-type]
+
+
+def test_knn_key_object_routes_like_its_string() -> None:
+    """A Key for a non-embedding field must not fall through to the default
+    embedding function. Key.__eq__ returns an Eq expression, which is always
+    truthy, so an unnormalized comparison sent every Key down that branch."""
+    as_string = _StubCollection()
+    with pytest.raises(ValueError, match="key not found in schema"):
+        _embed_knn(as_string, Knn(query="hello", key="not_a_real_field"))
+
+    as_key = _StubCollection()
+    with pytest.raises(ValueError, match="key not found in schema"):
+        _embed_knn(as_key, Knn(query="hello", key=Key("not_a_real_field")))
+
+    assert as_key.embed_calls == [], "a non-embedding key must not use the default embedding function"
+
+
+def test_knn_embedding_key_object_still_embeds() -> None:
+    """The Key spelling of the main embedding field keeps working."""
+    stub = _StubCollection()
+    result = _embed_knn(stub, Knn(query="hello", key=Key("#embedding")))
+
+    assert stub.embed_calls == [["hello"]], "main embedding field should use the default function"
+    assert result.query == [0.0, 1.0, 2.0]


### PR DESCRIPTION
## Description of changes

`Knn.key` is typed `Union[Key, str]` and the class docstring shows the `Key` spelling, but `_embed_knn_string_queries` compared it directly:

```python
if key == EMBEDDING_KEY:
```

`Key.__eq__` is overloaded to return an `Eq` expression rather than a bool, and `Eq` defines no `__bool__`, so the comparison is truthy for every `Key`. Any string query with a `Key` took the main-embedding branch and was embedded with the collection's default embedding function, whatever key was asked for. The per-key schema lookup and the sparse embedding-function path below were unreachable for `Key` inputs.

The two spellings of the same key therefore disagreed:

```python
Knn(query="hello", key="not_a_real_field")        # ValueError: key not found in schema
Knn(query="hello", key=Key("not_a_real_field"))   # no error, embedded with the default EF
```

The string form raises correctly; the documented object form silently returned neighbours from the wrong field.

This normalizes `Key` to its name before the comparison, matching the existing pattern in `chromadb/api/types.py`:

```python
if key is not None and isinstance(key, KeyType):
    key = key.name
```

Normalizing once also fixes the `key not in schema.keys` lookup further down, which failed the same way for a `Key`.

## Test plan

`pytest` adds `chromadb/test/api/test_knn_key.py` with two cases: a `Key` for an unknown field raises the same `ValueError` as the equivalent string and never calls the default embedding function, and `Key("#embedding")` still embeds. Both fail on `main` and pass with this change.

## Documentation Changes

None required.