### PR TITLE
[ENH](embeddings): Add OrcaRouter embedding function

### DIFF
--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -41,6 +41,7 @@ def test_get_builtins_holds() -> None:
         "JinaEmbeddingFunction",
         "MistralEmbeddingFunction",
         "MorphEmbeddingFunction",
+        "OrcaRouterEmbeddingFunction",
         "NomicEmbeddingFunction",
         "ONNXMiniLM_L6_V2",
         "OllamaEmbeddingFunction",

--- a/chromadb/test/ef/test_orcarouter_ef.py
+++ b/chromadb/test/ef/test_orcarouter_ef.py
@@ -1,0 +1,139 @@
+import os
+import pytest
+import numpy as np
+from chromadb.utils.embedding_functions.orcarouter_embedding_function import (
+    OrcaRouterEmbeddingFunction,
+)
+
+
+def test_orcarouter_embedding_function_with_api_key() -> None:
+    """Test OrcaRouter embedding function when API key is available."""
+    if os.environ.get("ORCAROUTER_API_KEY") is None:
+        pytest.skip("ORCAROUTER_API_KEY not set")
+
+    ef = OrcaRouterEmbeddingFunction(
+        model_name="openai/text-embedding-3-small"
+    )
+
+    # Test with plain text snippets
+    text_snippets = [
+        "OrcaRouter routes to 150+ models through one OpenAI-compatible endpoint.",
+        "Zero-trust security for AI agents on the same endpoint.",
+    ]
+
+    embeddings = ef(text_snippets)
+    assert embeddings is not None
+    assert len(embeddings) == 2
+    assert all(isinstance(emb, np.ndarray) for emb in embeddings)
+    assert all(len(emb) > 0 for emb in embeddings)
+
+
+def test_orcarouter_embedding_function_with_custom_parameters() -> None:
+    """Test OrcaRouter embedding function with custom parameters."""
+    if os.environ.get("ORCAROUTER_API_KEY") is None:
+        pytest.skip("ORCAROUTER_API_KEY not set")
+
+    ef = OrcaRouterEmbeddingFunction(
+        model_name="openai/text-embedding-3-small",
+        api_base="https://api.orcarouter.ai/v1",
+        encoding_format="float",
+        api_key_env_var="ORCAROUTER_API_KEY"
+    )
+
+    # Test with a simple snippet
+    text_snippet = ["OrcaRouter zero-trust gateway"]
+
+    embeddings = ef(text_snippet)
+    assert embeddings is not None
+    assert len(embeddings) == 1
+    assert isinstance(embeddings[0], np.ndarray)
+    assert len(embeddings[0]) > 0
+
+
+def test_orcarouter_embedding_function_config_roundtrip() -> None:
+    """Test that OrcaRouter embedding function configuration can be saved and restored."""
+    try:
+        import openai
+    except ImportError:
+        pytest.skip("openai package not installed")
+    if os.environ.get("ORCAROUTER_API_KEY") is None:
+        pytest.skip("ORCAROUTER_API_KEY not set")
+
+    ef = OrcaRouterEmbeddingFunction(
+        model_name="openai/text-embedding-3-small",
+        api_base="https://api.orcarouter.ai/v1",
+        encoding_format="float",
+        api_key_env_var="ORCAROUTER_API_KEY"
+    )
+
+    # Get configuration
+    config = ef.get_config()
+
+    # Verify configuration contains expected keys
+    assert "model_name" in config
+    assert "api_base" in config
+    assert "encoding_format" in config
+    assert "api_key_env_var" in config
+
+    # Verify values
+    assert config["model_name"] == "openai/text-embedding-3-small"
+    assert config["api_base"] == "https://api.orcarouter.ai/v1"
+    assert config["encoding_format"] == "float"
+    assert config["api_key_env_var"] == "ORCAROUTER_API_KEY"
+
+    # Test building from config
+    new_ef = OrcaRouterEmbeddingFunction.build_from_config(config)
+    new_config = new_ef.get_config()
+
+    # Configurations should match
+    assert config == new_config
+
+
+def test_orcarouter_embedding_function_name() -> None:
+    """Test that OrcaRouter embedding function returns correct name."""
+    assert OrcaRouterEmbeddingFunction.name() == "orcarouter"
+
+
+def test_orcarouter_embedding_function_spaces() -> None:
+    """Test that OrcaRouter embedding function supports expected spaces."""
+    try:
+        import openai
+    except ImportError:
+        pytest.skip("openai package not installed")
+    if os.environ.get("ORCAROUTER_API_KEY") is None:
+        pytest.skip("ORCAROUTER_API_KEY not set")
+
+    ef = OrcaRouterEmbeddingFunction(
+        model_name="openai/text-embedding-3-small",
+        api_key_env_var="ORCAROUTER_API_KEY"
+    )
+
+    # Test default space
+    assert ef.default_space() == "cosine"
+
+    # Test supported spaces
+    supported_spaces = ef.supported_spaces()
+    assert "cosine" in supported_spaces
+    assert "l2" in supported_spaces
+    assert "ip" in supported_spaces
+
+
+def test_orcarouter_embedding_function_validate_config() -> None:
+    """Test that OrcaRouter embedding function validates configuration correctly."""
+    # Valid configuration
+    valid_config = {
+        "model_name": "openai/text-embedding-3-small",
+        "api_key_env_var": "ORCAROUTER_API_KEY"
+    }
+
+    # This should not raise an exception
+    OrcaRouterEmbeddingFunction.validate_config(valid_config)
+
+    # Invalid configuration (missing required fields)
+    invalid_config = {
+        "model_name": "openai/text-embedding-3-small"
+        # Missing api_key_env_var
+    }
+
+    with pytest.raises(Exception):
+        OrcaRouterEmbeddingFunction.validate_config(invalid_config)

