### PR TITLE
[BUG](js-client): fix TOCTOU race in ChromaClient._path()

### DIFF
--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -84,6 +84,7 @@ export class ChromaClient {
   private _preflightChecks: ChecklistResponse | undefined;
   private _headers: Record<string, string> | undefined;
   private readonly apiClient: ReturnType<typeof createClient>;
+  private _pathPromise: Promise<{ tenant: string; database: string }> | undefined;
 
   /**
    * Creates a new ChromaClient instance.
@@ -189,20 +190,27 @@ export class ChromaClient {
   /** @ignore */
   public async _path(): Promise<{ tenant: string; database: string }> {
     if (!this._tenant || !this._database) {
-      const { tenant, databases } = await this.getUserIdentity();
-      const uniqueDBs = [...new Set(databases)];
-      this._tenant = tenant;
-      if (uniqueDBs.length === 0) {
-        throw new ChromaUnauthorizedError(
-          `Your API key does not have access to any DBs for tenant ${this.tenant}`,
-        );
+      if (!this._pathPromise) {
+        this._pathPromise = (async () => {
+          const { tenant, databases } = await this.getUserIdentity();
+          const uniqueDBs = [...new Set(databases)];
+          this._tenant = tenant;
+          if (uniqueDBs.length === 0) {
+            throw new ChromaUnauthorizedError(
+              `Your API key does not have access to any DBs for tenant ${this.tenant}`,
+            );
+          }
+          if (uniqueDBs.length > 1 || uniqueDBs[0] === "*") {
+            throw new ChromaValueError(
+              "Your API key is scoped to more than 1 DB. Please provide a DB name to the CloudClient constructor",
+            );
+          }
+          const database = uniqueDBs[0];
+          this._database = database;
+          return { tenant, database };
+        })();
       }
-      if (uniqueDBs.length > 1 || uniqueDBs[0] === "*") {
-        throw new ChromaValueError(
-          "Your API key is scoped to more than 1 DB. Please provide a DB name to the CloudClient constructor",
-        );
-      }
-      this._database = uniqueDBs[0];
+      return this._pathPromise!;
     }
     return { tenant: this._tenant, database: this._database };
   }


### PR DESCRIPTION
## Summary

`ChromaClient._path()` has a TOCTOU race: two concurrent callers that reach the method before `_tenant`/`_database` are populated both enter the `if (!this._tenant || !this._database)` block and each fire `getUserIdentity()`. This means:

- Two redundant auth round-trips on every cold start with concurrent usage
- Non-deterministic `_tenant`/`_database` if `getUserIdentity()` returns different values across calls (e.g. token rotation)

## Fix

Same lazy-promise pattern already used elsewhere: store the resolution as a promise on first call, return the same promise to all concurrent callers. Only one `getUserIdentity()` call reaches the network.

```ts
private _pathPromise: Promise<{ tenant: string; database: string }> | undefined;

public async _path() {
  if (!this._tenant || !this._database) {
    if (!this._pathPromise) {
      this._pathPromise = (async () => { /* ... getUserIdentity ... */ })();
    }
    return this._pathPromise!;
  }
  return { tenant: this._tenant, database: this._database };
}
```

## Changes

- `clients/new-js/packages/chromadb/src/chroma-client.ts`: add `_pathPromise` field, wrap `_path()` body in lazy promise

## Test plan

- [x] TypeScript type-check: no new errors introduced (pre-existing `Set<string>` iteration error unchanged; pre-existing `string | undefined` type error resolved by the fix)
- [x] Concurrent calls to `_path()` now share a single `getUserIdentity()` call

Fixes #7494