### PR TITLE
[BUG](foundation-api): Propagate FE status on wiki reads

### DIFF
--- a/rust/foundation-api/src/foundation_chroma.rs
+++ b/rust/foundation-api/src/foundation_chroma.rs
@@ -58,7 +58,7 @@ impl ChromaError for FoundationChromaClientError {
             FoundationChromaClientError::MissingIngressUrl
             | FoundationChromaClientError::InvalidIngressUrl { .. } => ErrorCodes::Internal,
             FoundationChromaClientError::InvalidToken(_) => ErrorCodes::InvalidArgument,
-            FoundationChromaClientError::Client(_) => ErrorCodes::Internal,
+            FoundationChromaClientError::Client(err) => client_error_code(err),
         }
     }
 }
@@ -197,6 +197,24 @@ impl FoundationChromaClient {
     /// Drops the cached trajectory collection identity for `tenant`.
     pub fn invalidate_trajectories(&self, tenant: &str) {
         self.invalidate(tenant, &self.trajectories_collection_name);
+    }
+}
+
+/// The error code a proxied FE failure should surface to our caller.
+///
+/// When the FE answered with a status, that status is the best description of
+/// what happened and we pass it through. This matters most for 429: the FE
+/// rejects a request when the collection is already at its concurrency limit,
+/// and a caller told "too many requests" can back off, where one told "internal
+/// error" has no reason to. Reporting a rate-limit rejection as an internal
+/// error hides a healthy, retryable signal behind a fault.
+///
+/// Failures with no status — a dropped connection, a malformed body — are ours
+/// rather than the caller's, so they stay internal.
+pub(crate) fn client_error_code(err: &ChromaHttpClientError) -> ErrorCodes {
+    match err {
+        ChromaHttpClientError::ApiError(_, status) => ErrorCodes::from(*status),
+        _ => ErrorCodes::Internal,
     }
 }
 
@@ -480,6 +498,57 @@ mod tests {
         );
         assert!(!FoundationChromaClientError::MissingIngressUrl.is_not_found());
         assert!(!FoundationChromaClientError::InvalidToken("nope".to_string()).is_not_found());
+    }
+
+    #[test]
+    fn client_error_code_preserves_the_fe_status() {
+        use reqwest::StatusCode;
+        // The case this exists for: the FE's rate limiter turned us away.
+        assert_eq!(
+            client_error_code(&ChromaHttpClientError::ApiError(
+                "Too many requests; backoff and try again".to_string(),
+                StatusCode::TOO_MANY_REQUESTS,
+            )),
+            ErrorCodes::ResourceExhausted
+        );
+        assert_eq!(
+            client_error_code(&ChromaHttpClientError::ApiError(
+                "missing".to_string(),
+                StatusCode::NOT_FOUND,
+            )),
+            ErrorCodes::NotFound
+        );
+        assert_eq!(
+            client_error_code(&ChromaHttpClientError::ApiError(
+                "boom".to_string(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )),
+            ErrorCodes::Internal
+        );
+        // No status of its own: a connection-level failure is our fault.
+        assert_eq!(
+            client_error_code(&ChromaHttpClientError::NoBackendAvailable),
+            ErrorCodes::Internal
+        );
+    }
+
+    #[test]
+    fn resolve_error_surfaces_a_rate_limit_as_rate_limited() {
+        use reqwest::StatusCode;
+        // Resolving the collection is its own hop to the FE and can be
+        // throttled just like the read that follows it.
+        assert_eq!(
+            FoundationChromaClientError::Client(ChromaHttpClientError::ApiError(
+                "Too many requests; backoff and try again".to_string(),
+                StatusCode::TOO_MANY_REQUESTS,
+            ))
+            .code(),
+            ErrorCodes::ResourceExhausted
+        );
+        assert_eq!(
+            FoundationChromaClientError::MissingIngressUrl.code(),
+            ErrorCodes::Internal
+        );
     }
 
     #[test]

--- a/rust/foundation-api/src/routes/read_page.rs
+++ b/rust/foundation-api/src/routes/read_page.rs
@@ -9,6 +9,7 @@
 //! the Foundation Chroma client, which enforces auth, quota,
 //! metering, and billing.
 
+use crate::foundation_chroma::client_error_code;
 use crate::routes::links::page_url;
 use crate::routes::{caller_token, whoami::whoami_and_authorize};
 use crate::wiki::page::{meta_int, meta_str, meta_str_array};
@@ -79,7 +80,7 @@ impl ChromaError for ReadPageError {
             ReadPageError::RouteDisabled => ErrorCodes::Internal,
             ReadPageError::MissingToken => ErrorCodes::InvalidArgument,
             ReadPageError::Resolve(err) => err.code(),
-            ReadPageError::Query(_) => ErrorCodes::Internal,
+            ReadPageError::Query(err) => client_error_code(err),
             ReadPageError::PageNotFound => ErrorCodes::NotFound,
         }
     }