--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -427,6 +427,7 @@ class TestEmbeddingFunctionSchemas:
             "jina": "CHROMA_JINA_API_KEY",
             "mistral": "MISTRAL_API_KEY",
             "morph": "MORPH_API_KEY",
+            "orcarouter": "ORCAROUTER_API_KEY",
             "voyageai": "CHROMA_VOYAGE_API_KEY",
             "cloudflare_workers_ai": "CHROMA_CLOUDFLARE_API_KEY",
             "together_ai": "CHROMA_TOGETHER_AI_API_KEY",

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -73,6 +73,9 @@ from chromadb.utils.embedding_functions.mistral_embedding_function import (
 from chromadb.utils.embedding_functions.morph_embedding_function import (
     MorphEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.orcarouter_embedding_function import (
+    OrcaRouterEmbeddingFunction,
+)
 from chromadb.utils.embedding_functions.nomic_embedding_function import (
     NomicEmbeddingFunction,
     NomicQueryConfig,
@@ -117,6 +120,7 @@ _all_classes: Set[str] = {
     "JinaEmbeddingFunction",
     "MistralEmbeddingFunction",
     "MorphEmbeddingFunction",
+    "OrcaRouterEmbeddingFunction",
     "NomicEmbeddingFunction",
     "VoyageAIEmbeddingFunction",
     "ONNXMiniLM_L6_V2",
@@ -160,6 +164,7 @@ known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignor
     "jina": JinaEmbeddingFunction,
     "mistral": MistralEmbeddingFunction,
     "morph": MorphEmbeddingFunction,
+    "orcarouter": OrcaRouterEmbeddingFunction,
     "nomic": NomicEmbeddingFunction,
     "voyageai": VoyageAIEmbeddingFunction,
     "onnx_mini_lm_l6_v2": ONNXMiniLM_L6_V2,
@@ -288,6 +293,7 @@ __all__ = [
     "JinaQueryConfig",
     "MistralEmbeddingFunction",
     "MorphEmbeddingFunction",
+    "OrcaRouterEmbeddingFunction",
     "NomicEmbeddingFunction",
     "NomicQueryConfig",
     "VoyageAIEmbeddingFunction",

--- a/chromadb/utils/embedding_functions/orcarouter_embedding_function.py
+++ b/chromadb/utils/embedding_functions/orcarouter_embedding_function.py
@@ -1,0 +1,147 @@
+from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
+from typing import List, Dict, Any, Optional
+import os
+import numpy as np
+from chromadb.utils.embedding_functions.schemas import validate_config_schema
+import warnings
+
+
+class OrcaRouterEmbeddingFunction(EmbeddingFunction[Documents]):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model_name: str = "openai/text-embedding-3-small",
+        api_base: str = "https://api.orcarouter.ai/v1",
+        encoding_format: str = "float",
+        api_key_env_var: str = "ORCAROUTER_API_KEY",
+    ):
+        """
+        Initialize the OrcaRouterEmbeddingFunction.
+
+        Args:
+            api_key (str, optional): The API key for the OrcaRouter API. If not provided,
+                it will be read from the environment variable specified by api_key_env_var.
+            model_name (str, optional): The name of the model to use for embeddings.
+                Defaults to "openai/text-embedding-3-small".
+            api_base (str, optional): The base URL for the OrcaRouter API.
+                Defaults to "https://api.orcarouter.ai/v1".
+            encoding_format (str, optional): The format for embeddings (float or base64).
+                Defaults to "float".
+            api_key_env_var (str, optional): Environment variable name that contains your API key.
+                Defaults to "ORCAROUTER_API_KEY".
+        """
+        try:
+            import openai
+        except ImportError:
+            raise ValueError(
+                "The openai python package is not installed. Please install it with `pip install openai`. "
+                "Note: OrcaRouter uses the OpenAI client library for API communication."
+            )
+
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
+
+        self.api_key_env_var = api_key_env_var
+        self.api_key = api_key or os.getenv(api_key_env_var)
+        if not self.api_key:
+            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+
+        self.model_name = model_name
+        self.api_base = api_base
+        self.encoding_format = encoding_format
+
+        # Initialize the OpenAI client with OrcaRouter's base URL
+        self.client = openai.OpenAI(
+            api_key=self.api_key,
+            base_url=self.api_base,
+        )
+
+    def __call__(self, input: Documents) -> Embeddings:
+        """
+        Generate embeddings for the given documents.
+
+        Args:
+            input: Documents to generate embeddings for.
+
+        Returns:
+            Embeddings for the documents.
+        """
+        # Handle empty input
+        if not input:
+            return []
+
+        # Prepare embedding parameters
+        embedding_params: Dict[str, Any] = {
+            "model": self.model_name,
+            "input": input,
+            "encoding_format": self.encoding_format,
+        }
+
+        # Get embeddings from OrcaRouter API
+        response = self.client.embeddings.create(**embedding_params)
+
+        # Extract embeddings from response
+        return [np.array(data.embedding, dtype=np.float32) for data in response.data]
+
+    @staticmethod
+    def name() -> str:
+        return "orcarouter"
+
+    def default_space(self) -> Space:
+        # OrcaRouter embeddings work best with cosine similarity
+        return "cosine"
+
+    def supported_spaces(self) -> List[Space]:
+        return ["cosine", "l2", "ip"]
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+        # Extract parameters from config
+        api_key_env_var = config.get("api_key_env_var")
+        model_name = config.get("model_name")
+        api_base = config.get("api_base")
+        encoding_format = config.get("encoding_format")
+
+        if api_key_env_var is None or model_name is None:
+            assert False, "This code should not be reached"
+
+        # Create and return the embedding function
+        return OrcaRouterEmbeddingFunction(
+            api_key_env_var=api_key_env_var,
+            model_name=model_name,
+            api_base=api_base if api_base is not None else "https://api.orcarouter.ai/v1",
+            encoding_format=encoding_format if encoding_format is not None else "float",
+        )
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "api_key_env_var": self.api_key_env_var,
+            "model_name": self.model_name,
+            "api_base": self.api_base,
+            "encoding_format": self.encoding_format,
+        }
+
+    def validate_config_update(
+        self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+    ) -> None:
+        if "model_name" in new_config:
+            raise ValueError(
+                "The model name cannot be changed after the embedding function has been initialized."
+            )
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        """
+        Validate the configuration using the JSON schema.
+
+        Args:
+            config: Configuration to validate
+
+        Raises:
+            ValidationError: If the configuration does not match the schema
+        """
+        validate_config_schema(config, "orcarouter")

--- a/clients/new-js/packages/ai-embeddings/all/package.json
+++ b/clients/new-js/packages/ai-embeddings/all/package.json
@@ -44,6 +44,7 @@
     "@chroma-core/jina": "workspace:^",
     "@chroma-core/mistral": "workspace:^",
     "@chroma-core/morph": "workspace:^",
+    "@chroma-core/orcarouter": "workspace:^",
     "@chroma-core/ollama": "workspace:^",
     "@chroma-core/openai": "workspace:^",
     "@chroma-core/together-ai": "workspace:^",

--- a/clients/new-js/packages/ai-embeddings/all/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/all/src/index.ts
@@ -6,6 +6,7 @@ export * from "@chroma-core/huggingface-server";
 export * from "@chroma-core/jina";
 export * from "@chroma-core/mistral";
 export * from "@chroma-core/morph";
+export * from "@chroma-core/orcarouter";
 export * from "@chroma-core/ollama";
 export * from "@chroma-core/openai";
 export * from "@chroma-core/together-ai";

--- a/clients/new-js/packages/ai-embeddings/common/src/schema-utils.ts
+++ b/clients/new-js/packages/ai-embeddings/common/src/schema-utils.ts
@@ -25,6 +25,7 @@ import cloudflareWorkersAiSchema from "../../../../../../schemas/embedding_funct
 import togetherAiSchema from "../../../../../../schemas/embedding_functions/together_ai.json";
 import mistralSchema from "../../../../../../schemas/embedding_functions/mistral.json";
 import morphSchema from "../../../../../../schemas/embedding_functions/morph.json";
+import orcaRouterSchema from "../../../../../../schemas/embedding_functions/orcarouter.json";
 import chromaCloudQwenSchema from "../../../../../../schemas/embedding_functions/chroma-cloud-qwen.json";
 import chromaCloudSpladeSchema from "../../../../../../schemas/embedding_functions/chroma-cloud-splade.json";
 import chromaBm25Schema from "../../../../../../schemas/embedding_functions/chroma_bm25.json";
@@ -78,6 +79,7 @@ const schemaMap = {
 	"together-ai": togetherAiSchema as Schema,
 	mistral: mistralSchema as Schema,
 	morph: morphSchema as Schema,
+	orcarouter: orcaRouterSchema as Schema,
 	"chroma-cloud-qwen": chromaCloudQwenSchema as Schema,
 	"chroma-cloud-splade": chromaCloudSpladeSchema as Schema,
 	chroma_bm25: chromaBm25Schema as Schema,

--- a/clients/new-js/packages/ai-embeddings/orcarouter/README.md
+++ b/clients/new-js/packages/ai-embeddings/orcarouter/README.md
@@ -1,0 +1,69 @@
+# @chroma-core/orcarouter
+
+Chroma integration for [OrcaRouter](https://www.orcarouter.ai) embedding models.
+
+OrcaRouter is an OpenAI-compatible gateway that routes to 150+ frontier and
+open-weight models through one endpoint, and runs gateway-level, zero-trust
+security for AI agents on the same endpoint — screening every prompt/response
+and governing every tool call on a default-deny basis, with no application code
+changes.
+
+## Installation
+
+```bash
+npm install @chroma-core/orcarouter
+```
+
+## Usage
+
+```typescript
+import { OrcaRouterEmbeddingFunction } from '@chroma-core/orcarouter';
+
+// Initialize the embedding function
+const orcarouterEmbedding = new OrcaRouterEmbeddingFunction({
+  api_key: 'your-orcarouter-api-key', // or set ORCAROUTER_API_KEY env var
+  model_name: 'openai/text-embedding-3-small', // default
+  api_base: 'https://api.orcarouter.ai/v1', // default
+  encoding_format: 'float' // default
+});
+
+// Generate embeddings
+const texts = [
+  'OrcaRouter routes to 150+ models through a single OpenAI-compatible endpoint.',
+  'Zero-trust security for AI agents on the same endpoint.'
+];
+
+const embeddings = await orcarouterEmbedding.generate(texts);
+console.log(embeddings);
+```
+
+## Configuration
+
+The `OrcaRouterEmbeddingFunction` constructor accepts the following options:
+
+- `api_key` (optional): Your OrcaRouter API key. If not provided, it will read from the environment variable specified by `api_key_env_var`.
+- `model_name` (optional): The OrcaRouter embedding model to use. Defaults to `'openai/text-embedding-3-small'`.
+- `api_base` (optional): The base URL for the OrcaRouter API. Defaults to `'https://api.orcarouter.ai/v1'`.
+- `encoding_format` (optional): The format for embeddings ('float' or 'base64'). Defaults to `'float'`.
+- `api_key_env_var` (optional): The environment variable name for the API key. Defaults to `'ORCAROUTER_API_KEY'`.
+
+## Environment Variables
+
+Set your OrcaRouter API key as an environment variable:
+
+```bash
+export ORCAROUTER_API_KEY="your-orcarouter-api-key"
+```
+
+## Features
+
+- **Multi-Model Access**: One endpoint for 150+ frontier and open-weight models
+- **OpenAI-Compatible**: Uses the standard OpenAI SDK with OrcaRouter's API endpoint
+- **Zero-Trust Security**: Gateway-level screening of every prompt/response on a default-deny basis
+- **Batch Processing**: Supports multiple inputs in a single API call
+
+## API Reference
+
+For more information about OrcaRouter's embedding models and API, visit:
+- [OrcaRouter Embedding API Documentation](https://api.orcarouter.ai/v1)
+- [OrcaRouter Website](https://www.orcarouter.ai)

--- a/clients/new-js/packages/ai-embeddings/orcarouter/jest.config.ts
+++ b/clients/new-js/packages/ai-embeddings/orcarouter/jest.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+      },
+    ],
+  },
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  setupFiles: ["./jest.setup.ts"],
+};
+
+export default config;

--- a/clients/new-js/packages/ai-embeddings/orcarouter/jest.setup.ts
+++ b/clients/new-js/packages/ai-embeddings/orcarouter/jest.setup.ts
@@ -1,0 +1,3 @@
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: "../../../.env" });

--- a/clients/new-js/packages/ai-embeddings/orcarouter/package.json
+++ b/clients/new-js/packages/ai-embeddings/orcarouter/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@chroma-core/orcarouter",
+  "version": "0.1.0",
+  "private": false,
+  "description": "OrcaRouter embedding provider for Chroma",
+  "main": "dist/cjs/orcarouter.cjs",
+  "types": "dist/orcarouter.d.ts",
+  "module": "dist/orcarouter.legacy-esm.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/orcarouter.d.ts",
+        "default": "./dist/orcarouter.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/orcarouter.d.cts",
+        "default": "./dist/cjs/orcarouter.cjs"
+      }
+    }
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rimraf dist",
+    "prebuild": "rimraf dist",
+    "build": "tsup",
+    "watch": "tsup --watch",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "dotenv": "^16.3.1",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.0",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "tsup": "^8.3.5"
+  },
+  "peerDependencies": {
+    "chromadb": "workspace:^"
+  },
+  "dependencies": {
+    "@chroma-core/ai-embeddings-common": "workspace:^",
+    "openai": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/clients/new-js/packages/ai-embeddings/orcarouter/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/orcarouter/src/index.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { OrcaRouterEmbeddingFunction } from "./index";
+
+describe("OrcaRouterEmbeddingFunction", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const MODEL = "openai/text-embedding-3-small";
+
+  const defaultParametersTest = "should initialize with default parameters";
+  if (!process.env.ORCAROUTER_API_KEY) {
+    it.skip(defaultParametersTest, () => { });
+  } else {
+    it(defaultParametersTest, () => {
+      const embedder = new OrcaRouterEmbeddingFunction();
+      expect(embedder.name).toBe("orcarouter");
+
+      const config = embedder.getConfig();
+      expect(config.model_name).toBe(MODEL);
+      expect(config.api_key_env_var).toBe("ORCAROUTER_API_KEY");
+      expect(config.api_base).toBe("https://api.orcarouter.ai/v1");
+      expect(config.encoding_format).toBe("float");
+    });
+  }
+
+  const customParametersTest = "should initialize with custom parameters";
+  if (!process.env.ORCAROUTER_API_KEY) {
+    it.skip(customParametersTest, () => { });
+  } else {
+    it(customParametersTest, () => {
+      const embedder = new OrcaRouterEmbeddingFunction({
+        model_name: "custom-model",
+        api_base: "https://custom-api.com/v1",
+        encoding_format: "base64",
+        api_key_env_var: "ORCAROUTER_API_KEY",
+      });
+
+      const config = embedder.getConfig();
+      expect(config.model_name).toBe("custom-model");
+      expect(config.api_base).toBe("https://custom-api.com/v1");
+      expect(config.encoding_format).toBe("base64");
+      expect(config.api_key_env_var).toBe("ORCAROUTER_API_KEY");
+    });
+  }
+
+  it("should throw custom error for missing API key", () => {
+    const originalEnv = process.env.ORCAROUTER_API_KEY;
+    delete process.env.ORCAROUTER_API_KEY;
+
+    try {
+      expect(() => {
+        new OrcaRouterEmbeddingFunction();
+      }).toThrow("API key not found");
+    } finally {
+      if (originalEnv) {
+        process.env.ORCAROUTER_API_KEY = originalEnv;
+      }
+    }
+  });
+
+  it("should use custom API key environment variable", () => {
+    process.env.CUSTOM_ORCAROUTER_API_KEY = "test-api-key";
+
+    try {
+      const embedder = new OrcaRouterEmbeddingFunction({
+        api_key_env_var: "CUSTOM_ORCAROUTER_API_KEY",
+      });
+
+      expect(embedder.getConfig().api_key_env_var).toBe(
+        "CUSTOM_ORCAROUTER_API_KEY",
+      );
+    } finally {
+      delete process.env.CUSTOM_ORCAROUTER_API_KEY;
+    }
+  });
+
+  const buildFromConfigTest = "should build from config";
+  if (!process.env.ORCAROUTER_API_KEY) {
+    it.skip(buildFromConfigTest, () => { });
+  } else {
+    it(buildFromConfigTest, () => {
+      const config = {
+        api_key_env_var: "ORCAROUTER_API_KEY",
+        model_name: "config-model",
+        api_base: "https://config-api.com/v1",
+        encoding_format: "float" as const,
+      };
+
+      const embedder = OrcaRouterEmbeddingFunction.buildFromConfig(config);
+
+      expect(embedder.getConfig()).toEqual(config);
+    });
+  }
+
+  const generateEmbeddingsTest = "should generate embeddings";
+  if (!process.env.ORCAROUTER_API_KEY) {
+    it.skip(generateEmbeddingsTest, () => { });
+  } else {
+    it(generateEmbeddingsTest, async () => {
+      const embedder = new OrcaRouterEmbeddingFunction();
+      const texts = ["Hello world", "Test text"];
+      const embeddings = await embedder.generate(texts);
+
+      expect(embeddings.length).toBe(texts.length);
+
+      embeddings.forEach((embedding) => {
+        expect(embedding.length).toBeGreaterThan(0);
+      });
+
+      expect(embeddings[0]).not.toEqual(embeddings[1]);
+    });
+  }
+});

