### PR TITLE
[BUG](compactor): Don't dead-letter on a missing WorkQueue

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -419,8 +419,24 @@ impl CompactionManager {
                 Err(ref e) => {
                     let job_id = resp.job_id;
                     let error_msg = e.to_string();
-                    self.scheduler.fail_job(job_id).await;
-                    tracing::error!("Failed to compact collection: {} - {}", job_id, error_msg);
+                    // A collection is only charged for failures it could plausibly
+                    // be the cause of. `Unavailable` means this node could not
+                    // reach something it needed, so the next attempt — elsewhere,
+                    // or here after a restart — may well succeed. Charging the
+                    // collection for it would spend its retry budget on our
+                    // outage and dead-letter it permanently.
+                    if e.code() == ErrorCodes::Unavailable {
+                        self.scheduler.release_job_without_penalty(job_id);
+                        tracing::error!(
+                            "Compaction for {} failed on an unavailable dependency, \
+                             not counted against the collection - {}",
+                            job_id,
+                            error_msg
+                        );
+                    } else {
+                        self.scheduler.fail_job(job_id).await;
+                        tracing::error!("Failed to compact collection: {} - {}", job_id, error_msg);
+                    }
                 }
             }
             completed_collections.push(resp);

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -19,6 +19,7 @@ use crate::compactor::types::CompactionJob;
 #[derive(Debug, Clone)]
 pub(crate) struct SchedulerMetrics {
     job_failure_count: Counter<u64>,
+    unpenalized_job_failure_count: Counter<u64>,
     unaddressable_jobs_count: Gauge<u64>,
 }
 
