### PR TITLE
[ENH](wqs): Add manual work deletion RPC

### DIFF
--- a/idl/chromadb/proto/workqueue.proto
+++ b/idl/chromadb/proto/workqueue.proto
@@ -30,6 +30,12 @@ message FailFunctionRequest {
     string input_coll_id = 2;
 }
 
+// Removes one queued attached-function invocation from WQS.
+message DeleteWorkRequest {
+    string fn_id = 1;
+    string input_coll_id = 2;
+}
+
 message GetWorkRequest {
     string shard_id = 1;
     uint32 limit = 2;
@@ -51,5 +57,6 @@ service WorkQueueService {
     rpc PushWork(PushWorkRequest) returns (google.protobuf.Empty);
     rpc FinishWork(FinishWorkRequest) returns (google.protobuf.Empty);
     rpc FailFunction(FailFunctionRequest) returns (google.protobuf.Empty);
+    rpc DeleteWork(DeleteWorkRequest) returns (google.protobuf.Empty);
     rpc GetWork(GetWorkRequest) returns (GetWorkResponse);
 }

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -416,6 +416,22 @@ impl QueueState {
         true
     }
 
+    pub fn delete_work(
+        &mut self,
+        fn_id: &AttachedFunctionUuid,
+        input_coll_id: &CollectionUuid,
+    ) -> bool {
+        let key = (*fn_id, *input_coll_id);
+        if self.dedup_index.remove(&key).is_none() {
+            return false;
+        }
+
+        self.pending_work
+            .retain(|record| record.fn_id != *fn_id || record.input_coll_id != *input_coll_id);
+        self.dirty = true;
+        true
+    }
+
     /// Mark work as successfully completed.
     /// Removes the queue entry once completion reaches the queued frontier;
     /// otherwise leaves the queued entry unchanged.
@@ -625,5 +641,23 @@ mod tests {
 
         state.finish_work_success(&fn_id, &coll_id, 60);
         assert_eq!(state.pending_work.len(), 0);
+    }
+
+    #[test]
+    fn test_delete_work_removes_entry_and_persists() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+        let other_fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let other_coll_id = CollectionUuid(Uuid::new_v4());
+
+        state.push_work(fn_id, coll_id, 100, 100);
+        state.push_work(other_fn_id, other_coll_id, 200, 200);
+        assert!(state.delete_work(&fn_id, &coll_id));
+        assert!(!state.delete_work(&fn_id, &coll_id));
+
+        let reloaded = QueueState::from_parquet_bytes(&state.to_parquet_bytes().unwrap()).unwrap();
+        assert!(!reloaded.contains_entry(&fn_id, &coll_id));
+        assert!(reloaded.contains_entry(&other_fn_id, &other_coll_id));
     }
 }

--- a/rust/worker/src/work_queue/work_queue_client.rs
+++ b/rust/worker/src/work_queue/work_queue_client.rs
@@ -1,8 +1,8 @@
 use crate::fn_consumer::config::GrpcWorkQueueConfig;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::chroma_proto::{
-    work_queue_service_client::WorkQueueServiceClient, FailFunctionRequest, FinishWorkRequest,
-    GetWorkRequest, GetWorkResponse, PushWorkRequest,
+    work_queue_service_client::WorkQueueServiceClient, DeleteWorkRequest, FailFunctionRequest,
+    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest,
 };
 use std::time::Duration;
 use tonic::transport::Endpoint;
