### PR TITLE
[ENH](compactor): Recover crashed compactions

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -1,4 +1,4 @@
-use super::ongoing_compactions::OngoingCompactions;
+use super::ongoing_jobs::OngoingJobs;
 use super::scheduler::Scheduler;
 use super::scheduler_policy::LasCompactionTimeSchedulerPolicy;
 use super::RebuildMessage;
@@ -128,8 +128,8 @@ pub(crate) enum CompactionError {
     FailedToCompact,
     #[error("Invalid collection UUID in config: {0}")]
     InvalidCollectionUuid(String),
-    #[error("Failed to initialize ongoing compaction state: {0}")]
-    OngoingCompactionState(#[source] std::io::Error),
+    #[error("Failed to initialize ongoing job state: {0}")]
+    OngoingJobState(#[source] std::io::Error),
 }
 
 impl ChromaError for CompactionError {
@@ -137,7 +137,7 @@ impl ChromaError for CompactionError {
         match self {
             CompactionError::FailedToCompact => ErrorCodes::Internal,
             CompactionError::InvalidCollectionUuid(_) => ErrorCodes::InvalidArgument,
-            CompactionError::OngoingCompactionState(_) => ErrorCodes::Internal,
+            CompactionError::OngoingJobState(_) => ErrorCodes::Internal,
         }
     }
 }
@@ -623,11 +623,10 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
                 .await?;
         let job_expiry_seconds = config.compactor.job_expiry_seconds;
         let max_failure_count = config.compactor.max_failure_count;
-        let ongoing_compactions =
-            OngoingCompactions::for_member(&config.compactor.compaction_state_directory, &my_ip)
-                .map_err(|error| {
-                    Box::new(CompactionError::OngoingCompactionState(error)) as Box<dyn ChromaError>
-                })?;
+        let ongoing_jobs =
+            OngoingJobs::for_member(&config.compactor.compaction_state_directory, &my_ip).map_err(
+                |error| Box::new(CompactionError::OngoingJobState(error)) as Box<dyn ChromaError>,
+            )?;
         let scheduler = Scheduler::new(
             my_ip,
             log.clone(),
@@ -637,7 +636,7 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
             min_compaction_size,
             assignment_policy,
             disabled_collections,
-            ongoing_compactions,
+            ongoing_jobs,
             job_expiry_seconds,
             max_failure_count,
         );
@@ -1296,8 +1295,8 @@ mod tests {
         assignment_policy.set_members(vec![my_member.member_id.clone()]);
 
         let state_directory = tempfile::tempdir().unwrap();
-        let ongoing_compactions =
-            OngoingCompactions::for_member(state_directory.path(), &my_member.member_id).unwrap();
+        let ongoing_jobs =
+            OngoingJobs::for_member(state_directory.path(), &my_member.member_id).unwrap();
 
         let mut scheduler = Scheduler::new(
             my_member.member_id.clone(),
@@ -1308,7 +1307,7 @@ mod tests {
             min_compaction_size,
             assignment_policy,
             HashSet::new(),
-            ongoing_compactions,
+            ongoing_jobs,
             job_expiry_seconds,
             max_failure_count,
         );

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -1,3 +1,4 @@
+use super::ongoing_compactions::OngoingCompactions;
 use super::scheduler::Scheduler;
 use super::scheduler_policy::LasCompactionTimeSchedulerPolicy;
 use super::RebuildMessage;
@@ -127,6 +128,8 @@ pub(crate) enum CompactionError {
     FailedToCompact,
     #[error("Invalid collection UUID in config: {0}")]
     InvalidCollectionUuid(String),
+    #[error("Failed to initialize ongoing compaction state: {0}")]
+    OngoingCompactionState(#[source] std::io::Error),
 }
 
 impl ChromaError for CompactionError {
@@ -134,6 +137,7 @@ impl ChromaError for CompactionError {
         match self {
             CompactionError::FailedToCompact => ErrorCodes::Internal,
             CompactionError::InvalidCollectionUuid(_) => ErrorCodes::InvalidArgument,
+            CompactionError::OngoingCompactionState(_) => ErrorCodes::Internal,
         }
     }
 }
@@ -219,7 +223,7 @@ impl CompactionManager {
     #[instrument(name = "CompactionManager::start_compaction_batch", skip(self))]
     async fn start_compaction_batch(&mut self) {
         self.process_completions().await;
-        let compact_awaiter_channel = &self.compact_awaiter_channel;
+        let compact_awaiter_channel = self.compact_awaiter_channel.clone();
         self.scheduler.schedule().await;
 
         let jobs: Vec<_> = self.scheduler.get_jobs().cloned().collect();
@@ -254,6 +258,8 @@ impl CompactionManager {
                     error = ?e,
                     "Failed to send start scheduled compaction task"
                 );
+                self.scheduler
+                    .release_job_without_penalty(job.collection_id.into());
             }
         }
     }
@@ -617,6 +623,11 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
                 .await?;
         let job_expiry_seconds = config.compactor.job_expiry_seconds;
         let max_failure_count = config.compactor.max_failure_count;
+        let ongoing_compactions =
+            OngoingCompactions::for_member(&config.compactor.compaction_state_directory, &my_ip)
+                .map_err(|error| {
+                    Box::new(CompactionError::OngoingCompactionState(error)) as Box<dyn ChromaError>
+                })?;
         let scheduler = Scheduler::new(
             my_ip,
             log.clone(),
@@ -626,6 +637,7 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
             min_compaction_size,
             assignment_policy,
             disabled_collections,
+            ongoing_compactions,
             job_expiry_seconds,
             max_failure_count,
         );
@@ -839,6 +851,7 @@ impl Component for CompactionManager {
 
     async fn on_start(&mut self, ctx: &ComponentContext<Self>) -> () {
         tracing::info!("Starting CompactionManager");
+        self.scheduler.recover_crashed_jobs().await;
         ctx.scheduler.schedule(
             ScheduledCompactMessage {},
             self.context.compaction_interval,
@@ -1282,6 +1295,10 @@ mod tests {
         let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
         assignment_policy.set_members(vec![my_member.member_id.clone()]);
 
+        let state_directory = tempfile::tempdir().unwrap();
+        let ongoing_compactions =
+            OngoingCompactions::for_member(state_directory.path(), &my_member.member_id).unwrap();
+
         let mut scheduler = Scheduler::new(
             my_member.member_id.clone(),
             log.clone(),
@@ -1291,6 +1308,7 @@ mod tests {
             min_compaction_size,
             assignment_policy,
             HashSet::new(),
+            ongoing_compactions,
             job_expiry_seconds,
             max_failure_count,
         );

--- a/rust/worker/src/compactor/config.rs
+++ b/rust/worker/src/compactor/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TaskRunnerConfig {
@@ -115,6 +116,10 @@ pub struct CompactorConfig {
     #[serde(default = "CompactorConfig::default_max_failure_count")]
     pub max_failure_count: i32,
 
+    /// Node-local directory containing one crash-recovery state file per compactor member.
+    #[serde(default = "CompactorConfig::default_compaction_state_directory")]
+    pub compaction_state_directory: PathBuf,
+
     /// When true, use pointer-based fetch (ScoutLogFragments + direct storage reads)
     /// instead of gRPC PullLogs for log fetching.
     #[serde(default)]
@@ -197,6 +202,10 @@ impl CompactorConfig {
         5
     }
 
+    fn default_compaction_state_directory() -> PathBuf {
+        PathBuf::from("/cache/compaction-state")
+    }
+
     fn default_use_fragment_fetch() -> bool {
         false
     }
@@ -225,6 +234,7 @@ impl Default for CompactorConfig {
             repair_log_offsets_timeout_seconds:
                 CompactorConfig::default_repair_log_offsets_timeout_seconds(),
             max_failure_count: CompactorConfig::default_max_failure_count(),
+            compaction_state_directory: CompactorConfig::default_compaction_state_directory(),
             use_fragment_fetch: CompactorConfig::default_use_fragment_fetch(),
             collections_for_fragment_fetch: Vec::new(),
             fragment_fetcher_cache: chroma_cache::CacheConfig::default(),

--- a/rust/worker/src/compactor/mod.rs
+++ b/rust/worker/src/compactor/mod.rs
@@ -1,6 +1,6 @@
 mod compaction_manager;
 pub(crate) mod config;
-mod ongoing_compactions;
+mod ongoing_jobs;
 mod scheduler;
 mod scheduler_policy;
 mod types;

--- a/rust/worker/src/compactor/mod.rs
+++ b/rust/worker/src/compactor/mod.rs
@@ -1,5 +1,6 @@
 mod compaction_manager;
 pub(crate) mod config;
+mod ongoing_compactions;
 mod scheduler;
 mod scheduler_policy;
 mod types;

--- a/rust/worker/src/compactor/ongoing_compactions.rs
+++ b/rust/worker/src/compactor/ongoing_compactions.rs
@@ -1,0 +1,243 @@
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use chroma_types::CollectionUuid;
+use uuid::Uuid;
+
+/// Persists the collections whose compactions may be interrupted by a process crash.
+#[derive(Debug)]
+pub(crate) struct OngoingCompactions {
+    path: PathBuf,
+    collection_ids: HashSet<CollectionUuid>,
+}
+
+impl OngoingCompactions {
+    /// Opens the state file assigned to one compactor member.
+    ///
+    /// The member ID becomes the file name beneath `directory`, which keeps
+    /// multiple compactor pods using the same node-local volume isolated.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the member ID cannot safely form a file name or the
+    /// state file cannot be read or created. Malformed lines are discarded so
+    /// local state corruption cannot put the compactor into a crash loop.
+    pub(crate) fn for_member(directory: &Path, member_id: &str) -> io::Result<Self> {
+        if member_id.is_empty()
+            || !member_id
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid compactor member ID for state file: {member_id:?}"),
+            ));
+        }
+
+        Self::load(directory.join(format!("{member_id}.txt")))
+    }
+
+    /// Loads a state file, creating an empty one when it does not yet exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file cannot be read or created. Malformed lines
+    /// are discarded while valid collection UUIDs remain recoverable.
+    pub(crate) fn load(path: PathBuf) -> io::Result<Self> {
+        let collection_ids = match fs::read_to_string(&path) {
+            Ok(contents) => {
+                let mut collection_ids = HashSet::new();
+                for (line_number, line) in contents.lines().enumerate() {
+                    let line = line.trim();
+                    if line.is_empty() {
+                        continue;
+                    }
+                    match Uuid::parse_str(line) {
+                        Ok(collection_id) => {
+                            collection_ids.insert(CollectionUuid(collection_id));
+                        }
+                        Err(error) => {
+                            tracing::error!(
+                                path = %path.display(),
+                                line_number = line_number + 1,
+                                line,
+                                error = ?error,
+                                "Discarding malformed ongoing-compaction state",
+                            );
+                        }
+                    }
+                }
+                collection_ids
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => HashSet::new(),
+            Err(error) => return Err(error),
+        };
+
+        let state = Self {
+            path,
+            collection_ids,
+        };
+        state.persist(&state.collection_ids)?;
+        Ok(state)
+    }
+
+    pub(crate) fn collection_ids(&self) -> impl Iterator<Item = CollectionUuid> + '_ {
+        self.collection_ids.iter().copied()
+    }
+
+    /// Records a collection before its compaction can begin.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the updated state cannot be durably replaced. The
+    /// in-memory state remains unchanged when persistence fails.
+    pub(crate) fn insert(&mut self, collection_id: CollectionUuid) -> io::Result<bool> {
+        if self.collection_ids.contains(&collection_id) {
+            return Ok(false);
+        }
+
+        let mut next = self.collection_ids.clone();
+        next.insert(collection_id);
+        self.replace(next)
+    }
+
+    /// Removes a collection after its compaction reaches a terminal state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the updated state cannot be durably replaced. The
+    /// in-memory state remains unchanged when persistence fails.
+    pub(crate) fn remove(&mut self, collection_id: CollectionUuid) -> io::Result<bool> {
+        if !self.collection_ids.contains(&collection_id) {
+            return Ok(false);
+        }
+
+        let mut next = self.collection_ids.clone();
+        next.remove(&collection_id);
+        self.replace(next)
+    }
+
+    fn replace(&mut self, next: HashSet<CollectionUuid>) -> io::Result<bool> {
+        self.persist(&next)?;
+        self.collection_ids = next;
+        Ok(true)
+    }
+
+    fn persist(&self, collection_ids: &HashSet<CollectionUuid>) -> io::Result<()> {
+        let parent = self.path.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("state file has no parent: {}", self.path.display()),
+            )
+        })?;
+        fs::create_dir_all(parent)?;
+
+        let file_name = self.path.file_name().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("state file has no file name: {}", self.path.display()),
+            )
+        })?;
+        let temporary_path = self
+            .path
+            .with_file_name(format!(".{}.tmp", file_name.to_string_lossy()));
+        let mut temporary = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&temporary_path)?;
+
+        let mut sorted_ids: Vec<_> = collection_ids.iter().map(|id| id.0).collect();
+        sorted_ids.sort_unstable();
+        for collection_id in sorted_ids {
+            writeln!(temporary, "{collection_id}")?;
+        }
+        temporary.sync_all()?;
+        fs::rename(&temporary_path, &self.path)?;
+        File::open(parent)?.sync_all()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    fn collection_id(value: &str) -> CollectionUuid {
+        CollectionUuid::from_str(value).unwrap()
+    }
+
+    #[test]
+    fn transitions_are_durable_and_sorted() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("member.txt");
+        let first = collection_id("00000000-0000-0000-0000-000000000001");
+        let second = collection_id("00000000-0000-0000-0000-000000000002");
+
+        let mut state = OngoingCompactions::load(path.clone()).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "");
+        assert!(state.insert(second).unwrap());
+        assert!(state.insert(first).unwrap());
+        assert!(!state.insert(first).unwrap());
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "00000000-0000-0000-0000-000000000001\n\
+             00000000-0000-0000-0000-000000000002\n"
+        );
+
+        let mut reopened = OngoingCompactions::load(path.clone()).unwrap();
+        let mut recovered: Vec<_> = reopened.collection_ids().collect();
+        recovered.sort_unstable();
+        assert_eq!(recovered, vec![first, second]);
+
+        assert!(reopened.remove(first).unwrap());
+        assert!(!reopened.remove(first).unwrap());
+        assert!(reopened.remove(second).unwrap());
+        assert_eq!(fs::read_to_string(path).unwrap(), "");
+    }
+
+    #[test]
+    fn malformed_uuid_is_discarded_without_losing_valid_entries() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("member.txt");
+        let valid = collection_id("00000000-0000-0000-0000-000000000001");
+        fs::write(&path, "not-a-uuid\n00000000-0000-0000-0000-000000000001\n").unwrap();
+
+        let state = OngoingCompactions::load(path.clone()).unwrap();
+
+        assert_eq!(state.collection_ids().collect::<Vec<_>>(), vec![valid]);
+        assert_eq!(
+            fs::read_to_string(path).unwrap(),
+            "00000000-0000-0000-0000-000000000001\n"
+        );
+    }
+
+    #[test]
+    fn failed_persistence_does_not_publish_the_new_in_memory_state() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("member.txt");
+        let collection_id = collection_id("00000000-0000-0000-0000-000000000001");
+        let mut state = OngoingCompactions::load(path.clone()).unwrap();
+        fs::remove_file(&path).unwrap();
+        fs::create_dir(&path).unwrap();
+
+        assert!(state.insert(collection_id).is_err());
+        assert_eq!(state.collection_ids().collect::<Vec<_>>(), Vec::new());
+    }
+
+    #[test]
+    fn member_ids_are_isolated_and_validated() {
+        let directory = tempfile::tempdir().unwrap();
+
+        let first = OngoingCompactions::for_member(directory.path(), "compactor-0").unwrap();
+        let second = OngoingCompactions::for_member(directory.path(), "compactor-1").unwrap();
+
+        assert_ne!(first.path, second.path);
+        let error = OngoingCompactions::for_member(directory.path(), "../compactor").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+}

