### PR TITLE
[ENH](work-queue): Add exponential retry backoff

### DIFF
--- a/examples/work_queue_config.yaml
+++ b/examples/work_queue_config.yaml
@@ -1,5 +1,7 @@
 work_queue:
   storage_path: "work-queue/queue.parquet"
+  retry_backoff_initial_seconds: 10
+  retry_backoff_max_seconds: 600
   persistence:
     time_threshold_seconds: 5
     pending_threshold: 10

--- a/k8s/work-queue-config.yaml
+++ b/k8s/work-queue-config.yaml
@@ -6,6 +6,8 @@ data:
   config.yaml: |
     work_queue:
       storage_path: "work-queue/queue.parquet"
+      retry_backoff_initial_seconds: 10
+      retry_backoff_max_seconds: 600
       persistence:
         time_threshold_seconds: 2
         pending_threshold: 100

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -260,6 +260,8 @@ work_queue_service:
           bandwidth_allocation: [0.7, 0.3]
   work_queue:
     storage_path: "workqueue_state.parquet"
+    retry_backoff_initial_seconds: 10
+    retry_backoff_max_seconds: 600
     persistence:
       time_threshold_seconds: 2
       pending_threshold: 100

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -259,6 +259,8 @@ work_queue_service:
           bandwidth_allocation: [0.7, 0.3]
   work_queue:
     storage_path: "workqueue_state.parquet"
+    retry_backoff_initial_seconds: 10
+    retry_backoff_max_seconds: 600
     persistence:
       time_threshold_seconds: 2
       pending_threshold: 100

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -259,6 +259,8 @@ work_queue_service:
           bandwidth_allocation: [0.7, 0.3]
   work_queue:
     storage_path: "workqueue_state.parquet"
+    retry_backoff_initial_seconds: 10
+    retry_backoff_max_seconds: 600
     persistence:
       time_threshold_seconds: 2
       pending_threshold: 100

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -22,7 +22,8 @@ use chroma_system::{
     TaskError,
 };
 use chroma_types::{
-    AttachedFunctionUuid, Collection, CollectionUuid, JobId, Schema, SegmentFlushInfo, SegmentUuid,
+    AttachedFunctionUuid, Collection, CollectionUuid, GetCollectionsError, JobId, Schema,
+    SegmentFlushInfo, SegmentUuid,
 };
 use opentelemetry::metrics::Counter;
 use thiserror::Error;
