### PR TITLE
[BUG](fn-consumer): Prefetch records only

### DIFF
--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -1035,6 +1035,10 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
         let prefetch_segments = if self.context.is_rebuild() {
             shard_index = Some(self.context.rebuild_shard_idx());
             vec![output.record_segment]
+        } else if self.context.is_fn_consumer {
+            // Function consumers only read records while materializing the
+            // attached function's input, so avoid warming unrelated segments.
+            vec![output.record_segment]
         } else {
             let mut segments = vec![output.metadata_segment, output.record_segment];
             if vector_segment.r#type != chroma_types::SegmentType::HnswDistributed {


### PR DESCRIPTION
## Summary

Fn-consumer work only materializes record data, but the log-fetch orchestrator also warmed metadata and vector segments.

This change limits fn-consumer prefetching to the record segment while preserving the existing rebuild and normal-compaction paths.

## Impact

Fn-consumer avoids unnecessary cache warming and object-storage reads for segments it does not consume.

## Validation

- Pre-commit checks run during commit
- Test run intentionally skipped at request