### PR TITLE
[ENH](wqs): Add manual work insertion RPC

### DIFF
--- a/idl/chromadb/proto/workqueue.proto
+++ b/idl/chromadb/proto/workqueue.proto
@@ -30,6 +30,14 @@ message FailFunctionRequest {
     string input_coll_id = 2;
 }
 
+// Adds one attached-function invocation directly to WQS.
+message AddWorkRequest {
+    string fn_id = 1;
+    string input_coll_id = 2;
+    int64 compaction_offset = 3;
+    int32 failure_count = 4;
+}
+
 message GetWorkRequest {
     string shard_id = 1;
     uint32 limit = 2;
@@ -51,5 +59,6 @@ service WorkQueueService {
     rpc PushWork(PushWorkRequest) returns (google.protobuf.Empty);
     rpc FinishWork(FinishWorkRequest) returns (google.protobuf.Empty);
     rpc FailFunction(FailFunctionRequest) returns (google.protobuf.Empty);
+    rpc AddWork(AddWorkRequest) returns (google.protobuf.Empty);
     rpc GetWork(GetWorkRequest) returns (GetWorkResponse);
 }

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -362,6 +362,38 @@ impl QueueState {
         true
     }
 
+    pub fn add_work(
+        &mut self,
+        fn_id: AttachedFunctionUuid,
+        input_coll_id: CollectionUuid,
+        compaction_offset: i64,
+        failure_count: i32,
+    ) -> bool {
+        let key = (fn_id, input_coll_id);
+        if self.dedup_index.contains_key(&key) {
+            return false;
+        }
+
+        let record = WorkQueueRecord {
+            fn_id,
+            input_coll_id,
+            completion_offset: compaction_offset,
+            compaction_offset,
+            insertion_order: self.next_insertion_order,
+            failure_count,
+        };
+        self.next_insertion_order += 1;
+        self.dedup_index.insert(
+            key,
+            QueueOffsets {
+                compaction_offset: record.compaction_offset,
+            },
+        );
+        self.pending_work.push_back(record);
+        self.dirty = true;
+        true
+    }
+
     pub(crate) fn contains_entry(
         &self,
         fn_id: &AttachedFunctionUuid,
@@ -625,5 +657,21 @@ mod tests {
 
         state.finish_work_success(&fn_id, &coll_id, 60);
         assert_eq!(state.pending_work.len(), 0);
+    }
+
+    #[test]
+    fn test_add_work_persists_explicit_failure_count() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let coll_id = CollectionUuid(Uuid::new_v4());
+
+        assert!(state.add_work(fn_id, coll_id, 120, 4));
+        assert!(!state.add_work(fn_id, coll_id, 220, 0));
+
+        let reloaded = QueueState::from_parquet_bytes(&state.to_parquet_bytes().unwrap()).unwrap();
+        assert_eq!(reloaded.pending_work.len(), 1);
+        assert_eq!(reloaded.pending_work[0].completion_offset, 120);
+        assert_eq!(reloaded.pending_work[0].compaction_offset, 120);
+        assert_eq!(reloaded.pending_work[0].failure_count, 4);
     }
 }

--- a/rust/worker/src/work_queue/work_queue_client.rs
+++ b/rust/worker/src/work_queue/work_queue_client.rs
@@ -1,8 +1,8 @@
 use crate::fn_consumer::config::GrpcWorkQueueConfig;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::chroma_proto::{
-    work_queue_service_client::WorkQueueServiceClient, FailFunctionRequest, FinishWorkRequest,
-    GetWorkRequest, GetWorkResponse, PushWorkRequest,
+    work_queue_service_client::WorkQueueServiceClient, AddWorkRequest, FailFunctionRequest,
+    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest,
 };
 use std::time::Duration;
 use tonic::transport::Endpoint;