--- a/clients/new-js/packages/ai-embeddings/orcarouter/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/orcarouter/src/index.ts
@@ -1,0 +1,108 @@
+import {
+  ChromaValueError,
+  EmbeddingFunction,
+  EmbeddingFunctionSpace,
+  registerEmbeddingFunction,
+} from "chromadb";
+import { validateConfigSchema } from "@chroma-core/ai-embeddings-common";
+import OpenAI from "openai";
+
+const NAME = "orcarouter";
+
+export interface OrcaRouterConfig {
+  api_key_env_var: string;
+  model_name: string;
+  api_base?: string;
+  encoding_format?: 'float' | 'base64';
+}
+
+export interface OrcaRouterEmbeddingFunctionConfig {
+  api_key?: string;
+  model_name?: string;
+  api_base?: string;
+  encoding_format?: 'float' | 'base64';
+  api_key_env_var?: string;
+}
+
+export class OrcaRouterEmbeddingFunction implements EmbeddingFunction {
+  public readonly name = NAME;
+  private readonly apiKeyEnvVar: string;
+  private readonly modelName: string;
+  private readonly encodingFormat: 'float' | 'base64';
+  private readonly apiBase: string;
+  private client: OpenAI;
+
+  constructor(config: OrcaRouterEmbeddingFunctionConfig = {}) {
+    const {
+      api_key,
+      model_name = 'openai/text-embedding-3-small',
+      api_base = 'https://api.orcarouter.ai/v1',
+      encoding_format = 'float',
+      api_key_env_var = 'ORCAROUTER_API_KEY'
+    } = config;
+
+    // Get API key from config or environment
+    const apiKey = api_key || process.env[api_key_env_var];
+    if (!apiKey) {
+      throw new Error(`API key not found. Please set ${api_key_env_var} environment variable or provide api_key in config.`);
+    }
+
+    this.modelName = model_name;
+    this.encodingFormat = encoding_format;
+    this.apiKeyEnvVar = api_key_env_var;
+    this.apiBase = api_base;
+
+    this.client = new OpenAI({
+      apiKey,
+      baseURL: api_base,
+    });
+  }
+
+  public async generate(texts: string[]): Promise<number[][]> {
+    const response = await this.client.embeddings.create({
+      model: this.modelName,
+      input: texts,
+      encoding_format: this.encodingFormat,
+    });
+
+    return response.data.map(item => item.embedding);
+  }
+
+  public defaultSpace(): EmbeddingFunctionSpace {
+    return "cosine";
+  }
+
+  public supportedSpaces(): EmbeddingFunctionSpace[] {
+    return ["cosine", "l2", "ip"];
+  }
+
+  public static buildFromConfig(config: OrcaRouterConfig): OrcaRouterEmbeddingFunction {
+    return new OrcaRouterEmbeddingFunction({
+      model_name: config.model_name,
+      api_key_env_var: config.api_key_env_var,
+      api_base: config.api_base,
+      encoding_format: config.encoding_format,
+    });
+  }
+
+  public getConfig(): OrcaRouterConfig {
+    return {
+      api_key_env_var: this.apiKeyEnvVar,
+      model_name: this.modelName,
+      api_base: this.apiBase,
+      encoding_format: this.encodingFormat,
+    };
+  }
+
+  public validateConfigUpdate(newConfig: Record<string, any>): void {
+    if (this.getConfig().model_name !== newConfig.model_name) {
+      throw new ChromaValueError("Model name cannot be updated");
+    }
+  }
+
+  public static validateConfig(config: OrcaRouterConfig): void {
+    validateConfigSchema(config, NAME);
+  }
+}
+
+registerEmbeddingFunction(NAME, OrcaRouterEmbeddingFunction);

