### PR TITLE
[BUG](api): fix order-dependent bool/int check in validate_where

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1277,7 +1277,11 @@ def validate_where(where: Where) -> None:
                     )
                 if isinstance(operand, list) and (
                     len(operand) == 0
-                    or not all(isinstance(x, type(operand[0])) for x in operand)
+                    or not all(
+                        (bool if isinstance(x, bool) else type(x))
+                        is (bool if isinstance(operand[0], bool) else type(operand[0]))
+                        for x in operand
+                    )
                 ):
                     raise ValueError(
                         f"Expected where operand value to be a non-empty list, and all values to be of the same type "

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -2276,6 +2276,23 @@ def test_where_contains_validation():
     )
 
 
+def test_where_in_bool_int_order_independent():
+    """$in/$nin must reject mixed bool/int lists regardless of element order."""
+    from chromadb.api.types import validate_where
+
+    with pytest.raises(ValueError):
+        validate_where({"f": {"$in": [True, 1]}})
+    with pytest.raises(ValueError):
+        validate_where({"f": {"$in": [1, True]}})
+    with pytest.raises(ValueError):
+        validate_where({"f": {"$nin": [False, 0]}})
+    with pytest.raises(ValueError):
+        validate_where({"f": {"$nin": [0, False]}})
+    # homogeneous lists must still pass
+    validate_where({"f": {"$in": [1, 2, 3]}})
+    validate_where({"f": {"$in": [True, False]}})
+
+
 def _is_python_local_segment(client):
     """Return True when the client is backed by the Python local segment API
     (which does not yet support array metadata)."""


### PR DESCRIPTION
## Summary

`validate_where` uses `isinstance(x, type(operand[0]))` to enforce homogeneity in `$in`/`$nin` lists. Because `bool` is a subclass of `int`, the result is order-dependent:

- `{"$in": [True, 1]}` raises (correct — first element is bool, 1 fails `isinstance(1, bool)`)
- `{"$in": [1, True]}` silently passes (bug — first element is int, `isinstance(True, int)` is True)

The fix applies the same normalize-before-compare pattern already used in `_validate_metadata_list_value` (same file): treat `bool` as `bool`, not as `int`.

## Changes

- `chromadb/api/types.py` line 1280: replace `isinstance(x, type(operand[0]))` with a bool-normalized type comparison
- `chromadb/test/test_api.py`: add `test_where_in_bool_int_order_independent` covering both orderings for `$in` and `$nin`

## Test plan

- [x] `[True, 1]` raises `ValueError`
- [x] `[1, True]` raises `ValueError` (was silently passing before fix)
- [x] `[False, 0]` and `[0, False]` both raise `ValueError`
- [x] `[1, 2, 3]` and `[True, False]` still pass (homogeneous)
- [x] `pytest chromadb/test/test_api.py::test_where_in_bool_int_order_independent` passes

Fixes #7181