### PR TITLE
fix: AsyncHttpClient TLS verification and cross-client transport isolation

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -138,12 +138,14 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
                 + " (https://github.com/chroma-core/chroma)"
             )
 
-            self._clients[loop_hash] = httpx.AsyncClient(
-                timeout=None,
-                headers=headers,
-                verify=self._settings.chroma_server_ssl_verify or False,
-                limits=self.http_limits,
-            )
+            client_kwargs = {
+                "timeout": None,
+                "headers": headers,
+                "limits": self.http_limits,
+            }
+            if self._settings.chroma_server_ssl_verify is not None:
+                client_kwargs["verify"] = self._settings.chroma_server_ssl_verify
+            self._clients[loop_hash] = httpx.AsyncClient(**client_kwargs)
 
         return self._clients[loop_hash]
 

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -75,10 +75,13 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     # Mixing asyncio and threading in this manner usually discouraged, but
     # this gives a better user experience with practically no downsides.
     # https://github.com/encode/httpx/issues/2058
-    _clients: Dict[int, httpx.AsyncClient] = {}
-
     def __init__(self, system: System):
         super().__init__(system)
+
+        # Instance-scoped client cache: each AsyncFastAPI instance owns its
+        # own transports so headers, auth, and TLS settings cannot leak
+        # between clients in the same event loop (#6869).
+        self._clients: Dict[int, httpx.AsyncClient] = {}
 
         system.settings.require("chroma_server_host")
         system.settings.require("chroma_server_http_port")


### PR DESCRIPTION
## Summary

Two security fixes for the async HTTP client:

## Fix 1: TLS verification disabled by default (#7511)

`verify=self._settings.chroma_server_ssl_verify or False` evaluates to `False` when the setting is None (default), disabling chain+hostname verification — MITM possible. The sync client with identical settings verifies correctly.

**Fix:** Only pass `verify` when explicitly configured; httpx default (verify) applies otherwise.

## Fix 2: Cross-client credential leakage (#6869)

`_clients` was a class-level dict, so all AsyncFastAPI instances in the same event loop shared one httpx transport. A client created with custom auth/headers/TLS would be reused by a later client with different settings — sending the FIRST client's credentials. Calling stop() on one client also drained transports still used by others.

**Fix:** Moved `_clients` to instance scope in `__init__`. Each client now owns its transports; stop() closes only its own.

## Verification

```python
# TLS: async client now refuses untrusted self-signed cert by default
await chromadb.AsyncHttpClient(host="127.0.0.1", ssl=True)  # SSLCertVerificationError (was: handshake OK)

# Transport: client2 no longer reuses client1's headers
c1 = AsyncHttpClient(settings=Settings(chroma_server_headers={"X-A": "1"}))
c2 = AsyncHttpClient(settings=Settings(chroma_server_headers={"X-B": "2"}))
# Before: c2's requests carry c1's X-A header. After: isolated.
```

Fixes #7511, #6869