### PR TITLE
[ENH](wqs): Add manual function DLQ RPC

### DIFF
--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -1565,6 +1565,29 @@ func (s *Coordinator) FailAttachedFunction(ctx context.Context, req *coordinator
 	return &coordinatorpb.FailAttachedFunctionResponse{FailureCount: failureCount}, nil
 }
 
+// SetAttachedFunctionFailureCount sets the failure count for an async function invocation.
+func (s *Coordinator) SetAttachedFunctionFailureCount(ctx context.Context, req *coordinatorpb.SetAttachedFunctionFailureCountRequest) (*coordinatorpb.SetAttachedFunctionFailureCountResponse, error) {
+	if req.FailureCount < 0 {
+		return nil, status.Error(codes.InvalidArgument, "failure_count must be non-negative")
+	}
+	attachedFunctionID, err := uuid.Parse(req.AttachedFunctionId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid attached_function_id: %v", err)
+	}
+	collectionID, err := types.ToUniqueID(&req.CollectionId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid collection_id: %v", err)
+	}
+	failureCount, err := s.catalog.metaDomain.AttachedFunctionDb(ctx).SetFailureCount(attachedFunctionID, collectionID.String(), req.FailureCount)
+	if err != nil {
+		if err == common.ErrAttachedFunctionNotFound {
+			return nil, status.Errorf(codes.NotFound, "attached function not found")
+		}
+		return nil, err
+	}
+	return &coordinatorpb.SetAttachedFunctionFailureCountResponse{FailureCount: failureCount}, nil
+}
+
 // FinalizeAsyncAttachedFunctionRepair sets heap_entry_pending back to false after repair
 func (s *Coordinator) FinalizeAsyncAttachedFunctionRepair(ctx context.Context, req *coordinatorpb.FinalizeAsyncAttachedFunctionRepairRequest) (*coordinatorpb.FinalizeAsyncAttachedFunctionRepairResponse, error) {
 	log := log.With(zap.String("attached_function_id", req.AttachedFunctionId))

--- a/go/pkg/sysdb/grpc/task_service.go
+++ b/go/pkg/sysdb/grpc/task_service.go
@@ -193,6 +193,10 @@ func (s *Server) FailAttachedFunction(ctx context.Context, req *coordinatorpb.Fa
 	return s.coordinator.FailAttachedFunction(ctx, req)
 }
 
+func (s *Server) SetAttachedFunctionFailureCount(ctx context.Context, req *coordinatorpb.SetAttachedFunctionFailureCountRequest) (*coordinatorpb.SetAttachedFunctionFailureCountResponse, error) {
+	return s.coordinator.SetAttachedFunctionFailureCount(ctx, req)
+}
+
 func (s *Server) CheckInvocationStatus(ctx context.Context, req *coordinatorpb.CheckInvocationStatusRequest) (*coordinatorpb.CheckInvocationStatusResponse, error) {
 	log.Info("CheckInvocationStatus",
 		zap.Int("items_count", len(req.Items)))

--- a/go/pkg/sysdb/metastore/db/dao/attached_function_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/attached_function_test.go
@@ -398,11 +398,14 @@ func (suite *AttachedFunctionDbTestSuite) TestAttachedFunctionDb_FailureCount() 
 	failureCount, err = suite.Db.IncrementFailureCount(attachedFunction.ID, attachedFunction.InputCollectionID)
 	suite.Require().NoError(err)
 	suite.Equal(int32(2), failureCount)
+	failureCount, err = suite.Db.SetFailureCount(attachedFunction.ID, attachedFunction.InputCollectionID, 7)
+	suite.Require().NoError(err)
+	suite.Equal(int32(7), failureCount)
 
 	functions, err := suite.Db.GetAttachedFunctions(&attachedFunction.ID, nil, nil, nil, nil, true)
 	suite.Require().NoError(err)
 	suite.Require().Len(functions, 1)
-	suite.Equal(int32(2), functions[0].FailureCount)
+	suite.Equal(int32(7), functions[0].FailureCount)
 
 }
 

--- a/go/pkg/sysdb/metastore/db/dao/task.go
+++ b/go/pkg/sysdb/metastore/db/dao/task.go
@@ -150,6 +150,21 @@ func (s *attachedFunctionDb) IncrementFailureCount(id uuid.UUID, collectionID st
 	return failureCount, nil
 }
 
+func (s *attachedFunctionDb) SetFailureCount(id uuid.UUID, collectionID string, failureCount int32) (int32, error) {
+	result := s.db.Raw(`
+		UPDATE attached_functions
+		SET failure_count = ?, updated_at = ?
+		WHERE id = ? AND input_collection_id = ? AND is_deleted = false
+		RETURNING failure_count`, failureCount, time.Now(), id, collectionID).Scan(&failureCount)
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return 0, common.ErrAttachedFunctionNotFound
+	}
+	return failureCount, nil
+}
+
 // GetAttachedFunctions is a consolidated getter that supports various query patterns
 // Parameters can be nil to indicate they should not be filtered on
 // - id: DEPRECATED - Use ids instead. Filter by attached function ID

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
@@ -133,6 +133,27 @@ func (_m *IAttachedFunctionDb) IncrementFailureCount(id uuid.UUID, collectionID 
 	return r0, r1
 }
 
