### PR TITLE
[BUG](hnsw): reject bool in HNSW param validators

### DIFF
--- a/chromadb/segment/impl/vector/hnsw_params.py
+++ b/chromadb/segment/impl/vector/hnsw_params.py
@@ -9,17 +9,17 @@ Validator = Callable[[Union[str, int, float]], bool]
 
 param_validators: Dict[str, Validator] = {
     "hnsw:space": lambda p: bool(re.match(r"^(l2|cosine|ip)$", str(p))),
-    "hnsw:construction_ef": lambda p: isinstance(p, int),
-    "hnsw:search_ef": lambda p: isinstance(p, int),
-    "hnsw:M": lambda p: isinstance(p, int),
-    "hnsw:num_threads": lambda p: isinstance(p, int),
-    "hnsw:resize_factor": lambda p: isinstance(p, (int, float)),
+    "hnsw:construction_ef": lambda p: isinstance(p, int) and not isinstance(p, bool),
+    "hnsw:search_ef": lambda p: isinstance(p, int) and not isinstance(p, bool),
+    "hnsw:M": lambda p: isinstance(p, int) and not isinstance(p, bool),
+    "hnsw:num_threads": lambda p: isinstance(p, int) and not isinstance(p, bool),
+    "hnsw:resize_factor": lambda p: isinstance(p, (int, float)) and not isinstance(p, bool),
 }
 
 # Extra params used for persistent hnsw
 persistent_param_validators: Dict[str, Validator] = {
-    "hnsw:batch_size": lambda p: isinstance(p, int) and p > 2,
-    "hnsw:sync_threshold": lambda p: isinstance(p, int) and p > 2,
+    "hnsw:batch_size": lambda p: isinstance(p, int) and not isinstance(p, bool) and p > 2,
+    "hnsw:sync_threshold": lambda p: isinstance(p, int) and not isinstance(p, bool) and p > 2,
 }
 
 

--- a/chromadb/test/segment/test_hnsw_params.py
+++ b/chromadb/test/segment/test_hnsw_params.py
@@ -1,0 +1,44 @@
+import pytest
+
+from chromadb.segment.impl.vector.hnsw_params import (
+    HnswParams,
+    PersistentHnswParams,
+)
+
+
+def test_bool_rejected_for_int_params():
+    """bool values must not pass HNSW int validators (bool is a subclass of int)."""
+    for param, value in [
+        ("hnsw:construction_ef", True),
+        ("hnsw:construction_ef", False),
+        ("hnsw:search_ef", True),
+        ("hnsw:M", True),
+        ("hnsw:num_threads", False),
+        ("hnsw:resize_factor", True),
+    ]:
+        with pytest.raises(ValueError):
+            HnswParams.extract({param: value})
+
+
+def test_bool_rejected_for_persistent_int_params():
+    """bool values must not pass persistent HNSW int validators."""
+    for param, value in [
+        ("hnsw:batch_size", True),
+        ("hnsw:sync_threshold", False),
+    ]:
+        with pytest.raises(ValueError):
+            PersistentHnswParams.extract({param: value})
+
+
+def test_valid_int_params_accepted():
+    """Valid int values must still pass validation."""
+    metadata = HnswParams.extract(
+        {
+            "hnsw:construction_ef": 100,
+            "hnsw:search_ef": 50,
+            "hnsw:M": 16,
+            "hnsw:num_threads": 4,
+            "hnsw:resize_factor": 1.2,
+        }
+    )
+    assert metadata["hnsw:construction_ef"] == 100


### PR DESCRIPTION
## Summary

`bool` is a subclass of `int` in Python, so `isinstance(True, int)` returns `True`. This means `True` and `False` silently pass the integer validators for all HNSW parameters (`construction_ef`, `search_ef`, `M`, `num_threads`, `batch_size`, `sync_threshold`, and `resize_factor`), producing a nearly unusable index without any error.

## Changes

- `chromadb/segment/impl/vector/hnsw_params.py`: added `and not isinstance(p, bool)` to all six int validators in `param_validators` and `persistent_param_validators`
- `chromadb/test/segment/test_hnsw_params.py`: new test file verifying bool values are rejected and valid int values are still accepted

## Test plan

- [x] `test_bool_rejected_for_int_params` — `True`/`False` passed to each int param raises `ValueError`
- [x] `test_bool_rejected_for_persistent_int_params` — same for `batch_size` and `sync_threshold`
- [x] `test_valid_int_params_accepted` — valid integer values still pass validation
- [x] All 3 tests pass locally (`pytest chromadb/test/segment/test_hnsw_params.py -v`)

Fixes #7288