### PR TITLE
[ENH](wqs): Add manual unDLQ CLI command

### DIFF
--- a/rust/worker/src/bin/work_queue_cli.rs
+++ b/rust/worker/src/bin/work_queue_cli.rs
@@ -59,6 +59,17 @@ enum Commands {
         #[arg(short, long)]
         offset: i64,
     },
+
+    /// Reset a dead-lettered function's failure count so it can be processed again
+    Undlq {
+        /// Function ID (UUID format)
+        #[arg(short, long)]
+        function_id: String,
+
+        /// Collection ID (UUID format)
+        #[arg(short, long)]
+        collection_id: String,
+    },
 }
 
 #[tokio::main]
@@ -107,6 +118,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .finish_work(function_id, collection_id, offset)
                 .await?;
             println!("✓ Work marked as finished");
+        }
+
+        Commands::Undlq {
+            function_id,
+            collection_id,
+        } => {
+            client
+                .set_function_failure_count(function_id, collection_id, 0)
+                .await?;
+            println!("✓ Function removed from DLQ");
         }
     }
 


### PR DESCRIPTION
## Description of changes

This just adds the CLI command to hit the WQS's undlq endpoint

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