+// SetFailureCount provides a mock function with given fields: id, collectionID, failureCount
+func (_m *IAttachedFunctionDb) SetFailureCount(id uuid.UUID, collectionID string, failureCount int32) (int32, error) {
+	ret := _m.Called(id, collectionID, failureCount)
+	if len(ret) == 0 {
+		panic("no return value specified for SetFailureCount")
+	}
+	var r0 int32
+	if rf, ok := ret.Get(0).(func(uuid.UUID, string, int32) int32); ok {
+		r0 = rf(id, collectionID, failureCount)
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+	var r1 error
+	if rf, ok := ret.Get(1).(func(uuid.UUID, string, int32) error); ok {
+		r1 = rf(id, collectionID, failureCount)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 // GetAttachedFunctions provides a mock function with given fields: id, name, inputCollectionID, outputCollectionID, ids, onlyReady
 func (_m *IAttachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, outputCollectionID *string, ids []uuid.UUID, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
 	ret := _m.Called(id, name, inputCollectionID, outputCollectionID, ids, onlyReady)

--- a/go/pkg/sysdb/metastore/db/dbmodel/task.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/task.go
@@ -51,6 +51,7 @@ type IAttachedFunctionDb interface {
 	UpdateCompletionOffsetAndHeapEntry(id uuid.UUID, collectionID string, newOffset int64) error
 	UpdateHeapEntryPending(id uuid.UUID, collectionID string, heapEntryPending bool) error
 	IncrementFailureCount(id uuid.UUID, collectionID string) (int32, error)
+	SetFailureCount(id uuid.UUID, collectionID string, failureCount int32) (int32, error)
 	Finish(id uuid.UUID) error
 	SoftDelete(inputCollectionID string, name string) error
 	SoftDeleteByID(id uuid.UUID, inputCollectionID uuid.UUID) error

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -635,6 +635,16 @@ message FailAttachedFunctionResponse {
   int32 failure_count = 1;
 }
 
+message SetAttachedFunctionFailureCountRequest {
+  string attached_function_id = 1;
+  string collection_id = 2;
+  int32 failure_count = 3;
+}
+
+message SetAttachedFunctionFailureCountResponse {
+  int32 failure_count = 1;
+}
+
 message DetachFunctionRequest {
   string name = 1;
   bool delete_output = 2; // If true and output_collection_id is not null, atomically soft-delete the output collection
@@ -808,5 +818,6 @@ service SysDB {
   rpc TryFinishAsyncAttachedFunctionInvocation(TryFinishAsyncAttachedFunctionInvocationRequest) returns (TryFinishAsyncAttachedFunctionInvocationResponse) {}
   rpc FinalizeAsyncAttachedFunctionRepair(FinalizeAsyncAttachedFunctionRepairRequest) returns (FinalizeAsyncAttachedFunctionRepairResponse) {}
   rpc FailAttachedFunction(FailAttachedFunctionRequest) returns (FailAttachedFunctionResponse) {}
+  rpc SetAttachedFunctionFailureCount(SetAttachedFunctionFailureCountRequest) returns (SetAttachedFunctionFailureCountResponse) {}
   rpc IncrementCompactionFailureCount(IncrementCompactionFailureCountRequest) returns (IncrementCompactionFailureCountResponse) {}
 }

--- a/idl/chromadb/proto/workqueue.proto
+++ b/idl/chromadb/proto/workqueue.proto
@@ -30,6 +30,13 @@ message FailFunctionRequest {
     string input_coll_id = 2;
 }
 
+// Sets the failure count for one queued attached-function invocation.
+message SetFunctionFailureCountRequest {
+    string fn_id = 1;
+    string input_coll_id = 2;
+    int32 failure_count = 3;
+}
+
 message GetWorkRequest {
     string shard_id = 1;
     uint32 limit = 2;
@@ -51,5 +58,6 @@ service WorkQueueService {
     rpc PushWork(PushWorkRequest) returns (google.protobuf.Empty);
     rpc FinishWork(FinishWorkRequest) returns (google.protobuf.Empty);
     rpc FailFunction(FailFunctionRequest) returns (google.protobuf.Empty);
+    rpc SetFunctionFailureCount(SetFunctionFailureCountRequest) returns (google.protobuf.Empty);
     rpc GetWork(GetWorkRequest) returns (GetWorkResponse);
 }

--- a/rust/rust-sysdb/src/server.rs
+++ b/rust/rust-sysdb/src/server.rs
@@ -46,8 +46,10 @@ use chroma_types::chroma_proto::{
     ListCollectionVersionsResponse, ListCollectionsToGcRequest, ListCollectionsToGcResponse,
     ListDatabasesRequest, ListDatabasesResponse, MarkVersionForDeletionRequest,
     MarkVersionForDeletionResponse, ResetStateResponse, RestoreCollectionRequest,
-    RestoreCollectionResponse, SetLastCompactionTimeForTenantRequest, SetTenantResourceNameRequest,
-    SetTenantResourceNameResponse, TryFinishAsyncAttachedFunctionInvocationRequest,
+    RestoreCollectionResponse, SetAttachedFunctionFailureCountRequest,
+    SetAttachedFunctionFailureCountResponse, SetLastCompactionTimeForTenantRequest,
+    SetTenantResourceNameRequest, SetTenantResourceNameResponse,
+    TryFinishAsyncAttachedFunctionInvocationRequest,
     TryFinishAsyncAttachedFunctionInvocationResponse, UpdateCollectionRequest,
     UpdateCollectionResponse, UpdateSegmentRequest, UpdateSegmentResponse,
 };
@@ -998,6 +1000,15 @@ impl SysDb for SysdbService {
     ) -> Result<Response<FailAttachedFunctionResponse>, Status> {
         Err(Status::unimplemented(
             "fail_attached_function is not supported",
+        ))
+    }
+
+    async fn set_attached_function_failure_count(
+        &self,
+        _request: Request<SetAttachedFunctionFailureCountRequest>,
+    ) -> Result<Response<SetAttachedFunctionFailureCountResponse>, Status> {
+        Err(Status::unimplemented(
+            "set_attached_function_failure_count is not supported",
         ))
     }
 

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -1649,6 +1649,18 @@ impl GrpcSysDb {
             .failure_count)
     }
 
+    pub async fn set_attached_function_failure_count(
+        &mut self,
+        request: chroma_proto::SetAttachedFunctionFailureCountRequest,
+    ) -> Result<i32, tonic::Status> {
+        Ok(self
+            .client
+            .set_attached_function_failure_count(request)
+            .await?
+            .into_inner()
+            .failure_count)
+    }
+
     pub async fn get_collections_to_gc(
         &mut self,
         cutoff_time: Option<SystemTime>,
@@ -2941,6 +2953,19 @@ impl SysDb {
                 "fail_attached_function is not supported for SqliteSysDb",
             )),
             SysDb::Test(test) => test.fail_attached_function(request).await,
+        }
+    }
+
+    pub async fn set_attached_function_failure_count(
+        &mut self,
+        request: chroma_proto::SetAttachedFunctionFailureCountRequest,
+    ) -> Result<i32, tonic::Status> {
+        match self {
+            SysDb::Grpc(grpc) => grpc.set_attached_function_failure_count(request).await,
+            SysDb::Sqlite(_) => Err(tonic::Status::unimplemented(
+                "set_attached_function_failure_count is not supported for SqliteSysDb",
+            )),
+            SysDb::Test(test) => test.set_attached_function_failure_count(request).await,
         }
     }
 

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -785,6 +785,15 @@ impl TestSysDb {
         ))
     }
 
+    pub(crate) async fn set_attached_function_failure_count(
+        &mut self,
+        _request: chroma_types::chroma_proto::SetAttachedFunctionFailureCountRequest,
+    ) -> Result<i32, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "set_attached_function_failure_count is not supported for TestSysDb",
+        ))
+    }
+
     pub(crate) async fn try_finish_async_attached_function_invocation(
         &mut self,
         request: chroma_types::chroma_proto::TryFinishAsyncAttachedFunctionInvocationRequest,

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -416,6 +416,31 @@ impl QueueState {
         true
     }
 
+    /// Sets the failure count for a queued entry.
+    ///
+    /// `None` means the entry is absent. `Some(false)` means the entry was
+    /// already at the requested value, which is still a successful,
+    /// idempotent update.
+    pub fn set_failure_count(
+        &mut self,
+        fn_id: &AttachedFunctionUuid,
+        input_coll_id: &CollectionUuid,
+        failure_count: i32,
+    ) -> Option<bool> {
+        let record = self
+            .pending_work
+            .iter_mut()
+            .find(|record| record.fn_id == *fn_id && record.input_coll_id == *input_coll_id)?;
+
+        if record.failure_count == failure_count {
+            return Some(false);
+        }
+
+        record.failure_count = failure_count;
+        self.dirty = true;
+        Some(true)
+    }
+
     /// Mark work as successfully completed.
     /// Removes the queue entry once completion reaches the queued frontier;
     /// otherwise leaves the queued entry unchanged.
@@ -573,6 +598,24 @@ mod tests {
 
         assert!(state.push_work(fn_id, coll_id, 20, 20));
         assert_eq!(state.pending_work[0].failure_count, 5);
+    }
+
+    #[test]
+    fn test_set_failure_count_is_idempotent_and_reports_missing_entries() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+
+        assert_eq!(state.set_failure_count(&fn_id, &coll_id, 0), None);
+
+        state.push_work(fn_id, coll_id, 10, 10);
+        state.dirty = false;
+
+        assert_eq!(state.set_failure_count(&fn_id, &coll_id, 0), Some(false));
+        assert!(!state.dirty);
+        assert_eq!(state.set_failure_count(&fn_id, &coll_id, 3), Some(true));
+        assert!(state.dirty);
+        assert_eq!(state.pending_work[0].failure_count, 3);
     }
 
     #[test]

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -182,6 +182,69 @@ mod tests {
         .await;
     }
 