--- a/clients/new-js/packages/ai-embeddings/orcarouter/tsconfig.json
+++ b/clients/new-js/packages/ai-embeddings/orcarouter/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./src",
+    "stripInternal": true,
+    "composite": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test",
+    "**/*.test.ts"
+  ],
+  "references": [
+    {
+      "path": "../common"
+    },
+    {
+      "path": "../../chromadb"
+    }
+  ]
+}

--- a/clients/new-js/packages/ai-embeddings/orcarouter/tsup.config.ts
+++ b/clients/new-js/packages/ai-embeddings/orcarouter/tsup.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, Options } from "tsup";
+import * as fs from "fs";
+
+export default defineConfig((options: Options) => {
+  const commonOptions: Partial<Options> = {
+    entry: {
+      orcarouter: "src/index.ts",
+    },
+    sourcemap: true,
+    dts: {
+      compilerOptions: {
+        composite: false,
+        declaration: true,
+        emitDeclarationOnly: false,
+      },
+    },
+    ...options,
+  };
+
+  return [
+    {
+      ...commonOptions,
+      format: ["esm"],
+      outExtension: () => ({ js: ".mjs" }),
+      clean: true,
+      async onSuccess() {
+        // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
+        fs.copyFileSync("dist/orcarouter.mjs", "dist/orcarouter.legacy-esm.js");
+      },
+    },
+    {
+      ...commonOptions,
+      format: "cjs",
+      outDir: "./dist/cjs/",
+      outExtension: () => ({ js: ".cjs" }),
+    },
+  ];
+});

