### PR TITLE
[BUG](foundation-api): Pin granola collection to 1 dim

### DIFF
--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -294,14 +294,23 @@ pub async fn foundation_init(
 
 /// Dense-index dimensionality to pin a source collection to.
 ///
-/// Most sources (e.g. notion) carry 1024-dim vectors supplied by the
-/// writer. The Google Drive source instead carries no vectors of its own —
-/// the caller upserts records without embeddings — so it is pinned to a
-/// single dimension (with no embedding function, like currents /
-/// wiki_revisions) to keep the dense index trivially small.
+/// Sources split into two groups. Most of them — notion, and the per-user
+/// agent-session collections — carry real 1024-dim vectors that the writer
+/// computes and upserts. The backend-driven sources, Google Drive and
+/// Granola, carry no vectors of their own: their connectors run with
+/// embedding inference disabled and upsert a 1-element placeholder, because
+/// a Chroma record needs at least one dimension and these collections are
+/// read by the wiki's attached function rather than by vector search.
+///
+/// Pinning that second group to a single dimension is what lets their
+/// writes land at all. A collection pinned to 1024 rejects every
+/// placeholder upsert with a dimension mismatch, and because a
+/// collection's dimension is fixed at creation, the rejection is
+/// permanent. Add a source here whenever its connector is configured for
+/// no embedding (`DenseEmbeddingModel::NoEmbed`, in hosted-chroma).
 fn source_dimension(source_name: &str) -> Option<i32> {
     match source_kind_for_collection_name(source_name) {
-        Ok("google_drive") => Some(1),
+        Ok("google_drive") | Ok("granola") => Some(1),
         _ => Some(1024),
     }
 }
@@ -559,9 +568,13 @@ mod tests {
     use std::time::SystemTime;
 
     #[test]
-    fn gdrive_source_is_single_dimension_others_are_1024() {
+    fn vectorless_sources_are_single_dimension_others_are_1024() {
+        // The Drive and Granola connectors upsert a 1-element placeholder
+        // vector, so their collections have to be pinned to one dimension.
         assert_eq!(source_dimension("gdrive"), Some(1));
         assert_eq!(source_dimension("gdrive_master"), Some(1));
+        assert_eq!(source_dimension("granola"), Some(1));
+        assert_eq!(source_dimension("granola_master"), Some(1));
         assert_eq!(source_dimension("notion"), Some(1024));
         // Unknown sources fall back to the default 1024 dims.
         assert_eq!(source_dimension("unknown_source"), Some(1024));


### PR DESCRIPTION
Granola meeting notes never reach the Foundation wiki. Every note is fetched and rendered fine, then rejected by Chroma on write, retried until the job dead-letters, and dropped. This has been true for every team set up since 2026-07-29.

## What breaks

A Foundation source collection is pinned to a dense-index dimension when `/api/init` provisions a team's workspace. That dimension is fixed at creation, and every later write into the collection has to match it.

Sources fall into two groups. Most of them — Notion, and the per-user agent-session collections — carry real 1024-dimension vectors that the writer computes and upserts. **Google Drive and Granola carry no vectors at all.** Their connectors run with embedding inference switched off, because their records are read by the wiki's attached function rather than by vector search, and they upsert a 1-element placeholder vector only because a Chroma record needs at least one dimension.

`source_dimension` names only Drive, so Granola falls through to the 1024 default. Every Granola write then fails:

```
InvalidArgumentError: Collection expecting embedding with dimension of 1024, got 1 (400 Bad Request)
```

The indexer retries, exhausts the budget, dead-letters the job, and marks the row `failed` in the sync status ledger.

## How it got here

Two changes, five weeks apart:

- **#7314 (2026-06-24), "[BUG] Gdrive set to 1-dim"** — Drive hit this exact failure and was fixed by naming `google_drive` in the match arm.
- **#7362 (2026-07-13), "Add granola collection"** — Granola joined `indexed_source_collections` and inherited the 1024 default.

## Evidence

Two staging teams synced Granola within the same hour, on the same build:

| team | discovered | scraped | indexed | failed |
| --- | --- | --- | --- | --- |
| `4af1aaaa…` | 17 | 17 | **0** | **17** |
| `df80b515…` | 3 | 3 | **3** | 0 |

The failing team's `granola` collection was created at 1024 dimensions; the working team's at 1. The connector config on the failing team was correct (`{"dense": {"model": "none"}}`), which rules out the connector side.

In production, **14 of 15 teams have a `granola` collection at 1024 dimensions.** The single correct one was created 2026-07-15, before the provisioning change reached prod, so the sync writer created it lazily at the right dimension. That team is the only one that has ever indexed a Granola note.

No customer is hitting this today — Granola sits behind the `granola-connector` PostHog flag, default off (hosted-chroma#8209). Turning that flag on without this fix breaks 14 teams.

## The change

Name both vector-less sources in the match arm, and state in the doc comment which property puts a source in that group, so the next backend-driven source doesn't repeat the bug.

## What this does not fix

**Collections already created at 1024 dimensions stay broken.** A collection's dimension is fixed at creation and `/api/init` is get-or-create, so re-running init hands back the existing collection untouched. Each one has to be deleted and recreated. That is safe: every write failed, so no Granola record was ever stored in them.

Two follow-ups stay open on CHR-597, both in `hosted-chroma`:

- **The sync-status UI discards `failed` rows**, so a source whose every job died renders identically to one nobody ever connected — which is why this went unnoticed for 19 days and why the reporter saw the status panel empty itself while he watched. `aggregate.ts` drops any row whose stage is not one of the five pipeline rungs, before the source gets an entry.
- **The status summary copy** leads with the indexed count (so a working sync reads "0 indexed") and labels `latest_item` as though it were the scrape time.

## Testing

`vectorless_sources_are_single_dimension_others_are_1024` covers `granola` and `granola_master` alongside the existing Drive and Notion cases. `cargo clippy -p foundation-api --all-targets` and `cargo fmt --check` are clean.

Refs [CHR-597](https://linear.app/trychroma/issue/CHR-597/granola-sync-doesnt-seem-to-work-copy-is-confusing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