+    #[tokio::test]
+    async fn test_k8s_integration_set_function_failure_count_dlqs_work() {
+        with_work_queue_test(|mut ctx| async move {
+            let collection_id = CollectionUuid::new();
+            create_test_collection(
+                &mut ctx.sysdb,
+                collection_id,
+                &ctx.tenant_id,
+                &ctx.database_name,
+            )
+            .await
+            .expect("Failed to create collection");
+            let function_id = create_test_attached_function(&mut ctx.sysdb, collection_id)
+                .await
+                .expect("Failed to create attached function");
+
+            ctx.work_queue_client
+                .push_work(function_id.to_string(), collection_id.to_string(), 100, 100)
+                .await
+                .expect("Failed to push work");
+            ctx.work_queue_client
+                .set_function_failure_count(function_id.to_string(), collection_id.to_string(), 3)
+                .await
+                .expect("Failed to set function failure count");
+            ctx.work_queue_client
+                .set_function_failure_count(function_id.to_string(), collection_id.to_string(), 3)
+                .await
+                .expect("Failed to retry setting function failure count");
+
+            let functions = ctx
+                .sysdb
+                .list_attached_functions(collection_id)
+                .await
+                .expect("Failed to fetch attached functions");
+            let function = functions
+                .iter()
+                .find(|function| function.id == function_id.to_string())
+                .expect("Attached function was not returned");
+            assert_eq!(function.failure_count, 3);
+
+            let dlq_filtered = ctx
+                .work_queue_client
+                .get_work_with_failure_limit("test_shard".to_string(), 10, 3)
+                .await
+                .expect("Failed to fetch DLQ-filtered work");
+            assert!(dlq_filtered
+                .items
+                .iter()
+                .all(|item| item.fn_id != function_id.to_string()));
+
+            let visible = ctx
+                .work_queue_client
+                .get_work_with_failure_limit("test_shard".to_string(), 10, 4)
+                .await
+                .expect("Failed to fetch work above DLQ threshold");
+            assert!(visible
+                .items
+                .iter()
+                .any(|item| item.fn_id == function_id.to_string()));
+        })
+        .await;
+    }
+
     // Note: In a real scenario, updating collection log position would be done
     // through the log service, not sysdb. For testing work queue repair logic,
     // we rely on the sysdb methods to simulate repair conditions.