--- a/clients/new-js/pnpm-lock.yaml
+++ b/clients/new-js/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@chroma-core/morph':
         specifier: workspace:^
         version: link:../morph
+      '@chroma-core/orcarouter':
+        specifier: workspace:^
+        version: link:../orcarouter
       '@chroma-core/ollama':
         specifier: workspace:^
         version: link:../ollama
@@ -424,6 +427,40 @@ importers:
         version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
 
   packages/ai-embeddings/morph:
+    dependencies:
+      '@chroma-core/ai-embeddings-common':
+        specifier: workspace:^
+        version: link:../common
+      chromadb:
+        specifier: workspace:^
+        version: link:../../chromadb
+      openai:
+        specifier: ^4.0.0
+        version: 4.102.0(ws@8.18.2)(zod@3.24.4)
+    devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.5.0
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3))
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.46)(typescript@5.8.3)
+      tsup:
+        specifier: ^8.3.5
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+
+  packages/ai-embeddings/orcarouter:
     dependencies:
       '@chroma-core/ai-embeddings-common':
         specifier: workspace:^

--- a/docs/mintlify/docs.json
+++ b/docs/mintlify/docs.json
@@ -213,6 +213,7 @@
               "integrations/embedding-models/jina-ai",
               "integrations/embedding-models/mistral",
               "integrations/embedding-models/morph",
