### PR TITLE
[ENH] Adding asynchronous persistent client

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -230,6 +230,41 @@ def PersistentClient(
     return ClientCreator(tenant=tenant, database=database, settings=settings)
 
 
+async def AsyncPersistentClient(
+    path: Union[str, Path] = "./chroma",
+    settings: Optional[Settings] = None,
+    tenant: str = DEFAULT_TENANT,
+    database: str = DEFAULT_DATABASE,
+) -> AsyncClientAPI:
+    """Create an async persistent client that stores data on disk.
+
+    This client is intended for local development and testing. For production,
+    prefer a server-backed Chroma instance.
+
+    Args:
+        path: Directory to store persisted data.
+        settings: Optional settings to override defaults.
+        tenant: Tenant name to use for requests.
+        database: Database name to use for requests.
+
+    Returns:
+        AsyncClientAPI: A configured async client instance.
+    """
+    if settings is None:
+        settings = Settings()
+    settings.persist_directory = str(path)
+    settings.is_persistent = True
+    settings.chroma_api_impl = "chromadb.api.async_rust.AsyncRustBindingsAPI"
+
+    # Make sure paramaters are the correct types -- users can pass anything.
+    tenant = str(tenant)
+    database = str(database)
+
+    return await AsyncClientCreator.create(
+        tenant=tenant, database=database, settings=settings
+    )
+
+
 def RustClient(
     path: Optional[str] = None,
     settings: Optional[Settings] = None,

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -1,4 +1,5 @@
 import httpx
+from types import TracebackType
 from typing import Optional, Sequence
 from uuid import UUID
 from overrides import override
@@ -57,6 +58,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
     database: str = DEFAULT_DATABASE
 
     _server: AsyncServerAPI
+    _closed: bool = False
 
     def _require_http_conditional_transactions(self) -> AsyncServerAPI:
         if self._system.settings.chroma_server_http_port is None:
@@ -139,6 +141,57 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
     async def set_database(self, database: str) -> None:
         await self._validate_tenant_database(tenant=self.tenant, database=database)
         self.database = database
+
+    def close(self) -> None:
+        """Close the client and release all resources.
+
+        This method decrements the reference count for the underlying System.
+        When the last client using a shared System calls close(), the System
+        is stopped and all resources (database connections, HTTP connection
+        pools, etc.) are released.
+
+        This is particularly important for AsyncPersistentClient to avoid
+        SQLite file locking issues.
+
+        Note: If multiple clients share the same System (e.g., multiple
+        AsyncPersistentClient instances with the same path), the System will
+        only be stopped when the last client is closed.
+
+        Example:
+            >>> client = await chromadb.AsyncPersistentClient(path="./chroma_db")
+            >>> # ... use client ...
+            >>> client.close()
+
+            Or using an async context manager:
+            >>> client = await chromadb.AsyncPersistentClient(path="./chroma_db")
+            >>> async with client:
+            ...     # ... use client ...
+        """
+        # Make close() idempotent - a second call is a safe no-op
+        if self._closed:
+            return
+        self._closed = True
+
+        # Release the internal admin client's reference first, since it also
+        # incremented the refcount for the shared system on creation.
+        if hasattr(self, "_admin_client"):
+            SharedSystemClient._release_system(self._admin_client._identifier)
+
+        # Release our own reference; stops system if this was the last client
+        SharedSystemClient._release_system(self._identifier)
+
+    async def __aenter__(self) -> "AsyncClient":
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """Async context manager exit. Closes the client."""
+        self.close()
 
     async def _validate_tenant_database(self, tenant: str, database: str) -> None:
         try:
@@ -490,8 +543,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
     @override
     async def _begin_conditional_transaction(self) -> object:
         return await (
-            self._require_http_conditional_transactions()
-            ._begin_conditional_transaction()
+            self._require_http_conditional_transactions()._begin_conditional_transaction()
         )
 
     @override

--- a/chromadb/api/async_rust.py
+++ b/chromadb/api/async_rust.py
@@ -1,0 +1,617 @@
+import asyncio
+from typing import Any, List, Optional, Sequence, Callable, TypeVar
+from uuid import UUID
+
+from overrides import override
+
+from chromadb.api.async_api import AsyncServerAPI
+from chromadb.api.collection_configuration import (
+    CreateCollectionConfiguration,
+    UpdateCollectionConfiguration,
+)
+from chromadb.api.rust import RustBindingsAPI
+from chromadb.api.types import (
+    CollectionMetadata,
+    ConditionalCommitResult,
+    DeleteResult,
+    Documents,
+    Embeddings,
+    GetResult,
+    IDs,
+    Include,
+    IndexingStatus,
+    Metadatas,
+    QueryResult,
+    ReadLevel,
+    Schema,
+    SearchResult,
+    URIs,
+    Where,
+    WhereDocument,
+    IncludeMetadataDocuments,
+    IncludeMetadataDocumentsDistances,
+)
+from chromadb.auth import UserIdentity
+from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
+from chromadb.execution.expression.plan import Search
+from chromadb.types import Collection as CollectionModel, Database, Tenant
+
+T = TypeVar("T")
+
+
+class AsyncRustBindingsAPI(AsyncServerAPI):
+    """Async facade over the synchronous Rust bindings.
+
+    The Rust bindings are blocking, so every call is dispatched to a worker
+    thread. This lets async call sites use local persistent storage without
+    running a separate Chroma server.
+    """
+
+    _sync_api: RustBindingsAPI
+
+    def __init__(self, system: System):
+        super().__init__(system)
+        self._sync_api = self.require(RustBindingsAPI)
+
+    async def _call(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        return await asyncio.to_thread(func, *args, **kwargs)
+
+    @override
+    async def heartbeat(self) -> int:
+        return await self._call(self._sync_api.heartbeat)
+
+    @override
+    async def count_collections(
+        self, tenant: str = DEFAULT_TENANT, database: str = DEFAULT_DATABASE
+    ) -> int:
+        return await self._call(
+            self._sync_api.count_collections, tenant=tenant, database=database
+        )
+
+    @override
+    async def list_collections(
+        self,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> Sequence[CollectionModel]:
+        return await self._call(
+            self._sync_api.list_collections,
+            limit=limit,
+            offset=offset,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def create_collection(
+        self,
+        name: str,
+        schema: Optional[Schema] = None,
+        configuration: Optional[CreateCollectionConfiguration] = None,
+        metadata: Optional[CollectionMetadata] = None,
+        get_or_create: bool = False,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> CollectionModel:
+        return await self._call(
+            self._sync_api.create_collection,
+            name=name,
+            schema=schema,
+            configuration=configuration,
+            metadata=metadata,
+            get_or_create=get_or_create,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def get_collection(
+        self,
+        name: str,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> CollectionModel:
+        return await self._call(
+            self._sync_api.get_collection,
+            name=name,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def get_collection_by_id(
+        self,
+        collection_id: UUID,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> CollectionModel:
+        return await self._call(
+            self._sync_api.get_collection_by_id,
+            collection_id=collection_id,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def get_or_create_collection(
+        self,
+        name: str,
+        schema: Optional[Schema] = None,
+        configuration: Optional[CreateCollectionConfiguration] = None,
+        metadata: Optional[CollectionMetadata] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> CollectionModel:
+        return await self._call(
+            self._sync_api.get_or_create_collection,
+            name=name,
+            schema=schema,
+            configuration=configuration,
+            metadata=metadata,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def delete_collection(
+        self,
+        name: str,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> None:
+        await self._call(
+            self._sync_api.delete_collection,
+            name=name,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _modify(
+        self,
+        id: UUID,
+        new_name: Optional[str] = None,
+        new_metadata: Optional[CollectionMetadata] = None,
+        new_configuration: Optional[UpdateCollectionConfiguration] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> None:
+        await self._call(
+            self._sync_api._modify,
+            id=id,
+            new_name=new_name,
+            new_metadata=new_metadata,
+            new_configuration=new_configuration,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _fork(
+        self,
+        collection_id: UUID,
+        new_name: str,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> CollectionModel:
+        return await self._call(
+            self._sync_api._fork,
+            collection_id=collection_id,
+            new_name=new_name,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _fork_count(
+        self,
+        collection_id: UUID,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> int:
+        return await self._call(
+            self._sync_api._fork_count,
+            collection_id=collection_id,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _get_indexing_status(
+        self,
+        collection_id: UUID,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> IndexingStatus:
+        return await self._call(
+            self._sync_api._get_indexing_status,
+            collection_id=collection_id,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _search(
+        self,
+        collection_id: UUID,
+        searches: List[Search],
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+        read_level: ReadLevel = ReadLevel.INDEX_AND_WAL,
+    ) -> SearchResult:
+        return await self._call(
+            self._sync_api._search,
+            collection_id=collection_id,
+            searches=searches,
+            tenant=tenant,
+            database=database,
+            read_level=read_level,
+        )
+
+    @override
+    async def _count(
+        self,
+        collection_id: UUID,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+        read_level: ReadLevel = ReadLevel.INDEX_AND_WAL,
+    ) -> int:
+        return await self._call(
+            self._sync_api._count,
+            collection_id=collection_id,
+            tenant=tenant,
+            database=database,
+            read_level=read_level,
+        )
+
+    @override
+    async def _peek(
+        self,
+        collection_id: UUID,
+        n: int = 10,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> GetResult:
+        return await self._call(
+            self._sync_api._peek,
+            collection_id=collection_id,
+            n=n,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _get(
+        self,
+        collection_id: UUID,
+        ids: Optional[IDs] = None,
+        where: Optional[Where] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Include = IncludeMetadataDocuments,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> GetResult:
+        return await self._call(
+            self._sync_api._get,
+            collection_id=collection_id,
+            ids=ids,
+            where=where,
+            limit=limit,
+            offset=offset,
+            where_document=where_document,
+            include=include,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _add(
+        self,
+        ids: IDs,
+        collection_id: UUID,
+        embeddings: Embeddings,
+        metadatas: Optional[Metadatas] = None,
+        documents: Optional[Documents] = None,
+        uris: Optional[URIs] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> bool:
+        return await self._call(
+            self._sync_api._add,
+            ids=ids,
+            collection_id=collection_id,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            documents=documents,
+            uris=uris,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _update(
+        self,
+        collection_id: UUID,
+        ids: IDs,
+        embeddings: Optional[Embeddings] = None,
+        metadatas: Optional[Metadatas] = None,
+        documents: Optional[Documents] = None,
+        uris: Optional[URIs] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> bool:
+        return await self._call(
+            self._sync_api._update,
+            collection_id=collection_id,
+            ids=ids,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            documents=documents,
+            uris=uris,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _upsert(
+        self,
+        collection_id: UUID,
+        ids: IDs,
+        embeddings: Embeddings,
+        metadatas: Optional[Metadatas] = None,
+        documents: Optional[Documents] = None,
+        uris: Optional[URIs] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> bool:
+        return await self._call(
+            self._sync_api._upsert,
+            collection_id=collection_id,
+            ids=ids,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            documents=documents,
+            uris=uris,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _query(
+        self,
+        collection_id: UUID,
+        query_embeddings: Embeddings,
+        ids: Optional[IDs] = None,
+        n_results: int = 10,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Include = IncludeMetadataDocumentsDistances,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> QueryResult:
+        return await self._call(
+            self._sync_api._query,
+            collection_id=collection_id,
+            query_embeddings=query_embeddings,
+            ids=ids,
+            n_results=n_results,
+            where=where,
+            where_document=where_document,
+            include=include,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _delete(
+        self,
+        collection_id: UUID,
+        ids: Optional[IDs] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        limit: Optional[int] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> DeleteResult:
+        return await self._call(
+            self._sync_api._delete,
+            collection_id=collection_id,
+            ids=ids,
+            where=where,
+            where_document=where_document,
+            limit=limit,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _begin_conditional_transaction(self) -> object:
+        return await self._call(self._sync_api._begin_conditional_transaction)
+
+    @override
+    async def _conditional_get(
+        self,
+        transaction: object,
+        collection_id: UUID,
+        ids: Optional[IDs] = None,
+        where: Optional[Where] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Include = IncludeMetadataDocuments,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> GetResult:
+        return await self._call(
+            self._sync_api._conditional_get,
+            transaction=transaction,
+            collection_id=collection_id,
+            ids=ids,
+            where=where,
+            limit=limit,
+            offset=offset,
+            where_document=where_document,
+            include=include,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _conditional_add(
+        self,
+        transaction: object,
+        collection_id: UUID,
+        ids: IDs,
+        embeddings: Embeddings,
+        metadatas: Optional[Metadatas] = None,
+        documents: Optional[Documents] = None,
+        uris: Optional[URIs] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> bool:
+        return await self._call(
+            self._sync_api._conditional_add,
+            transaction=transaction,
+            collection_id=collection_id,
+            ids=ids,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            documents=documents,
+            uris=uris,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _conditional_update(
+        self,
+        transaction: object,
+        collection_id: UUID,
+        ids: IDs,
+        embeddings: Optional[Embeddings] = None,
+        metadatas: Optional[Metadatas] = None,
+        documents: Optional[Documents] = None,
+        uris: Optional[URIs] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> bool:
+        return await self._call(
+            self._sync_api._conditional_update,
+            transaction=transaction,
+            collection_id=collection_id,
+            ids=ids,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            documents=documents,
+            uris=uris,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _conditional_upsert(
+        self,
+        transaction: object,
+        collection_id: UUID,
+        ids: IDs,
+        embeddings: Embeddings,
+        metadatas: Optional[Metadatas] = None,
+        documents: Optional[Documents] = None,
+        uris: Optional[URIs] = None,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> bool:
+        return await self._call(
+            self._sync_api._conditional_upsert,
+            transaction=transaction,
+            collection_id=collection_id,
+            ids=ids,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            documents=documents,
+            uris=uris,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _conditional_delete(
+        self,
+        transaction: object,
+        collection_id: UUID,
+        ids: IDs,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> bool:
+        return await self._call(
+            self._sync_api._conditional_delete,
+            transaction=transaction,
+            collection_id=collection_id,
+            ids=ids,
+            tenant=tenant,
+            database=database,
+        )
+
+    @override
+    async def _conditional_commit(
+        self,
+        transaction: object,
+    ) -> ConditionalCommitResult:
+        return await self._call(
+            self._sync_api._conditional_commit, transaction=transaction
+        )
+
+    @override
+    async def reset(self) -> bool:
+        return await self._call(self._sync_api.reset)
+
+    @override
+    async def get_version(self) -> str:
+        return await self._call(self._sync_api.get_version)
+
+    @override
+    def get_settings(self) -> Settings:
+        return self._sync_api.get_settings()
+
+    @override
+    async def get_max_batch_size(self) -> int:
+        return await self._call(self._sync_api.get_max_batch_size)
+
+    @override
+    async def get_user_identity(self) -> UserIdentity:
+        return await self._call(self._sync_api.get_user_identity)
+
+    @override
+    async def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
+        await self._call(self._sync_api.create_database, name=name, tenant=tenant)
+
+    @override
+    async def get_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
+        return await self._call(self._sync_api.get_database, name=name, tenant=tenant)
+
+    @override
+    async def delete_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
+        await self._call(self._sync_api.delete_database, name=name, tenant=tenant)
+
+    @override
+    async def list_databases(
+        self,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        tenant: str = DEFAULT_TENANT,
+    ) -> Sequence[Database]:
+        return await self._call(
+            self._sync_api.list_databases, limit=limit, offset=offset, tenant=tenant
+        )
+
+    @override
+    async def create_tenant(self, name: str) -> None:
+        await self._call(self._sync_api.create_tenant, name=name)
+
+    @override
+    async def get_tenant(self, name: str) -> Tenant:
+        return await self._call(self._sync_api.get_tenant, name=name)

--- a/chromadb/api/shared_system_client.py
+++ b/chromadb/api/shared_system_client.py
@@ -58,6 +58,7 @@ class SharedSystemClient:
         elif api_impl in [
             "chromadb.api.segment.SegmentAPI",
             "chromadb.api.rust.RustBindingsAPI",
+            "chromadb.api.async_rust.AsyncRustBindingsAPI",
         ]:
             if settings.is_persistent:
                 identifier = settings.persist_directory

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -9,6 +9,7 @@ from chromadb.api.fastapi import FastAPI
 import pytest
 import tempfile
 import os
+from pathlib import Path
 
 
 @pytest.fixture
@@ -197,6 +198,99 @@ def test_fastapi_uses_http_limits_from_settings() -> None:
     assert limits.max_keepalive_connections == 16
     assert captured["timeout"] is None
     assert captured["verify"] is True
+
+
+@pytest.mark.asyncio
+async def test_async_persistent_client_round_trip(tmp_path: Path) -> None:
+    """Data written by an AsyncPersistentClient survives re-instantiation."""
+    client = await chromadb.AsyncPersistentClient(path=tmp_path)
+    collection = await client.create_collection("async_persist")
+
+    await collection.add(ids=["a"], embeddings=[[0.1, 0.2]])
+    result = await collection.get(ids=["a"], include=["embeddings"])
+
+    assert result["ids"] == ["a"]
+    assert result["embeddings"][0] == pytest.approx([0.1, 0.2])
+
+    client.close()
+
+    client2 = await chromadb.AsyncPersistentClient(path=tmp_path)
+    collection2 = await client2.get_collection("async_persist")
+    result2 = await collection2.get(ids=["a"], include=["embeddings"])
+
+    assert result2["ids"] == ["a"]
+    assert result2["embeddings"][0] == pytest.approx([0.1, 0.2])
+
+    client2.close()
+
+
+@pytest.mark.asyncio
+async def test_async_persistent_client_concurrent_operations(tmp_path: Path) -> None:
+    """Operations issued concurrently on one client all complete correctly.
+
+    The sync bindings are dispatched to worker threads, so overlapping calls
+    must not interfere with one another.
+    """
+    client = await chromadb.AsyncPersistentClient(path=tmp_path)
+    try:
+        collection = await client.create_collection("async_concurrent")
+
+        await asyncio.gather(
+            *[
+                collection.add(ids=[f"id-{i}"], embeddings=[[float(i), 0.0]])
+                for i in range(32)
+            ]
+        )
+        assert await collection.count() == 32
+
+        results = await asyncio.gather(
+            *[collection.get(ids=[f"id-{i}"]) for i in range(32)]
+        )
+        assert [r["ids"] for r in results] == [[f"id-{i}"] for i in range(32)]
+    finally:
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_persistent_client_close(tmp_path: Path) -> None:
+    """close() releases the system and is idempotent."""
+    client = await chromadb.AsyncPersistentClient(path=tmp_path)
+    await client.create_collection("async_close")
+
+    client.close()
+    assert client._closed
+
+    # A second close() is a safe no-op.
+    client.close()
+
+    # The persist directory can be reopened after closing.
+    reopened = await chromadb.AsyncPersistentClient(path=tmp_path)
+    assert [c.name for c in await reopened.list_collections()] == ["async_close"]
+    reopened.close()
+
+
+@pytest.mark.asyncio
+async def test_async_persistent_client_context_manager(tmp_path: Path) -> None:
+    """The async client closes itself when used as an async context manager."""
+    client = await chromadb.AsyncPersistentClient(path=tmp_path)
+    async with client:
+        collection = await client.create_collection("async_ctx")
+        await collection.add(ids=["a"], embeddings=[[0.1, 0.2]])
+
+    assert client._closed
+
+
+@pytest.mark.asyncio
+async def test_async_persistent_client_reports_missing_collection(
+    tmp_path: Path,
+) -> None:
+    """Errors raised by the sync bindings propagate through the async wrapper."""
+    client = await chromadb.AsyncPersistentClient(path=tmp_path)
+    try:
+        with pytest.raises(chromadb.errors.NotFoundError):
+            await client.get_collection("does_not_exist")
+    finally:
+        client.close()
 
 
 def test_persistent_client_close() -> None:

--- a/docs/mintlify/reference/python/client.mdx
+++ b/docs/mintlify/reference/python/client.mdx
@@ -48,6 +48,30 @@ prefer a server-backed Chroma instance.
 </ParamField>
 
 
+### AsyncPersistentClient
+
+Create an async persistent client that stores data on disk.
+
+This client is intended for local development and testing. For production,
+prefer a server-backed Chroma instance.
+
+<ParamField path="path" type="Union[str, Path]">
+  Directory to store persisted data.
+</ParamField>
+
+<ParamField path="settings" type="Optional[Settings]">
+  Optional settings to override defaults.
+</ParamField>
+
+<ParamField path="tenant" type="str">
+  Tenant name to use for requests.
+</ParamField>
+
+<ParamField path="database" type="str">
+  Database name to use for requests.
+</ParamField>
+
+
 ### HttpClient
 
 Create a client that connects to a Chroma server.

--- a/docs/scripts/generate_python_reference.py
+++ b/docs/scripts/generate_python_reference.py
@@ -120,6 +120,7 @@ def get_documentation_sections() -> list[SectionConfig]:
             items=[
                 ("EphemeralClient", chromadb.EphemeralClient),
                 ("PersistentClient", chromadb.PersistentClient),
+                ("AsyncPersistentClient", chromadb.AsyncPersistentClient),
                 ("HttpClient", chromadb.HttpClient),
                 ("AsyncHttpClient", chromadb.AsyncHttpClient),
                 ("CloudClient", chromadb.CloudClient),


### PR DESCRIPTION
## Description of changes

Per feedback in https://github.com/chroma-core/chroma/issues/2200, adding support for asynchronous persistent client.

Supersedes #6449, which went stale. Same change rebased onto current `main` as a single commit, since `AsyncServerAPI` had picked up some new abstract methods and signature changes in the meantime.

- New functionality
  - Implementing an asynchronous persistent client, `AsyncPersistentClient` for the local/testing environments would be beneficial for the developer experience, as it means they either don't have to start a separate process or they don't have to change code paths (e.g., in the event they do local development with a persistent client but production environments use asynchronous HTTP Client). It's backed by `AsyncRustBindingsAPI`, which delegates to the existing `RustBindingsAPI` on a worker thread, so local behavior stays identical between the sync and async clients.
  - Also adding `close()` and async context manager support to `AsyncClient`, which didn't have either. That's not much of an issue for the HTTP client, but a persistent client holds the SQLite file, so there should be a public way to release it. It's refcounted the same way as `Client.close()`.

## Test plan

_How are these changes tested?_

Tests are passing locally, new tests have been added in `test_client` covering round trip persistence, concurrent operations, `close()`, and the context manager.

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

None, this is additive.

## Observability plan

_What is the plan to instrument and monitor this change?_

No new instrumentation, since the existing telemetry events are emitted from the sync path this delegates to.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

Added `AsyncPersistentClient` to `docs/scripts/generate_python_reference.py` and included the generated reference entry.