--- a/rust/worker/src/work_queue/work_queue_client.rs
+++ b/rust/worker/src/work_queue/work_queue_client.rs
@@ -2,7 +2,7 @@ use crate::fn_consumer::config::GrpcWorkQueueConfig;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::chroma_proto::{
     work_queue_service_client::WorkQueueServiceClient, FailFunctionRequest, FinishWorkRequest,
-    GetWorkRequest, GetWorkResponse, PushWorkRequest,
+    GetWorkRequest, GetWorkResponse, PushWorkRequest, SetFunctionFailureCountRequest,
 };
 use std::time::Duration;
 use tonic::transport::Endpoint;
@@ -116,6 +116,23 @@ impl WorkQueueClient {
             .fail_function(Request::new(FailFunctionRequest {
                 fn_id,
                 input_coll_id,
+            }))
+            .await
+            .map_err(|e| Box::new(WorkQueueClientError::RequestError(e)) as Box<dyn ChromaError>)?;
+        Ok(())
+    }
+
+    pub async fn set_function_failure_count(
+        &mut self,
+        fn_id: String,
+        input_coll_id: String,
+        failure_count: i32,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        self.client
+            .set_function_failure_count(Request::new(SetFunctionFailureCountRequest {
+                fn_id,
+                input_coll_id,
+                failure_count,
             }))
             .await
             .map_err(|e| Box::new(WorkQueueClientError::RequestError(e)) as Box<dyn ChromaError>)?;

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -53,6 +53,14 @@ pub struct UpdateFunctionFailureCountMessage {
 }
 
 #[derive(Debug)]
+pub struct SetFunctionFailureCountMessage {
+    pub fn_id: AttachedFunctionUuid,
+    pub input_coll_id: CollectionUuid,
+    pub failure_count: i32,
+    pub response_tx: oneshot::Sender<Result<bool, WorkQueueError>>,
+}
+
+#[derive(Debug)]
 pub(crate) struct WorkQueueReadyMessage;
 
 #[derive(Debug, Clone)]
@@ -423,6 +431,29 @@ impl Handler<UpdateFunctionFailureCountMessage> for WorkQueueManager {
             tracing::warn!(
                 "Failed to acknowledge function failure count update - receiver dropped"
             );
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<SetFunctionFailureCountMessage> for WorkQueueManager {
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        msg: SetFunctionFailureCountMessage,
+        _ctx: &ComponentContext<WorkQueueManager>,
+    ) {
+        let result =
+            match self
+                .state
+                .set_failure_count(&msg.fn_id, &msg.input_coll_id, msg.failure_count)
+            {
+                Some(_) => self.persist().await.map(|_| true),
+                None => Ok(false),
+            };
+        if msg.response_tx.send(result).is_err() {
+            tracing::warn!("Failed to acknowledge function failure count set");
         }
     }
 }

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -1,14 +1,15 @@
 use crate::work_queue::types::{FinishResult, WorkQueueError};
 use crate::work_queue::work_queue_manager::{
-    FinishWorkMessage, GetWorkMessage, PushWorkMessage, UpdateFunctionFailureCountMessage,
-    WorkQueueManager,
+    FinishWorkMessage, GetWorkMessage, PushWorkMessage, SetFunctionFailureCountMessage,
+    UpdateFunctionFailureCountMessage, WorkQueueManager,
 };
 use chroma_sysdb::SysDb;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     work_queue_service_server::{WorkQueueService, WorkQueueServiceServer},
     FailAttachedFunctionRequest, FailFunctionRequest, FinalizeAsyncAttachedFunctionRepairRequest,
-    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest, WorkItemResult,
+    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest,
+    SetAttachedFunctionFailureCountRequest, SetFunctionFailureCountRequest, WorkItemResult,
 };
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use std::str::FromStr;
@@ -176,6 +177,63 @@ impl WorkQueueService for WorkQueueServer {
         })?;
 
         Ok(Response::new(()))