@@ -69,7 +69,6 @@ impl WorkQueueClient {
         &mut self,
         fn_id: String,
         input_coll_id: String,
-        completion_offset: i64,
         compaction_offset: i64,
     ) -> Result<(), Box<dyn ChromaError>> {
         let request = Request::new(PushWorkRequest {
@@ -116,6 +115,26 @@ impl WorkQueueClient {
             .fail_function(Request::new(FailFunctionRequest {
                 fn_id,
                 input_coll_id,
+            }))
+            .await
+            .map_err(|e| Box::new(WorkQueueClientError::RequestError(e)) as Box<dyn ChromaError>)?;
+        Ok(())
+    }
+
+    pub async fn add_work(
+        &mut self,
+        fn_id: String,
+        input_coll_id: String,
+        completion_offset: i64,
+        compaction_offset: i64,
+        failure_count: i32,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        self.client
+            .add_work(Request::new(AddWorkRequest {
+                fn_id,
+                input_coll_id,
+                compaction_offset,
+                failure_count,
             }))
             .await
             .map_err(|e| Box::new(WorkQueueClientError::RequestError(e)) as Box<dyn ChromaError>)?;

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -53,6 +53,15 @@ pub struct UpdateFunctionFailureCountMessage {
 }
 
 #[derive(Debug)]
+pub struct AddWorkMessage {
+    pub fn_id: AttachedFunctionUuid,
+    pub input_coll_id: CollectionUuid,
+    pub compaction_offset: i64,
+    pub failure_count: i32,
+    pub response_tx: oneshot::Sender<Result<bool, WorkQueueError>>,
+}
+
+#[derive(Debug)]
 pub(crate) struct WorkQueueReadyMessage;
 
 #[derive(Debug, Clone)]
@@ -423,6 +432,28 @@ impl Handler<UpdateFunctionFailureCountMessage> for WorkQueueManager {
             tracing::warn!(
                 "Failed to acknowledge function failure count update - receiver dropped"
             );
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<AddWorkMessage> for WorkQueueManager {
+    type Result = ();
+
+    async fn handle(&mut self, msg: AddWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
+        let added = self.state.add_work(
+            msg.fn_id,
+            msg.input_coll_id,
+            msg.compaction_offset,
+            msg.failure_count,
+        );
+        let result = if added {
+            self.persist().await.map(|_| true)
+        } else {
+            Ok(false)
+        };
+        if msg.response_tx.send(result).is_err() {
+            tracing::warn!("Failed to acknowledge manual work add");
         }
     }
 }

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -1,14 +1,15 @@
 use crate::work_queue::types::{FinishResult, WorkQueueError};
 use crate::work_queue::work_queue_manager::{
-    FinishWorkMessage, GetWorkMessage, PushWorkMessage, UpdateFunctionFailureCountMessage,
-    WorkQueueManager,
+    AddWorkMessage, FinishWorkMessage, GetWorkMessage, PushWorkMessage,
+    UpdateFunctionFailureCountMessage, WorkQueueManager,
 };
 use chroma_sysdb::SysDb;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     work_queue_service_server::{WorkQueueService, WorkQueueServiceServer},
-    FailAttachedFunctionRequest, FailFunctionRequest, FinalizeAsyncAttachedFunctionRepairRequest,
-    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest, WorkItemResult,
+    AddWorkRequest, FailAttachedFunctionRequest, FailFunctionRequest,
+    FinalizeAsyncAttachedFunctionRepairRequest, FinishWorkRequest, GetWorkRequest, GetWorkResponse,
+    PushWorkRequest, WorkItemResult,
 };
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use std::str::FromStr;
@@ -176,6 +177,42 @@ impl WorkQueueService for WorkQueueServer {
         })?;
 
         Ok(Response::new(()))
+    }
+
+    async fn add_work(&self, request: Request<AddWorkRequest>) -> Result<Response<()>, Status> {
+        let req = request.into_inner();
+        if req.failure_count < 0 {
+            return Err(Status::invalid_argument(
+                "failure_count must be non-negative",
+            ));
+        }
+        let fn_id = AttachedFunctionUuid::from_str(&req.fn_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid fn_id: {}", e)))?;
+        let input_coll_id = CollectionUuid::from_str(&req.input_coll_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid collection_id: {}", e)))?;
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        self.manager
+            .receiver()
+            .send(
+                AddWorkMessage {
+                    fn_id,
+                    input_coll_id,
+                    compaction_offset: req.compaction_offset,
+                    failure_count: req.failure_count,
+                    response_tx,
+                },
+                None,
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Failed to add work: {}", e)))?;
+        match response_rx
+            .await
+            .map_err(|e| Status::internal(format!("Failed to receive work add: {}", e)))?
+            .map_err(|e| Status::internal(e.to_string()))?
+        {
+            true => Ok(Response::new(())),
+            false => Err(Status::already_exists("Work queue entry already exists")),
+        }
     }
 
     async fn get_work(


### PR DESCRIPTION
## Summary

- Adds WQS-only `AddWork` with explicit completion offset, compaction offset, and failure count.
- Persists the supplied record directly to the WQS Parquet snapshot without consulting SysDB.
- Rejects an existing `(fn_id, input_coll_id)` with `AlreadyExists` rather than silently overwriting it.

## Testing

- Queue-state test verifies explicit failure-count persistence, Parquet reload, and duplicate rejection.