### PR TITLE
[BUG](worker): Fail compactor startup when WorkQueue client init fails

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -718,23 +718,26 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
         )
         .await?;
 
-        // Initialize WorkQueueClient if config is provided
+        // Initialize WorkQueueClient if config is provided. A configured
+        // WorkQueue is a hard dependency: without the client this compactor
+        // fails every compaction of a collection with an async attached
+        // function, and compaction is sharded by collection, so those
+        // collections never compact anywhere. Fail startup instead of
+        // degrading — the process exits and kubelet restarts the pod with
+        // backoff until the WorkQueue is reachable.
         let work_queue_client = match &config.work_queue {
             Some(work_queue_config) => {
-                match WorkQueueClient::try_from_config(work_queue_config).await {
-                    Ok(client) => {
-                        tracing::info!(
-                            "WorkQueue client initialized for {}:{}",
-                            work_queue_config.host,
-                            work_queue_config.port
-                        );
-                        Some(client)
-                    }
-                    Err(err) => {
-                        tracing::warn!("Failed to initialize WorkQueue client: {:?}", err);
-                        None
-                    }
-                }
+                let client = WorkQueueClient::try_from_config(work_queue_config)
+                    .await
+                    .inspect_err(|err| {
+                        tracing::error!("Failed to initialize WorkQueue client: {:?}", err);
+                    })?;
+                tracing::info!(
+                    "WorkQueue client initialized for {}:{}",
+                    work_queue_config.host,
+                    work_queue_config.port
+                );
+                Some(client)
             }
             None => {
                 tracing::info!(


### PR DESCRIPTION
## What this fixes

A compactor that starts up while the work-queue service is briefly unreachable silently loses the ability to run async attached functions — permanently, until someone restarts the pod by hand. This PR makes that startup failure fatal instead: the process exits, Kubernetes restarts it with backoff, and the pod only serves traffic once the work queue is actually reachable.

## Why silent degradation is dangerous here

Compaction is sharded by collection: each collection is compacted by exactly one compactor pod. When a compactor compacts a collection that has an async attached function, it must queue the function's next run into the work queue; without a work-queue client, the whole compaction aborts. Both facts together mean one degraded pod does not reduce capacity — it permanently blocks every attached-function collection assigned to it. Those collections never commit a compaction, so their attached functions are never scheduled, and everything downstream of them stalls.

The failure is also nearly invisible: the pod stays Ready, compacts function-less collections normally, and only logs a warning once at boot.

## What happened in production

During the 2026-08-19 07:52 UTC rollout, one production compactor (`compaction-service-3`) hit a transient connection failure to the work-queue service at boot. For the next 36 hours it aborted every attached-function compaction on its shard — about 58,000 failures logged as `Compaction failed: AttachedFunction(WorkQueueUnavailable)` — which froze Foundation sync for the affected tenants: their jobs piled up at the `indexed` stage with zero reaching `synthesized`. Deleting the pod fixed it immediately.

## The change

In the compaction manager's constructor (`CompactionManager::try_from_config` in `rust/worker/src/compactor/compaction_manager.rs`), a configured work queue is now treated as a hard dependency: if `WorkQueueClient::try_from_config` fails, the error propagates and startup fails, instead of being downgraded to a warning and `None`. Kubernetes' crash-loop backoff provides the retry. Deployments with no `work_queue` config keep the existing behavior (async attached functions unsupported, logged at startup).

This matches how the fn-consumer service already treats the same client: its startup returns immediately when the work-queue client cannot be created.

## Alternatives considered

- **In-process retry with backoff before failing**: rejected — kubelet's restart backoff already provides exactly this, and failing fast keeps the readiness signal honest during the retry window.
- **Lazy connection (`connect_lazy`)**: rejected — it hides the same unreachability until the first compaction with a function, which reintroduces a quieter version of the original problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
