### PR TITLE
[BUG](grpc): Isolate default retry status set

### DIFF
--- a/chromadb/proto/utils.py
+++ b/chromadb/proto/utils.py
@@ -19,12 +19,14 @@ class RetryOnRpcErrorClientInterceptor(
     def __init__(
         self,
         max_attempts: int = 5,
-        retryable_status_codes: Set[grpc.StatusCode] = set(
-            [grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.UNKNOWN]
-        ),
+        retryable_status_codes: Optional[Set[grpc.StatusCode]] = None,
     ) -> None:
         self.max_attempts = max_attempts
-        self.retryable_status_codes = retryable_status_codes
+        self.retryable_status_codes = (
+            retryable_status_codes
+            if retryable_status_codes is not None
+            else {grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.UNKNOWN}
+        )
 
     def _intercept_call(self, continuation, client_call_details, request_or_iterator):
         sleep_span: Optional[Span] = None

--- a/chromadb/test/test_proto_utils.py
+++ b/chromadb/test/test_proto_utils.py
@@ -1,0 +1,15 @@
+import grpc
+
+from chromadb.proto.utils import RetryOnRpcErrorClientInterceptor
+
+
+def test_default_retryable_status_codes_are_not_shared() -> None:
+    first = RetryOnRpcErrorClientInterceptor()
+    second = RetryOnRpcErrorClientInterceptor()
+
+    first.retryable_status_codes.add(grpc.StatusCode.CANCELLED)
+
+    assert second.retryable_status_codes == {
+        grpc.StatusCode.UNAVAILABLE,
+        grpc.StatusCode.UNKNOWN,
+    }


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Give every default `RetryOnRpcErrorClientInterceptor` its own retryable status-code set.
  - Add a regression test that mutates one interceptor and verifies that a second interceptor retains only the documented `UNAVAILABLE` and `UNKNOWN` defaults.

The previous mutable default argument was created once when the module was imported. Every interceptor constructed without an explicit set therefore shared the same object. Runtime customization of one interceptor could silently change the retry policy of unrelated gRPC clients created later in the same process.

The `None` sentinel keeps explicitly supplied sets behaving as before while constructing a fresh default set for each instance.

No issue is linked; this was found during a code audit, and searches found no existing issue or PR for this interceptor state leak.

## Test plan

- [x] `maturin develop` builds and installs the local Rust/Python bindings
- [x] Focused regression test passes
- [x] Full Python core suite aligned with the Rust-bindings CI target: 779 passed, 152 skipped, 1 xfailed
- [x] All configured pre-commit hooks pass, including Black, Flake8, and strict Mypy

## Migration plan

No migration or compatibility action is required. The constructor signature still accepts the same optional set of gRPC status codes.

## Observability plan

No new instrumentation is needed. This change only isolates in-process default configuration state.

## Documentation Changes

No user-facing API or documented default changes. The existing default retry codes remain `UNAVAILABLE` and `UNKNOWN`.
