### PR TITLE
ci: run all pre-commit hooks in one invocation so failures don't mask each other

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -269,19 +269,12 @@ jobs:
           github-token: ${{ github.token }}
       - name: Run pre-commit
         shell: bash
+        env:
+          # mypy is configured in .pre-commit-config.yaml but not yet CI-ready
+          # (see #2054); skip it here so it does not fail the job.
+          SKIP: mypy
         run: |
-          pre-commit run --all-files trailing-whitespace
-          pre-commit run --all-files mixed-line-ending
-          pre-commit run --all-files end-of-file-fixer
-          pre-commit run --all-files requirements-txt-fixer
-          pre-commit run --all-files check-xml
-          pre-commit run --all-files check-merge-conflict
-          pre-commit run --all-files check-case-conflict
-          pre-commit run --all-files check-docstring-first
-          pre-commit run --all-files black
-          pre-commit run --all-files flake8
-          pre-commit run --all-files prettier
-          pre-commit run --all-files check-yaml
+          pre-commit run --all-files --show-diff-on-failure
         continue-on-error: true
       - name: Cargo fmt check
         shell: bash


### PR DESCRIPTION
## Summary

Fixes #7560 (mechanical half).

## Problem

The lint job chains 12 pre-commit hooks as separate bash commands. GitHub runs the step with `-e`, so the first failing hook aborts the step and every later hook is skipped. Since `trailing-whitespace` currently fails on main, the real behavior on every PR is: trailing-whitespace fails → step aborts → continue-on-error swallows it → job green. black, flake8, and prettier never run.

Also, the hand-maintained hook list has drifted from .pre-commit-config.yaml (mypy is configured there but absent from CI).

## Fix

- Replaced 12 hand-listed hook invocations with a single `pre-commit run --all-files --show-diff-on-failure`
- Added `SKIP: mypy` env (mypy is configured but not CI-ready — #2054)

The hook list can no longer drift, and one failing hook no longer masks the rest.

## Not included (maintainer call)

Removing `continue-on-error: true` to make lint blocking — requires landing a formatting sweep first, per the issue discussion.

Fixes #7560