+    }
+
+    async fn set_function_failure_count(
+        &self,
+        request: Request<SetFunctionFailureCountRequest>,
+    ) -> Result<Response<()>, Status> {
+        let req = request.into_inner();
+        if req.failure_count < 0 {
+            return Err(Status::invalid_argument(
+                "failure_count must be non-negative",
+            ));
+        }
+        let fn_id = AttachedFunctionUuid::from_str(&req.fn_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid fn_id: {}", e)))?;
+        let input_coll_id = CollectionUuid::from_str(&req.input_coll_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid collection_id: {}", e)))?;
+
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        self.manager
+            .receiver()
+            .send(
+                SetFunctionFailureCountMessage {
+                    fn_id,
+                    input_coll_id,
+                    failure_count: req.failure_count,
+                    response_tx,
+                },
+                None,
+            )
+            .await
+            .map_err(|e| {
+                Status::internal(format!("Failed to mirror failure count to WQS: {}", e))
+            })?;
+
+        match response_rx
+            .await
+            .map_err(|e| {
+                Status::internal(format!("Failed to receive WQS failure count update: {}", e))
+            })?
+            .map_err(|e| Status::internal(e.to_string()))?
+        {
+            true => {
+                let mut sysdb = self.sysdb.clone();
+                sysdb
+                    .set_attached_function_failure_count(SetAttachedFunctionFailureCountRequest {
+                        attached_function_id: req.fn_id,
+                        collection_id: req.input_coll_id,
+                        failure_count: req.failure_count,
+                    })
+                    .await
+                    .map_err(|e| {
+                        Status::internal(format!("Failed to set function failure count: {}", e))
+                    })?;
+                Ok(Response::new(()))
+            }
+            false => Err(Status::not_found("Work queue entry not found")),
+        }
     }
 
     async fn get_work(


### PR DESCRIPTION
## Summary

- Adds a SysDB RPC to set an attached function’s failure count to an exact non-negative value, scoped by `(fn_id, input_coll_id)`.
- Adds WQS `SetFunctionFailureCount`: updates SysDB first, then durably mirrors the returned count into the WQS Parquet snapshot.
- Returns `NotFound` when the WQS entry is absent, while leaving SysDB as the authoritative count.

## Testing

- Go SysDB DAO test for absolute assignment.
- Tilt-gated WQS integration test covering SysDB state and `GetWork` DLQ filtering.
- Go package compile check.