@@ -114,6 +114,21 @@ impl WorkQueueClient {
     ) -> Result<(), Box<dyn ChromaError>> {
         self.client
             .fail_function(Request::new(FailFunctionRequest {
+                fn_id,
+                input_coll_id,
+            }))
+            .await
+            .map_err(|e| Box::new(WorkQueueClientError::RequestError(e)) as Box<dyn ChromaError>)?;
+        Ok(())
+    }
+
+    pub async fn delete_work(
+        &mut self,
+        fn_id: String,
+        input_coll_id: String,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        self.client
+            .delete_work(Request::new(DeleteWorkRequest {
                 fn_id,
                 input_coll_id,
             }))

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -53,6 +53,13 @@ pub struct UpdateFunctionFailureCountMessage {
 }
 
 #[derive(Debug)]
+pub struct DeleteWorkMessage {
+    pub fn_id: AttachedFunctionUuid,
+    pub input_coll_id: CollectionUuid,
+    pub response_tx: oneshot::Sender<Result<(), WorkQueueError>>,
+}
+
+#[derive(Debug)]
 pub(crate) struct WorkQueueReadyMessage;
 
 #[derive(Debug, Clone)]
@@ -423,6 +430,22 @@ impl Handler<UpdateFunctionFailureCountMessage> for WorkQueueManager {
             tracing::warn!(
                 "Failed to acknowledge function failure count update - receiver dropped"
             );
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<DeleteWorkMessage> for WorkQueueManager {
+    type Result = ();
+
+    async fn handle(&mut self, msg: DeleteWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
+        let result = if self.state.delete_work(&msg.fn_id, &msg.input_coll_id) {
+            self.persist().await
+        } else {
+            Ok(())
+        };
+        if msg.response_tx.send(result).is_err() {
+            tracing::warn!("Failed to acknowledge work deletion");
         }
     }
 }

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -1,14 +1,15 @@
 use crate::work_queue::types::{FinishResult, WorkQueueError};
 use crate::work_queue::work_queue_manager::{
-    FinishWorkMessage, GetWorkMessage, PushWorkMessage, UpdateFunctionFailureCountMessage,
-    WorkQueueManager,
+    DeleteWorkMessage, FinishWorkMessage, GetWorkMessage, PushWorkMessage,
+    UpdateFunctionFailureCountMessage, WorkQueueManager,
 };
 use chroma_sysdb::SysDb;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     work_queue_service_server::{WorkQueueService, WorkQueueServiceServer},
-    FailAttachedFunctionRequest, FailFunctionRequest, FinalizeAsyncAttachedFunctionRepairRequest,
-    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest, WorkItemResult,
+    DeleteWorkRequest, FailAttachedFunctionRequest, FailFunctionRequest,
+    FinalizeAsyncAttachedFunctionRepairRequest, FinishWorkRequest, GetWorkRequest, GetWorkResponse,
+    PushWorkRequest, WorkItemResult,
 };
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use std::str::FromStr;
@@ -175,6 +176,35 @@ impl WorkQueueService for WorkQueueServer {
             Status::internal(format!("Failed to receive failure count update: {}", e))
         })?;
 
+        Ok(Response::new(()))
+    }
+
+    async fn delete_work(
+        &self,
+        request: Request<DeleteWorkRequest>,
+    ) -> Result<Response<()>, Status> {
+        let req = request.into_inner();
+        let fn_id = AttachedFunctionUuid::from_str(&req.fn_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid fn_id: {}", e)))?;
+        let input_coll_id = CollectionUuid::from_str(&req.input_coll_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid collection_id: {}", e)))?;
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        self.manager
+            .receiver()
+            .send(
+                DeleteWorkMessage {
+                    fn_id,
+                    input_coll_id,
+                    response_tx,
+                },
+                None,
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Failed to delete work: {}", e)))?;
+        response_rx
+            .await
+            .map_err(|e| Status::internal(format!("Failed to receive work deletion: {}", e)))?
+            .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(()))
     }
 


### PR DESCRIPTION
## Summary

- Adds WQS-only `DeleteWork(fn_id, input_coll_id)`.
- Deletes the keyed queue entry and durably persists the updated Parquet snapshot.
- Missing entries are intentionally idempotent successes; no SysDB call is made.

## Testing

- Queue-state test verifies deletion, idempotency, and Parquet reload persistence.