### PR TITLE
[BUG](api): Preserve SPANN create fields

### DIFF
--- a/chromadb/api/collection_configuration.py
+++ b/chromadb/api/collection_configuration.py
@@ -251,6 +251,12 @@ def json_to_create_spann_configuration(
         config["ef_search"] = json_map["ef_search"]
     if "max_neighbors" in json_map:
         config["max_neighbors"] = json_map["max_neighbors"]
+    if "reassign_neighbor_count" in json_map:
+        config["reassign_neighbor_count"] = json_map["reassign_neighbor_count"]
+    if "split_threshold" in json_map:
+        config["split_threshold"] = json_map["split_threshold"]
+    if "merge_threshold" in json_map:
+        config["merge_threshold"] = json_map["merge_threshold"]
     return config
 
 

--- a/chromadb/test/configurations/test_collection_configuration.py
+++ b/chromadb/test/configurations/test_collection_configuration.py
@@ -13,6 +13,7 @@ from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
     UpdateCollectionConfiguration,
     load_collection_configuration_from_json,
+    load_create_collection_configuration_from_json,
     CreateHNSWConfiguration,
     UpdateHNSWConfiguration,
     CreateSpannConfiguration,
@@ -26,6 +27,24 @@ from chromadb.test.conftest import ClientFactories
 from chromadb.test.conftest import is_spann_disabled_mode, skip_reason_spann_disabled
 from chromadb.types import Collection as CollectionModel
 from typing import Optional, TypedDict
+
+
+def test_load_create_spann_configuration_preserves_supported_fields() -> None:
+    spann_config: CreateSpannConfiguration = {
+        "search_nprobe": 10,
+        "write_nprobe": 11,
+        "space": "cosine",
+        "ef_construction": 100,
+        "ef_search": 101,
+        "max_neighbors": 64,
+        "reassign_neighbor_count": 32,
+        "split_threshold": 100,
+        "merge_threshold": 50,
+    }
+
+    loaded = load_create_collection_configuration_from_json({"spann": spann_config})
+
+    assert loaded["spann"] == spann_config
 
 
 class LegacyEmbeddingFunction(EmbeddingFunction[Embeddable]):


### PR DESCRIPTION
### Summary

- preserve reassign_neighbor_count, split_threshold, and merge_threshold when loading a create SPANN configuration from JSON
- add a regression test that round-trips every supported create SPANN field

### Testing

- PYTHONPATH=/private/tmp/chroma-audit-deps python3 -m pytest -q -p no:cacheprovider chromadb/test/configurations/test_collection_configuration.py::test_load_create_spann_configuration_preserves_supported_fields chromadb/test/configurations/test_collection_configuration.py::test_overwrite_spann_configuration chromadb/test/configurations/test_collection_configuration.py::test_invalid_configuration
- Black 23.3 check on both changed files
- Flake8 7.0 with the repository configuration on both changed files