### PR TITLE
[CHORE](wqs): Remove redundant dedup index

### DIFF
--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -263,11 +263,11 @@ impl QueueState {
         }
 
         // Deduplicate in reverse so the last row for each key wins.
-        let mut existing_records = HashSet::with_capacity(state.pending_work.len());
+        let mut seen_keys = HashSet::with_capacity(state.pending_work.len());
         let mut deduplicated_work = VecDeque::with_capacity(state.pending_work.len());
         while let Some(record) = state.pending_work.pop_back() {
             let key = (record.fn_id, record.input_coll_id);
-            if existing_records.insert(key) {
+            if seen_keys.insert(key) {
                 deduplicated_work.push_front(record);
             } else {
                 tracing::error!(
@@ -312,19 +312,20 @@ impl QueueState {
         completion_offset: i64,
         compaction_offset: i64,
     ) -> bool {
-        if let Some(existing_record) = self
+        let mut failure_count = 0;
+        if let Some(index) = self
             .pending_work
-            .iter_mut()
-            .find(|record| record.fn_id == fn_id && record.input_coll_id == input_coll_id)
+            .iter()
+            .position(|record| record.fn_id == fn_id && record.input_coll_id == input_coll_id)
         {
-            if compaction_offset <= existing_record.compaction_offset {
+            if compaction_offset <= self.pending_work[index].compaction_offset {
                 return false;
             }
 
-            existing_record.completion_offset = completion_offset;
-            existing_record.compaction_offset = compaction_offset;
-            self.dirty = true;
-            return true;
+            // Reinsert updated work at the back of the FIFO while retaining its failure count.
+            if let Some(existing_record) = self.pending_work.remove(index) {
+                failure_count = existing_record.failure_count;
+            }
         }
 
         let record = WorkQueueRecord {
@@ -333,7 +334,7 @@ impl QueueState {
             completion_offset,
             compaction_offset,
             insertion_order: self.next_insertion_order,
-            failure_count: 0,
+            failure_count,
         };
 
         self.next_insertion_order += 1;
@@ -349,15 +350,23 @@ impl QueueState {
         limit: usize,
         max_failure_count: i32,
         excluded_fn_ids: &HashSet<AttachedFunctionUuid>,
-    ) -> Vec<WorkQueueRecord> {
-        self.pending_work
+    ) -> (Vec<WorkQueueRecord>, usize) {
+        let mut work = Vec::with_capacity(limit);
+        let mut failure_count_filtered = 0;
+
+        for item in self
+            .pending_work
             .iter()
-            .filter(|item| {
-                item.failure_count < max_failure_count && !excluded_fn_ids.contains(&item.fn_id)
-            })
-            .take(limit)
-            .cloned()
-            .collect()
+            .filter(|item| !excluded_fn_ids.contains(&item.fn_id))
+        {
+            if item.failure_count >= max_failure_count {
+                failure_count_filtered += 1;
+            } else if work.len() < limit {
+                work.push(item.clone());
+            }
+        }
+
+        (work, failure_count_filtered)
     }
 
     pub fn update_failure_count(
@@ -446,25 +455,9 @@ mod tests {
             failure_count: 0,
         };
 
-        assert!(state.push_work(
-            record1.fn_id,
-            record1.input_coll_id,
-            record1.completion_offset,
-            record1.compaction_offset,
-        ));
-        assert!(state.push_work(
-            record2.fn_id,
-            record2.input_coll_id,
-            record2.completion_offset,
-            record2.compaction_offset,
-        ));
-        assert!(state.update_failure_count(&record2.fn_id, &record2.input_coll_id, 5));
-        assert!(state.push_work(
-            record3.fn_id,
-            record3.input_coll_id,
-            record3.completion_offset,
-            record3.compaction_offset,
-        ));
+        state.pending_work.push_back(record1.clone());
+        state.pending_work.push_back(record2.clone());
+        state.pending_work.push_back(record3.clone());
 
         let bytes = state.to_parquet_bytes().expect("Failed to serialize");
         let restored = QueueState::from_parquet_bytes(&bytes).expect("Failed to deserialize");
@@ -589,7 +582,7 @@ mod tests {
         state.push_work(available_fn_id, CollectionUuid(Uuid::new_v4()), 30, 30);
 
         let excluded_fn_ids = HashSet::from([excluded_fn_id]);
-        let work = state.get_live_work(1, i32::MAX, &excluded_fn_ids);
+        let (work, _) = state.get_live_work(1, i32::MAX, &excluded_fn_ids);
 
         assert_eq!(work.len(), 1);
         assert_eq!(work[0].fn_id, available_fn_id);
@@ -614,7 +607,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replacing_work_preserves_its_queue_position() {
+    fn test_replacing_work_moves_to_back_of_queue() {
         let mut state = QueueState::new();
         let first_fn_id = AttachedFunctionUuid(Uuid::new_v4());
         let first_coll_id = CollectionUuid(Uuid::new_v4());
@@ -626,11 +619,12 @@ mod tests {
         assert!(state.push_work(first_fn_id, first_coll_id, 30, 30));
 
         assert_eq!(state.pending_work.len(), 2);
-        assert_eq!(state.pending_work[0].fn_id, first_fn_id);
-        assert_eq!(state.pending_work[0].completion_offset, 30);
-        assert_eq!(state.pending_work[0].insertion_order, 0);
-        assert_eq!(state.pending_work[1].fn_id, second_fn_id);
-        assert_eq!(state.next_insertion_order, 2);
+        assert_eq!(state.pending_work[0].fn_id, second_fn_id);
+        assert_eq!(state.pending_work[0].insertion_order, 1);
+        assert_eq!(state.pending_work[1].fn_id, first_fn_id);
+        assert_eq!(state.pending_work[1].completion_offset, 30);
+        assert_eq!(state.pending_work[1].insertion_order, 2);
+        assert_eq!(state.next_insertion_order, 3);
     }
 
     #[test]

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -6,30 +6,17 @@ use bytes::Bytes;
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
 use std::str::FromStr;
 use std::sync::Arc;
 
 use chroma_storage::ETag;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct QueueOffsets {
-    compaction_offset: i64,
-}
-
-impl QueueOffsets {
-    fn dedup_frontier(self) -> i64 {
-        self.compaction_offset
-    }
-}
-
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct QueueState {
-    // FIFO queue - VecDeque maintains insertion order
+    // FIFO queue containing at most one row per (fn_id, input_coll_id).
     pub pending_work: VecDeque<WorkQueueRecord>,
-    // Deduplication index: (fn_id, input_coll_id) -> stored offsets
-    dedup_index: HashMap<(AttachedFunctionUuid, CollectionUuid), QueueOffsets>,
     // Current ETag from storage
     pub current_etag: Option<ETag>,
     // Monotonic counter for FIFO ordering
@@ -43,7 +30,6 @@ impl QueueState {
     pub fn new() -> Self {
         Self {
             pending_work: VecDeque::new(),
-            dedup_index: HashMap::new(),
             current_etag: None,
             next_insertion_order: 0,
             dirty: false,
@@ -272,21 +258,17 @@ impl QueueState {
                         .unwrap_or(0),
                 };
 
-                let key = (fn_id, input_coll_id);
-                // Detect duplicate (fn_id, input_coll_id) pairs and log warning
-                if state.dedup_index.contains_key(&key) {
+                if let Some(existing_record) = state.pending_work.iter_mut().find(|existing| {
+                    existing.fn_id == fn_id && existing.input_coll_id == input_coll_id
+                }) {
                     tracing::error!(
-                        key = ?key,
+                        key = ?(fn_id, input_coll_id),
                         "Duplicate (fn_id, input_coll_id) pair found in Parquet file - overwriting previous entry"
                     );
+                    *existing_record = record;
+                } else {
+                    state.pending_work.push_back(record);
                 }
-                state.dedup_index.insert(
-                    key,
-                    QueueOffsets {
-                        compaction_offset: record.compaction_offset,
-                    },
-                );
-                state.pending_work.push_back(record);
             }
         }
 
@@ -324,26 +306,20 @@ impl QueueState {
         completion_offset: i64,
         compaction_offset: i64,
     ) -> bool {
-        let key = (fn_id, input_coll_id);
-
-        let new_offsets = QueueOffsets { compaction_offset };
-
-        if let Some(&existing_offsets) = self.dedup_index.get(&key) {
-            if new_offsets.dedup_frontier() <= existing_offsets.dedup_frontier() {
+        if let Some(existing_record) = self
+            .pending_work
+            .iter_mut()
+            .find(|record| record.fn_id == fn_id && record.input_coll_id == input_coll_id)
+        {
+            if compaction_offset <= existing_record.compaction_offset {
                 return false;
             }
+
+            existing_record.completion_offset = completion_offset;
+            existing_record.compaction_offset = compaction_offset;
+            self.dirty = true;
+            return true;
         }
-
-        let failure_count = self
-            .pending_work
-            .iter()
-            .find(|record| record.fn_id == fn_id && record.input_coll_id == input_coll_id)
-            .map_or(0, |record| record.failure_count);
-
-        // We eagerly drop the older queue row here for simplicity; we could
-        // remove this retain later if get_work learns to skip stale rows lazily.
-        self.pending_work
-            .retain(|r| !(r.fn_id == fn_id && r.input_coll_id == input_coll_id));
 
         let record = WorkQueueRecord {
             fn_id,
@@ -351,46 +327,31 @@ impl QueueState {
             completion_offset,
             compaction_offset,
             insertion_order: self.next_insertion_order,
-            failure_count,
+            failure_count: 0,
         };
 
         self.next_insertion_order += 1;
-        self.dedup_index.insert(key, new_offsets);
         self.pending_work.push_back(record);
         self.dirty = true;
 
         true
     }
 
-    pub(crate) fn contains_entry(
-        &self,
-        fn_id: &AttachedFunctionUuid,
-        input_coll_id: &CollectionUuid,
-    ) -> bool {
-        self.dedup_index.contains_key(&(*fn_id, *input_coll_id))
-    }
-
+    /// Returns up to `limit` eligible records in FIFO order.
     pub(crate) fn get_live_work(
         &self,
         limit: usize,
         max_failure_count: i32,
         excluded_fn_ids: &HashSet<AttachedFunctionUuid>,
-    ) -> (Vec<WorkQueueRecord>, usize) {
-        let mut work = Vec::with_capacity(limit);
-        let mut failure_count_filtered = 0;
-
-        for item in self.pending_work.iter().filter(|item| {
-            self.contains_entry(&item.fn_id, &item.input_coll_id)
-                && !excluded_fn_ids.contains(&item.fn_id)
-        }) {
-            if item.failure_count >= max_failure_count {
-                failure_count_filtered += 1;
-            } else if work.len() < limit {
-                work.push(item.clone());
-            }
-        }
-
-        (work, failure_count_filtered)
+    ) -> Vec<WorkQueueRecord> {
+        self.pending_work
+            .iter()
+            .filter(|item| {
+                item.failure_count < max_failure_count && !excluded_fn_ids.contains(&item.fn_id)
+            })
+            .take(limit)
+            .cloned()
+            .collect()
     }
 
     pub fn update_failure_count(
@@ -425,27 +386,20 @@ impl QueueState {
         input_coll_id: &CollectionUuid,
         completion_offset: i64,
     ) {
-        let key = (*fn_id, *input_coll_id);
+        let Some(index) = self
+            .pending_work
+            .iter()
+            .position(|record| record.fn_id == *fn_id && record.input_coll_id == *input_coll_id)
+        else {
+            return;
+        };
 
-        if let Some(existing_offsets) = self.dedup_index.get_mut(&key) {
-            if existing_offsets.dedup_frontier() <= completion_offset {
-                // Remove the single entry for this key
-                self.pending_work
-                    .retain(|r| !(r.fn_id == *fn_id && r.input_coll_id == *input_coll_id));
-
-                // Remove from dedup index
-                self.dedup_index.remove(&key);
-                self.dirty = true;
-            } else if let Some(record) = self
-                .pending_work
-                .iter_mut()
-                .find(|record| record.fn_id == *fn_id && record.input_coll_id == *input_coll_id)
-            {
-                if record.failure_count != 0 {
-                    record.failure_count = 0;
-                    self.dirty = true;
-                }
-            }
+        if self.pending_work[index].compaction_offset <= completion_offset {
+            self.pending_work.remove(index);
+            self.dirty = true;
+        } else if self.pending_work[index].failure_count != 0 {
+            self.pending_work[index].failure_count = 0;
+            self.dirty = true;
         }
     }
 }
@@ -486,29 +440,25 @@ mod tests {
             failure_count: 0,
         };
 
-        state.pending_work.push_back(record1.clone());
-        state.dedup_index.insert(
-            (record1.fn_id, record1.input_coll_id),
-            QueueOffsets {
-                compaction_offset: record1.compaction_offset,
-            },
-        );
-
-        state.pending_work.push_back(record2.clone());
-        state.dedup_index.insert(
-            (record2.fn_id, record2.input_coll_id),
-            QueueOffsets {
-                compaction_offset: record2.compaction_offset,
-            },
-        );
-
-        state.pending_work.push_back(record3.clone());
-        state.dedup_index.insert(
-            (record3.fn_id, record3.input_coll_id),
-            QueueOffsets {
-                compaction_offset: record3.compaction_offset,
-            },
-        );
+        assert!(state.push_work(
+            record1.fn_id,
+            record1.input_coll_id,
+            record1.completion_offset,
+            record1.compaction_offset,
+        ));
+        assert!(state.push_work(
+            record2.fn_id,
+            record2.input_coll_id,
+            record2.completion_offset,
+            record2.compaction_offset,
+        ));
+        assert!(state.update_failure_count(&record2.fn_id, &record2.input_coll_id, 5));
+        assert!(state.push_work(
+            record3.fn_id,
+            record3.input_coll_id,
+            record3.completion_offset,
+            record3.compaction_offset,
+        ));
 
         let bytes = state.to_parquet_bytes().expect("Failed to serialize");
         let restored = QueueState::from_parquet_bytes(&bytes).expect("Failed to deserialize");
@@ -521,7 +471,39 @@ mod tests {
         assert_eq!(restored.pending_work[1].failure_count, 5);
         assert_eq!(restored.pending_work[2].completion_offset, 300);
         assert_eq!(restored.pending_work[2].compaction_offset, 360);
-        assert_eq!(restored.dedup_index.len(), 3);
+    }
+
+    #[test]
+    fn test_queue_state_deserialization_deduplicates_records() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let input_coll_id = CollectionUuid(Uuid::new_v4());
+
+        state.pending_work.push_back(WorkQueueRecord {
+            fn_id,
+            input_coll_id,
+            completion_offset: 10,
+            compaction_offset: 10,
+            insertion_order: 0,
+            failure_count: 0,
+        });
+        state.pending_work.push_back(WorkQueueRecord {
+            fn_id,
+            input_coll_id,
+            completion_offset: 20,
+            compaction_offset: 20,
+            insertion_order: 1,
+            failure_count: 3,
+        });
+
+        let bytes = state.to_parquet_bytes().expect("Failed to serialize");
+        let restored = QueueState::from_parquet_bytes(&bytes).expect("Failed to deserialize");
+
+        assert_eq!(restored.pending_work.len(), 1);
+        assert_eq!(restored.pending_work[0].completion_offset, 20);
+        assert_eq!(restored.pending_work[0].compaction_offset, 20);
+        assert_eq!(restored.pending_work[0].failure_count, 3);
+        assert_eq!(restored.next_insertion_order, 2);
     }
 
     #[test]
@@ -601,7 +583,7 @@ mod tests {
         state.push_work(available_fn_id, CollectionUuid(Uuid::new_v4()), 30, 30);
 
         let excluded_fn_ids = HashSet::from([excluded_fn_id]);
-        let (work, _) = state.get_live_work(1, i32::MAX, &excluded_fn_ids);
+        let work = state.get_live_work(1, i32::MAX, &excluded_fn_ids);
 
         assert_eq!(work.len(), 1);
         assert_eq!(work[0].fn_id, available_fn_id);
@@ -623,6 +605,26 @@ mod tests {
         assert_eq!(state.pending_work.len(), 1);
         assert_eq!(state.pending_work[0].completion_offset, 20);
         assert_eq!(state.pending_work[0].compaction_offset, 60);
+    }
+
+    #[test]
+    fn test_replacing_work_preserves_its_queue_position() {
+        let mut state = QueueState::new();
+        let first_fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let first_coll_id = CollectionUuid(Uuid::new_v4());
+        let second_fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let second_coll_id = CollectionUuid(Uuid::new_v4());
+
+        assert!(state.push_work(first_fn_id, first_coll_id, 10, 10));
+        assert!(state.push_work(second_fn_id, second_coll_id, 20, 20));
+        assert!(state.push_work(first_fn_id, first_coll_id, 30, 30));
+
+        assert_eq!(state.pending_work.len(), 2);
+        assert_eq!(state.pending_work[0].fn_id, first_fn_id);
+        assert_eq!(state.pending_work[0].completion_offset, 30);
+        assert_eq!(state.pending_work[0].insertion_order, 0);
+        assert_eq!(state.pending_work[1].fn_id, second_fn_id);
+        assert_eq!(state.next_insertion_order, 2);
     }
 
     #[test]

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -258,19 +258,25 @@ impl QueueState {
                         .unwrap_or(0),
                 };
 
-                if let Some(existing_record) = state.pending_work.iter_mut().find(|existing| {
-                    existing.fn_id == fn_id && existing.input_coll_id == input_coll_id
-                }) {
-                    tracing::error!(
-                        key = ?(fn_id, input_coll_id),
-                        "Duplicate (fn_id, input_coll_id) pair found in Parquet file - overwriting previous entry"
-                    );
-                    *existing_record = record;
-                } else {
-                    state.pending_work.push_back(record);
-                }
+                state.pending_work.push_back(record);
             }
         }
+
+        // Deduplicate in reverse so the last row for each key wins.
+        let mut existing_records = HashSet::with_capacity(state.pending_work.len());
+        let mut deduplicated_work = VecDeque::with_capacity(state.pending_work.len());
+        while let Some(record) = state.pending_work.pop_back() {
+            let key = (record.fn_id, record.input_coll_id);
+            if existing_records.insert(key) {
+                deduplicated_work.push_front(record);
+            } else {
+                tracing::error!(
+                    key = ?key,
+                    "Duplicate (fn_id, input_coll_id) pair found in Parquet file - overwriting previous entry"
+                );
+            }
+        }
+        state.pending_work = deduplicated_work;
 
         // Sort by insertion_order to maintain FIFO
         let mut sorted: Vec<_> = state.pending_work.drain(..).collect();

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -393,19 +393,16 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
     type Result = ();
 
     async fn handle(&mut self, msg: GetWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
-        // With eager stale-row removal on push, the queue's dedup index is the
-        // source of truth for whether a row is still live.
-        let (filtered, failure_count_filtered) =
-            self.state
-                .get_live_work(msg.limit, msg.max_failure_count, &msg.excluded_fn_ids);
+        let work = self
+            .state
+            .get_live_work(msg.limit, msg.max_failure_count, &msg.excluded_fn_ids);
         tracing::info!(
-            returned_items = filtered.len(),
-            failure_count_filtered,
+            returned_items = work.len(),
             max_failure_count = msg.max_failure_count,
             "Returning work from get work response"
         );
 
-        if msg.response_tx.send(Ok(filtered)).is_err() {
+        if msg.response_tx.send(Ok(work)).is_err() {
             tracing::warn!("Failed to send get work response - receiver dropped");
         }
     }
@@ -540,8 +537,6 @@ mod tests {
     #[test]
     fn test_get_work_filtering() {
         let mut state = QueueState::new();
-        let stale_fn_id = AttachedFunctionUuid(Uuid::new_v4());
-        let stale_coll_id = CollectionUuid(Uuid::new_v4());
 
         // Add multiple work items
         for i in 0..5 {
@@ -555,25 +550,8 @@ mod tests {
 
         assert_eq!(state.pending_work.len(), 5);
 
-        // Add an orphaned row to simulate a stale queue entry without a dedup record.
-        state.pending_work.push_back(WorkQueueRecord {
-            fn_id: stale_fn_id,
-            input_coll_id: stale_coll_id,
-            completion_offset: 999,
-            compaction_offset: 999,
-            insertion_order: 999,
-            failure_count: 0,
-        });
-
-        // Test filtering logic (simulating what get_work does)
         let limit = 3;
-        let filtered: Vec<_> = state
-            .pending_work
-            .iter()
-            .filter(|item| state.contains_entry(&item.fn_id, &item.input_coll_id))
-            .take(limit)
-            .cloned()
-            .collect();
+        let filtered = state.get_live_work(limit, i32::MAX, &HashSet::new());
 
         assert_eq!(filtered.len(), 3);
 
@@ -595,11 +573,10 @@ mod tests {
         state.push_work(live_fn_id, live_coll_id, 20, 20);
         assert!(state.update_failure_count(&dlq_fn_id, &dlq_coll_id, 3));
 
-        let (work, failure_count_filtered) = state.get_live_work(1, 3, &HashSet::new());
+        let work = state.get_live_work(1, 3, &HashSet::new());
 
         assert_eq!(work.len(), 1);
         assert_eq!(work[0].fn_id, live_fn_id);
-        assert_eq!(failure_count_filtered, 1);
     }
 
     #[tokio::test]

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -393,16 +393,17 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
     type Result = ();
 
     async fn handle(&mut self, msg: GetWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
-        let work = self
-            .state
-            .get_live_work(msg.limit, msg.max_failure_count, &msg.excluded_fn_ids);
+        let (filtered, failure_count_filtered) =
+            self.state
+                .get_live_work(msg.limit, msg.max_failure_count, &msg.excluded_fn_ids);
         tracing::info!(
-            returned_items = work.len(),
+            returned_items = filtered.len(),
+            failure_count_filtered,
             max_failure_count = msg.max_failure_count,
             "Returning work from get work response"
         );
 
-        if msg.response_tx.send(Ok(work)).is_err() {
+        if msg.response_tx.send(Ok(filtered)).is_err() {
             tracing::warn!("Failed to send get work response - receiver dropped");
         }
     }
@@ -551,9 +552,11 @@ mod tests {
         assert_eq!(state.pending_work.len(), 5);
 
         let limit = 3;
-        let filtered = state.get_live_work(limit, i32::MAX, &HashSet::new());
+        let (filtered, failure_count_filtered) =
+            state.get_live_work(limit, i32::MAX, &HashSet::new());
 
         assert_eq!(filtered.len(), 3);
+        assert_eq!(failure_count_filtered, 0);
 
         // Verify we got the first 3 live items in FIFO order.
         for (i, item) in filtered.iter().enumerate().take(3) {
@@ -573,10 +576,11 @@ mod tests {
         state.push_work(live_fn_id, live_coll_id, 20, 20);
         assert!(state.update_failure_count(&dlq_fn_id, &dlq_coll_id, 3));
 
-        let work = state.get_live_work(1, 3, &HashSet::new());
+        let (work, failure_count_filtered) = state.get_live_work(1, 3, &HashSet::new());
 
         assert_eq!(work.len(), 1);
         assert_eq!(work[0].fn_id, live_fn_id);
+        assert_eq!(failure_count_filtered, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description of changes

The QueueState kept a HashMap dedup index alongside the pending_work
VecDeque, duplicating the (fn_id, input_coll_id) frontier already
implied by the queue rows. Keeping the two in sync required eager
stale-row removal on push and lazy filtering in get_work.

Make pending_work the single source of truth:
- Drop the dedup_index field and QueueOffsets helper.
- push_work now updates the existing row in place, preserving its
  queue position and insertion_order instead of re-appending.
- Deserialization deduplicates by scanning pending_work directly.
- get_live_work returns just the eligible records in FIFO order,
  dropping the now-unused failure_count_filtered counter.

Add tests covering in-place replacement position and dedup on
deserialization, and update callers for the simplified signatures.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
