### PR TITLE
Replace ValueError/TypeError with InvalidArgumentError in client-facing validation

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -227,7 +227,7 @@ def normalize_embeddings(
         return None
 
     if len(target) == 0:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected Embeddings to be non-empty list or numpy array, got {target}"
         )
 
@@ -248,7 +248,7 @@ def normalize_embeddings(
             ):
                 return [np.array(row, dtype=np.float32) for row in target]
 
-    raise ValueError(
+    raise errors.InvalidArgumentError(
         f"Expected embeddings to be a list of floats or ints, a list of lists, a numpy array, or a list of numpy arrays, got {target}"
     )
 
@@ -451,7 +451,7 @@ def _validate_record_set_length_consistency(record_set: BaseRecordSet) -> None:
     lengths = [len(lst) for lst in record_set.values() if lst is not None]  # type: ignore[arg-type]
 
     if not lengths:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"At least one of one of {', '.join(record_set.keys())} must be provided"
         )
 
@@ -462,7 +462,7 @@ def _validate_record_set_length_consistency(record_set: BaseRecordSet) -> None:
     ]
 
     if zero_lengths:
-        raise ValueError(f"Non-empty lists are required for {zero_lengths}")
+        raise errors.InvalidArgumentError(f"Non-empty lists are required for {zero_lengths}")
 
     if len(set(lengths)) > 1:
         error_str = ", ".join(
@@ -470,7 +470,7 @@ def _validate_record_set_length_consistency(record_set: BaseRecordSet) -> None:
             for key, lst in record_set.items()
             if lst is not None  # type: ignore[arg-type]
         )
