### PR TITLE
[ENH](foundation-api): Distribute page source IDs across chunks

### DIFF
--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -2,6 +2,11 @@ use chroma_sysdb::SysDbConfig;
 use frontend_core::config::{load_yaml_with_env, BaseServerConfig};
 use serde::{Deserialize, Serialize};
 
+/// Default byte target for one page `source_ids` metadata value.
+///
+/// This leaves headroom below Chroma Cloud's 4 KiB metadata-value limit.
+pub(crate) const DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES: usize = 3 * 1024;
+
 /// Top-level config for the foundation-api HTTP server.
 ///
 /// Embeds `BaseServerConfig` (port, listen address, payload size, circuit
@@ -37,6 +42,10 @@ pub struct FoundationConfig {
     // metadata rather than living as a deployment-side config field.
     #[serde(default = "FoundationConfig::default_wiki_collection")]
     pub wiki_collection: String,
+    /// Maximum combined UTF-8 byte length of the source IDs placed in one
+    /// page chunk's `source_ids` metadata value.
+    #[serde(default = "FoundationConfig::default_max_source_ids_value_bytes")]
+    pub max_source_ids_value_bytes: usize,
     #[serde(default = "FoundationConfig::default_trajectories_collection")]
     pub trajectories_collection: String,
     #[serde(default = "FoundationConfig::default_wiki_revisions_collection")]
@@ -114,6 +123,9 @@ impl FoundationConfig {
     fn default_wiki_collection() -> String {
         "wiki".to_string()
     }
+    fn default_max_source_ids_value_bytes() -> usize {
+        DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES
+    }
     fn default_trajectories_collection() -> String {
         "generate_trajectories".to_string()
     }
@@ -160,6 +172,7 @@ impl Default for FoundationConfig {
             database_name: Self::default_database_name(),
             frontend_ingress_url: None,
             wiki_collection: Self::default_wiki_collection(),
+            max_source_ids_value_bytes: Self::default_max_source_ids_value_bytes(),
             trajectories_collection: Self::default_trajectories_collection(),
             wiki_revisions_collection: Self::default_wiki_revisions_collection(),
             currents_collection: Self::default_currents_collection(),
@@ -197,6 +210,7 @@ mod tests {
                 database_name: "FOUNDATION".to_string(),
                 frontend_ingress_url: None,
                 wiki_collection: "wiki".to_string(),
+                max_source_ids_value_bytes: 3 * 1024,
                 trajectories_collection: "generate_trajectories".to_string(),
                 wiki_revisions_collection: "wiki_revisions".to_string(),
                 currents_collection: "currents".to_string(),
@@ -218,5 +232,15 @@ mod tests {
                 foundation_ui_origin: None,
             }
         );
+    }
+
+    #[test]
+    fn max_source_ids_value_bytes_is_overridable() {
+        let config: FoundationConfig = serde_json::from_value(serde_json::json!({
+            "max_source_ids_value_bytes": 2048,
+        }))
+        .expect("config should deserialize");
+
+        assert_eq!(config.max_source_ids_value_bytes, 2048);
     }
 }

--- a/rust/foundation-api/src/routes/read_page.rs
+++ b/rust/foundation-api/src/routes/read_page.rs
@@ -3,15 +3,15 @@
 //!
 //! Search returns chunk-level hits; this route reassembles a whole page: fetch
 //! every chunk for the slug, order them by `chunk_id`, and join their
-//! documents. The per-page metadata (title, categories, …) is stamped
-//! identically on every chunk, so it is read off the head chunk. Like the other
-//! wiki routes it proxies to the FE through
+//! documents. Scalar page metadata is read from the head chunk, while array
+//! metadata that may be distributed is unioned across every chunk. Like the
+//! other wiki routes it proxies to the FE through
 //! the Foundation Chroma client, which enforces auth, quota,
 //! metering, and billing.
 
 use crate::routes::links::page_url;
 use crate::routes::{caller_token, whoami::whoami_and_authorize};
-use crate::wiki::page::{meta_int, meta_str, meta_str_array};
+use crate::wiki::page::{meta_int, meta_str};
 use crate::wiki::WikiClientError;
 use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
 use axum::{extract::State, http::HeaderMap, Json};
@@ -23,6 +23,7 @@ use chroma_types::{
     Metadata, MetadataComparison, MetadataExpression, MetadataValue, PrimitiveOperator, Where,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use validator::Validate;
 
 /// Request body for `POST /api/read-page`.
@@ -71,6 +72,10 @@ pub enum ReadPageError {
     /// No chunks exist for the requested page slug.
     #[error("page not found")]
     PageNotFound,
+    /// Stored page metadata has the wrong type. Treat this as data loss instead
+    /// of silently replacing metadata that the route could not decode.
+    #[error("page '{slug}' has non-array '{key}' metadata")]
+    MalformedArrayMetadata { slug: String, key: &'static str },
 }
 
 impl ChromaError for ReadPageError {
@@ -81,6 +86,7 @@ impl ChromaError for ReadPageError {
             ReadPageError::Resolve(err) => err.code(),
             ReadPageError::Query(_) => ErrorCodes::Internal,
             ReadPageError::PageNotFound => ErrorCodes::NotFound,
+            ReadPageError::MalformedArrayMetadata { .. } => ErrorCodes::DataLoss,
         }
     }
 }
@@ -181,7 +187,7 @@ async fn read_full_page(
         .await
         .map_err(ReadPageError::Query)?;
 
-    Ok(assemble_page(slug, chunks_from_response(response)))
+    assemble_page(slug, chunks_from_response(response))
 }
 
 /// Flattens a single-payload [`SearchResponse`] into `(document, metadata)`
@@ -210,24 +216,30 @@ fn chunks_from_response(response: SearchResponse) -> Vec<(String, Metadata)> {
 }
 
 /// Orders the chunks of a single page by `chunk_id`, joins their documents into
-/// the full markdown, and reads the per-page metadata off the head chunk. Pure
-/// (no I/O) so the ordering/join behaviour is unit-testable. Returns `None`
-/// when there are no chunks.
-fn assemble_page(slug: &str, mut chunks: Vec<(String, Metadata)>) -> Option<FoundationPage> {
+/// the full markdown, reads scalar per-page metadata off the head chunk, and
+/// safely unions preserved array metadata across all chunks. Pure (no I/O) so
+/// the ordering/join behaviour is unit-testable. Returns `None` when there are
+/// no chunks.
+fn assemble_page(
+    slug: &str,
+    mut chunks: Vec<(String, Metadata)>,
+) -> Result<Option<FoundationPage>, ReadPageError> {
     if chunks.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     chunks.sort_by_key(|(_, meta)| meta_int(meta, "chunk_id").unwrap_or(0));
 
+    let categories = page_string_array(slug, &chunks, "categories")?;
+    let source_ids = page_string_array(slug, &chunks, "source_ids")?;
     let content: String = chunks.iter().map(|(doc, _)| doc.as_str()).collect();
     let head = &chunks[0].1;
 
-    Some(FoundationPage {
+    Ok(Some(FoundationPage {
         slug: slug.to_string(),
         title: meta_str(head, "title").unwrap_or_else(|| slug.to_string()),
-        categories: meta_str_array(head, "categories"),
-        source_ids: meta_str_array(head, "source_ids"),
+        categories,
+        source_ids,
         version: meta_int(head, "version")
             .and_then(|version| u32::try_from(version).ok())
             .unwrap_or(0),
@@ -235,7 +247,39 @@ fn assemble_page(slug: &str, mut chunks: Vec<(String, Metadata)>) -> Option<Foun
         last_written_by: meta_str(head, "last_written_by"),
         content,
         url: None,
-    })
+    }))
+}
+
+/// Reads optional page-level array metadata across every chunk. Missing fields
+/// are the canonical representation of an empty array, while values found on
+/// any chunk are retained and deduplicated. A wrong-typed value fails the read
+/// so a later full-page rewrite cannot silently discard undecodable metadata.
+fn page_string_array(
+    slug: &str,
+    chunks: &[(String, Metadata)],
+    key: &'static str,
+) -> Result<Vec<String>, ReadPageError> {
+    let mut values = Vec::new();
+    let mut seen = HashSet::new();
+    for (_, metadata) in chunks {
+        match metadata.get(key) {
+            None => {}
+            Some(MetadataValue::StringArray(chunk_values)) => {
+                for value in chunk_values {
+                    if seen.insert(value.clone()) {
+                        values.push(value.clone());
+                    }
+                }
+            }
+            Some(_) => {
+                return Err(ReadPageError::MalformedArrayMetadata {
+                    slug: slug.to_string(),
+                    key,
+                });
+            }
+        }
+    }
+    Ok(values)
 }
 
 #[cfg(test)]
@@ -274,7 +318,9 @@ mod tests {
             ("hello ".to_string(), chunk_meta(0)),
         ];
 
-        let page = assemble_page("my-page", chunks).expect("page");
+        let page = assemble_page("my-page", chunks)
+            .expect("valid metadata")
+            .expect("page");
 
         assert_eq!(page.slug, "my-page");
         assert_eq!(page.title, "My Page");
@@ -294,7 +340,9 @@ mod tests {
     fn assemble_page_falls_back_to_slug_when_title_missing() {
         let mut meta = Metadata::new();
         meta.insert("chunk_id".to_string(), MetadataValue::Int(0));
-        let page = assemble_page("orphan", vec![("body".to_string(), meta)]).expect("page");
+        let page = assemble_page("orphan", vec![("body".to_string(), meta)])
+            .expect("valid metadata")
+            .expect("page");
 
         assert_eq!(page.title, "orphan");
         assert!(page.categories.is_empty());
@@ -306,7 +354,56 @@ mod tests {
 
     #[test]
     fn assemble_page_returns_none_without_chunks() {
-        assert!(assemble_page("empty", Vec::new()).is_none());
+        assert!(assemble_page("empty", Vec::new())
+            .expect("valid metadata")
+            .is_none());
+    }
+
+    #[test]
+    fn assemble_page_rejects_malformed_preserved_array_metadata() {
+        for key in ["source_ids", "categories"] {
+            let head = chunk_meta(0);
+            let mut malformed = chunk_meta(1);
+            malformed.insert(
+                key.to_string(),
+                MetadataValue::Str("not-an-array".to_string()),
+            );
+
+            let err = assemble_page(
+                "broken",
+                vec![("head".to_string(), head), ("body".to_string(), malformed)],
+            )
+            .expect_err("malformed page metadata should fail the read");
+
+            assert!(matches!(
+                err,
+                ReadPageError::MalformedArrayMetadata {
+                    ref slug,
+                    key: malformed_key,
+                } if slug == "broken" && malformed_key == key
+            ));
+            assert_eq!(err.code(), ErrorCodes::DataLoss);
+        }
+    }
+
+    #[test]
+    fn assemble_page_recovers_preserved_metadata_from_non_head_chunks() {
+        let mut head = chunk_meta(0);
+        head.remove("source_ids");
+        head.remove("categories");
+
+        let page = assemble_page(
+            "recoverable",
+            vec![
+                ("head".to_string(), head),
+                ("body".to_string(), chunk_meta(1)),
+            ],
+        )
+        .expect("valid metadata")
+        .expect("page");
+
+        assert_eq!(page.source_ids, vec!["slack_master:abc".to_string()]);
+        assert_eq!(page.categories, vec!["eng".to_string()]);
     }
 
     #[test]

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -376,6 +376,7 @@ pub(crate) async fn run_upsert_page(
         i64::from(version),
         categories,
         &request.source_ids,
+        server.config.foundation.max_source_ids_value_bytes,
         author,
         &request.last_written_by,
     )?;
@@ -598,7 +599,6 @@ mod tests {
     use super::*;
     use crate::config::FoundationApiConfig;
     use crate::routes::CHROMA_TOKEN_HEADER;
-    use crate::wiki::page::MAX_SOURCE_IDS_VALUE_BYTES;
     use axum::http::HeaderValue;
     use chroma::{
         client::{ChromaHttpClientOptions, ChromaRetryOptions},
@@ -808,6 +808,9 @@ mod tests {
             .map(|fill| format!("slack_master:{}", fill.to_string().repeat(1187)))
             .to_vec();
         assert!(source_ids.iter().all(|source_id| source_id.len() == 1200));
+        let mut config = FoundationApiConfig::default();
+        config.foundation.max_source_ids_value_bytes = 2500;
+        let max_source_ids_value_bytes = config.foundation.max_source_ids_value_bytes;
 
         let sparse = (0..chunks.len())
             .map(|index| SparseVector::new(vec![index as u32], vec![1.0]).expect("sparse vector"))
@@ -823,6 +826,7 @@ mod tests {
             1,
             &[],
             &source_ids,
+            max_source_ids_value_bytes,
             None,
             "00000000-0000-0000-0000-000000000001",
         )
@@ -899,13 +903,13 @@ mod tests {
         assert_eq!(distributed.len(), 2, "source IDs should span two chunks");
         let first_value_bytes = distributed[0].iter().map(String::len).sum::<usize>();
         assert!(first_value_bytes > 1024);
-        assert!(first_value_bytes <= MAX_SOURCE_IDS_VALUE_BYTES);
+        assert!(first_value_bytes <= max_source_ids_value_bytes);
         assert!(
             !distributed[1].is_empty(),
             "overflow must occupy another chunk"
         );
         assert!(distributed.iter().all(|source_ids| {
-            source_ids.iter().map(String::len).sum::<usize>() <= MAX_SOURCE_IDS_VALUE_BYTES
+            source_ids.iter().map(String::len).sum::<usize>() <= max_source_ids_value_bytes
         }));
         assert_eq!(
             distributed.into_iter().flatten().collect::<Vec<_>>(),

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -12,7 +12,7 @@ use crate::foundation_chroma::{is_not_found, FoundationChromaClient};
 use crate::routes::{caller_token, whoami::whoami_and_authorize};
 use crate::wiki::chunking::{chunk_content, title_from_content, ChunkRecordId, ChunkingConfig};
 use crate::wiki::embed::WikiEmbedder;
-use crate::wiki::page::{build_metadatas, kind_for};
+use crate::wiki::page::{build_metadatas, kind_for, PageMetadataError};
 use crate::wiki::WikiClientError;
 use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
 use axum::{extract::State, http::HeaderMap, Json};
@@ -137,6 +137,9 @@ pub enum UpsertPageError {
     /// Computing dense Qwen embeddings failed.
     #[error("dense wiki embedding failed: {0}")]
     DenseEmbed(ChromaHttpClientError),
+    /// Page metadata cannot be represented within the per-value size target.
+    #[error(transparent)]
+    PageMetadata(#[from] PageMetadataError),
     /// A proxied record-I/O call (`get`/`upsert`/`delete`/`commit`) to the FE failed.
     #[error("chroma record I/O failed: {0}")]
     RecordIo(ChromaHttpClientError),
@@ -165,6 +168,7 @@ impl ChromaError for UpsertPageError {
             UpsertPageError::Resolve(err) => err.code(),
             UpsertPageError::Embed(err) => err.code(),
             UpsertPageError::DenseEmbed(_) => ErrorCodes::Internal,
+            UpsertPageError::PageMetadata(_) => ErrorCodes::ResourceExhausted,
             UpsertPageError::RecordIo(err) if is_conditional_conflict(err) => {
                 ErrorCodes::FailedPrecondition
             }
@@ -374,7 +378,7 @@ pub(crate) async fn run_upsert_page(
         &request.source_ids,
         author,
         &request.last_written_by,
-    );
+    )?;
 
     let doc_batch: Vec<Option<String>> = chunks
         .iter()
@@ -594,13 +598,18 @@ mod tests {
     use super::*;
     use crate::config::FoundationApiConfig;
     use crate::routes::CHROMA_TOKEN_HEADER;
+    use crate::wiki::page::MAX_SOURCE_IDS_VALUE_BYTES;
     use axum::http::HeaderValue;
+    use chroma::{
+        client::{ChromaHttpClientOptions, ChromaRetryOptions},
+        ChromaHttpClient,
+    };
     use chroma_sysdb::{SysDb, TestSysDb};
     use chroma_system::System;
-    use chroma_types::{Collection, CollectionUuid};
-    use httpmock::MockServer;
+    use chroma_types::{Collection, CollectionUuid, SparseVector};
+    use httpmock::{HttpMockResponse, MockServer};
     use serde_json::{json, Value};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     fn request(
         slug: &str,
@@ -773,6 +782,136 @@ mod tests {
             }
         ));
         assert_eq!(err.code(), ErrorCodes::ResourceExhausted);
+    }
+
+    #[tokio::test]
+    async fn conditional_upsert_accommodates_source_id_metadata_overflow() {
+        let mock_server = MockServer::start_async().await;
+        let collection_model = wiki_collection();
+        let client = ChromaHttpClient::new(ChromaHttpClientOptions {
+            endpoint: mock_server.base_url().parse().expect("mock endpoint"),
+            tenant_id: Some(collection_model.tenant.clone()),
+            database_name: Some(collection_model.database.clone()),
+            retry_options: ChromaRetryOptions {
+                max_retries: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let collection = ChromaCollection::from_collection_model(client, collection_model.clone());
+
+        let content = "# Title\n\nFirst body paragraph.\n\nSecond body paragraph.";
+        let chunks = chunk_content("foo", content, &ChunkingConfig { max_bytes: 32 });
+        assert!(chunks.len() >= 2, "test page must provide overflow space");
+
+        let source_ids = ['a', 'b', 'c']
+            .map(|fill| format!("slack_master:{}", fill.to_string().repeat(1187)))
+            .to_vec();
+        assert!(source_ids.iter().all(|source_id| source_id.len() == 1200));
+
+        let sparse = (0..chunks.len())
+            .map(|index| SparseVector::new(vec![index as u32], vec![1.0]).expect("sparse vector"))
+            .collect();
+        let metadatas = build_metadatas(
+            "foo",
+            &chunks,
+            sparse,
+            "page",
+            "Title",
+            10,
+            20,
+            1,
+            &[],
+            &source_ids,
+            None,
+            "00000000-0000-0000-0000-000000000001",
+        )
+        .expect("page chunks should accommodate source IDs");
+
+        let ids = chunks
+            .iter()
+            .map(|chunk| chunk.id.clone())
+            .collect::<Vec<_>>();
+        let documents = chunks
+            .iter()
+            .map(|chunk| Some(chunk.text.clone()))
+            .collect::<Vec<_>>();
+        let embeddings = vec![vec![1.0]; chunks.len()];
+        let metadatas = metadatas
+            .into_iter()
+            .map(metadata_to_update_metadata)
+            .map(Some)
+            .collect::<Vec<_>>();
+
+        let captured_commit = Arc::new(Mutex::new(None));
+        let captured_commit_for_mock = Arc::clone(&captured_commit);
+        let commit_path = collection_path(&collection_model, "conditional/commit");
+        let commit_mock = mock_server
+            .mock_async(move |when, then| {
+                when.method("POST").path(commit_path);
+                then.respond_with(move |request| {
+                    let body: Value = serde_json::from_slice(request.body_ref())
+                        .expect("conditional commit should be JSON");
+                    *captured_commit_for_mock.lock().expect("capture lock") = Some(body);
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .body(
+                            json!({
+                                "first_inserted_record_offset": 7,
+                                "record_count": chunks.len(),
+                            })
+                            .to_string(),
+                        )
+                        .build()
+                });
+            })
+            .await;
+
+        let mut transaction = collection.conditional();
+        transaction
+            .upsert(ids, embeddings, Some(documents), None, Some(metadatas))
+            .await
+            .expect("buffer upsert");
+        transaction.commit().await.expect("commit upsert");
+
+        let commit = captured_commit
+            .lock()
+            .expect("capture lock")
+            .clone()
+            .expect("captured commit");
+        let serialized_metadatas = commit
+            .pointer("/operations/0/payload/metadatas")
+            .and_then(Value::as_array)
+            .expect("upsert metadata array");
+        let distributed = serialized_metadatas
+            .iter()
+            .filter_map(|metadata| metadata.get("source_ids"))
+            .map(|source_ids| {
+                source_ids
+                    .as_array()
+                    .expect("source_ids array")
+                    .iter()
+                    .map(|source_id| source_id.as_str().expect("source ID string").to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(distributed.len(), 2, "source IDs should span two chunks");
+        let first_value_bytes = distributed[0].iter().map(String::len).sum::<usize>();
+        assert!(first_value_bytes > 1024);
+        assert!(first_value_bytes <= MAX_SOURCE_IDS_VALUE_BYTES);
+        assert!(
+            !distributed[1].is_empty(),
+            "overflow must occupy another chunk"
+        );
+        assert!(distributed.iter().all(|source_ids| {
+            source_ids.iter().map(String::len).sum::<usize>() <= MAX_SOURCE_IDS_VALUE_BYTES
+        }));
+        assert_eq!(
+            distributed.into_iter().flatten().collect::<Vec<_>>(),
+            source_ids
+        );
+        assert_eq!(commit_mock.calls(), 1);
     }
 
     #[tokio::test]
@@ -950,6 +1089,16 @@ mod tests {
             reqwest::StatusCode::PRECONDITION_FAILED,
         ));
         assert_eq!(err.code(), ErrorCodes::FailedPrecondition);
+    }
+
+    #[test]
+    fn page_metadata_errors_map_to_resource_exhausted() {
+        let err = UpsertPageError::PageMetadata(PageMetadataError::InsufficientChunks {
+            required: 2,
+            available: 1,
+        });
+
+        assert_eq!(err.code(), ErrorCodes::ResourceExhausted);
     }
 
     #[test]

--- a/rust/foundation-api/src/wiki/page.rs
+++ b/rust/foundation-api/src/wiki/page.rs
@@ -7,6 +7,21 @@ use chroma_types::{Metadata, MetadataValue, SparseVector};
 /// Slugs that are seeded system pages rather than content/category pages.
 const SYSTEM_SLUGS: [&str; 3] = ["", "meta", "categories"];
 
+/// Conservative target for one `source_ids` metadata value, leaving headroom
+/// below Chroma Cloud's 4 KiB limit.
+pub(crate) const MAX_SOURCE_IDS_VALUE_BYTES: usize = 3 * 1024;
+
+/// Failures while assigning page-level metadata to record chunks.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PageMetadataError {
+    /// One source ID cannot fit in a metadata value by itself.
+    #[error("source ID is {bytes} bytes; maximum per chunk is {limit} bytes")]
+    SourceIdTooLarge { bytes: usize, limit: usize },
+    /// The page does not have enough chunks for all bounded source-ID arrays.
+    #[error("source IDs require {required} chunks, but the page has {available}")]
+    InsufficientChunks { required: usize, available: usize },
+}
+
 /// The page `kind` stamped on every chunk.
 pub(crate) fn kind_for(slug: &str) -> &'static str {
     if SYSTEM_SLUGS.contains(&slug) {
@@ -18,8 +33,14 @@ pub(crate) fn kind_for(slug: &str) -> &'static str {
     }
 }
 
-/// Builds the per-chunk metadata: the always-on fields plus the sparse vector,
-/// with `categories` / `source_ids` stamped on every chunk only when non-empty.
+/// Builds the per-chunk metadata: the always-on fields plus the sparse vector.
+/// Categories are stamped on every chunk, while source IDs are packed into
+/// consecutive chunks so each `source_ids` value stays within Chroma's limit.
+///
+/// # Errors
+///
+/// Returns [`PageMetadataError`] if one source ID exceeds the value target or
+/// the page has too few chunks to store all source IDs.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_metadatas(
     slug: &str,
@@ -34,11 +55,13 @@ pub(crate) fn build_metadatas(
     source_ids: &[String],
     author: Option<&str>,
     last_written_by: &str,
-) -> Vec<Metadata> {
-    chunks
+) -> Result<Vec<Metadata>, PageMetadataError> {
+    let source_ids_by_chunk = distribute_source_ids(source_ids, chunks.len())?;
+    Ok(chunks
         .iter()
         .zip(sparse)
-        .map(|(chunk, sparse_vec)| {
+        .zip(source_ids_by_chunk)
+        .map(|((chunk, sparse_vec), chunk_source_ids)| {
             let mut meta = Metadata::new();
             meta.insert("slug".to_string(), MetadataValue::Str(slug.to_string()));
             meta.insert(
@@ -68,10 +91,10 @@ pub(crate) fn build_metadatas(
                     MetadataValue::StringArray(categories.to_vec()),
                 );
             }
-            if !source_ids.is_empty() {
+            if !chunk_source_ids.is_empty() {
                 meta.insert(
                     "source_ids".to_string(),
-                    MetadataValue::StringArray(source_ids.to_vec()),
+                    MetadataValue::StringArray(chunk_source_ids),
                 );
             }
             if let Some(author) = author {
@@ -79,7 +102,48 @@ pub(crate) fn build_metadatas(
             }
             meta
         })
-        .collect()
+        .collect())
+}
+
+/// Greedily packs source IDs in input order. Chroma measures a string-array
+/// metadata value as the sum of its strings' UTF-8 byte lengths.
+fn distribute_source_ids(
+    source_ids: &[String],
+    num_chunks: usize,
+) -> Result<Vec<Vec<String>>, PageMetadataError> {
+    let mut distributed = Vec::new();
+    let mut current_chunk = Vec::new();
+    let mut chunk_bytes = 0;
+
+    for source_id in source_ids {
+        let source_id_bytes = source_id.len();
+        if source_id_bytes > MAX_SOURCE_IDS_VALUE_BYTES {
+            return Err(PageMetadataError::SourceIdTooLarge {
+                bytes: source_id_bytes,
+                limit: MAX_SOURCE_IDS_VALUE_BYTES,
+            });
+        }
+        if !current_chunk.is_empty() && chunk_bytes + source_id_bytes > MAX_SOURCE_IDS_VALUE_BYTES {
+            distributed.push(current_chunk);
+            current_chunk = Vec::new();
+            chunk_bytes = 0;
+        }
+        current_chunk.push(source_id.clone());
+        chunk_bytes += source_id_bytes;
+    }
+    if !current_chunk.is_empty() {
+        distributed.push(current_chunk);
+    }
+
+    if distributed.len() > num_chunks {
+        return Err(PageMetadataError::InsufficientChunks {
+            required: distributed.len(),
+            available: num_chunks,
+        });
+    }
+    distributed.resize_with(num_chunks, Vec::new);
+
+    Ok(distributed)
 }
 
 /// Reads a string-valued metadata field, or `None` if it is absent or a
@@ -153,7 +217,8 @@ mod tests {
             &["slack_master:abc".to_string()],
             Some("Claude Sonnet 4.5"),
             "00000000-0000-0000-0000-000000000001",
-        );
+        )
+        .expect("metadata should fit");
 
         assert_eq!(metas.len(), 2);
         let first = &metas[0];
@@ -188,10 +253,83 @@ mod tests {
                 "slack_master:abc".to_string()
             ]))
         );
+        assert!(!metas[1].contains_key("source_ids"));
         assert!(matches!(
             metas[1].get(SPARSE_KEY),
             Some(MetadataValue::SparseVector(_))
         ));
+    }
+
+    #[test]
+    fn build_metadatas_distributes_source_ids_within_value_limit() {
+        let chunks = vec![
+            chunk(0, 0, "Title"),
+            chunk(1, 2, "Body"),
+            chunk(2, 3, "More body"),
+        ];
+        let source_ids = vec!["a".repeat(1536), "b".repeat(1536), "é".repeat(1536)];
+        let metas = build_metadatas(
+            "foo",
+            &chunks,
+            vec![sparse(1), sparse(2), sparse(3)],
+            "page",
+            "Title",
+            10,
+            20,
+            3,
+            &[],
+            &source_ids,
+            None,
+            "00000000-0000-0000-0000-000000000001",
+        )
+        .expect("metadata should fit");
+
+        let distributed: Vec<Vec<String>> = metas
+            .iter()
+            .filter_map(|meta| match meta.get("source_ids") {
+                Some(MetadataValue::StringArray(values)) => Some(values.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            distributed,
+            vec![source_ids[..2].to_vec(), source_ids[2..].to_vec()]
+        );
+        assert!(distributed.iter().all(|values| {
+            values.iter().map(String::len).sum::<usize>() <= MAX_SOURCE_IDS_VALUE_BYTES
+        }));
+        assert!(!metas[2].contains_key("source_ids"));
+    }
+
+    #[test]
+    fn distribute_source_ids_rejects_an_individually_oversized_id() {
+        let oversized = "a".repeat(MAX_SOURCE_IDS_VALUE_BYTES + 1);
+
+        let err = distribute_source_ids(&[oversized], 2).expect_err("source ID should not fit");
+
+        assert_eq!(
+            err,
+            PageMetadataError::SourceIdTooLarge {
+                bytes: MAX_SOURCE_IDS_VALUE_BYTES + 1,
+                limit: MAX_SOURCE_IDS_VALUE_BYTES,
+            }
+        );
+    }
+
+    #[test]
+    fn distribute_source_ids_rejects_too_few_chunks() {
+        let source_ids = vec!["a".repeat(MAX_SOURCE_IDS_VALUE_BYTES), "b".to_string()];
+
+        let err = distribute_source_ids(&source_ids, 1).expect_err("two chunks should be required");
+
+        assert_eq!(
+            err,
+            PageMetadataError::InsufficientChunks {
+                required: 2,
+                available: 1,
+            }
+        );
     }
 
     #[test]
@@ -210,7 +348,8 @@ mod tests {
             &[],
             None,
             "00000000-0000-0000-0000-000000000001",
-        );
+        )
+        .expect("metadata should fit");
 
         assert!(!metas[0].contains_key("categories"));
         assert!(!metas[0].contains_key("source_ids"));

--- a/rust/foundation-api/src/wiki/page.rs
+++ b/rust/foundation-api/src/wiki/page.rs
@@ -7,10 +7,6 @@ use chroma_types::{Metadata, MetadataValue, SparseVector};
 /// Slugs that are seeded system pages rather than content/category pages.
 const SYSTEM_SLUGS: [&str; 3] = ["", "meta", "categories"];
 
-/// Conservative target for one `source_ids` metadata value, leaving headroom
-/// below Chroma Cloud's 4 KiB limit.
-pub(crate) const MAX_SOURCE_IDS_VALUE_BYTES: usize = 3 * 1024;
-
 /// Failures while assigning page-level metadata to record chunks.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum PageMetadataError {
@@ -53,10 +49,12 @@ pub(crate) fn build_metadatas(
     version: i64,
     categories: &[String],
     source_ids: &[String],
+    max_source_ids_value_bytes: usize,
     author: Option<&str>,
     last_written_by: &str,
 ) -> Result<Vec<Metadata>, PageMetadataError> {
-    let source_ids_by_chunk = distribute_source_ids(source_ids, chunks.len())?;
+    let source_ids_by_chunk =
+        distribute_source_ids(source_ids, chunks.len(), max_source_ids_value_bytes)?;
     Ok(chunks
         .iter()
         .zip(sparse)
@@ -110,6 +108,7 @@ pub(crate) fn build_metadatas(
 fn distribute_source_ids(
     source_ids: &[String],
     num_chunks: usize,
+    max_value_bytes: usize,
 ) -> Result<Vec<Vec<String>>, PageMetadataError> {
     let mut distributed = Vec::new();
     let mut current_chunk = Vec::new();
@@ -117,13 +116,13 @@ fn distribute_source_ids(
 
     for source_id in source_ids {
         let source_id_bytes = source_id.len();
-        if source_id_bytes > MAX_SOURCE_IDS_VALUE_BYTES {
+        if source_id_bytes > max_value_bytes {
             return Err(PageMetadataError::SourceIdTooLarge {
                 bytes: source_id_bytes,
-                limit: MAX_SOURCE_IDS_VALUE_BYTES,
+                limit: max_value_bytes,
             });
         }
-        if !current_chunk.is_empty() && chunk_bytes + source_id_bytes > MAX_SOURCE_IDS_VALUE_BYTES {
+        if !current_chunk.is_empty() && chunk_bytes + source_id_bytes > max_value_bytes {
             distributed.push(current_chunk);
             current_chunk = Vec::new();
             chunk_bytes = 0;
@@ -176,6 +175,7 @@ pub(crate) fn meta_str_array(meta: &Metadata, key: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES;
     use crate::wiki::chunking::ChunkRecordId;
 
     fn chunk(chunk_id: usize, line_no: usize, text: &str) -> Chunk {
@@ -215,6 +215,7 @@ mod tests {
             3,
             &["a".to_string()],
             &["slack_master:abc".to_string()],
+            DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES,
             Some("Claude Sonnet 4.5"),
             "00000000-0000-0000-0000-000000000001",
         )
@@ -279,6 +280,7 @@ mod tests {
             3,
             &[],
             &source_ids,
+            DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES,
             None,
             "00000000-0000-0000-0000-000000000001",
         )
@@ -297,31 +299,36 @@ mod tests {
             vec![source_ids[..2].to_vec(), source_ids[2..].to_vec()]
         );
         assert!(distributed.iter().all(|values| {
-            values.iter().map(String::len).sum::<usize>() <= MAX_SOURCE_IDS_VALUE_BYTES
+            values.iter().map(String::len).sum::<usize>() <= DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES
         }));
         assert!(!metas[2].contains_key("source_ids"));
     }
 
     #[test]
     fn distribute_source_ids_rejects_an_individually_oversized_id() {
-        let oversized = "a".repeat(MAX_SOURCE_IDS_VALUE_BYTES + 1);
+        let oversized = "a".repeat(DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES + 1);
 
-        let err = distribute_source_ids(&[oversized], 2).expect_err("source ID should not fit");
+        let err = distribute_source_ids(&[oversized], 2, DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES)
+            .expect_err("source ID should not fit");
 
         assert_eq!(
             err,
             PageMetadataError::SourceIdTooLarge {
-                bytes: MAX_SOURCE_IDS_VALUE_BYTES + 1,
-                limit: MAX_SOURCE_IDS_VALUE_BYTES,
+                bytes: DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES + 1,
+                limit: DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES,
             }
         );
     }
 
     #[test]
     fn distribute_source_ids_rejects_too_few_chunks() {
-        let source_ids = vec!["a".repeat(MAX_SOURCE_IDS_VALUE_BYTES), "b".to_string()];
+        let source_ids = vec![
+            "a".repeat(DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES),
+            "b".to_string(),
+        ];
 
-        let err = distribute_source_ids(&source_ids, 1).expect_err("two chunks should be required");
+        let err = distribute_source_ids(&source_ids, 1, DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES)
+            .expect_err("two chunks should be required");
 
         assert_eq!(
             err,
@@ -346,6 +353,7 @@ mod tests {
             1,
             &[],
             &[],
+            DEFAULT_MAX_SOURCE_IDS_VALUE_BYTES,
             None,
             "00000000-0000-0000-0000-000000000001",
         )


### PR DESCRIPTION
## Description of changes

Page source IDs were stamped identically on every chunk, so a page
with many or large source IDs could push a single source_ids metadata
value past Chroma Cloud's per-value size limit and fail the upsert.

Pack source IDs greedily in input order across consecutive chunks,
keeping each source_ids value within a conservative 3 KiB target.
build_metadatas now returns PageMetadataError when a single source ID
is too large or the page has too few chunks to hold them all; upsert
maps this to ResourceExhausted.

On read, scalar metadata is still taken from the head chunk, but
array metadata (categories, source_ids) is unioned and deduplicated
across every chunk so distributed values reassemble correctly. A
wrong-typed value fails the read with DataLoss rather than silently
discarding undecodable metadata on a later full-page rewrite.

NOTE(rescrv):  Embedded within is an assumption that adding a source
will grow the number of chunks in a page.  This was empirically the case
with wiki gen.

## Test plan

CI

## Migration plan

Backwards compatible read, forwards compatible write.

## Observability plan

Existing.

## Documentation Changes

N/A

Co-authored-by: AI
