### PR TITLE
[BUG](metadata): delete_collection leaks array metadata

### DIFF
--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -457,6 +457,7 @@ class SqliteMetadataSegment(MetadataReader):
             # Manually delete metadata; cannot use cascade because
             # that triggers on replace
             metadata_t = Table("embedding_metadata")
+            metadata_array_t = Table("embedding_metadata_array")
 
             q = (
                 self._db.querybuilder()
@@ -464,8 +465,14 @@ class SqliteMetadataSegment(MetadataReader):
                 .where(metadata_t.id == ParameterValue(id))
                 .delete()
             )
-            sql, params = get_sql(q)
-            cur.execute(sql, params)
+            q_arr = (
+                self._db.querybuilder()
+                .from_(metadata_array_t)
+                .where(metadata_array_t.id == ParameterValue(id))
+                .delete()
+            )
+            cur.execute(*get_sql(q))
+            cur.execute(*get_sql(q_arr))
 
     @trace_method("SqliteMetadataSegment._update_record", OpenTelemetryGranularity.ALL)
     def _update_record(self, cur: Cursor, record: LogRecord) -> None:
@@ -595,21 +602,25 @@ class SqliteMetadataSegment(MetadataReader):
     def delete(self) -> None:
         t = Table("embeddings")
         t1 = Table("embedding_metadata")
+        t1a = Table("embedding_metadata_array")
         t2 = Table("embedding_fulltext_search")
+        segment_ids = (
+            self._db.querybuilder()
+            .from_(t)
+            .select(t.id)
+            .where(t.segment_id == ParameterValue(self._db.uuid_to_db(self._id)))
+        )
         q0 = (
             self._db.querybuilder()
             .from_(t1)
             .delete()
-            .where(
-                t1.id.isin(
-                    self._db.querybuilder()
-                    .from_(t)
-                    .select(t.id)
-                    .where(
-                        t.segment_id == ParameterValue(self._db.uuid_to_db(self._id))
-                    )
-                )
-            )
+            .where(t1.id.isin(segment_ids))
+        )
+        q0a = (
+            self._db.querybuilder()
+            .from_(t1a)
+            .delete()
+            .where(t1a.id.isin(segment_ids))
         )
         q = (
             self._db.querybuilder()
@@ -630,20 +641,12 @@ class SqliteMetadataSegment(MetadataReader):
             self._db.querybuilder()
             .from_(t2)
             .delete()
-            .where(
-                t2.rowid.isin(
-                    self._db.querybuilder()
-                    .from_(t)
-                    .select(t.id)
-                    .where(
-                        t.segment_id == ParameterValue(self._db.uuid_to_db(self._id))
-                    )
-                )
-            )
+            .where(t2.rowid.isin(segment_ids))
         )
         with self._db.tx() as cur:
             cur.execute(*get_sql(q_fts))
             cur.execute(*get_sql(q0))
+            cur.execute(*get_sql(q0a))
             cur.execute(*get_sql(q))
 
 

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -1012,6 +1012,20 @@ impl SqliteSysDb {
         .execute(&mut *conn)
         .await?;
 
+        // Delete array metadata (list-valued) for the same embedding ids
+        sqlx::query(
+            r#"
+            DELETE FROM embedding_metadata_array
+            WHERE id IN (
+                SELECT id FROM embeddings
+                WHERE segment_id IN (SELECT id FROM segments WHERE collection = $1)
+            )
+            "#,
+        )
+        .bind(collection_id.to_string())
+        .execute(&mut *conn)
+        .await?;
+
         // Delete embeddings fulltext search records
         sqlx::query(
             r#"


### PR DESCRIPTION
## Summary

`delete_collection` deletes rows from `embedding_metadata` (scalar values) and `embedding_fulltext_search`, but leaves rows in `embedding_metadata_array` (list-valued metadata) behind. SQLite auto-increments the `embeddings.id` counter starting from 1 after all rows are removed, so the next collection's first record inherits the orphaned array rows and returns metadata it never had.

The bug affects `PersistentClient` (Rust sysdb path) and the Python `SegmentAPI` path identically.

## Root cause

`embedding_metadata_array` was added in migration 00006 as a separate table. Both the Rust `delete_collection_with_conn` function and the Python `SqliteMetadataSegment.delete()` method clean up `embedding_metadata` but never touch `embedding_metadata_array`.

## Changes

- `rust/sysdb/src/sqlite.rs`: added `DELETE FROM embedding_metadata_array` with the same subquery pattern used for `embedding_metadata`, executed before the `embeddings` delete
- `chromadb/segment/impl/metadata/sqlite.py`:
  - `delete()`: added `q0a` to delete from `embedding_metadata_array` (also refactored the repeated `segment_ids` subquery into a variable)
  - `_delete_record()`: added deletion of `embedding_metadata_array` rows alongside `embedding_metadata` rows

## Test plan

- [x] Diff reviewed — only the intended tables are added to the delete sequence
- [x] Both the Rust sysdb path and Python segment path are fixed
- [x] Fix follows the exact same pattern as the existing `embedding_metadata` deletes
- [ ] CI: end-to-end reproduction from issue #7594 should pass after Rust rebuild

Fixes #7594