@@ -296,6 +297,8 @@ pub enum CompactionError {
     DataFetchError(#[from] LogFetchOrchestratorError),
     #[error("Error resolving attached function state: {0}")]
     AttachedFunctionState(#[from] GetAttachedFunctionError),
+    #[error("Error resolving function input collections: {0}")]
+    FunctionInputCollections(#[from] GetCollectionsError),
     #[error("Error finishing async attached function work: {0}")]
     FinishAsyncWork(#[from] FinishAsyncWorkError),
     #[error("Error registering collection: {0}")]
@@ -328,6 +331,7 @@ impl ChromaError for CompactionError {
             CompactionError::CompactionContextError(e) => e.code(),
             CompactionError::DataFetchError(e) => e.code(),
             CompactionError::AttachedFunctionState(e) => e.code(),
+            CompactionError::FunctionInputCollections(e) => e.code(),
             CompactionError::FinishAsyncWork(e) => e.code(),
             CompactionError::RegisterError(e) => e.code(),
             CompactionError::PanicError(e) => e.code(),
@@ -343,6 +347,7 @@ impl ChromaError for CompactionError {
             Self::CompactionContextError(e) => e.should_trace_error(),
             Self::DataFetchError(e) => e.should_trace_error(),
             Self::AttachedFunctionState(e) => e.should_trace_error(),
+            Self::FunctionInputCollections(e) => e.should_trace_error(),
             Self::FinishAsyncWork(e) => e.should_trace_error(),
             Self::PanicError(e) => e.should_trace_error(),
             Self::RegisterError(e) => e.should_trace_error(),

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -1,6 +1,6 @@
 use chroma_error::{source_chain_contains, ChromaError};
 use chroma_log::grpc_log::GrpcPullLogsError;
-use chroma_sysdb::GetCollectionsOptions;
+use chroma_sysdb::{sysdb::GetAttachedFunctionError, GetCollectionsOptions};
 use chroma_system::{Operator, System};
 use chroma_types::{AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName};
 use std::collections::HashSet;
@@ -198,8 +198,8 @@ impl FunctionExecutionContext {
             .await?
             .into_iter()
             .find(|attached_function| attached_function.id == attached_function_id)
-            .ok_or(CompactionError::InvariantViolation(
-                "Missing resolved attached function state for fn-consumer input collection",
+            .ok_or(CompactionError::AttachedFunctionState(
+                GetAttachedFunctionError::NotFound,
             ))?;
 
         Ok(attached_function.completion_offset as i64)
@@ -244,7 +244,18 @@ impl FunctionExecutionContext {
             .is_some_and(|pull_error| Self::is_purged_pull_error(pull_error.as_ref()))
     }
 
-    async fn purge_deleted(
+    fn is_terminal_input_error(error: &CompactionError) -> bool {
+        error.code() == chroma_error::ErrorCodes::NotFound
+    }
+
+    fn finish_item(input: &FunctionExecutionInput) -> FinishAsyncWorkItem {
+        FinishAsyncWorkItem {
+            input_collection_id: input.collection_id,
+            completion_offset: input.queue_compaction_offset,
+        }
+    }
+
+    async fn finish_stale_work(
         compaction_context: CompactionContext,
         attached_function_id: AttachedFunctionUuid,
         work_items: Vec<FinishAsyncWorkItem>,
@@ -265,12 +276,53 @@ impl FunctionExecutionContext {
                 work_items,
                 work_queue_client,
             ))
-            .await
-            .map_err(|_| {
-                CompactionError::InvariantViolation("Failed to purge deleted fn-consumer work item")
-            })?;
+            .await?;
 
         Ok(())
+    }
+
+    async fn finish_stale_input(
+        compaction_context: CompactionContext,
+        attached_function_id: AttachedFunctionUuid,
+        input: &FunctionExecutionInput,
+        error: String,
+    ) -> Result<(), CompactionError> {
+        tracing::info!(
+            collection_id = %input.collection_id,
+            attached_function_id = %attached_function_id,
+            error,
+            "Finishing terminal fn-consumer work for a missing or deleted input"
+        );
+        Self::finish_stale_work(
+            compaction_context,
+            attached_function_id,
+            vec![Self::finish_item(input)],
+        )
+        .await
+    }
+
+    async fn resolve_input_or_finish_stale<T>(
+        compaction_context: CompactionContext,
+        attached_function_id: AttachedFunctionUuid,
+        input: &FunctionExecutionInput,
+        result: Result<T, CompactionError>,
+    ) -> Result<Option<T>, CompactionError> {
+        match result {
+            Ok(value) => Ok(Some(value)),
+            Err(error) if Self::is_terminal_input_error(&error) => {
+                let error_message = error.to_string();
+                drop(error);
+                Self::finish_stale_input(
+                    compaction_context,
+                    attached_function_id,
+                    input,
+                    error_message,
+                )
+                .await?;
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     async fn partition_live_and_stale_inputs(
@@ -292,10 +344,7 @@ impl FunctionExecutionContext {
                 limit: Some(fn_inputs.len() as u32),
                 ..Default::default()
             })
-            .await
-            .map_err(|_| {
-                CompactionError::InvariantViolation("Failed to resolve function input collections")
-            })?;
+            .await?;
         let live_collection_ids: HashSet<_> = collections
             .iter()
             .map(|collection| collection.collection_id)
@@ -320,14 +369,11 @@ impl FunctionExecutionContext {
                     attached_function_id = %attached_function_id,
                     "Finishing stale fn-consumer work for deleted input collection"
                 );
-                stale_work_items.push(FinishAsyncWorkItem {
-                    input_collection_id: input.collection_id,
-                    completion_offset: input.queue_compaction_offset,
-                });
+                stale_work_items.push(Self::finish_item(&input));
             }
         }
 
-        Self::purge_deleted(compaction_context, attached_function_id, stale_work_items).await?;
+        Self::finish_stale_work(compaction_context, attached_function_id, stale_work_items).await?;
 
         Ok((shared_database_name, live_inputs))
     }
@@ -346,12 +392,33 @@ impl FunctionExecutionContext {
         }
 
         let base_context = self.compaction_context;
-        let (shared_database_name, live_inputs) = Box::pin(Self::partition_live_and_stale_inputs(
-            base_context.clone(),
-            attached_function_id,
-            &fn_inputs,
-        ))
-        .await?;
+        let (shared_database_name, live_inputs) =
+            match Box::pin(Self::partition_live_and_stale_inputs(
+                base_context.clone(),
+                attached_function_id,
+                &fn_inputs,
+            ))
+            .await
+            {
+                Ok(partitioned) => partitioned,
+                Err(error) if Self::is_terminal_input_error(&error) => {
+                    tracing::info!(
+                        attached_function_id = %attached_function_id,
+                        error = %error,
+                        "Finishing fn-consumer batch after input resolution reported terminal state"
+                    );
+                    Self::finish_stale_work(
+                        base_context,
+                        attached_function_id,
+                        fn_inputs.iter().map(Self::finish_item).collect(),
+                    )
+                    .await?;
+                    return Ok(CompactionResponse::Success {
+                        job_id: attached_function_id.into(),
+                    });
+                }
+                Err(error) => return Err(error),
+            };
         if live_inputs.is_empty() {
             return Ok(CompactionResponse::Success {
                 job_id: attached_function_id.into(),
@@ -368,7 +435,17 @@ impl FunctionExecutionContext {
                 input.collection_id,
                 attached_function_id,
             )
-            .await?;
+            .await;
+            let Some(completion_offset) = Self::resolve_input_or_finish_stale(
+                base_context.clone(),
+                attached_function_id,
+                &input,
+                completion_offset,
+            )
+            .await?
+            else {
+                continue;
+            };
 
             if has_reached_queue_frontier(completion_offset, input.queue_compaction_offset) {
                 Self::finish_completed_work(
@@ -388,7 +465,17 @@ impl FunctionExecutionContext {
                 shared_database_name.clone(),
                 system.clone(),
             ))
-            .await?;
+            .await;
+            let Some(collection_data) = Self::resolve_input_or_finish_stale(
+                base_context.clone(),
+                attached_function_id,
+                &input,
+                collection_data,
+            )
+            .await?
+            else {
+                continue;
+            };
 
             let completion_offset = collection_data
                 .resolved_attached_functions
@@ -448,13 +535,18 @@ impl FunctionExecutionContext {
 mod tests {
     use super::{has_reached_queue_frontier, FunctionExecutionContext};
     use crate::execution::{
-        operators::fetch_log::FetchLogError,
+        operators::{
+            fetch_log::FetchLogError, get_attached_function::GetAttachedFunctionOperatorError,
+            get_collection_and_segments::GetCollectionAndSegmentsError,
+        },
         orchestration::{
             compact::CompactionError, log_fetch_orchestrator::LogFetchOrchestratorError,
         },
     };
-    use chroma_error::ChromaError;
+    use chroma_error::{ChromaError, ErrorCodes, TonicError};
     use chroma_log::grpc_log::GrpcPullLogsError;
+    use chroma_sysdb::sysdb::GetAttachedFunctionError;
+    use chroma_types::{GetCollectionWithSegmentsError, GetCollectionsError};
     use tonic::Status;
 
     #[test]
@@ -497,5 +589,66 @@ mod tests {
         assert!(!FunctionExecutionContext::should_backfill_on_fetch_error(
             &err
         ));
+    }
+
+    #[test]
+    fn missing_attached_function_is_terminal_input_error() {
+        let err = CompactionError::AttachedFunctionState(GetAttachedFunctionError::NotFound);
+
+        assert_eq!(err.code(), ErrorCodes::NotFound);
+        assert!(FunctionExecutionContext::is_terminal_input_error(&err));
+    }
+
+    #[test]
+    fn unavailable_attached_function_lookup_is_retryable() {
+        let err = CompactionError::AttachedFunctionState(
+            GetAttachedFunctionError::FailedToGetAttachedFunction(Status::unavailable("sysdb")),
+        );
+
+        assert_eq!(err.code(), ErrorCodes::Unavailable);
+        assert!(!FunctionExecutionContext::is_terminal_input_error(&err));
+    }
+
+    #[test]
+    fn not_found_collection_resolution_is_terminal_input_error() {
+        let err = CompactionError::FunctionInputCollections(GetCollectionsError::Internal(
+            Box::new(TonicError(Status::not_found("collection deleted"))),
+        ));
+
+        assert_eq!(err.code(), ErrorCodes::NotFound);
+        assert!(FunctionExecutionContext::is_terminal_input_error(&err));
+    }
+
+    #[test]
+    fn unavailable_collection_resolution_is_retryable() {
+        let err = CompactionError::FunctionInputCollections(GetCollectionsError::Internal(
+            Box::new(TonicError(Status::unavailable("sysdb unavailable"))),
+        ));
+
+        assert_eq!(err.code(), ErrorCodes::Unavailable);
+        assert!(!FunctionExecutionContext::is_terminal_input_error(&err));
+    }
+
+    #[test]
+    fn detached_function_during_fetch_is_terminal_input_error() {
+        let err = CompactionError::DataFetchError(LogFetchOrchestratorError::GetAttachedFunction(
+            GetAttachedFunctionOperatorError::NoAttachedFunctionFound,
+        ));
+
+        assert_eq!(err.code(), ErrorCodes::NotFound);
+        assert!(FunctionExecutionContext::is_terminal_input_error(&err));
+    }
+
+    #[test]
+    fn deleted_collection_during_fetch_is_terminal_input_error() {
+        let err =
+            CompactionError::DataFetchError(LogFetchOrchestratorError::GetCollectionAndSegments(
+                GetCollectionAndSegmentsError::SysDB(GetCollectionWithSegmentsError::NotFound(
+                    "deleted".to_string(),
+                )),
+            ));
+
+        assert_eq!(err.code(), ErrorCodes::NotFound);
+        assert!(FunctionExecutionContext::is_terminal_input_error(&err));
     }
 }

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -145,6 +145,8 @@ impl ChromaError for LogFetchOrchestratorError {
     fn code(&self) -> ErrorCodes {
         match self {
             LogFetchOrchestratorError::Aborted => ErrorCodes::Aborted,
+            LogFetchOrchestratorError::GetAttachedFunction(e) => e.code(),
+            LogFetchOrchestratorError::GetCollectionAndSegments(e) => e.code(),
             LogFetchOrchestratorError::SchemaMismatch(_)
             | LogFetchOrchestratorError::MultiShardMigrationNotSupported(_) => {
                 ErrorCodes::FailedPrecondition
@@ -577,6 +579,17 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
             Some(output) => output,
             None => return,
         };
+
+        if output.attached_functions.is_empty() {
+            self.terminate_with_result(
+                Err(LogFetchOrchestratorError::GetAttachedFunction(
+                    GetAttachedFunctionOperatorError::NoAttachedFunctionFound,
+                )),
+                ctx,
+            )
+            .await;
+            return;
+        }
 
         if output.attached_functions.len() != 1 {
             self.terminate_with_result(

--- a/rust/worker/src/work_queue/config.rs
+++ b/rust/worker/src/work_queue/config.rs
@@ -5,6 +5,10 @@ use serde::{Deserialize, Serialize};
 pub struct WorkQueueConfig {
     pub storage_path: String,
     pub persistence: PersistenceConfig,
+    #[serde(default = "WorkQueueConfig::default_retry_backoff_initial_seconds")]
+    pub retry_backoff_initial_seconds: u64,
+    #[serde(default = "WorkQueueConfig::default_retry_backoff_max_seconds")]
+    pub retry_backoff_max_seconds: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,6 +26,18 @@ impl Default for WorkQueueConfig {
                 time_threshold_seconds: 2,
                 pending_threshold: 100,
             },
+            retry_backoff_initial_seconds: Self::default_retry_backoff_initial_seconds(),
+            retry_backoff_max_seconds: Self::default_retry_backoff_max_seconds(),
         }
+    }
+}
+
+impl WorkQueueConfig {
+    fn default_retry_backoff_initial_seconds() -> u64 {
+        10
+    }
+
+    fn default_retry_backoff_max_seconds() -> u64 {
+        600
     }
 }

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -1,5 +1,5 @@
 use crate::work_queue::types::{WorkQueueError, WorkQueueRecord};
-use arrow::array::{Array, Int64Array, StringArray, UInt64Array};
+use arrow::array::{Array, Int64Array, StringArray, UInt32Array, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use bytes::Bytes;
@@ -21,6 +21,18 @@ impl QueueOffsets {
     fn dedup_frontier(self) -> i64 {
         self.compaction_offset
     }
+}
+
+fn exponential_retry_delay_ms(
+    initial_delay_seconds: u64,
+    max_delay_seconds: u64,
+    delivery_attempts: u32,
+) -> u64 {
+    let exponent = delivery_attempts.saturating_sub(1).min(63);
+    initial_delay_seconds
+        .saturating_mul(1_000)
+        .saturating_mul(1_u64 << exponent)
+        .min(max_delay_seconds.saturating_mul(1_000))
 }
 
 #[derive(Debug, Clone)]
@@ -59,6 +71,8 @@ impl QueueState {
             Field::new("completion_offset", DataType::Int64, false),
             Field::new("compaction_offset", DataType::Int64, false),
             Field::new("insertion_order", DataType::UInt64, false),
+            Field::new("delivery_attempts", DataType::UInt32, false),
+            Field::new("not_before_epoch_ms", DataType::UInt64, false),
         ]));
 
         let mut buffer = Vec::new();
@@ -91,6 +105,16 @@ impl QueueState {
                 .iter()
                 .map(|r| r.compaction_offset)
                 .collect();
+            let delivery_attempts: Vec<_> = self
+                .pending_work
+                .iter()
+                .map(|r| r.delivery_attempts)
+                .collect();
+            let not_before_epoch_ms: Vec<_> = self
+                .pending_work
+                .iter()
+                .map(|r| r.not_before_epoch_ms)
+                .collect();
 
             let batch = RecordBatch::try_new(
                 schema,
@@ -100,6 +124,8 @@ impl QueueState {
                     Arc::new(Int64Array::from(completion_offsets)),
                     Arc::new(Int64Array::from(compaction_offsets)),
                     Arc::new(UInt64Array::from(orders)),
+                    Arc::new(UInt32Array::from(delivery_attempts)),
+                    Arc::new(UInt64Array::from(not_before_epoch_ms)),
                 ],
             )
             .map_err(|e| WorkQueueError::Serialization(e.to_string()))?;
@@ -162,6 +188,12 @@ impl QueueState {
             let compaction_offsets_idx = schema
                 .column_with_name("compaction_offset")
                 .map(|(idx, _)| idx);
+            let delivery_attempts_idx = schema
+                .column_with_name("delivery_attempts")
+                .map(|(idx, _)| idx);
+            let not_before_epoch_ms_idx = schema
+                .column_with_name("not_before_epoch_ms")
+                .map(|(idx, _)| idx);
 
             let fn_ids = batch
                 .column(fn_ids_idx)
@@ -208,6 +240,32 @@ impl QueueState {
                         })
                 })
                 .transpose()?;
+            let delivery_attempts = delivery_attempts_idx
+                .map(|idx| {
+                    batch
+                        .column(idx)
+                        .as_any()
+                        .downcast_ref::<UInt32Array>()
+                        .ok_or_else(|| {
+                            WorkQueueError::Serialization(
+                                "Failed to downcast delivery attempts".to_string(),
+                            )
+                        })
+                })
+                .transpose()?;
+            let not_before_epoch_ms = not_before_epoch_ms_idx
+                .map(|idx| {
+                    batch
+                        .column(idx)
+                        .as_any()
+                        .downcast_ref::<UInt64Array>()
+                        .ok_or_else(|| {
+                            WorkQueueError::Serialization(
+                                "Failed to downcast not-before timestamps".to_string(),
+                            )
+                        })
+                })
+                .transpose()?;
 
             for i in 0..batch.num_rows() {
                 let fn_id = AttachedFunctionUuid::from_str(fn_ids.value(i))
@@ -243,6 +301,12 @@ impl QueueState {
                     completion_offset: completion_offset.unwrap_or(compaction_offset),
                     compaction_offset,
                     insertion_order: orders.value(i),
+                    delivery_attempts: delivery_attempts
+                        .filter(|attempts| attempts.is_valid(i))
+                        .map_or(0, |attempts| attempts.value(i)),
+                    not_before_epoch_ms: not_before_epoch_ms
+                        .filter(|not_before| not_before.is_valid(i))
+                        .map_or(0, |not_before| not_before.value(i)),
                 };
 
                 let key = (fn_id, input_coll_id);
@@ -318,6 +382,8 @@ impl QueueState {
             completion_offset,
             compaction_offset,
             insertion_order: self.next_insertion_order,
+            delivery_attempts: 0,
+            not_before_epoch_ms: 0,
         };
 
         self.next_insertion_order += 1;
@@ -328,12 +394,41 @@ impl QueueState {
         true
     }
 
-    pub(crate) fn contains_entry(
-        &self,
-        fn_id: &AttachedFunctionUuid,
-        input_coll_id: &CollectionUuid,
-    ) -> bool {
-        self.dedup_index.contains_key(&(*fn_id, *input_coll_id))
+    pub fn claim_work(
+        &mut self,
+        limit: usize,
+        now_epoch_ms: u64,
+        retry_backoff_initial_seconds: u64,
+        retry_backoff_max_seconds: u64,
+    ) -> Vec<WorkQueueRecord> {
+        let dedup_index = &self.dedup_index;
+        let mut claimed = Vec::with_capacity(limit);
+
+        for item in self.pending_work.iter_mut() {
+            if claimed.len() == limit {
+                break;
+            }
+            if !dedup_index.contains_key(&(item.fn_id, item.input_coll_id))
+                || item.not_before_epoch_ms > now_epoch_ms
+            {
+                continue;
+            }
+
+            item.delivery_attempts = item.delivery_attempts.saturating_add(1);
+            let retry_delay_ms = exponential_retry_delay_ms(
+                retry_backoff_initial_seconds,
+                retry_backoff_max_seconds,
+                item.delivery_attempts,
+            );
+            item.not_before_epoch_ms = now_epoch_ms.saturating_add(retry_delay_ms);
+            claimed.push(item.clone());
+        }
+
+        if !claimed.is_empty() {
+            self.dirty = true;
+        }
+
+        claimed
     }
 
     /// Mark work as successfully completed.
@@ -347,7 +442,7 @@ impl QueueState {
     ) {
         let key = (*fn_id, *input_coll_id);
 
-        if let Some(existing_offsets) = self.dedup_index.get_mut(&key) {
+        if let Some(existing_offsets) = self.dedup_index.get(&key).copied() {
             if existing_offsets.dedup_frontier() <= completion_offset {
                 // Remove the single entry for this key
                 self.pending_work
@@ -355,6 +450,14 @@ impl QueueState {
 
                 // Remove from dedup index
                 self.dedup_index.remove(&key);
+                self.dirty = true;
+            } else if let Some(item) = self
+                .pending_work
+                .iter_mut()
+                .find(|item| item.fn_id == *fn_id && item.input_coll_id == *input_coll_id)
+            {
+                item.delivery_attempts = 0;
+                item.not_before_epoch_ms = 0;
                 self.dirty = true;
             }
         }
@@ -376,6 +479,8 @@ mod tests {
             completion_offset: 100,
             compaction_offset: 140,
             insertion_order: 0,
+            delivery_attempts: 2,
+            not_before_epoch_ms: 12_345,
         };
 
         let record2 = WorkQueueRecord {
@@ -384,6 +489,8 @@ mod tests {
             completion_offset: 200,
             compaction_offset: 240,
             insertion_order: 1,
+            delivery_attempts: 0,
+            not_before_epoch_ms: 0,
         };
 
         let record3 = WorkQueueRecord {
@@ -392,6 +499,8 @@ mod tests {
             completion_offset: 300,
             compaction_offset: 360,
             insertion_order: 2,
+            delivery_attempts: 0,
+            not_before_epoch_ms: 0,
         };
 
         state.pending_work.push_back(record1.clone());
@@ -424,6 +533,8 @@ mod tests {
         assert_eq!(restored.pending_work.len(), 3);
         assert_eq!(restored.pending_work[0].completion_offset, 100);
         assert_eq!(restored.pending_work[0].compaction_offset, 140);
+        assert_eq!(restored.pending_work[0].delivery_attempts, 2);
+        assert_eq!(restored.pending_work[0].not_before_epoch_ms, 12_345);
         assert_eq!(restored.pending_work[1].completion_offset, 200);
         assert_eq!(restored.pending_work[1].compaction_offset, 240);
         assert_eq!(restored.pending_work[2].completion_offset, 300);
@@ -466,6 +577,8 @@ mod tests {
         assert_eq!(restored.pending_work.len(), 1);
         assert_eq!(restored.pending_work[0].completion_offset, 100);
         assert_eq!(restored.pending_work[0].compaction_offset, 100);
+        assert_eq!(restored.pending_work[0].delivery_attempts, 0);
+        assert_eq!(restored.pending_work[0].not_before_epoch_ms, 0);
     }
 
     #[test]
@@ -487,6 +600,214 @@ mod tests {
     }
 
     #[test]
+    fn test_claim_work_applies_capped_exponential_backoff() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+        let start_ms = 1_000;
+
+        state.push_work(fn_id, coll_id, 20, 40);
+
+        let first = state.claim_work(1, start_ms, 10, 25);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].delivery_attempts, 1);
+        assert_eq!(first[0].not_before_epoch_ms, start_ms + 10_000);
+        assert!(state.claim_work(1, start_ms + 9_999, 10, 25).is_empty());
+
+        let second = state.claim_work(1, start_ms + 10_000, 10, 25);
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].delivery_attempts, 2);
+        assert_eq!(second[0].not_before_epoch_ms, start_ms + 30_000);
+        assert!(state.claim_work(1, start_ms + 29_999, 10, 25).is_empty());
+
+        let third = state.claim_work(1, start_ms + 30_000, 10, 25);
+        assert_eq!(third.len(), 1);
+        assert_eq!(third[0].delivery_attempts, 3);
+        assert_eq!(third[0].not_before_epoch_ms, start_ms + 55_000);
+    }
+
+    #[test]
+    fn test_claim_work_skips_backed_off_front_row() {
+        const FIRST_CLAIM_MS: u64 = 1_000;
+        const INITIAL_BACKOFF_SECONDS: u64 = 10;
+        const MAX_BACKOFF_SECONDS: u64 = 60;
+
+        let mut state = QueueState::new();
+        let first_fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let first_coll_id = CollectionUuid(Uuid::new_v4());
+        let second_fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let second_coll_id = CollectionUuid(Uuid::new_v4());
+
+        state.push_work(first_fn_id, first_coll_id, 20, 40);
+        state.push_work(second_fn_id, second_coll_id, 20, 40);
+
+        // Claiming the front row makes it ineligible for another 10 seconds.
+        assert_eq!(
+            state.claim_work(
+                1,
+                FIRST_CLAIM_MS,
+                INITIAL_BACKOFF_SECONDS,
+                MAX_BACKOFF_SECONDS,
+            ),
+            vec![WorkQueueRecord {
+                fn_id: first_fn_id,
+                input_coll_id: first_coll_id,
+                completion_offset: 20,
+                compaction_offset: 40,
+                insertion_order: 0,
+                delivery_attempts: 1,
+                not_before_epoch_ms: 11_000,
+            }]
+        );
+
+        // At the same time, the backed-off front row is skipped and later work is claimable.
+        assert_eq!(
+            state.claim_work(
+                1,
+                FIRST_CLAIM_MS,
+                INITIAL_BACKOFF_SECONDS,
+                MAX_BACKOFF_SECONDS,
+            ),
+            vec![WorkQueueRecord {
+                fn_id: second_fn_id,
+                input_coll_id: second_coll_id,
+                completion_offset: 20,
+                compaction_offset: 40,
+                insertion_order: 1,
+                delivery_attempts: 1,
+                not_before_epoch_ms: 11_000,
+            }]
+        );
+
+        // Neither row can be redelivered before its deadline.
+        assert_eq!(
+            Vec::<WorkQueueRecord>::new(),
+            state.claim_work(1, 10_999, INITIAL_BACKOFF_SECONDS, MAX_BACKOFF_SECONDS,)
+        );
+
+        // At the deadline, FIFO ordering makes the original front row eligible again.
+        assert_eq!(
+            state.claim_work(1, 11_000, INITIAL_BACKOFF_SECONDS, MAX_BACKOFF_SECONDS,),
+            vec![WorkQueueRecord {
+                fn_id: first_fn_id,
+                input_coll_id: first_coll_id,
+                completion_offset: 20,
+                compaction_offset: 40,
+                insertion_order: 0,
+                delivery_attempts: 2,
+                not_before_epoch_ms: 31_000,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_retry_schedule_survives_queue_state_round_trip() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+
+        state.push_work(fn_id, coll_id, 20, 40);
+        assert_eq!(
+            state.claim_work(1, 1_000, 10, 60),
+            vec![WorkQueueRecord {
+                fn_id,
+                input_coll_id: coll_id,
+                completion_offset: 20,
+                compaction_offset: 40,
+                insertion_order: 0,
+                delivery_attempts: 1,
+                not_before_epoch_ms: 11_000,
+            }]
+        );
+
+        let bytes = state.to_parquet_bytes().expect("queue should serialize");
+        let mut restored =
+            QueueState::from_parquet_bytes(&bytes).expect("queue should deserialize");
+
+        assert_eq!(
+            restored.pending_work,
+            VecDeque::from([WorkQueueRecord {
+                fn_id,
+                input_coll_id: coll_id,
+                completion_offset: 20,
+                compaction_offset: 40,
+                insertion_order: 0,
+                delivery_attempts: 1,
+                not_before_epoch_ms: 11_000,
+            }])
+        );
+        assert_eq!(
+            Vec::<WorkQueueRecord>::new(),
+            restored.claim_work(1, 10_999, 10, 60)
+        );
+        assert_eq!(
+            restored.claim_work(1, 11_000, 10, 60),
+            vec![WorkQueueRecord {
+                fn_id,
+                input_coll_id: coll_id,
+                completion_offset: 20,
+                compaction_offset: 40,
+                insertion_order: 0,
+                delivery_attempts: 2,
+                not_before_epoch_ms: 31_000,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_newer_work_resets_retry_schedule() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+
+        state.push_work(fn_id, coll_id, 20, 40);
+        state.claim_work(1, 1_000, 10, 60);
+        assert!(state.push_work(fn_id, coll_id, 30, 60));
+
+        assert_eq!(
+            state.pending_work,
+            VecDeque::from([WorkQueueRecord {
+                fn_id,
+                input_coll_id: coll_id,
+                completion_offset: 30,
+                compaction_offset: 60,
+                insertion_order: 1,
+                delivery_attempts: 0,
+                not_before_epoch_ms: 0,
+            }])
+        );
+        assert_eq!(
+            state.claim_work(1, 1_000, 10, 60),
+            vec![WorkQueueRecord {
+                fn_id,
+                input_coll_id: coll_id,
+                completion_offset: 30,
+                compaction_offset: 60,
+                insertion_order: 1,
+                delivery_attempts: 1,
+                not_before_epoch_ms: 11_000,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_terminal_finish_removes_backed_off_work() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+
+        state.push_work(fn_id, coll_id, 20, 40);
+        state.claim_work(1, 1_000, 10, 60);
+        state.finish_work_success(&fn_id, &coll_id, 40);
+
+        assert_eq!(VecDeque::<WorkQueueRecord>::new(), state.pending_work);
+        assert_eq!(
+            Vec::<WorkQueueRecord>::new(),
+            state.claim_work(1, 11_000, 10, 60)
+        );
+    }
+
+    #[test]
     fn test_finish_work_waits_for_compaction_offset() {
         let mut state = QueueState::new();
 
@@ -496,10 +817,16 @@ mod tests {
         state.push_work(fn_id, coll_id, 20, 60);
         assert_eq!(state.pending_work.len(), 1);
 
+        let claimed = state.claim_work(1, 1_000, 10, 60);
+        assert_eq!(claimed[0].delivery_attempts, 1);
+        assert_eq!(claimed[0].not_before_epoch_ms, 11_000);
+
         state.finish_work_success(&fn_id, &coll_id, 40);
         assert_eq!(state.pending_work.len(), 1);
         assert_eq!(state.pending_work[0].completion_offset, 20);
         assert_eq!(state.pending_work[0].compaction_offset, 60);
+        assert_eq!(state.pending_work[0].delivery_attempts, 0);
+        assert_eq!(state.pending_work[0].not_before_epoch_ms, 0);
 
         state.finish_work_success(&fn_id, &coll_id, 60);
         assert_eq!(state.pending_work.len(), 0);

--- a/rust/worker/src/work_queue/types.rs
+++ b/rust/worker/src/work_queue/types.rs
@@ -10,6 +10,8 @@ pub struct WorkQueueRecord {
     pub completion_offset: i64,
     pub compaction_offset: i64,
     pub insertion_order: u64,
+    pub delivery_attempts: u32,
+    pub not_before_epoch_ms: u64,
 }
 
 #[derive(Error, Debug, Clone)]
@@ -65,7 +67,7 @@ impl ChromaError for WorkQueueError {
 }
 
 // Stub types for future sysdb integration
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(dead_code)]
 pub enum FinishResult {
     Success,

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -10,7 +10,7 @@ use chroma_sysdb::SysDb;
 use chroma_system::{Component, ComponentContext, ComponentRuntime, Handler};
 use chroma_types::chroma_proto::TryFinishAsyncAttachedFunctionInvocationRequest;
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::oneshot;
 use tonic::Code;
 
@@ -82,6 +82,15 @@ impl WorkQueueManager {
             pending_push_responses: Vec::new(),
             pending_finish_responses: Vec::new(),
         }
+    }
+
+    fn now_epoch_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX)
     }
 
     // V1: Memberlist methods commented out
@@ -382,16 +391,12 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
     type Result = ();
 
     async fn handle(&mut self, msg: GetWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
-        // With eager stale-row removal on push, the queue's dedup index is the
-        // source of truth for whether a row is still live.
-        let filtered: Vec<_> = self
-            .state
-            .pending_work
-            .iter()
-            .filter(|item| self.state.contains_entry(&item.fn_id, &item.input_coll_id))
-            .take(msg.limit)
-            .cloned()
-            .collect();
+        let filtered = self.state.claim_work(
+            msg.limit,
+            Self::now_epoch_ms(),
+            self.config.retry_backoff_initial_seconds,
+            self.config.retry_backoff_max_seconds,
+        );
         tracing::info!("Returning {} items from get work response", filtered.len());
 
         if msg.response_tx.send(Ok(filtered)).is_err() {
@@ -449,6 +454,8 @@ mod tests {
                 time_threshold_seconds: 2,
                 pending_threshold: 100, // Set high to avoid auto-persist in tests
             },
+            retry_backoff_initial_seconds: 10,
+            retry_backoff_max_seconds: 60,
         }
     }
 
@@ -532,17 +539,11 @@ mod tests {
             completion_offset: 999,
             compaction_offset: 999,
             insertion_order: 999,
+            delivery_attempts: 0,
+            not_before_epoch_ms: 0,
         });
 
-        // Test filtering logic (simulating what get_work does)
-        let limit = 3;
-        let filtered: Vec<_> = state
-            .pending_work
-            .iter()
-            .filter(|item| state.contains_entry(&item.fn_id, &item.input_coll_id))
-            .take(limit)
-            .cloned()
-            .collect();
+        let filtered = state.claim_work(3, 1_000, 10, 60);
 
         assert_eq!(filtered.len(), 3);
 
@@ -679,6 +680,20 @@ mod tests {
         assert!(WorkQueueManager::is_stale_async_invocation_not_found(
             &tonic::Status::not_found("collection not found")
         ));
+    }
+
+    #[tokio::test]
+    async fn missing_invocation_finishes_as_stale_success() {
+        let (mut manager, _temp_dir) = create_test_manager().await;
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+
+        let result = manager
+            .try_finish_invocation(&fn_id, &coll_id, 100)
+            .await
+            .expect("a missing invocation should be terminal success");
+
+        assert_eq!(FinishResult::Success, result);
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

Claimed work now records a delivery attempt count and a
not-before timestamp so redeliveries follow a capped exponential
backoff instead of being retried immediately on every poll.

GetWorkMessage handling moves from a read-only dedup filter to a
claim_work path that stamps each returned record and persists the
retry schedule, which survives queue-state parquet round-trips.
Successful compaction of newer work resets the schedule; terminal
completion removes the row entirely.

Function execution treats NotFound input errors (detached
functions, deleted input collections) as terminal, finishing the
stale work rather than looping. New config keys
retry_backoff_initial_seconds and retry_backoff_max_seconds default
to 10 and 600 seconds and are wired through the sample and k8s
configs.

## Test plan

CI

## Migration plan

Parquet, so columns add-able.

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
