### PR TITLE
fix(test): use idiomatic Jest error assertions

### DIFF
--- a/clients/js/packages/chromadb-core/test/add.collections.test.ts
+++ b/clients/js/packages/chromadb-core/test/add.collections.test.ts
@@ -6,7 +6,7 @@ import { OpenAIEmbeddingFunction } from "../src/embeddings/OpenAIEmbeddingFuncti
 import { CohereEmbeddingFunction } from "../src/embeddings/CohereEmbeddingFunction";
 import { VoyageAIEmbeddingFunction } from "../src/embeddings/VoyageAIEmbeddingFunction";
 import { ChromaClient } from "../src/ChromaClient";
-import { ChromaNotFoundError } from "../src/Errors";
+import { ChromaNotFoundError, InvalidArgumentError } from "../src/Errors";
 
 describe("add collections", () => {
   // connects to the unauthenticated chroma instance started in
@@ -107,13 +107,9 @@ describe("add collections", () => {
         embeddingFunction: embedder,
       });
 
-      try {
-        await embedder.generate(DOCUMENTS);
-      } catch (e: any) {
-        expect(e.message).toMatch(
-          "This model does not support specifying dimensions.",
-        );
-      }
+      await expect(embedder.generate(DOCUMENTS)).rejects.toThrow(
+        "This model does not support specifying dimensions.",
+      );
     });
   }
 
@@ -190,11 +186,9 @@ describe("add collections", () => {
     const ids = IDS.concat(["test1"]);
     const embeddings = EMBEDDINGS.concat([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]);
     const metadatas = METADATAS.concat([{ test: "test1", float_value: 0.1 }]);
-    try {
-      await collection.add({ ids, embeddings, metadatas });
-    } catch (e: any) {
-      expect(e.message).toMatch("duplicates");
-    }
+    await expect(
+      collection.add({ ids, embeddings, metadatas }),
+    ).rejects.toThrow("duplicates");
   });
 
   test("should error on empty embedding", async () => {
@@ -202,10 +196,8 @@ describe("add collections", () => {
     const ids = ["id1"];
     const embeddings = [[]];
     const metadatas = [{ test: "test1", float_value: 0.1 }];
-    try {
-      await collection.add({ ids, embeddings, metadatas });
-    } catch (e: any) {
-      expect(e.message).toMatch("got empty embedding at pos");
-    }
+    await expect(
+      collection.add({ ids, embeddings, metadatas }),
+    ).rejects.toThrow("got empty embedding at pos");
   });
 });

--- a/clients/js/packages/chromadb-core/test/get.collection.test.ts
+++ b/clients/js/packages/chromadb-core/test/get.collection.test.ts
@@ -44,18 +44,14 @@ describe("get collections", () => {
       embeddings: EMBEDDINGS,
       metadatas: METADATAS,
     });
-    try {
-      await collection.get({
+    await expect(
+      collection.get({
         where: {
           //@ts-ignore supposed to fail
           test: { $contains: "hello" },
         },
-      });
-    } catch (error: any) {
-      expect(error).toBeDefined();
-      expect(error).toBeInstanceOf(InvalidArgumentError);
-      expect(error.message).toMatchInlineSnapshot(`"Invalid where clause"`);
-    }
+      }),
+    ).rejects.toThrow(InvalidArgumentError);
   });
 
   test("it should get embedding with matching documents", async () => {


### PR DESCRIPTION
Converts manual try/catch error handling to idiomatic Jest patterns in 2 test files:

- get.collection.test.ts: Replace try/catch with expect().rejects.toThrow(InvalidArgumentError)
- add.collections.test.ts: Replace 3 try/catch blocks with expect().rejects.toThrow()

These changes make tests more concise, ensure proper failure when expected error is not thrown, and follow Jest best practices. Focused PR per issue discussion.

Closes #2801