--- a/rust/worker/src/compactor/ongoing_jobs.rs
+++ b/rust/worker/src/compactor/ongoing_jobs.rs
@@ -8,12 +8,12 @@ use uuid::Uuid;
 
 /// Persists the collections whose compactions may be interrupted by a process crash.
 #[derive(Debug)]
-pub(crate) struct OngoingCompactions {
+pub(crate) struct OngoingJobs {
     path: PathBuf,
     collection_ids: HashSet<CollectionUuid>,
 }
 
-impl OngoingCompactions {
+impl OngoingJobs {
     /// Opens the state file assigned to one compactor member.
     ///
     /// The member ID becomes the file name beneath `directory`, which keeps
@@ -64,7 +64,7 @@ impl OngoingCompactions {
                                 line_number = line_number + 1,
                                 line,
                                 error = ?error,
-                                "Discarding malformed ongoing-compaction state",
+                                "Discarding malformed ongoing-job state",
                             );
                         }
                     }
@@ -178,7 +178,7 @@ mod tests {
         let first = collection_id("00000000-0000-0000-0000-000000000001");
         let second = collection_id("00000000-0000-0000-0000-000000000002");
 
-        let mut state = OngoingCompactions::load(path.clone()).unwrap();
+        let mut state = OngoingJobs::load(path.clone()).unwrap();
         assert_eq!(fs::read_to_string(&path).unwrap(), "");
         assert!(state.insert(second).unwrap());
         assert!(state.insert(first).unwrap());
@@ -189,7 +189,7 @@ mod tests {
              00000000-0000-0000-0000-000000000002\n"
         );
 
-        let mut reopened = OngoingCompactions::load(path.clone()).unwrap();
+        let mut reopened = OngoingJobs::load(path.clone()).unwrap();
         let mut recovered: Vec<_> = reopened.collection_ids().collect();
         recovered.sort_unstable();
         assert_eq!(recovered, vec![first, second]);
@@ -207,7 +207,7 @@ mod tests {
         let valid = collection_id("00000000-0000-0000-0000-000000000001");
         fs::write(&path, "not-a-uuid\n00000000-0000-0000-0000-000000000001\n").unwrap();
 
-        let state = OngoingCompactions::load(path.clone()).unwrap();
+        let state = OngoingJobs::load(path.clone()).unwrap();
 
         assert_eq!(state.collection_ids().collect::<Vec<_>>(), vec![valid]);
         assert_eq!(
@@ -221,7 +221,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("member.txt");
         let collection_id = collection_id("00000000-0000-0000-0000-000000000001");
-        let mut state = OngoingCompactions::load(path.clone()).unwrap();
+        let mut state = OngoingJobs::load(path.clone()).unwrap();
         fs::remove_file(&path).unwrap();
         fs::create_dir(&path).unwrap();
 
@@ -233,11 +233,11 @@ mod tests {
     fn member_ids_are_isolated_and_validated() {
         let directory = tempfile::tempdir().unwrap();
 
-        let first = OngoingCompactions::for_member(directory.path(), "compactor-0").unwrap();
-        let second = OngoingCompactions::for_member(directory.path(), "compactor-1").unwrap();
+        let first = OngoingJobs::for_member(directory.path(), "compactor-0").unwrap();
+        let second = OngoingJobs::for_member(directory.path(), "compactor-1").unwrap();
 
         assert_ne!(first.path, second.path);
-        let error = OngoingCompactions::for_member(directory.path(), "../compactor").unwrap_err();
+        let error = OngoingJobs::for_member(directory.path(), "../compactor").unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
     }
 }

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -13,6 +13,7 @@ use opentelemetry::metrics::{Counter, Gauge};
 use serde::Deserialize;
 use uuid::Uuid;
 
+use crate::compactor::ongoing_compactions::OngoingCompactions;
 use crate::compactor::scheduler_policy::SchedulerPolicy;
 use crate::compactor::types::CompactionJob;
 
@@ -103,6 +104,8 @@ pub(crate) struct Scheduler {
     deleted_collections: HashMap<CollectionUuid, Option<TopologyName>>,
     collections_needing_repair: HashMap<CollectionUuid, (DatabaseName, i64)>,
     in_progress_jobs: HashMap<JobId, InProgressJob>,
+    recovered_jobs: HashSet<CollectionUuid>,
+    ongoing_compactions: OngoingCompactions,
     job_expiry_seconds: u64,
     max_failure_count: i32,
     metrics: SchedulerMetrics,
@@ -124,9 +127,11 @@ impl Scheduler {
         min_compaction_size: usize,
         assignment_policy: Box<dyn AssignmentPolicy>,
         disabled_collections: HashSet<CollectionUuid>,
+        ongoing_compactions: OngoingCompactions,
         job_expiry_seconds: u64,
         max_failure_count: i32,
     ) -> Scheduler {
+        let recovered_jobs = ongoing_compactions.collection_ids().collect();
         Scheduler {
             my_member_id: my_ip,
             log,
@@ -143,6 +148,8 @@ impl Scheduler {
             deleted_collections: HashMap::new(),
             collections_needing_repair: HashMap::new(),
             in_progress_jobs: HashMap::new(),
+            recovered_jobs,
+            ongoing_compactions,
             job_expiry_seconds,
             max_failure_count,
             metrics: SchedulerMetrics::default(),
@@ -526,20 +533,27 @@ impl Scheduler {
         self.job_queue.extend(selected);
         self.metrics
             .set_unaddressable_jobs_count(dropped_jobs_count as u64);
-        // At this point, nobody should modify the job queue and every collection
-        // in the job queue will definitely be compacted. It is now safe to add
-        // them to the in-progress set.
-        let job_ids: Vec<_> = self
-            .job_queue
-            .iter()
-            .map(|j| (j.collection_id, j.database_name.clone()))
-            .collect();
-        for (collection_id, database_name) in job_ids {
-            self.add_in_progress(collection_id, database_name);
+        // Persist before dispatch so a process failure cannot leave a running
+        // compaction untracked. A crash between this write and dispatch can
+        // charge a collection that did not start; that false positive is the
+        // deliberate cost of at-least-once crash accounting.
+        let queued_jobs = std::mem::take(&mut self.job_queue);
+        for job in queued_jobs {
+            if self.add_in_progress(job.collection_id, job.database_name.clone()) {
+                self.job_queue.push(job);
+            }
         }
     }
 
     async fn is_job_in_progress(&mut self, collection_id: &CollectionUuid) -> bool {
+        if self.recovered_jobs.contains(collection_id) {
+            tracing::info!(
+                collection_id = %collection_id,
+                "Compaction is awaiting crash recovery, skipping",
+            );
+            return true;
+        }
+
         let job_id = (*collection_id).into();
         match self.in_progress_jobs.get(&job_id) {
             Some(job) if job.is_expired() => {
@@ -548,23 +562,49 @@ impl Scheduler {
                     collection_id
                 );
                 self.fail_job(job_id).await;
-                false
+                self.recovered_jobs.contains(collection_id)
             }
             Some(_) => true,
             None => false,
         }
     }
 
-    fn add_in_progress(&mut self, collection_id: CollectionUuid, database_name: DatabaseName) {
+    fn add_in_progress(
+        &mut self,
+        collection_id: CollectionUuid,
+        database_name: DatabaseName,
+    ) -> bool {
+        if let Err(error) = self.ongoing_compactions.insert(collection_id) {
+            tracing::error!(
+                collection_id = %collection_id,
+                error = ?error,
+                "Skipping compaction because its ongoing state could not be persisted",
+            );
+            return false;
+        }
+
         self.in_progress_jobs.insert(
             collection_id.into(),
             InProgressJob::new(self.job_expiry_seconds, database_name),
         );
+        true
+    }
+
+    fn clear_ongoing_compaction(&mut self, collection_id: CollectionUuid) {
+        if let Err(error) = self.ongoing_compactions.remove(collection_id) {
+            tracing::error!(
+                collection_id = %collection_id,
+                error = ?error,
+                "Failed to clear terminal compaction from crash-recovery state",
+            );
+        }
     }
 
     pub(crate) fn succeed_job(&mut self, job_id: JobId) {
         tracing::info!("Compaction for {} just successfully finished", job_id);
-        if self.in_progress_jobs.remove(&job_id).is_none() {
+        if self.in_progress_jobs.remove(&job_id).is_some() {
+            self.clear_ongoing_compaction(CollectionUuid(job_id.0));
+        } else {
             tracing::warn!(
                 "Expired compaction for {} just successfully finished.",
                 job_id
@@ -586,7 +626,9 @@ impl Scheduler {
             job_id
         );
         self.metrics.increment_unpenalized_job_failure_count();
-        if self.in_progress_jobs.remove(&job_id).is_none() {
+        if self.in_progress_jobs.remove(&job_id).is_some() {
+            self.clear_ongoing_compaction(CollectionUuid(job_id.0));
+        } else {
             tracing::warn!("Expired compaction for {} was released.", job_id);
         }
     }
@@ -617,6 +659,9 @@ impl Scheduler {
                         job_id,
                         e
                     );
+                    self.recovered_jobs.insert(collection_id);
+                } else {
+                    self.clear_ongoing_compaction(collection_id);
                 }
             }
             None => {
@@ -624,6 +669,101 @@ impl Scheduler {
                     "Expired compaction for {} just unsuccessfully finished.",
                     job_id
                 );
+            }
+        }
+    }
+
+    /// Charges compactions left in the state file by a previous process.
+    ///
+    /// Each recovered collection remains excluded from scheduling until sysdb
+    /// accepts its failure-count increment. Missing collections are terminal and
+    /// are removed from the state file without an increment. The sysdb increment
+    /// precedes removal from disk, so a second crash in that interval can charge
+    /// the collection twice rather than lose the crash failure entirely.
+    pub(crate) async fn recover_crashed_jobs(&mut self) {
+        if self.recovered_jobs.is_empty() {
+            return;
+        }
+
+        let recovered_jobs: Vec<_> = self.recovered_jobs.iter().copied().collect();
+        tracing::warn!(
+            count = recovered_jobs.len(),
+            "Recovering compactions interrupted by a previous process",
+        );
+
+        const BATCH_SIZE: usize = 1_000;
+        for batch in recovered_jobs.chunks(BATCH_SIZE) {
+            let collections = match self
+                .sysdb
+                .get_collections(GetCollectionsOptions {
+                    collection_ids: Some(batch.to_vec()),
+                    database_or_topology: None,
+                    limit: Some(batch.len() as u32),
+                    offset: 0,
+                    include_soft_deleted: false,
+                    collection_id: None,
+                    name: None,
+                    tenant: None,
+                })
+                .await
+            {
+                Ok(collections) => collections,
+                Err(error) => {
+                    tracing::error!(
+                        error = ?error,
+                        count = batch.len(),
+                        "Failed to load collections awaiting compaction crash recovery",
+                    );
+                    continue;
+                }
+            };
+
+            let mut collections_by_id: HashMap<_, _> = collections
+                .into_iter()
+                .map(|collection| (collection.collection_id, collection))
+                .collect();
+            for collection_id in batch {
+                let Some(collection) = collections_by_id.remove(collection_id) else {
+                    tracing::warn!(
+                        collection_id = %collection_id,
+                        "Removing missing collection from compaction crash-recovery state",
+                    );
+                    self.recovered_jobs.remove(collection_id);
+                    self.clear_ongoing_compaction(*collection_id);
+                    continue;
+                };
+                let Some(database_name) = DatabaseName::new(collection.database) else {
+                    tracing::error!(
+                        collection_id = %collection_id,
+                        "Removing collection with invalid database name from compaction crash-recovery state",
+                    );
+                    self.recovered_jobs.remove(collection_id);
+                    self.clear_ongoing_compaction(*collection_id);
+                    continue;
+                };
+
+                match self
+                    .sysdb
+                    .increment_compaction_failure_count(*collection_id, &database_name)
+                    .await
+                {
+                    Ok(()) => {
+                        tracing::warn!(
+                            collection_id = %collection_id,
+                            "Charged collection for a compaction interrupted by process failure",
+                        );
+                        self.metrics.increment_job_failure_count();
+                        self.recovered_jobs.remove(collection_id);
+                        self.clear_ongoing_compaction(*collection_id);
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            collection_id = %collection_id,
+                            error = ?error,
+                            "Failed to charge collection for interrupted compaction",
+                        );
+                    }
+                }
             }
         }
     }
@@ -655,6 +795,8 @@ impl Scheduler {
     pub(crate) async fn schedule(&mut self) {
         // For now, we clear the job queue every time, assuming we will not have any pending jobs running
         self.job_queue.clear();
+
+        self.recover_crashed_jobs().await;
 
         if self.memberlist.is_none() || self.memberlist.as_ref().unwrap().is_empty() {
             tracing::error!("Memberlist is not set or empty. Cannot schedule compaction jobs.");
@@ -710,6 +852,8 @@ impl Scheduler {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::PathBuf;
     use std::str::FromStr;
 
     use serial_test::serial;
@@ -722,12 +866,20 @@ mod tests {
     use chroma_sysdb::TestSysDb;
     use chroma_types::{Collection, LogRecord, Operation, OperationRecord};
 
+    fn temporary_ongoing_compactions(member_id: &str) -> (tempfile::TempDir, OngoingCompactions) {
+        let state_directory = tempfile::tempdir().unwrap();
+        let ongoing_compactions =
+            OngoingCompactions::for_member(state_directory.path(), member_id).unwrap();
+        (state_directory, ongoing_compactions)
+    }
+
     /// Shared setup for scheduler tests.
     struct SchedulerFixture {
         scheduler: Scheduler,
         collection_uuid_1: CollectionUuid,
         collection_uuid_2: CollectionUuid,
         my_member: Member,
+        state_directory: tempfile::TempDir,
     }
 
     impl SchedulerFixture {
@@ -825,6 +977,9 @@ mod tests {
             let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
             assignment_policy.set_members(vec![my_member.member_id.clone()]);
 
+            let (state_directory, ongoing_compactions) =
+                temporary_ongoing_compactions(&my_member.member_id);
+
             let scheduler = Scheduler::new(
                 my_member.member_id.clone(),
                 log,
@@ -834,6 +989,7 @@ mod tests {
                 1,
                 assignment_policy,
                 HashSet::new(),
+                ongoing_compactions,
                 3600,
                 max_failure_count,
             );
@@ -843,7 +999,24 @@ mod tests {
                 collection_uuid_1,
                 collection_uuid_2,
                 my_member,
+                state_directory,
             }
+        }
+
+        fn state_file(&self) -> PathBuf {
+            self.state_directory
+                .path()
+                .join(format!("{}.txt", self.my_member.member_id))
+        }
+
+        fn persisted_collection_ids(&self) -> Vec<CollectionUuid> {
+            let mut collection_ids = fs::read_to_string(self.state_file())
+                .unwrap()
+                .lines()
+                .map(|line| CollectionUuid::from_str(line).unwrap())
+                .collect::<Vec<_>>();
+            collection_ids.sort_unstable();
+            collection_ids
         }
 
         /// Clear env vars that may leak between tests.
@@ -889,6 +1062,106 @@ mod tests {
         assert_eq!(jobs.len(), 2);
         assert_eq!(jobs[0].collection_id, f.collection_uuid_1);
         assert_eq!(jobs[1].collection_id, f.collection_uuid_2);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn every_terminal_transition_updates_the_state_file() {
+        SchedulerFixture::clear_env_vars();
+        let mut f = SchedulerFixture::new();
+        f.scheduler.set_memberlist(vec![f.my_member.clone()]);
+
+        f.scheduler.schedule().await;
+        assert_eq!(
+            f.persisted_collection_ids(),
+            vec![f.collection_uuid_1, f.collection_uuid_2]
+        );
+
+        f.scheduler.succeed_job(f.collection_uuid_1.into());
+        assert_eq!(f.persisted_collection_ids(), vec![f.collection_uuid_2]);
+
+        f.scheduler
+            .release_job_without_penalty(f.collection_uuid_2.into());
+        assert_eq!(f.persisted_collection_ids(), Vec::new());
+
+        f.scheduler.schedule().await;
+        f.scheduler.fail_job(f.collection_uuid_1.into()).await;
+        assert_eq!(f.persisted_collection_ids(), vec![f.collection_uuid_2]);
+
+        f.scheduler.succeed_job(f.collection_uuid_2.into());
+        assert_eq!(f.persisted_collection_ids(), Vec::new());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn restart_charges_only_the_compaction_left_ongoing() {
+        SchedulerFixture::clear_env_vars();
+        let mut f = SchedulerFixture::with_max_failure_count(1);
+        f.scheduler.set_memberlist(vec![f.my_member.clone()]);
+
+        f.scheduler.schedule().await;
+        f.scheduler.succeed_job(f.collection_uuid_2.into());
+        assert_eq!(f.persisted_collection_ids(), vec![f.collection_uuid_1]);
+
+        let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
+        assignment_policy.set_members(vec![f.my_member.member_id.clone()]);
+        let ongoing_compactions = OngoingCompactions::load(f.state_file()).unwrap();
+        let mut restarted = Scheduler::new(
+            f.my_member.member_id.clone(),
+            f.scheduler.log.clone(),
+            f.scheduler.sysdb.clone(),
+            Box::new(LasCompactionTimeSchedulerPolicy {}),
+            1000,
+            1,
+            assignment_policy,
+            HashSet::new(),
+            ongoing_compactions,
+            3600,
+            1,
+        );
+        restarted.set_memberlist(vec![f.my_member.clone()]);
+
+        restarted.schedule().await;
+
+        let jobs: Vec<_> = restarted.get_jobs().cloned().collect();
+        assert_eq!(
+            jobs,
+            vec![CompactionJob {
+                collection_id: f.collection_uuid_2,
+                database_name: DatabaseName::new("database_2").unwrap(),
+                tenant_id: "tenant_2".to_string(),
+            }]
+        );
+        assert_eq!(f.persisted_collection_ids(), vec![f.collection_uuid_2]);
+
+        let collections = restarted
+            .sysdb
+            .get_collections(GetCollectionsOptions {
+                collection_ids: Some(vec![f.collection_uuid_1, f.collection_uuid_2]),
+                database_or_topology: None,
+                limit: Some(2),
+                offset: 0,
+                include_soft_deleted: false,
+                collection_id: None,
+                name: None,
+                tenant: None,
+            })
+            .await
+            .unwrap();
+        let mut failure_counts: Vec<_> = collections
+            .into_iter()
+            .map(|collection| {
+                (
+                    collection.collection_id,
+                    collection.compaction_failure_count,
+                )
+            })
+            .collect();
+        failure_counts.sort_unstable();
+        assert_eq!(
+            failure_counts,
+            vec![(f.collection_uuid_1, 1), (f.collection_uuid_2, 0)]
+        );
     }
 
     #[tokio::test]
@@ -1084,6 +1357,9 @@ mod tests {
         let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
         assignment_policy.set_members(vec![my_member.member_id.clone()]);
 
+        let (_state_directory, ongoing_compactions) =
+            temporary_ongoing_compactions(&my_member.member_id);
+
         let mut scheduler = Scheduler::new(
             my_member.member_id.clone(),
             log,
@@ -1093,6 +1369,7 @@ mod tests {
             1,
             assignment_policy,
             HashSet::new(),
+            ongoing_compactions,
             3600,
             3,
         );
@@ -1183,6 +1460,9 @@ mod tests {
         let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
         assignment_policy.set_members(vec![my_member.member_id.clone()]);
 
+        let (_state_directory, ongoing_compactions) =
+            temporary_ongoing_compactions(&my_member.member_id);
+
         let mut scheduler = Scheduler::new(
             my_member.member_id.clone(),
             log,
@@ -1192,6 +1472,7 @@ mod tests {
             1,
             assignment_policy,
             HashSet::new(),
+            ongoing_compactions,
             3600,
             3,
         );
@@ -1467,6 +1748,9 @@ mod tests {
         let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
         assignment_policy.set_members(vec![my_member.member_id.clone()]);
 
+        let (_state_directory, ongoing_compactions) =
+            temporary_ongoing_compactions(&my_member.member_id);
+
         let mut scheduler = Scheduler::new(
             my_member.member_id.clone(),
             log,
@@ -1476,6 +1760,7 @@ mod tests {
             1,
             assignment_policy,
             HashSet::new(),
+            ongoing_compactions,
             3600,              // job_expiry_seconds
             max_failure_count, // max_failure_count
         );

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -13,7 +13,7 @@ use opentelemetry::metrics::{Counter, Gauge};
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::compactor::ongoing_compactions::OngoingCompactions;
+use crate::compactor::ongoing_jobs::OngoingJobs;
 use crate::compactor::scheduler_policy::SchedulerPolicy;
 use crate::compactor::types::CompactionJob;
 
@@ -105,7 +105,7 @@ pub(crate) struct Scheduler {
     collections_needing_repair: HashMap<CollectionUuid, (DatabaseName, i64)>,
     in_progress_jobs: HashMap<JobId, InProgressJob>,
     recovered_jobs: HashSet<CollectionUuid>,
-    ongoing_compactions: OngoingCompactions,
+    ongoing_jobs: OngoingJobs,
     job_expiry_seconds: u64,
     max_failure_count: i32,
     metrics: SchedulerMetrics,
@@ -127,11 +127,11 @@ impl Scheduler {
         min_compaction_size: usize,
         assignment_policy: Box<dyn AssignmentPolicy>,
         disabled_collections: HashSet<CollectionUuid>,
-        ongoing_compactions: OngoingCompactions,
+        ongoing_jobs: OngoingJobs,
         job_expiry_seconds: u64,
         max_failure_count: i32,
     ) -> Scheduler {
-        let recovered_jobs = ongoing_compactions.collection_ids().collect();
+        let recovered_jobs = ongoing_jobs.collection_ids().collect();
         Scheduler {
             my_member_id: my_ip,
             log,
@@ -149,7 +149,7 @@ impl Scheduler {
             collections_needing_repair: HashMap::new(),
             in_progress_jobs: HashMap::new(),
             recovered_jobs,
-            ongoing_compactions,
+            ongoing_jobs,
             job_expiry_seconds,
             max_failure_count,
             metrics: SchedulerMetrics::default(),
@@ -574,7 +574,7 @@ impl Scheduler {
         collection_id: CollectionUuid,
         database_name: DatabaseName,
     ) -> bool {
-        if let Err(error) = self.ongoing_compactions.insert(collection_id) {
+        if let Err(error) = self.ongoing_jobs.insert(collection_id) {
             tracing::error!(
                 collection_id = %collection_id,
                 error = ?error,
@@ -590,8 +590,8 @@ impl Scheduler {
         true
     }
 
-    fn clear_ongoing_compaction(&mut self, collection_id: CollectionUuid) {
-        if let Err(error) = self.ongoing_compactions.remove(collection_id) {
+    fn clear_ongoing_job(&mut self, collection_id: CollectionUuid) {
+        if let Err(error) = self.ongoing_jobs.remove(collection_id) {
             tracing::error!(
                 collection_id = %collection_id,
                 error = ?error,
@@ -603,7 +603,7 @@ impl Scheduler {
     pub(crate) fn succeed_job(&mut self, job_id: JobId) {
         tracing::info!("Compaction for {} just successfully finished", job_id);
         if self.in_progress_jobs.remove(&job_id).is_some() {
-            self.clear_ongoing_compaction(CollectionUuid(job_id.0));
+            self.clear_ongoing_job(CollectionUuid(job_id.0));
         } else {
             tracing::warn!(
                 "Expired compaction for {} just successfully finished.",
@@ -627,7 +627,7 @@ impl Scheduler {
         );
         self.metrics.increment_unpenalized_job_failure_count();
         if self.in_progress_jobs.remove(&job_id).is_some() {
-            self.clear_ongoing_compaction(CollectionUuid(job_id.0));
+            self.clear_ongoing_job(CollectionUuid(job_id.0));
         } else {
             tracing::warn!("Expired compaction for {} was released.", job_id);
         }
@@ -661,7 +661,7 @@ impl Scheduler {
                     );
                     self.recovered_jobs.insert(collection_id);
                 } else {
-                    self.clear_ongoing_compaction(collection_id);
+                    self.clear_ongoing_job(collection_id);
                 }
             }
             None => {
@@ -729,7 +729,7 @@ impl Scheduler {
                         "Removing missing collection from compaction crash-recovery state",
                     );
                     self.recovered_jobs.remove(collection_id);
-                    self.clear_ongoing_compaction(*collection_id);
+                    self.clear_ongoing_job(*collection_id);
                     continue;
                 };
                 let Some(database_name) = DatabaseName::new(collection.database) else {
@@ -738,7 +738,7 @@ impl Scheduler {
                         "Removing collection with invalid database name from compaction crash-recovery state",
                     );
                     self.recovered_jobs.remove(collection_id);
-                    self.clear_ongoing_compaction(*collection_id);
+                    self.clear_ongoing_job(*collection_id);
                     continue;
                 };
 
@@ -754,7 +754,7 @@ impl Scheduler {
                         );
                         self.metrics.increment_job_failure_count();
                         self.recovered_jobs.remove(collection_id);
-                        self.clear_ongoing_compaction(*collection_id);
+                        self.clear_ongoing_job(*collection_id);
                     }
                     Err(error) => {
                         tracing::error!(
@@ -866,11 +866,10 @@ mod tests {
     use chroma_sysdb::TestSysDb;
     use chroma_types::{Collection, LogRecord, Operation, OperationRecord};
 
-    fn temporary_ongoing_compactions(member_id: &str) -> (tempfile::TempDir, OngoingCompactions) {
+    fn temporary_ongoing_jobs(member_id: &str) -> (tempfile::TempDir, OngoingJobs) {
         let state_directory = tempfile::tempdir().unwrap();
-        let ongoing_compactions =
-            OngoingCompactions::for_member(state_directory.path(), member_id).unwrap();
-        (state_directory, ongoing_compactions)
+        let ongoing_jobs = OngoingJobs::for_member(state_directory.path(), member_id).unwrap();
+        (state_directory, ongoing_jobs)
     }
 
     /// Shared setup for scheduler tests.
@@ -977,8 +976,7 @@ mod tests {
             let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
             assignment_policy.set_members(vec![my_member.member_id.clone()]);
 
-            let (state_directory, ongoing_compactions) =
-                temporary_ongoing_compactions(&my_member.member_id);
+            let (state_directory, ongoing_jobs) = temporary_ongoing_jobs(&my_member.member_id);
 
             let scheduler = Scheduler::new(
                 my_member.member_id.clone(),
@@ -989,7 +987,7 @@ mod tests {
                 1,
                 assignment_policy,
                 HashSet::new(),
-                ongoing_compactions,
+                ongoing_jobs,
                 3600,
                 max_failure_count,
             );
@@ -1105,7 +1103,7 @@ mod tests {
 
         let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
         assignment_policy.set_members(vec![f.my_member.member_id.clone()]);
-        let ongoing_compactions = OngoingCompactions::load(f.state_file()).unwrap();
+        let ongoing_jobs = OngoingJobs::load(f.state_file()).unwrap();
         let mut restarted = Scheduler::new(
             f.my_member.member_id.clone(),
             f.scheduler.log.clone(),
@@ -1115,7 +1113,7 @@ mod tests {
             1,
             assignment_policy,
             HashSet::new(),
-            ongoing_compactions,
+            ongoing_jobs,
             3600,
             1,
         );
@@ -1357,8 +1355,7 @@ mod tests {
         let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
         assignment_policy.set_members(vec![my_member.member_id.clone()]);
 
-        let (_state_directory, ongoing_compactions) =
-            temporary_ongoing_compactions(&my_member.member_id);
+        let (_state_directory, ongoing_jobs) = temporary_ongoing_jobs(&my_member.member_id);
 
         let mut scheduler = Scheduler::new(
             my_member.member_id.clone(),
@@ -1369,7 +1366,7 @@ mod tests {
             1,
             assignment_policy,
             HashSet::new(),
-            ongoing_compactions,
+            ongoing_jobs,
             3600,
             3,
         );
@@ -1460,8 +1457,7 @@ mod tests {
         let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
         assignment_policy.set_members(vec![my_member.member_id.clone()]);
 
-        let (_state_directory, ongoing_compactions) =
-            temporary_ongoing_compactions(&my_member.member_id);
+        let (_state_directory, ongoing_jobs) = temporary_ongoing_jobs(&my_member.member_id);
 
         let mut scheduler = Scheduler::new(
             my_member.member_id.clone(),
@@ -1472,7 +1468,7 @@ mod tests {
             1,
             assignment_policy,
             HashSet::new(),
-            ongoing_compactions,
+            ongoing_jobs,
             3600,
             3,
         );
@@ -1748,8 +1744,7 @@ mod tests {
         let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::default());
         assignment_policy.set_members(vec![my_member.member_id.clone()]);
 
-        let (_state_directory, ongoing_compactions) =
-            temporary_ongoing_compactions(&my_member.member_id);
+        let (_state_directory, ongoing_jobs) = temporary_ongoing_jobs(&my_member.member_id);
 
         let mut scheduler = Scheduler::new(
             my_member.member_id.clone(),
@@ -1760,7 +1755,7 @@ mod tests {
             1,
             assignment_policy,
             HashSet::new(),
-            ongoing_compactions,
+            ongoing_jobs,
             3600,              // job_expiry_seconds
             max_failure_count, // max_failure_count
         );

--- a/rust/worker/tests/config_from_specific_path.rs
+++ b/rust/worker/tests/config_from_specific_path.rs
@@ -133,6 +133,7 @@ fn test_config_from_specific_path() {
                     max_compaction_size: 10000
                     max_partition_size: 5000
                     disabled_collections: []
+                    compaction_state_directory: "/var/lib/chroma/compaction-state"
                 blockfile_provider:
                     arrow:
                         block_manager_config:
@@ -194,6 +195,13 @@ fn test_config_from_specific_path() {
             56789
         );
         assert_eq!(config.compaction_service.grpc.max_concurrent_streams, 456);
+        assert_eq!(
+            config
+                .compaction_service
+                .compactor
+                .compaction_state_directory,
+            std::path::PathBuf::from("/var/lib/chroma/compaction-state")
+        );
         match config.compaction_service.blockfile_provider {
             BlockfileProviderConfig::Arrow(arrow_config) => {
                 assert_eq!(


### PR DESCRIPTION
## Description of changes

A compactor process that crashes mid-compaction previously left the
collection unaccounted for: its failure was never charged and the
in-memory in-progress set was lost on restart.

Add OngoingCompactions, a node-local state file (one per compactor
member) that durably records which collections have a compaction that
may be interrupted by a crash. The scheduler writes the collection to
disk before dispatch and clears it on every terminal transition
(succeed, fail, release). On startup the scheduler charges each
collection still recorded in the file with a compaction failure via
sysdb, keeping it out of scheduling until the increment is accepted.

The write-before-dispatch and increment-before-clear ordering favors
at-least-once crash accounting: a crash in either window can charge a
collection twice rather than lose the failure. Malformed state lines
are discarded so local corruption cannot trigger a crash loop.

Add compaction_state_directory to CompactorConfig (default
/cache/compaction-state) and cover the transitions, restart
accounting, and state-file durability with tests.

## Test plan

CI

## Migration plan

Backwards-compatible

## Observability plan

Tracing messages.

## Documentation Changes

N/A

Co-authored-by: AI