@@ -27,7 +28,19 @@ impl Default for SchedulerMetrics {
         let meter = opentelemetry::global::meter("chroma_compactor");
         let job_failure_count = meter
             .u64_counter("compactor_job_failure_count")
-            .with_description("Number of compaction job failures")
+            .with_description(
+                "Compaction job failures charged to the collection, which count toward \
+                 max_failure_count and can eventually dead-letter it. Failures the \
+                 collection could not have caused are counted separately, under \
+                 compactor_unpenalized_job_failure_count",
+            )
+            .build();
+        let unpenalized_job_failure_count = meter
+            .u64_counter("compactor_unpenalized_job_failure_count")
+            .with_description(
+                "Compaction job failures not counted against the collection, because the \
+                 cause was node-local rather than anything about the collection",
+            )
             .build();
         let unaddressable_jobs_count = meter
             .u64_gauge("compactor_unaddressable_jobs_count")
@@ -36,6 +49,7 @@ impl Default for SchedulerMetrics {
 
         Self {
             job_failure_count,
+            unpenalized_job_failure_count,
             unaddressable_jobs_count,
         }
     }
@@ -44,6 +58,10 @@ impl Default for SchedulerMetrics {
 impl SchedulerMetrics {
     fn increment_job_failure_count(&self) {
         self.job_failure_count.add(1, &[]);
+    }
+
+    fn increment_unpenalized_job_failure_count(&self) {
+        self.unpenalized_job_failure_count.add(1, &[]);
     }
 
     fn set_unaddressable_jobs_count(&self, count: u64) {
@@ -554,6 +572,25 @@ impl Scheduler {
         }
     }
 
+    /// Releases a job that failed for a reason the collection cannot influence —
+    /// a dependency this node could not reach, say. The job is cleared so it can
+    /// be scheduled again, but the collection's failure count is left untouched.
+    ///
+    /// Counting these would be actively harmful: five such failures dead-letter
+    /// the collection permanently (`verify_and_enrich_collections` then drops it
+    /// on every tick), so a transient node-local outage would take a healthy
+    /// collection out of compaction forever and nothing would put it back.
+    pub(crate) fn release_job_without_penalty(&mut self, job_id: JobId) {
+        tracing::info!(
+            "Releasing compaction for {} without counting it against the collection",
+            job_id
+        );
+        self.metrics.increment_unpenalized_job_failure_count();
+        if self.in_progress_jobs.remove(&job_id).is_none() {
+            tracing::warn!("Expired compaction for {} was released.", job_id);
+        }
+    }
+
     /// Marks a job as failed and persists the failure count to sysdb.
     pub(crate) async fn fail_job(&mut self, job_id: JobId) {
         tracing::info!("Failing compaction for {}", job_id.0);
@@ -950,6 +987,35 @@ mod tests {
             "collection_1 should be excluded after max failures"
         );
         assert_eq!(jobs[0].collection_id, f.collection_uuid_2);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn released_jobs_never_dead_letter_the_collection() {
+        SchedulerFixture::clear_env_vars();
+        let max_failure_count = 3;
+        let mut f = SchedulerFixture::with_max_failure_count(max_failure_count);
+
+        f.scheduler.set_memberlist(vec![f.my_member.clone()]);
+
+        // Well past the dead-letter threshold. A node-local fault must never
+        // exhaust a collection's retry budget, however often it recurs.
+        for _ in 0..(max_failure_count * 3) {
+            f.scheduler.schedule().await;
+            let jobs: Vec<&CompactionJob> = f.scheduler.get_jobs().collect();
+            assert_eq!(jobs.len(), 2, "both collections stay schedulable");
+            f.scheduler
+                .release_job_without_penalty(f.collection_uuid_1.into());
+            f.scheduler.succeed_job(f.collection_uuid_2.into());
+        }
+
+        f.scheduler.schedule().await;
+        let jobs: Vec<&CompactionJob> = f.scheduler.get_jobs().collect();
+        assert_eq!(
+            jobs.len(),
+            2,
+            "collection_1 must still be scheduled after repeated releases"
+        );
     }
 
     #[tokio::test]

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -122,6 +122,11 @@ pub enum AttachedFunctionOrchestratorError {
     FunctionContextNotSet,
     #[error("Invariant violation: {0}")]
     InvariantViolation(String),
+    /// This compactor has no WorkQueue client, so an async attached function
+    /// cannot be queued here. A property of the node, not of the collection —
+    /// another compactor, or this one after a restart, can do the work.
+    #[error("No WorkQueue client on this compactor; cannot queue async attached function")]
+    WorkQueueUnavailable,
     #[error("Failed to materialize log: {0}")]
     MaterializeLog(#[from] MaterializeLogOperatorError),
     #[error("Compaction context error: {0}")]
@@ -173,6 +178,7 @@ impl ChromaError for AttachedFunctionOrchestratorError {
             AttachedFunctionOrchestratorError::MaterializeLog(e) => e.code(),
             AttachedFunctionOrchestratorError::FunctionContextNotSet => ErrorCodes::Internal,
             AttachedFunctionOrchestratorError::InvariantViolation(_) => ErrorCodes::Internal,
+            AttachedFunctionOrchestratorError::WorkQueueUnavailable => ErrorCodes::Unavailable,
             AttachedFunctionOrchestratorError::CompactionContext(e) => e.code(),
             AttachedFunctionOrchestratorError::OutputCollectionIdNotSet => ErrorCodes::Internal,
             AttachedFunctionOrchestratorError::Channel(e) => e.code(),
@@ -207,6 +213,7 @@ impl ChromaError for AttachedFunctionOrchestratorError {
             AttachedFunctionOrchestratorError::MaterializeLog(e) => e.should_trace_error(),
             AttachedFunctionOrchestratorError::FunctionContextNotSet => true,
             AttachedFunctionOrchestratorError::InvariantViolation(_) => true,
+            AttachedFunctionOrchestratorError::WorkQueueUnavailable => true,
             AttachedFunctionOrchestratorError::CompactionContext(e) => e.should_trace_error(),
             AttachedFunctionOrchestratorError::OutputCollectionIdNotSet => true,
             AttachedFunctionOrchestratorError::Channel(e) => e.should_trace_error(),
@@ -874,9 +881,7 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
                         "Async attached function found but no WorkQueue client configured"
                     );
                     self.terminate_with_result(
-                        Err(AttachedFunctionOrchestratorError::InvariantViolation(
-                            "Async function requires WorkQueue configuration".to_string(),
-                        )),
+                        Err(AttachedFunctionOrchestratorError::WorkQueueUnavailable),
                         ctx,
                     )
                     .await;
@@ -1211,8 +1216,11 @@ impl Handler<TaskResult<QueueFunctionOutput, QueueFunctionError>> for AttachedFu
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_pulled_log_offset, AttachedFunctionOrchestrator};
+    use super::{
+        resolve_pulled_log_offset, AttachedFunctionOrchestrator, AttachedFunctionOrchestratorError,
+    };
     use crate::execution::orchestration::compact::CollectionCompactInfo;
+    use chroma_error::{ChromaError, ErrorCodes};
     use chroma_types::{Collection, CollectionUuid};
 
     #[test]
@@ -1253,6 +1261,22 @@ mod tests {
         assert_eq!(
             AttachedFunctionOrchestrator::queued_compaction_offset(&collection_info),
             200
+        );
+    }
+
+    #[test]
+    fn missing_work_queue_reports_unavailable_not_internal() {
+        // The compaction manager routes on this code: `Unavailable` releases the
+        // job without charging the collection, anything else counts toward the
+        // dead-letter threshold. Reporting this as `Internal` is what let a
+        // node-local outage permanently stall healthy collections.
+        assert_eq!(
+            AttachedFunctionOrchestratorError::WorkQueueUnavailable.code(),
+            ErrorCodes::Unavailable
+        );
+        assert_eq!(
+            AttachedFunctionOrchestratorError::InvariantViolation("boom".to_string()).code(),
+            ErrorCodes::Internal
         );
     }
 }


### PR DESCRIPTION
CHR-619

## The failure this prevents

A collection that fails compaction five times is dropped from compaction **permanently**. `verify_and_enrich_collections` skips it on every scheduler tick, nothing re-drives it, and no alert fires. The only visible consequence is that its log grows without bound and its queries get slower forever.

That is a reasonable defence against a collection that genuinely cannot be compacted. It is the wrong answer when the compaction failed for a reason the collection had no part in.

## What happened in production

Between **2026-07-27 23:02 and 2026-07-29 03:50 UTC**, three compaction-service pods came up without a WorkQueue client. A compactor in that state cannot queue an async attached function, so it failed the entire compaction — after the compaction work itself had already succeeded:

```
[AttachedFunctionOrchestrator]: Prepared sync attached function 'wiki_revision_history'
[AttachedFunctionOrchestrator]: Queueing async attached function 'wiki_currents'
Async attached function found but no WorkQueue client configured
Compaction failed: AttachedFunction(InvariantViolation("Async function requires WorkQueue configuration"))
```

Every collection assigned to one of those pods during that window burned its entire five-attempt budget and dead-lettered. Five collections were lost this way. One was Foundation's wiki, which then spent three weeks accumulating log until someone noticed its searches took twelve seconds — at which point a concurrency limit sized for fast queries began rejecting 98% of reads against it.

The condition was node-local and temporary. Another compactor, or the same one after a restart, would have compacted these collections without complaint.

## The change

**Report the case distinctly.** A missing WorkQueue client becomes `AttachedFunctionOrchestratorError::WorkQueueUnavailable`, carrying `ErrorCodes::Unavailable` rather than being flattened into a generic `InvariantViolation` with `Internal`.

**Route on it.** When a compaction fails with `Unavailable`, the manager calls `release_job_without_penalty` instead of `fail_job`: the job is cleared so it can be scheduled again, and the collection's `compaction_failure_count` in sysdb is left alone.

`Unavailable` is the right axis to switch on — it already means "this node could not reach something it needed", which is exactly the class of failure a collection should not be charged for. Any future dependency that reports it gets the same protection for free.

These releases are counted under `compactor_unpenalized_job_failure_count` and deliberately **not** under `compactor_job_failure_count`, so that counter keeps a single clear meaning: failures charged to a collection, which count toward `max_failure_count`. Its description is updated to say so.

## What "retryable" actually means here

Worth being precise, because the word oversells it. There is no retry loop, no backoff, and no attempt counter in this PR. The change only stops *penalising*. What produces the retry is the scheduler that already existed: because the collection was never charged a failure, it is still eligible on the next tick (`compaction_interval_sec`, 10 in production).

The consequences follow from that:

- **Unbounded.** Nothing counts these, so nothing caps them. It retries every ~10s for as long as the condition holds.
- **On the same pod.** Assignment is `assign_one(collection_id)` through rendezvous hashing, which is deterministic given the memberlist. A pod with a broken client keeps being handed the same collections until the memberlist changes.
- **Not free.** The failure lands in the attached-function phase, *after* compaction proper. In the production trace the log fetch, materialise, and all three segment-writer applications completed — 1.3 seconds — and were then discarded.

So this trades permanent silent damage for an indefinite, visible, self-healing loop that costs roughly 1.3s of wasted work per affected collection per tick. I think that is the right direction, but it is a trade rather than a clean win.

Note also that the loop is **not** what chroma#7601's dead-letter counter measures: with this PR these collections are no longer dead-lettered, so that signal stays at zero for this scenario. `compactor_unpenalized_job_failure_count` climbing steadily is the signal here.

## Alternatives considered

**Fail fast at compactor startup** when a configured WorkQueue client cannot be built. Today `compaction_manager.rs` swallows that into `None` with a log line and serves anyway, which is how a pod reaches this state at all. A node that cannot do the job would simply not take assignments, and the retry question would largely evaporate. This is arguably the stronger fix and it composes with this PR rather than replacing it — a collection can still meet an `Unavailable` dependency mid-flight. Left out because it is a decision about startup and readiness behaviour, not a bug fix, and it deserves its own discussion.

**Back off on the release path** — track consecutive unavailable-releases per collection and skip scheduling it for a growing interval. This bounds the wasted work that the unbounded loop above creates. Left out because it adds per-collection state to the scheduler for a cost that is small at current volumes (~13% of one compaction slot per affected collection), and it is easy to add later if `compactor_unpenalized_job_failure_count` shows it is warranted.

Happy to fold either in if reviewers would rather have it here than as a follow-up.

## Testing

- `released_jobs_never_dead_letter_the_collection` runs 3x the threshold worth of releases and asserts the collection stays schedulable. It mirrors the existing `collections_exceeding_failure_count_are_skipped` test, so the two read as a pair.
- `missing_work_queue_reports_unavailable_not_internal` pins the error code the routing depends on, and pins `InvariantViolation` as still `Internal` so the two do not drift back together.
- `cargo test -p worker --lib`: 236 passed. The 6 failures are all `test_k8s_integration_*`, which the default nextest profile excludes (`.config/nextest.toml`) because they need a live Tilt cluster.
- `cargo fmt --check` and `cargo clippy -p worker --all-targets -- -D warnings` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