-        raise ValueError(f"Unequal lengths for fields: {error_str}")
+        raise errors.InvalidArgumentError(f"Unequal lengths for fields: {error_str}")
 
 
 def validate_record_set_for_embedding(
@@ -480,7 +480,7 @@ def validate_record_set_for_embedding(
     Validates that the Record is ready to be embedded, i.e. that it contains exactly one of the embeddable fields.
     """
     if record_set["embeddings"] is not None:
-        raise ValueError("Attempting to embed a record that already has embeddings.")
+        raise errors.InvalidArgumentError("Attempting to embed a record that already has embeddings.")
     if embeddable_fields is None:
         embeddable_fields = get_default_embeddable_record_set_fields()
     validate_record_set_contains_one(record_set, embeddable_fields)
@@ -495,7 +495,7 @@ def validate_record_set_contains_any(
     _validate_record_set_contains(record_set, contains_any)
 
     if not any(record_set[field] is not None for field in contains_any):  # type: ignore[literal-required]
-        raise ValueError(f"At least one of {', '.join(contains_any)} must be provided")
+        raise errors.InvalidArgumentError(f"At least one of {', '.join(contains_any)} must be provided")
 
 
 def validate_record_set_contains_one(
@@ -506,7 +506,7 @@ def validate_record_set_contains_one(
     """
     _validate_record_set_contains(record_set, contains_one)
     if sum(record_set[field] is not None for field in contains_one) != 1:  # type: ignore[literal-required]
-        raise ValueError(f"Exactly one of {', '.join(contains_one)} must be provided")
+        raise errors.InvalidArgumentError(f"Exactly one of {', '.join(contains_one)} must be provided")
 
 
 def _validate_record_set_contains(
@@ -516,7 +516,7 @@ def _validate_record_set_contains(
     Validates that all fields in contains are valid fields of the Record.
     """
     if any(field not in record_set for field in contains):
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Invalid field in contains: {', '.join(contains)}, available fields: {', '.join(record_set.keys())}"
         )
 
@@ -999,7 +999,7 @@ def validate_embedding_function(
     protocol_signature = signature(EmbeddingFunction.__call__).parameters.keys()
 
     if not function_signature == protocol_signature:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected EmbeddingFunction.__call__ to have the following signature: {protocol_signature}, got {function_signature}\n"
             "Please see https://docs.trychroma.com/guides/embeddings for details of the EmbeddingFunction interface.\n"
             "Please note the recent change to the EmbeddingFunction interface: https://docs.trychroma.com/deployment/migration#migration-to-0.4.16---november-7,-2023 \n"
@@ -1014,14 +1014,14 @@ class DataLoader(Protocol[L]):
 def validate_ids(ids: IDs) -> IDs:
     """Validates ids to ensure it is a list of strings"""
     if not isinstance(ids, list):
-        raise ValueError(f"Expected IDs to be a list, got {type(ids).__name__} as IDs")
+        raise errors.InvalidArgumentError(f"Expected IDs to be a list, got {type(ids).__name__} as IDs")
     if len(ids) == 0:
-        raise ValueError(f"Expected IDs to be a non-empty list, got {len(ids)} IDs")
+        raise errors.InvalidArgumentError(f"Expected IDs to be a non-empty list, got {len(ids)} IDs")
     seen = set()
     dups = set()
     for id_ in ids:
         if not isinstance(id_, str):
-            raise ValueError(f"Expected ID to be a str, got {id_}")
+            raise errors.InvalidArgumentError(f"Expected ID to be a str, got {id_}")
         if id_ in seen:
             dups.add(id_)
         else:
@@ -1050,7 +1050,7 @@ def validate_ids(ids: IDs) -> IDs:
 def _validate_metadata_list_value(key: str, value: list) -> None:
     """Validates a list metadata value: must be non-empty and homogeneously typed."""
     if len(value) == 0:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected metadata list value for key '{key}' to be non-empty"
         )
     first_type = type(value[0])
@@ -1060,7 +1060,7 @@ def _validate_metadata_list_value(key: str, value: list) -> None:
     for item in value:
         item_type = bool if isinstance(item, bool) else type(item)
         if item_type is not first_type or item_type not in (str, int, float, bool):
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected metadata list value for key '{key}' to contain only str, int, float, or bool "
                 f"and all elements must be the same type, got {value}"
             )
@@ -1069,22 +1069,22 @@ def _validate_metadata_list_value(key: str, value: list) -> None:
 def validate_metadata(metadata: Metadata) -> Metadata:
     """Validates metadata to ensure it is a dictionary of strings to strings, ints, floats, bools, SparseVectors, or lists thereof"""
     if not isinstance(metadata, dict) and metadata is not None:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected metadata to be a dict or None, got {type(metadata).__name__} as metadata"
         )
     if metadata is None:
         return metadata
     if len(metadata) == 0:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected metadata to be a non-empty dict, got {len(metadata)} metadata attributes"
         )
     for key, value in metadata.items():
         if key == META_KEY_CHROMA_DOCUMENT:
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected metadata to not contain the reserved key {META_KEY_CHROMA_DOCUMENT}"
             )
         if not isinstance(key, str):
-            raise TypeError(
+            raise errors.InvalidArgumentError(
                 f"Expected metadata key to be a str, got {key} which is a {type(key).__name__}"
             )
         # Check if value is a SparseVector (validation happens in __post_init__)
@@ -1096,7 +1096,7 @@ def validate_metadata(metadata: Metadata) -> Metadata:
         elif not isinstance(value, bool) and not isinstance(
             value, (str, int, float, type(None))
         ):
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected metadata value to be a str, int, float, bool, SparseVector, list, or None, got {value} which is a {type(value).__name__}"
             )
     return metadata
@@ -1105,16 +1105,16 @@ def validate_metadata(metadata: Metadata) -> Metadata:
 def validate_update_metadata(metadata: UpdateMetadata) -> UpdateMetadata:
     """Validates metadata to ensure it is a dictionary of strings to strings, ints, floats, bools, SparseVectors, or lists thereof"""
     if not isinstance(metadata, dict) and metadata is not None:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected metadata to be a dict or None, got {type(metadata)}"
         )
     if metadata is None:
         return metadata
     if len(metadata) == 0:
-        raise ValueError(f"Expected metadata to be a non-empty dict, got {metadata}")
+        raise errors.InvalidArgumentError(f"Expected metadata to be a non-empty dict, got {metadata}")
     for key, value in metadata.items():
         if not isinstance(key, str):
-            raise ValueError(f"Expected metadata key to be a str, got {key}")
+            raise errors.InvalidArgumentError(f"Expected metadata key to be a str, got {key}")
         # Check if value is a SparseVector (validation happens in __post_init__)
         if isinstance(value, SparseVector):
             pass  # Already validated in SparseVector.__post_init__
@@ -1124,7 +1124,7 @@ def validate_update_metadata(metadata: UpdateMetadata) -> UpdateMetadata:
         elif not isinstance(value, bool) and not isinstance(
             value, (str, int, float, type(None))
         ):
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected metadata value to be a str, int, float, bool, SparseVector, list, or None, got {value}"
             )
     return metadata
@@ -1177,7 +1177,7 @@ def deserialize_metadata(
 def validate_metadatas(metadatas: Metadatas) -> Metadatas:
     """Validates metadatas to ensure it is a list of dictionaries of strings to strings, ints, floats or bools"""
     if not isinstance(metadatas, list):
-        raise ValueError(f"Expected metadatas to be a list, got {metadatas}")
+        raise errors.InvalidArgumentError(f"Expected metadatas to be a list, got {metadatas}")
     for metadata in metadatas:
         validate_metadata(metadata)
     return metadatas
@@ -1189,17 +1189,17 @@ def validate_where(where: Where) -> None:
     or in the case of $and and $or, a list of where expressions
     """
     if not isinstance(where, dict):
-        raise ValueError(f"Expected where to be a dict, got {where}")
+        raise errors.InvalidArgumentError(f"Expected where to be a dict, got {where}")
     if len(where) != 1:
-        raise ValueError(f"Expected where to have exactly one operator, got {where}")
+        raise errors.InvalidArgumentError(f"Expected where to have exactly one operator, got {where}")
     for key, value in where.items():
         if not isinstance(key, str):
-            raise ValueError(f"Expected where key to be a str, got {key}")
+            raise errors.InvalidArgumentError(f"Expected where key to be a str, got {key}")
         # $contains and $not_contains are only valid as operators within a
         # field expression (e.g. {"field": {"$contains": val}}), not as
         # top-level where keys.
         if key in ("$contains", "$not_contains"):
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected where key to be a metadata field name or a logical "
                 f"operator ($and, $or), got {key}"
             )
@@ -1210,16 +1210,16 @@ def validate_where(where: Where) -> None:
             and key != "$nin"
             and not isinstance(value, (str, int, float, dict))
         ):
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected where value to be a str, int, float, or operator expression, got {value}"
             )
         if key == "$and" or key == "$or":
             if not isinstance(value, list):
-                raise ValueError(
+                raise errors.InvalidArgumentError(
                     f"Expected where value for $and or $or to be a list of where expressions, got {value}"
                 )
             if len(value) <= 1:
-                raise ValueError(
+                raise errors.InvalidArgumentError(
                     f"Expected where value for $and or $or to be a list with at least two where expressions, got {value}"
                 )
             for where_expression in value:
@@ -1228,7 +1228,7 @@ def validate_where(where: Where) -> None:
         if isinstance(value, dict):
             # Ensure there is only one operator
             if len(value) != 1:
-                raise ValueError(
+                raise errors.InvalidArgumentError(
                     f"Expected operator expression to have exactly one operator, got {value}"
                 )
 
@@ -1236,22 +1236,22 @@ def validate_where(where: Where) -> None:
                 # Only numbers can be compared with gt, gte, lt, lte
                 if operator in ["$gt", "$gte", "$lt", "$lte"]:
                     if not isinstance(operand, (int, float)):
-                        raise ValueError(
+                        raise errors.InvalidArgumentError(
                             f"Expected operand value to be an int or a float for operator {operator}, got {operand}"
                         )
                 if operator in ["$in", "$nin"]:
                     if not isinstance(operand, list):
-                        raise ValueError(
+                        raise errors.InvalidArgumentError(
                             f"Expected operand value to be an list for operator {operator}, got {operand}"
                         )
                 # $contains/$not_contains: scalar operand (checks if array field contains value)
                 if operator in ["$contains", "$not_contains"]:
                     if key == "#document" and not isinstance(operand, str):
-                        raise ValueError(
+                        raise errors.InvalidArgumentError(
                             f"Expected operand value to be a str for operator {operator} on #document, got {operand}"
                         )
                     if not isinstance(operand, (str, int, float, bool)):
-                        raise ValueError(
+                        raise errors.InvalidArgumentError(
                             f"Expected operand value to be a str, int, float, or bool for operator {operator}, got {operand}"
                         )
                 if operator not in [
@@ -1266,20 +1266,20 @@ def validate_where(where: Where) -> None:
                     "$contains",
                     "$not_contains",
                 ]:
-                    raise ValueError(
+                    raise errors.InvalidArgumentError(
                         f"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, "
                         f"$contains, $not_contains, got {operator}"
                     )
 
                 if not isinstance(operand, (str, int, float, bool, list)):
-                    raise ValueError(
+                    raise errors.InvalidArgumentError(
                         f"Expected where operand value to be a str, int, float, bool, or list of those type, got {operand}"
                     )
                 if isinstance(operand, list) and (
                     len(operand) == 0
                     or not all(isinstance(x, type(operand[0])) for x in operand)
                 ):
-                    raise ValueError(
+                    raise errors.InvalidArgumentError(
                         f"Expected where operand value to be a non-empty list, and all values to be of the same type "
                         f"got {operand}"
                     )
@@ -1291,11 +1291,11 @@ def validate_where_document(where_document: WhereDocument) -> None:
     a list of where_document expressions
     """
     if not isinstance(where_document, dict):
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected where document to be a dictionary, got {where_document}"
         )
     if len(where_document) != 1:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected where document to have exactly one operator, got {where_document}"
         )
     for operator, operand in where_document.items():
@@ -1307,27 +1307,27 @@ def validate_where_document(where_document: WhereDocument) -> None:
             "$and",
             "$or",
         ]:
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected where document operator to be one of $contains, $not_contains, $regex, $not_regex, $and, $or, got {operator}"
             )
         if operator == "$and" or operator == "$or":
             if not isinstance(operand, list):
-                raise ValueError(
+                raise errors.InvalidArgumentError(
                     f"Expected document value for $and or $or to be a list of where document expressions, got {operand}"
                 )
             if len(operand) <= 1:
-                raise ValueError(
+                raise errors.InvalidArgumentError(
                     f"Expected document value for $and or $or to be a list with at least two where document expressions, got {operand}"
                 )
             for where_document_expression in operand:
                 validate_where_document(where_document_expression)
         # Value is $contains/$not_contains/$regex/$not_regex operator
         elif not isinstance(operand, str):
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected where document operand value for operator {operator} to be a str, got {operand}"
             )
         elif len(operand) == 0:
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected where document operand value for operator {operator} to be a non-empty str"
             )
 
@@ -1337,20 +1337,20 @@ def validate_include(include: Include, dissalowed: Optional[Include] = None) -> 
     to control if distances is allowed"""
 
     if not isinstance(include, list):
-        raise ValueError(f"Expected include to be a list, got {include}")
+        raise errors.InvalidArgumentError(f"Expected include to be a list, got {include}")
     for item in include:
         if not isinstance(item, str):
-            raise ValueError(f"Expected include item to be a str, got {item}")
+            raise errors.InvalidArgumentError(f"Expected include item to be a str, got {item}")
 
         # Get the valid items from the Literal type inside the List
         valid_items = get_args(get_args(Include)[0])
         if item not in valid_items:
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected include item to be one of {', '.join(valid_items)}, got {item}"
             )
 
         if dissalowed is not None and any(item == e for e in dissalowed):
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Include item cannot be one of {', '.join(dissalowed)}, got {item}"
             )
 
@@ -1359,11 +1359,11 @@ def validate_n_results(n_results: int) -> int:
     """Validates n_results to ensure it is a positive Integer. Since hnswlib does not allow n_results to be negative."""
     # Check Number of requested results
     if not isinstance(n_results, int):
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected requested number of results to be a int, got {n_results}"
         )
     if n_results <= 0:
-        raise TypeError(
+        raise errors.InvalidArgumentError(
             f"Number of requested results {n_results}, cannot be negative, or zero."
         )
     return n_results
@@ -1372,25 +1372,25 @@ def validate_n_results(n_results: int) -> int:
 def validate_embeddings(embeddings: Embeddings) -> Embeddings:
     """Validates embeddings to ensure it is a list of numpy arrays of ints, or floats"""
     if not isinstance(embeddings, (list, np.ndarray)):
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected embeddings to be a list, got {type(embeddings).__name__}"
         )
     if len(embeddings) == 0:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected embeddings to be a list with at least one item, got {len(embeddings)} embeddings"
         )
     if not all([isinstance(e, np.ndarray) for e in embeddings]):
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             "Expected each embedding in the embeddings to be a numpy array, got "
             f"{list(set([type(e).__name__ for e in embeddings]))}"
         )
     for i, embedding in enumerate(embeddings):
         if embedding.ndim == 0:
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected a 1-dimensional array, got a 0-dimensional array {embedding}"
             )
         if embedding.size == 0:
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected each embedding in the embeddings to be a 1-dimensional numpy array with at least 1 int/float value. Got a 1-dimensional numpy array with no values at pos {i}"
             )
 
@@ -1401,7 +1401,7 @@ def validate_embeddings(embeddings: Embeddings) -> Embeddings:
             np.int32,
             np.int64,
         ]:
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 "Expected each value in the embedding to be a int or float, got an embedding with "
                 f"{embedding.dtype} - {embedding}"
             )
@@ -1422,16 +1422,16 @@ def validate_sparse_vectors(vectors: SparseVectors) -> SparseVectors:
     This function only validates the list structure and instance types.
     """
     if not isinstance(vectors, list):
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected sparse vectors to be a list, got {type(vectors).__name__}"
         )
     if len(vectors) == 0:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected sparse vectors to be a non-empty list, got {len(vectors)} sparse vectors"
         )
     for i, vector in enumerate(vectors):
         if not isinstance(vector, SparseVector):
-            raise ValueError(
+            raise errors.InvalidArgumentError(
                 f"Expected SparseVector instance at position {i}, got {type(vector).__name__}"
             )
     return vectors
@@ -1440,11 +1440,11 @@ def validate_sparse_vectors(vectors: SparseVectors) -> SparseVectors:
 def validate_documents(documents: Documents, nullable: bool = False) -> None:
     """Validates documents to ensure it is a list of strings"""
     if not isinstance(documents, list):
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected documents to be a list, got {type(documents).__name__}"
         )
     if len(documents) == 0:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected documents to be a non-empty list, got {len(documents)} documents"
         )
     for document in documents:
@@ -1452,20 +1452,20 @@ def validate_documents(documents: Documents, nullable: bool = False) -> None:
         if document is None and nullable:
             continue
         if not is_document(document):
-            raise ValueError(f"Expected document to be a str, got {document}")
+            raise errors.InvalidArgumentError(f"Expected document to be a str, got {document}")
 
 
 def validate_images(images: Images) -> None:
     """Validates images to ensure it is a list of numpy arrays"""
     if not isinstance(images, list):
-        raise ValueError(f"Expected images to be a list, got {type(images).__name__}")
+        raise errors.InvalidArgumentError(f"Expected images to be a list, got {type(images).__name__}")
     if len(images) == 0:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected images to be a non-empty list, got {len(images)} images"
         )
     for image in images:
         if not is_image(image):
-            raise ValueError(f"Expected image to be a numpy array, got {image}")
+            raise errors.InvalidArgumentError(f"Expected image to be a numpy array, got {image}")
 
 
 def validate_batch(
@@ -1479,7 +1479,7 @@ def validate_batch(
     limits: Dict[str, Any],
 ) -> None:
     if len(batch[0]) > limits["max_batch_size"]:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Batch size {len(batch[0])} exceeds maximum batch size {limits['max_batch_size']}"
         )
 
@@ -1577,7 +1577,7 @@ def validate_sparse_embedding_function(
     protocol_signature = signature(SparseEmbeddingFunction.__call__).parameters.keys()
 
     if not function_signature == protocol_signature:
-        raise ValueError(
+        raise errors.InvalidArgumentError(
             f"Expected SparseEmbeddingFunction.__call__ to have the following signature: {protocol_signature}, got {function_signature}\n"
             "Please see https://docs.trychroma.com/guides/embeddings for details of the SparseEmbeddingFunction interface.\n"
         )

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -60,7 +60,14 @@ class DuplicateIDError(ChromaError):
         return "DuplicateID"
 
 
-class InvalidArgumentError(ChromaError):
+class InvalidArgumentError(ChromaError, ValueError, TypeError):
+    """Raised for invalid user-supplied arguments.
+
+    Inherits from both ValueError and TypeError (in addition to
+    ChromaError) so that existing code catching either of those builtins
+    around Chroma API calls keeps working unchanged.
+    """
+
     @overrides
     def code(self) -> int:
         return 400


### PR DESCRIPTION
Addresses #3026.

## What changed
Replaces raw `ValueError`/`TypeError` raises with `chromadb.errors.InvalidArgumentError` across the module-level argument-validation functions in `chromadb/api/types.py`: `validate_ids`, `validate_metadata`, `validate_update_metadata`, `validate_metadatas`, `validate_where`, `validate_where_document`, `validate_include`, `validate_n_results`, `validate_embeddings`, `validate_sparse_vectors`, `validate_documents`, `validate_images`, `validate_batch`, `validate_embedding_function`, `validate_sparse_embedding_function`, and the `validate_record_set_*`/`normalize_embeddings` helpers.

## Backward compatibility
`InvalidArgumentError` now inherits from both `ValueError` and `TypeError` (in addition to `ChromaError`), not just `ChromaError`. This means:
- Existing user code catching `except ValueError` or `except TypeError` around Chroma API calls keeps working unchanged.
- The existing test suite's `pytest.raises(ValueError, ...)` / `pytest.raises(TypeError, ...)` assertions around these functions continue to pass as-is — verified by replicating the relevant assertions from `chromadb/test/test_api.py` (metadata/where/where_document/include/n_results validation paths) directly against the modified functions.

Without this, the change would have silently broken exception-type contracts for both external callers and the existing test suite, which is why I went with a compatible subclass rather than a clean-break new exception type.

## Scope (deliberate)
This PR only touches the standalone `validate_*` functions in `chromadb/api/types.py`. Two things are intentionally **not** touched:
1. The `pydantic.BaseModel` `@field_validator`/`@model_validator` methods further down the same file (`HNSWIndexConfig`, `SparseVectorIndexConfig`, `Schema`/CMEK validation, etc.) — pydantic requires validators to raise exactly `ValueError`, `TypeError`, or `AssertionError` to wrap them into a proper `pydantic.ValidationError`. Raising `InvalidArgumentError` there would silently break that wrapping.
2. Other files with `ValueError`/`TypeError` raises (`client.py`, `base_http_client.py`, `shared_system_client.py`, `configuration.py`, `collection_configuration.py`) — left out to keep this PR focused and reviewable rather than one large sweep across the whole codebase.

Happy to follow up with additional PRs for the remaining files if this approach looks right to a maintainer.

## Testing
Full editable install (`pip install -e .`) requires the Rust-backed bindings (maturin), which couldn't build in this sandboxed environment (no network access to crates.io, no Rust toolchain). Instead, I installed `chromadb`'s pure-Python runtime deps and:
- Confirmed the module imports and passes an AST/syntax check.
- Directly exercised the modified functions and replicated the exact assertions from `chromadb/test/test_api.py` covering these code paths (metadata dict/list validation, where/where_document validation, include validation, n_results validation) — all pass with the original error messages preserved and `isinstance(e, ValueError)`/`isinstance(e, TypeError)` both holding true.

CI should be able to run the full suite; flagging the local testing limitation for transparency.