+              "integrations/embedding-models/orcarouter",
               "integrations/embedding-models/nomic",
               "integrations/embedding-models/ollama",
               "integrations/embedding-models/open-clip",

--- a/docs/mintlify/docs/embeddings/embedding-functions.mdx
+++ b/docs/mintlify/docs/embeddings/embedding-functions.mdx
@@ -264,6 +264,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [Jina AI](../../integrations/embedding-models/jina-ai)                                   | ✓      | ✓          |
 | [Mistral](../../integrations/embedding-models/mistral)                                   | ✓      | ✓          |
 | [Morph](../../integrations/embedding-models/morph)                                       | ✓      | ✓          |
+| [OrcaRouter](../../integrations/embedding-models/orcarouter)                             | ✓      | ✓          |
 | [OpenAI](../../integrations/embedding-models/openai)                                     | ✓      | ✓          |
 | [Sentence Transformers](../../integrations/embedding-models/sentence-transformer)        | ✓      | ✓          |
 | [Together AI](../../integrations/embedding-models/together-ai)                           | ✓      | ✓          |
@@ -281,6 +282,7 @@ For TypeScript users, Chroma provides packages for a number of embedding model p
 | Jina                        | [@chroma-core/jina](https://www.npmjs.com/package/@chroma-core/jina)
 | Mistral                     | [@chroma-core/mistral](https://www.npmjs.com/package/@chroma-core/mistral)
 | Morph                       | [@chroma-core/morph](https://www.npmjs.com/package/@chroma-core/morph)
+| OrcaRouter                  | [@chroma-core/orcarouter](https://www.npmjs.com/package/@chroma-core/orcarouter)
 | Ollama                      | [@chroma-core/ollama](https://www.npmjs.com/package/@chroma-core/ollama)
 | OpenAI                      | [@chroma-core/openai](https://www.npmjs.com/package/@chroma-core/openai)
 | Perplexity                  | [@chroma-core/perplexity](https://www.npmjs.com/package/@chroma-core/perplexity)

--- a/docs/mintlify/integrations/chroma-integrations.mdx
+++ b/docs/mintlify/integrations/chroma-integrations.mdx
@@ -25,6 +25,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [Together AI](/integrations/embedding-models/together-ai) | <Icon icon="check" /> | <Icon icon="check" /> |
 | [Mistral](/integrations/embedding-models/mistral) | <Icon icon="check" /> | <Icon icon="check" /> |
 | [Morph](/integrations/embedding-models/morph) | <Icon icon="check" /> | <Icon icon="check" /> |
+| [OrcaRouter](/integrations/embedding-models/orcarouter) | <Icon icon="check" /> | <Icon icon="check" /> |
 
 
 ### Framework Integrations

--- a/docs/mintlify/integrations/embedding-models/orcarouter.mdx
+++ b/docs/mintlify/integrations/embedding-models/orcarouter.mdx
@@ -1,0 +1,59 @@
+---
+title: OrcaRouter
+---
+
+Chroma provides a convenient wrapper around [OrcaRouter](https://www.orcarouter.ai)'s OpenAI-compatible embedding API. This embedding function runs remotely on OrcaRouter's servers and requires an API key. You can get an API key by signing up for an account at [orcarouter.ai](https://www.orcarouter.ai).
+
+OrcaRouter is an OpenAI-compatible gateway that routes to 150+ frontier and open-weight models through a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+<Tabs>
+
+<Tab title="Python" icon="python">
+
+This embedding function relies on the `openai` python package, which you can install with `pip install openai`.
+
+```python
+import chromadb.utils.embedding_functions as embedding_functions
+orcarouter_ef = embedding_functions.OrcaRouterEmbeddingFunction(
+    api_key="YOUR_API_KEY",  # or set ORCAROUTER_API_KEY environment variable
+    model_name="openai/text-embedding-3-small"
+)
+orcarouter_ef(input=["OrcaRouter routes to 150+ models through one endpoint.", "Zero-trust security for AI agents."])
+```
+
+</Tab>
+
+<Tab title="TypeScript" icon="js">
+
+```typescript
+// npm install @chroma-core/orcarouter
+
+import { OrcaRouterEmbeddingFunction } from "@chroma-core/orcarouter";
+
+const embedder = new OrcaRouterEmbeddingFunction({
+    api_key: "apiKey", // or set ORCAROUTER_API_KEY environment variable
+    model_name: "openai/text-embedding-3-small",
+});
+
+// use directly
+const embeddings = await embedder.generate([
+    "OrcaRouter routes to 150+ models through one endpoint.",
+    "Zero-trust security for AI agents.",
+]);
+
+// pass documents to the .add and .query methods
+const collection = await client.createCollection({
+    name: "name",
+    embeddingFunction: embedder,
+});
+const collectionGet = await client.getCollection({
+    name: "name",
+    embeddingFunction: embedder,
+});
+```
+
+</Tab>
+
+</Tabs>
+
+For further details on OrcaRouter's models check the [model catalog](https://www.orcarouter.ai/models).

--- a/schemas/embedding_functions/orcarouter.json
+++ b/schemas/embedding_functions/orcarouter.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "OrcaRouter Embedding Function Schema",
+    "description": "Schema for the OrcaRouter embedding function configuration",
+    "version": "1.0.0",
+    "type": "object",
+    "properties": {
+        "model_name": {
+            "type": "string",
+            "description": "The name of the model to use for embeddings"
+        },
+        "api_key_env_var": {
+            "type": "string",
+            "description": "Environment variable name that contains your API key for the OrcaRouter API"
+        },
+        "api_base": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The base URL for the OrcaRouter API"
+        },
+        "encoding_format": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The format for embeddings (float or base64)"
+        }
+    },
+    "required": [
+        "api_key_env_var",
+        "model_name"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
## Description of changes

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class, named embedding provider for Chroma, mirroring the existing Morph OpenAI-compatible wiring.

- New functionality
  - **Python**: `OrcaRouterEmbeddingFunction` pointing at `https://api.orcarouter.ai/v1`, reads `ORCAROUTER_API_KEY` (or a custom `api_key_env_var`), defaults to the `openai/text-embedding-3-small` model. Registered in `known_embedding_functions` and exported from `chromadb.utils.embedding_functions`.
  - **Schema**: `schemas/embedding_functions/orcarouter.json` (same shape as `morph.json`), wired into the shared schema registry used by both Python and the JS client.
  - **JS**: new `@chroma-core/orcarouter` package using the OpenAI SDK against OrcaRouter's `/v1` base URL, exported from `@chroma-core/all` and registered in `@chroma-core/ai-embeddings-common`.
  - **Docs**: new `integrations/embedding-models/orcarouter.mdx` page plus provider-table rows in `embedding-functions.mdx`, `chroma-integrations.mdx`, and `docs.json`.
  - **Tests**: Python `chromadb/test/ef/test_orcarouter_ef.py`, schema env-var mapping + builtins list entries, and a JS jest suite.

OrcaRouter is an OpenAI-compatible gateway that routes to 150+ frontier and open-weight models through one endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Disclosure: I'm an engineer on the OrcaRouter team.

## Test plan

- [x] Python: `pytest chromadb/test/ef/test_orcarouter_ef.py chromadb/test/ef/test_ef.py chromadb/test/utils/test_embedding_function_schemas.py` — 78 passed, 9 skipped (pre-existing), 0 failed
- [x] JS: `pnpm --filter @chroma-core/orcarouter test` — 6 passed; `pnpm -r build` all packages green; `tsc --noEmit` clean on the new and `all` packages
- [x] Live: called `OrcaRouterEmbeddingFunction` with a real key against `https://api.orcarouter.ai/v1/embeddings` (`openai/text-embedding-3-small`) — HTTP 200, two 1536-dim float32 vectors
- [x] `config_to_embedding_function({"name": "orcarouter", ...})` dispatches to `OrcaRouterEmbeddingFunction`

## Migration plan

No migrations or compatibility changes. The new provider is additive; the shared schema registry remains backward compatible.

## Observability plan

No new instrumentation. The provider reuses the OpenAI SDK's standard error handling and returns per-request embeddings.

## Documentation Changes

Updated docs in `docs/mintlify` (integration page + provider tables). No docstrings for existing APIs were modified.
