### PR TITLE
fix: accept None metadata values in add(), matching update() and upse…

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -245,6 +245,7 @@ class CollectionCommon(Generic[ClientT]):
         add_metadatas = self._apply_sparse_embeddings_to_metadatas(
             add_records["metadatas"], add_records["documents"]
         )
+        add_metadatas = _drop_none_metadata_values(add_metadatas)
 
         return AddRequest(
             ids=add_records["ids"],
@@ -1037,3 +1038,31 @@ class CollectionCommon(Generic[ClientT]):
             limit=search._limit,
             select=search._select,
         )
+
+
+def _drop_none_metadata_values(
+    metadatas: Optional[List[Metadata]],
+) -> Optional[List[Metadata]]:
+    """Drop keys whose value is None before an add reaches the storage layer.
+
+    None is a legal metadata value: the `Metadata` alias is `Optional[...]`,
+    `validate_metadata` allows `type(None)` deliberately, and update() and
+    upsert() both read it as "this key has no value" and leave the key unset.
+    add() alone forwarded it, and the layer below rejects it with a different
+    exception per client - TypeError locally, ChromaError over HTTP - so the
+    same call was portable code in one deployment and a crash in the other.
+
+    A record left with nothing becomes None rather than an empty dict, matching
+    what _apply_sparse_embeddings_to_metadatas already does.
+    """
+    if metadatas is None:
+        return None
+
+    cleaned: List[Optional[Metadata]] = []
+    for metadata in metadatas:
+        if metadata is None:
+            cleaned.append(None)
+            continue
+        kept = {key: value for key, value in metadata.items() if value is not None}
+        cleaned.append(cast(Metadata, kept) if kept else None)
+    return cast(Optional[List[Metadata]], cleaned)

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -4021,3 +4021,39 @@ class TestRoundTripConversion:
         # Reconstruct and compare group_by
         restored = Search(group_by=GroupBy.from_dict(search_dict["group_by"]))
         assert restored.to_dict()["group_by"] == search_dict["group_by"]
+
+
+def test_add_accepts_none_metadata_value(client):
+    """None is a legal metadata value everywhere except add(), historically.
+
+    The Metadata alias is Optional, validate_metadata permits type(None) on
+    purpose, and update()/upsert() both treat None as "this key has no value".
+    add() forwarded it to the storage layer instead, which rejected it — and
+    with a different exception per client, so the same call was fine against a
+    PersistentClient and a crash against a server.
+    """
+    client.reset()
+    collection = client.create_collection("test_add_none_metadata")
+
+    collection.add(
+        ids=["a"],
+        embeddings=[[1.0, 0.0]],
+        metadatas=[{"city": "Dubai", "zip": None}],
+    )
+    assert collection.get(ids=["a"])["metadatas"][0] == {"city": "Dubai"}
+
+    # add() must agree with upsert(), which already handled this.
+    collection.upsert(
+        ids=["b"],
+        embeddings=[[0.0, 1.0]],
+        metadatas=[{"city": "Dubai", "zip": None}],
+    )
+    assert collection.get(ids=["b"])["metadatas"][0] == {"city": "Dubai"}
+
+    # A record left with nothing becomes None, not an empty dict.
+    collection.add(ids=["c"], embeddings=[[1.0, 1.0]], metadatas=[{"only": None}])
+    assert collection.get(ids=["c"])["metadatas"] == [None]
+
+    # None must still delete a key on update.
+    collection.update(ids=["a"], metadatas=[{"city": None}])
+    assert collection.get(ids=["a"])["metadatas"] == [None]


### PR DESCRIPTION
## Description of changes

`add()` was the only write operation that could not accept a `None` metadata value, even
though four other places in the library declare it legal:

- `Metadata` is `Mapping[str, Optional[Union[...]]]`, and `UpdateMetadata` lists `None`
  explicitly
- `validate_metadata()` permits it deliberately — `type(None)` is in the isinstance tuple
- the error that validator raises names `None` as an accepted type
- `update()` and `upsert()` both read it as "this key has no value" and leave the key unset

Because it passed validation and failed underneath, the error came from the storage layer —
and differed by client:

```python
col.add(ids=["b"], embeddings=[[0.0, 1.0]], metadatas=[{"city": "Dubai", "zip": None}])

# PersistentClient : TypeError: argument 'metadatas': Cannot convert Python object to MetadataValue
# HttpClient       : ChromaError: Failed to deserialize the JSON body into the target type:
#                    metadatas[0].zip: data did not match any variant of untagged enum ...
```

So `except TypeError` was correct locally and wrong against a server.

The decisive detail: **`upsert()` on a brand-new id with the same input already works** and
stores `{"city": "Dubai"}`. Transport and storage handle it; only `add()`'s path did not. This
change makes `add()` do what `upsert()` already did — drop keys whose value is `None` before
dispatch, and send `None` rather than an empty dict for a record left with nothing, matching
the existing empty-dict handling in `_apply_sparse_embeddings_to_metadatas`.

The fix is on the add path only. `normalize_insert_record_set` is shared by add, update and
upsert, so stripping there would have broken `None`-deletes-key on update.

- Improvements & Bug fixes
  - `add()` accepts `None` metadata values, consistent with `update()`, `upsert()`, the
    `Metadata` type and `validate_metadata()`

## Test plan

- [ ] Tests pass locally with `pytest` for python

Added `test_add_accepts_none_metadata_value` to `chromadb/test/test_api.py`. It pins all four
behaviours: `add()` drops the `None` key, `add()` and `upsert()` agree, a record left with
nothing becomes `None` rather than `{}`, and `None` still deletes a key on `update()`.

I could not run the full suite locally — `pip install -e .` builds the Rust workspace, and on
Windows that fails on the 260-character path limit inside a Cargo git submodule
(`googleapis/.../beyondcorp-clientconnectorservices_grpc_service_config.json`), before any of
this code is reached. Leaving the box unticked rather than claiming otherwise; CI will cover it.

The change is pure Python, so I verified it against the released wheel's compiled bindings
instead, in both directions — the behaviour must be wrong before the patch and right after:

```
without the fix : rejected  TypeError
with the fix    : accepted  {'city': 'Dubai'}
```

Also checked on a `chromadb/chroma:1.5.9` server via `HttpClient`, using a differential harness
that runs the same calls through the in-process and HTTP clients and diffs the results. It
reported one divergence before this change and none after, with `update()`/`upsert()`
key-deletion unaffected on both.

`black==23.3.0` reports both files unchanged.

## Migration plan

None. Input that previously raised now succeeds; nothing that previously succeeded changes
behaviour.

## Observability plan

None — no new failure modes or telemetry.
