### PR TITLE
[BUG](types): reject whitespace-padded names

### DIFF
--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -70,6 +70,15 @@ pub fn validate_name(name: impl AsRef<str>) -> Result<(), ValidationError> {
         return Ok(());
     }
 
+    // Surface leading/trailing whitespace before the generic alnum check so users
+    // get a message that names the actual problem. The debug-format print quotes
+    // the offending input so invisible whitespace shows up in the error text.
+    if name_str != name_str.trim() {
+        return Err(ValidationError::new("name").with_message(
+            format!("Expected a name without leading or trailing whitespace. Got: {name_str:?}").into(),
+        ));
+    }
+
     if !ALNUM_RE.is_match(name_str) {
         return Err(ValidationError::new("name").with_message(format!("Expected a name containing 3-512 characters from [a-zA-Z0-9._-], starting and ending with a character in [a-zA-Z0-9]. Got: {name_str}").into()));
     }
@@ -411,6 +420,27 @@ mod tests {
         assert!(validate_name("abc_").is_err());
         assert!(validate_name("abc-").is_err());
         assert!(validate_name("abc.").is_err());
+    }
+
+    #[test]
+    fn invalid_simple_name_leading_or_trailing_whitespace() {
+        // Regression for #7609: whitespace-padded names produced the generic
+        // alnum error message, hiding the actual (invisible) problem.
+        for bad in [" testDB", "testDB ", " testDB ", "\ttestDB", "testDB\n"] {
+            let err = validate_name(bad).unwrap_err();
+            let msg = err.message.as_deref().unwrap_or("");
+            assert!(
+                msg.contains("whitespace"),
+                "expected whitespace-specific error for {bad:?}, got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_simple_name_whitespace_only() {
+        for bad in ["   ", "\t\t", "\n"] {
+            assert!(validate_name(bad).is_err(), "expected {bad:?} to be rejected");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #7609.

The name validator ran `ALNUM_RE` first, so an input like `" testDB"` produced the generic character-class message:

> Expected a name containing 3-512 characters from [a-zA-Z0-9._-], starting and ending with a character in [a-zA-Z0-9].

The invisible padding stayed invisible in the error text — the user sees `testDB` and can't tell why validation failed.

## Fix

Detect leading/trailing whitespace explicitly in `validate_name` *before* the alnum check, and emit a whitespace-specific error. Debug-format the offending value so the padding renders visibly:

```rust
if name_str != name_str.trim() {
    return Err(ValidationError::new("name").with_message(
        format!("Expected a name without leading or trailing whitespace. Got: {name_str:?}").into(),
    ));
}
```

For `" testDB"` the message now ends with `Got: " testDB"` — the surrounding quotes make the whitespace unmistakable.

## Design notes

- **Explicit error rather than silent trim.** The issue floated both options. I chose the error path so no code path silently rewrites what the caller typed; a caller who genuinely wanted a leading space should get a clear rejection, not surprising truncation.
- **`str::trim`** covers ASCII space, tab, newline, CR, and Unicode whitespace, so `" testDB"`, `"\ttestDB"`, and `"testDB\n"` all hit the new branch.
- **Whitespace-only inputs** (`"   "`) still get rejected — they trim to `""`, `"" != "   "`, so the new branch fires with the whitespace-specific message. No regression on the empty-name path.

## Tests

Two new tests in `rust/types/src/validators.rs`:

- `invalid_simple_name_leading_or_trailing_whitespace` — verifies the new error message triggers for five padding variants (leading space, trailing space, both, leading tab, trailing newline).
- `invalid_simple_name_whitespace_only` — verifies whitespace-only names are still rejected.

## Verification

The change is a small guard added ahead of an existing branch, with tests modeled on the surrounding `invalid_simple_name_*` pattern. I have not run `cargo test` locally on this branch (Windows + no local Rust toolchain), but CI will exercise it. Happy to iterate on any failures.