### PR TITLE
[BUG](huggingface): Use Hugging Face InferenceClient for embeddings

### DIFF
--- a/chromadb/test/ef/test_huggingface_embedding_function.py
+++ b/chromadb/test/ef/test_huggingface_embedding_function.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+import numpy as np
+from chromadb.utils.embedding_functions import HuggingFaceEmbeddingFunction
+from typing import cast
+
+
+def test_huggingface_embedding_functino() -> None:
+    model_name = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+    api_key = "test-api-key"
+
+    with patch("huggingface_hub.InferenceClient") as mock_client:
+        mock_client_instance = MagicMock()
+        mock_client.return_value = mock_client_instance
+
+        mock_client_instance.feature_extraction.return_value = [
+            [0.1, 0.2, 0.3],
+            [0.4, 0.5, 0.6],
+        ]
+
+        ef = HuggingFaceEmbeddingFunction(
+            api_key=api_key,
+            model_name=model_name,
+        )
+
+        result = ef(["hello", "world"])
+
+        mock_client.assert_called_once_with(
+            provider="hf-inference",
+            api_key=api_key,
+        )
+
+        mock_client_instance.feature_extraction.assert_called_once_with(
+            ["hello", "world"],
+            model=model_name,
+        )
+
+        assert len(result) == 2
+
+        for embedding in result:
+            embedding_array = cast(np.ndarray, embedding)
+            assert isinstance(embedding_array, np.ndarray)
+            assert embedding_array.dtype == np.float32
+
+        np.testing.assert_array_equal(
+            result[0],
+            np.array([0.1, 0.2, 0.3], dtype=np.float32),
+        )
+
+        np.testing.assert_array_equal(
+            result[1],
+            np.array([0.4, 0.5, 0.6], dtype=np.float32),
+        )
+
+
+def test_huggingface_embedding_function_requires_huggingface_hub() -> None:
+    with patch.dict("sys.modules", {"huggingface_hub": None}):
+        try:
+            HuggingFaceEmbeddingFunction(
+                api_key="test-api-key",
+            )
+        except ValueError as e:
+            assert "huggingface_hub" in str(e)
+        else:
+            raise AssertionError("Expected ValueError")

--- a/chromadb/utils/embedding_functions/huggingface_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_embedding_function.py
@@ -28,10 +28,10 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
                 Defaults to "sentence-transformers/all-MiniLM-L6-v2".
         """
         try:
-            import httpx
+            from huggingface_hub import InferenceClient
         except ImportError:
             raise ValueError(
-                "The httpx python package is not installed. Please install it with `pip install httpx`"
+                "The huggingface_hub python package is not installed. Please install it with `pip install huggingface_hub`"
             )
 
         if api_key is not None:
@@ -53,9 +53,10 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
 
         self.model_name = model_name
 
-        self._api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{model_name}"
-        self._session = httpx.Client()
-        self._session.headers.update({"Authorization": f"Bearer {self.api_key}"})
+        self._client = InferenceClient(
+            provider="hf-inference",
+            api_key=self.api_key,
+        )
 
     def __call__(self, input: Documents) -> Embeddings:
         """
@@ -72,14 +73,13 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
             >>> texts = ["Hello, world!", "How are you?"]
             >>> embeddings = hugging_face(texts)
         """
-        # Call HuggingFace Embedding API for each document
-        response = self._session.post(
-            self._api_url,
-            json={"inputs": input, "options": {"wait_for_model": True}},
-        ).json()
+        result = self._client.feature_extraction(
+            list(input),
+            model=self.model_name,
+        )
 
         # Convert to numpy arrays
-        return [np.array(embedding, dtype=np.float32) for embedding in response]
+        return [np.array(embedding, dtype=np.float32) for embedding in result]
 
     @staticmethod
     def name() -> str:


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Replace the legacy Hugging Face inference endpoint with `huggingface_hub.InferenceClient`.
  - Use the `hf-inference` provider for remote feature extraction.
  - Preserve the existing `np.ndarray` / `np.float32` embedding output.
  - Add tests covering Hugging Face inference client initialization, inference calls, embedding output, and missing dependency handling.
- New functionality
  - None.

## Test plan

- [x] Focused Hugging Face embedding function tests pass locally with `pytest`.
- [x] Functional Hugging Face inference test passes against the remote Hugging Face inference service.
- [x] `pre-commit` passes for the changed files.
- [x] `mypy` passes for the changed files.
- [ ] Full Python test suite.

## Migration plan

No migration is required.

This change is backwards compatible with the existing `HuggingFaceEmbeddingFunction` interface and preserves the existing embedding output format (`np.ndarray` with `np.float32` dtype).

The change only replaces the underlying Hugging Face inference client used to generate embeddings.

## Observability plan

No additional observability changes are required.

The existing error handling and Hugging Face client behavior provide sufficient visibility for this change. No new metrics, logs, or tracing are necessary.

## Documentation Changes

No documentation changes are required.

The user-facing `HuggingFaceEmbeddingFunction` API remains unchanged, and the existing docstrings remain applicable.
