### PR TITLE
[BUG](worker): Skip in-progress function work

### DIFF
--- a/idl/chromadb/proto/workqueue.proto
+++ b/idl/chromadb/proto/workqueue.proto
@@ -34,6 +34,7 @@ message GetWorkRequest {
     string shard_id = 1;
     uint32 limit = 2;
     int32 max_failure_count = 3;
+    repeated string excluded_fn_ids = 4;
 }
 
 message WorkItemResult {

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -330,10 +330,11 @@ impl FnConsumerManager {
         let limit = self.context.get_work_batch_size;
         let resp = match self
             .work_queue_client
-            .get_work_with_failure_limit(
+            .get_work_with_failure_limit_excluding(
                 self.context.my_member_id.clone(),
                 limit,
                 self.context.max_failure_count,
+                self.in_progress.keys().map(ToString::to_string).collect(),
             )
             .await
         {

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -374,15 +374,15 @@ impl QueueState {
         &self,
         limit: usize,
         max_failure_count: i32,
+        excluded_fn_ids: &HashSet<AttachedFunctionUuid>,
     ) -> (Vec<WorkQueueRecord>, usize) {
         let mut work = Vec::with_capacity(limit);
         let mut failure_count_filtered = 0;
 
-        for item in self
-            .pending_work
-            .iter()
-            .filter(|item| self.contains_entry(&item.fn_id, &item.input_coll_id))
-        {
+        for item in self.pending_work.iter().filter(|item| {
+            self.contains_entry(&item.fn_id, &item.input_coll_id)
+                && !excluded_fn_ids.contains(&item.fn_id)
+        }) {
             if item.failure_count >= max_failure_count {
                 failure_count_filtered += 1;
             } else if work.len() < limit {
@@ -588,6 +588,23 @@ mod tests {
 
         assert_eq!(state.pending_work.len(), 1);
         assert_eq!(state.pending_work[0].failure_count, 0);
+    }
+
+    #[test]
+    fn test_get_live_work_skips_excluded_functions_before_limiting() {
+        let mut state = QueueState::new();
+        let excluded_fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let available_fn_id = AttachedFunctionUuid(Uuid::new_v4());
+
+        state.push_work(excluded_fn_id, CollectionUuid(Uuid::new_v4()), 10, 10);
+        state.push_work(excluded_fn_id, CollectionUuid(Uuid::new_v4()), 20, 20);
+        state.push_work(available_fn_id, CollectionUuid(Uuid::new_v4()), 30, 30);
+
+        let excluded_fn_ids = HashSet::from([excluded_fn_id]);
+        let (work, _) = state.get_live_work(1, i32::MAX, &excluded_fn_ids);
+
+        assert_eq!(work.len(), 1);
+        assert_eq!(work[0].fn_id, available_fn_id);
     }
 
     #[test]

--- a/rust/worker/src/work_queue/work_queue_client.rs
+++ b/rust/worker/src/work_queue/work_queue_client.rs
@@ -137,10 +137,22 @@ impl WorkQueueClient {
         limit: u32,
         max_failure_count: i32,
     ) -> Result<GetWorkResponse, Box<dyn ChromaError>> {
+        self.get_work_with_failure_limit_excluding(shard_id, limit, max_failure_count, Vec::new())
+            .await
+    }
+
+    pub async fn get_work_with_failure_limit_excluding(
+        &mut self,
+        shard_id: String,
+        limit: u32,
+        max_failure_count: i32,
+        excluded_fn_ids: Vec<String>,
+    ) -> Result<GetWorkResponse, Box<dyn ChromaError>> {
         let request = Request::new(GetWorkRequest {
             shard_id,
             limit,
             max_failure_count,
+            excluded_fn_ids,
         });
 
         let response =

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -10,6 +10,7 @@ use chroma_sysdb::SysDb;
 use chroma_system::{Component, ComponentContext, ComponentRuntime, Handler};
 use chroma_types::chroma_proto::TryFinishAsyncAttachedFunctionInvocationRequest;
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
+use std::collections::HashSet;
 use std::time::Duration;
 use tokio::sync::oneshot;
 use tonic::Code;
@@ -41,6 +42,7 @@ pub struct GetWorkMessage {
     pub shard_id: String,
     pub limit: usize,
     pub max_failure_count: i32,
+    pub excluded_fn_ids: HashSet<AttachedFunctionUuid>,
     pub response_tx: oneshot::Sender<Result<Vec<WorkQueueRecord>, WorkQueueError>>,
 }
 
@@ -394,7 +396,8 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
         // With eager stale-row removal on push, the queue's dedup index is the
         // source of truth for whether a row is still live.
         let (filtered, failure_count_filtered) =
-            self.state.get_live_work(msg.limit, msg.max_failure_count);
+            self.state
+                .get_live_work(msg.limit, msg.max_failure_count, &msg.excluded_fn_ids);
         tracing::info!(
             returned_items = filtered.len(),
             failure_count_filtered,
@@ -592,7 +595,7 @@ mod tests {
         state.push_work(live_fn_id, live_coll_id, 20, 20);
         assert!(state.update_failure_count(&dlq_fn_id, &dlq_coll_id, 3));
 
-        let (work, failure_count_filtered) = state.get_live_work(1, 3);
+        let (work, failure_count_filtered) = state.get_live_work(1, 3, &HashSet::new());
 
         assert_eq!(work.len(), 1);
         assert_eq!(work[0].fn_id, live_fn_id);

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -61,14 +61,6 @@ impl WorkQueueServer {
 impl WorkQueueService for WorkQueueServer {
     async fn push_work(&self, request: Request<PushWorkRequest>) -> Result<Response<()>, Status> {
         let req = request.into_inner();
-        let excluded_fn_ids = req
-            .excluded_fn_ids
-            .iter()
-            .map(|fn_id| {
-                AttachedFunctionUuid::from_str(fn_id)
-                    .map_err(|e| Status::invalid_argument(format!("Invalid excluded fn_id: {e}")))
-            })
-            .collect::<Result<_, _>>()?;
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
 
         let fn_id = AttachedFunctionUuid::from_str(&req.fn_id)

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -61,6 +61,14 @@ impl WorkQueueServer {
 impl WorkQueueService for WorkQueueServer {
     async fn push_work(&self, request: Request<PushWorkRequest>) -> Result<Response<()>, Status> {
         let req = request.into_inner();
+        let excluded_fn_ids = req
+            .excluded_fn_ids
+            .iter()
+            .map(|fn_id| {
+                AttachedFunctionUuid::from_str(fn_id)
+                    .map_err(|e| Status::invalid_argument(format!("Invalid excluded fn_id: {e}")))
+            })
+            .collect::<Result<_, _>>()?;
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
 
         let fn_id = AttachedFunctionUuid::from_str(&req.fn_id)
@@ -183,12 +191,21 @@ impl WorkQueueService for WorkQueueServer {
         request: Request<GetWorkRequest>,
     ) -> Result<Response<GetWorkResponse>, Status> {
         let req = request.into_inner();
+        let excluded_fn_ids = req
+            .excluded_fn_ids
+            .iter()
+            .map(|fn_id| {
+                AttachedFunctionUuid::from_str(fn_id)
+                    .map_err(|e| Status::invalid_argument(format!("Invalid excluded fn_id: {e}")))
+            })
+            .collect::<Result<_, _>>()?;
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
 
         let msg = GetWorkMessage {
             shard_id: req.shard_id,
             limit: req.limit as usize,
             max_failure_count: req.max_failure_count,
+            excluded_fn_ids,
             response_tx,
         };
 


### PR DESCRIPTION
## Summary
- add `excluded_fn_ids` to the `GetWork` request
- have fn-consumer exclude locally in-progress functions when polling
- filter exclusions before WQS applies its response limit

## Why
A slow function can occupy the leading `GetWork` rows. Without filtering before `limit`, every poll returns only that already-running function and cannot reach later functions with available capacity.

## Validation
- `cargo fmt --check`
- queue-state regression test added for excluded head rows