@@ -361,5 +362,33 @@ mod tests {
             ErrorCodes::InvalidArgument
         );
         assert_eq!(ReadPageError::RouteDisabled.code(), ErrorCodes::Internal);
+    }
+
+    #[test]
+    fn query_error_preserves_the_fe_status() {
+        use reqwest::StatusCode;
+        // A rate-limit rejection must stay a rate-limit rejection, so the
+        // caller can back off instead of treating it as a fault.
+        assert_eq!(
+            ReadPageError::Query(ChromaHttpClientError::ApiError(
+                "Too many requests; backoff and try again".to_string(),
+                StatusCode::TOO_MANY_REQUESTS,
+            ))
+            .code(),
+            ErrorCodes::ResourceExhausted
+        );
+        assert_eq!(
+            ReadPageError::Query(ChromaHttpClientError::ApiError(
+                "nope".to_string(),
+                StatusCode::FORBIDDEN,
+            ))
+            .code(),
+            ErrorCodes::PermissionDenied
+        );
+        // A failure with no status of its own is ours, not the caller's.
+        assert_eq!(
+            ReadPageError::Query(ChromaHttpClientError::NoBackendAvailable).code(),
+            ErrorCodes::Internal
+        );
     }
 }


### PR DESCRIPTION
CHR-619

## What's wrong

Reading a wiki page goes through Foundation's API, which does not hold the data itself — it proxies to the Chroma frontend, twice: once to resolve which collection the tenant's wiki lives in, then once more to fetch the page's chunks. Either hop can fail, and until now both reported *every* failure as an internal error.

One of those failures is not an internal error. The frontend caps how many searches may run at once against a single collection and refuses anything over the cap with HTTP 429, "too many requests". That is a statement about timing, not about correctness: the identical call a moment later usually succeeds.

Flattening it into a 500 asks the caller to do the opposite of the right thing. A 429 invites a retry after a pause; a 500 says something is broken and retrying is pointless. So a caller being politely asked to slow down is instead told the service is faulty, and has no signal telling it to back off — which is how the load ends up sustaining itself.

This is not hypothetical. In production **57% of `/api/read-page` calls currently return 500** (14,657 of 25,567 over two hours), and they are throttle rejections wearing a fault's clothing.

## The fix

Derive the reported code from the status the frontend actually returned, rather than discarding it. A 429 stays a rate-limit rejection, a 403 stays a permission problem, a 404 stays not-found.

Failures that carry no status of their own — a dropped connection, a body that would not parse, no backend available — are genuinely ours rather than the caller's, so those still report as internal.

The mapping itself is not new: `ErrorCodes` already knows how to convert an HTTP status, and this reuses it through one small shared helper.

## Scope

The helper is applied to both hops that a page read makes. Collection resolution is shared by every wiki route and can be throttled exactly like the read that follows it, so it gets the same treatment.

The same collapse still exists in the search and upsert-page routes. Those are left alone here to keep this reviewable; adopting the helper there is a one-line change each and worth doing next.

## Why this matters beyond tidiness

Nothing downstream can implement sane backoff while the signal it needs is being erased in transit. This is the prerequisite for that work, not a cosmetic status-code correction.

It does not fix the underlying contention — the wiki collection is never compacted, so each search spends ~97% of its time replaying an uncompacted log, which is what exhausts the concurrency budget in the first place. That is tracked separately in CHR-619.

## Testing

- New unit tests over both hops: 429 surfaces as rate-limited, other statuses pass through, and status-less failures remain internal.
- `cargo test -p foundation-api --lib`: 215 passed, 2 ignored, 0 failed.
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)