### PR TITLE
[ENH]: Shard work by fn-consumer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11595,6 +11595,7 @@ dependencies = [
  "frontend-core",
  "futures",
  "indicatif",
+ "kube",
  "mdac",
  "num_cpus",
  "opentelemetry",

--- a/Tiltfile
+++ b/Tiltfile
@@ -378,7 +378,7 @@ k8s_resource('rust-frontend-service:deployment:chroma', resource_deps=['sysdb:de
 k8s_resource('query-service:statefulset:chroma', resource_deps=['sysdb:deployment:chroma'], labels=["chroma"], port_forwards='50053:50051')
 k8s_resource('compaction-service:statefulset:chroma', resource_deps=['sysdb:deployment:chroma'] + ['work-queue-service:statefulset:chroma'], labels=["chroma"], port_forwards="50057:50051")
 k8s_resource('work-queue-service:statefulset:chroma', resource_deps=['sysdb:deployment:chroma'], labels=["chroma"], port_forwards="50058:50051")
-k8s_resource('fn-consumer:statefulset:chroma', resource_deps=['sysdb:deployment:chroma', 'work-queue-service:statefulset:chroma'], labels=["chroma"], port_forwards="50059:50051")
+k8s_resource('fn-consumer:deployment:chroma', resource_deps=['sysdb:deployment:chroma', 'work-queue-service:statefulset:chroma'], labels=["chroma"], port_forwards="50059:50051")
 k8s_resource('garbage-collector:statefulset:chroma', resource_deps=['k8s_setup', 'minio-deployment', 'rust-log-service:statefulset:chroma'], labels=["chroma"], port_forwards='50055:50055')
 
 # Production Chroma 2
@@ -422,7 +422,7 @@ groups = {
     'query-service:statefulset:chroma',
     'compaction-service:statefulset:chroma',
     'work-queue-service:statefulset:chroma',
-    'fn-consumer:statefulset:chroma',
+    'fn-consumer:deployment:chroma',
     'garbage-collector:statefulset:chroma',
     'jaeger',
     'grafana',
@@ -443,7 +443,7 @@ groups = {
     'query-service:statefulset:chroma2',
     'compaction-service:statefulset:chroma2',
     'work-queue-service:statefulset:chroma2',
-    'fn-consumer:statefulset:chroma2',
+    'fn-consumer:deployment:chroma2',
     'garbage-collector:statefulset:chroma2',
     'spanner-deployment',
   ],

--- a/Tiltfile
+++ b/Tiltfile
@@ -276,12 +276,15 @@ k8s_resource(
     'compaction-service-memberlist:MemberList:chroma',
     'garbage-collection-service-memberlist:MemberList:chroma',
     'rust-log-service-memberlist:MemberList:chroma',
+    'fn-consumer-memberlist:MemberList:chroma',
 
     'sysdb-serviceaccount:ServiceAccount:chroma',
     'sysdb-serviceaccount-rolebinding:RoleBinding:chroma',
     'sysdb-query-service-memberlist-binding:RoleBinding:chroma',
     'sysdb-compaction-service-memberlist-binding:RoleBinding:chroma',
     'sysdb-rust-log-service-memberlist-binding:RoleBinding:chroma',
+    'fn-consumer-memberlist-writer:Role:chroma',
+    'sysdb-fn-consumer-memberlist-writer:RoleBinding:chroma',
 
     'query-service-serviceaccount:ServiceAccount:chroma',
     'query-service-serviceaccount-rolebinding:RoleBinding:chroma',
@@ -298,6 +301,8 @@ k8s_resource(
     'fn-consumer-rust-log-service-memberlist-binding:RoleBinding:chroma',
     'fn-consumer-service-account:ServiceAccount:chroma',
     'fn-consumer-service-serviceaccount-rolebinding:RoleBinding:chroma',
+    'fn-consumer-memberlist-reader:Role:chroma',
+    'work-queue-service-fn-consumer-memberlist-reader:RoleBinding:chroma',
 
     'rust-frontend-service-serviceaccount:ServiceAccount:chroma',
     'rust-frontend-service-rolebinding:RoleBinding:chroma',
@@ -324,12 +329,15 @@ k8s_resource(
     'compaction-service-memberlist:MemberList:chroma2',
     'garbage-collection-service-memberlist:MemberList:chroma2',
     'rust-log-service-memberlist:MemberList:chroma2',
+    'fn-consumer-memberlist:MemberList:chroma2',
 
     'sysdb-serviceaccount:ServiceAccount:chroma2',
     'sysdb-serviceaccount-rolebinding:RoleBinding:chroma2',
     'sysdb-query-service-memberlist-binding:RoleBinding:chroma2',
     'sysdb-compaction-service-memberlist-binding:RoleBinding:chroma2',
     'sysdb-rust-log-service-memberlist-binding:RoleBinding:chroma2',
+    'fn-consumer-memberlist-writer:Role:chroma2',
+    'sysdb-fn-consumer-memberlist-writer:RoleBinding:chroma2',
 
     'query-service-serviceaccount:ServiceAccount:chroma2',
     'query-service-serviceaccount-rolebinding:RoleBinding:chroma2',
@@ -342,6 +350,9 @@ k8s_resource(
     'compaction-service-memberlist-readerwriter-binding:RoleBinding:chroma2',
     'compaction-service-serviceaccount:ServiceAccount:chroma2',
     'compaction-service-serviceaccount-rolebinding:RoleBinding:chroma2',
+
+    'fn-consumer-memberlist-reader:Role:chroma2',
+    'work-queue-service-fn-consumer-memberlist-reader:RoleBinding:chroma2',
 
     'rust-frontend-service-serviceaccount:ServiceAccount:chroma2',
     'rust-frontend-service-rolebinding:RoleBinding:chroma2',
@@ -367,7 +378,7 @@ k8s_resource('rust-frontend-service:deployment:chroma', resource_deps=['sysdb:de
 k8s_resource('query-service:statefulset:chroma', resource_deps=['sysdb:deployment:chroma'], labels=["chroma"], port_forwards='50053:50051')
 k8s_resource('compaction-service:statefulset:chroma', resource_deps=['sysdb:deployment:chroma'] + ['work-queue-service:statefulset:chroma'], labels=["chroma"], port_forwards="50057:50051")
 k8s_resource('work-queue-service:statefulset:chroma', resource_deps=['sysdb:deployment:chroma'], labels=["chroma"], port_forwards="50058:50051")
-k8s_resource('fn-consumer:deployment:chroma', resource_deps=['sysdb:deployment:chroma', 'work-queue-service:statefulset:chroma'], labels=["chroma"], port_forwards="50059:50051")
+k8s_resource('fn-consumer:statefulset:chroma', resource_deps=['sysdb:deployment:chroma', 'work-queue-service:statefulset:chroma'], labels=["chroma"], port_forwards="50059:50051")
 k8s_resource('garbage-collector:statefulset:chroma', resource_deps=['k8s_setup', 'minio-deployment', 'rust-log-service:statefulset:chroma'], labels=["chroma"], port_forwards='50055:50055')
 
 # Production Chroma 2
@@ -411,7 +422,7 @@ groups = {
     'query-service:statefulset:chroma',
     'compaction-service:statefulset:chroma',
     'work-queue-service:statefulset:chroma',
-    'fn-consumer:deployment:chroma',
+    'fn-consumer:statefulset:chroma',
     'garbage-collector:statefulset:chroma',
     'jaeger',
     'grafana',
@@ -432,7 +443,7 @@ groups = {
     'query-service:statefulset:chroma2',
     'compaction-service:statefulset:chroma2',
     'work-queue-service:statefulset:chroma2',
-    'fn-consumer:deployment:chroma2',
+    'fn-consumer:statefulset:chroma2',
     'garbage-collector:statefulset:chroma2',
     'spanner-deployment',
   ],

--- a/go/cmd/coordinator/cmd.go
+++ b/go/cmd/coordinator/cmd.go
@@ -67,6 +67,10 @@ func init() {
 	Cmd.Flags().StringVar(&conf.LogServiceMemberlistName, "log-memberlist-name", "rust-log-service-memberlist", "Log service memberlist name")
 	Cmd.Flags().StringVar(&conf.LogServicePodLabel, "log-pod-label", "rust-log-service", "Log service pod label")
 
+	// Function consumer memberlist
+	Cmd.Flags().StringVar(&conf.FnConsumerMemberlistName, "fn-consumer-memberlist-name", "fn-consumer-memberlist", "Function consumer memberlist name")
+	Cmd.Flags().StringVar(&conf.FnConsumerPodLabel, "fn-consumer-pod-label", "fn-consumer", "Function consumer pod label")
+
 	// Heap service config (colocated with log service)
 	Cmd.Flags().BoolVar(&conf.HeapServiceEnabled, "heap-service-enabled", false, "Enable heap service client")
 	Cmd.Flags().IntVar(&conf.HeapServicePort, "heap-service-port", 50052, "Heap service port (colocated with log service)")

--- a/go/pkg/sysdb/grpc/server.go
+++ b/go/pkg/sysdb/grpc/server.go
@@ -57,6 +57,10 @@ type Config struct {
 	LogServiceMemberlistName string
 	LogServicePodLabel       string
 
+	// Function consumer memberlist config
+	FnConsumerMemberlistName string
+	FnConsumerPodLabel       string
+
 	// Heap service config (colocated with log service)
 	HeapServiceEnabled          bool
 	HeapServicePort             int    // Default: 50052
@@ -105,17 +109,7 @@ func StartMemberListManagers(leaderCtx context.Context, config Config) error {
 	namespace := config.KubernetesNamespace
 
 	// Store managers for cleanup
-	managers := []struct {
-		serviceType    string
-		manager        *memberlist_manager.MemberlistManager
-		memberlistName string
-		podLabel       string
-	}{
-		{"query", nil, config.QueryServiceMemberlistName, config.QueryServicePodLabel},
-		{"compaction", nil, config.CompactionServiceMemberlistName, config.CompactionServicePodLabel},
-		{"garbage_collection", nil, config.GarbageCollectionServiceMemberlistName, config.GarbageCollectionServicePodLabel},
-		{"log", nil, config.LogServiceMemberlistName, config.LogServicePodLabel},
-	}
+	managers := memberlistManagerConfigs(config)
 
 	for i, m := range managers {
 		manager, err := createMemberlistManager(namespace, m.memberlistName, m.podLabel, config.WatchInterval, config.ReconcileInterval, config.ReconcileCount)
@@ -141,6 +135,23 @@ func StartMemberListManagers(leaderCtx context.Context, config Config) error {
 		m.manager.Stop()
 	}
 	return nil
+}
+
+type memberlistManagerConfig struct {
+	serviceType    string
+	manager        *memberlist_manager.MemberlistManager
+	memberlistName string
+	podLabel       string
+}
+
+func memberlistManagerConfigs(config Config) []memberlistManagerConfig {
+	return []memberlistManagerConfig{
+		{"query", nil, config.QueryServiceMemberlistName, config.QueryServicePodLabel},
+		{"compaction", nil, config.CompactionServiceMemberlistName, config.CompactionServicePodLabel},
+		{"garbage_collection", nil, config.GarbageCollectionServiceMemberlistName, config.GarbageCollectionServicePodLabel},
+		{"log", nil, config.LogServiceMemberlistName, config.LogServicePodLabel},
+		{"fn_consumer", nil, config.FnConsumerMemberlistName, config.FnConsumerPodLabel},
+	}
 }
 
 func NewWithGrpcProvider(config Config, provider grpcutils.GrpcProvider) (*Server, error) {

--- a/go/pkg/sysdb/grpc/server_memberlist_test.go
+++ b/go/pkg/sysdb/grpc/server_memberlist_test.go
@@ -1,0 +1,26 @@
+package grpc
+
+import "testing"
+
+func TestMemberlistManagerConfigsIncludesFnConsumer(t *testing.T) {
+	config := Config{
+		FnConsumerMemberlistName: "fn-consumer-memberlist",
+		FnConsumerPodLabel:       "fn-consumer",
+	}
+
+	managers := memberlistManagerConfigs(config)
+	if len(managers) != 5 {
+		t.Fatalf("expected 5 memberlist managers, got %d", len(managers))
+	}
+
+	fnConsumer := managers[4]
+	if fnConsumer.serviceType != "fn_consumer" {
+		t.Fatalf("expected fn_consumer manager, got %q", fnConsumer.serviceType)
+	}
+	if fnConsumer.memberlistName != config.FnConsumerMemberlistName {
+		t.Fatalf("expected memberlist %q, got %q", config.FnConsumerMemberlistName, fnConsumer.memberlistName)
+	}
+	if fnConsumer.podLabel != config.FnConsumerPodLabel {
+		t.Fatalf("expected pod label %q, got %q", config.FnConsumerPodLabel, fnConsumer.podLabel)
+	}
+}

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.92
+version: 0.1.93
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/fn-consumer-memberlist-cr.yaml
+++ b/k8s/distributed-chroma/templates/fn-consumer-memberlist-cr.yaml
@@ -1,0 +1,64 @@
+apiVersion: chroma.cluster/v1
+kind: MemberList
+metadata:
+  name: fn-consumer-memberlist
+  namespace: {{ .Values.namespace }}
+spec:
+  members:
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fn-consumer-memberlist-writer
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups: ["chroma.cluster"]
+    resources: ["memberlists"]
+    resourceNames: ["fn-consumer-memberlist"]
+    verbs: ["get", "update", "patch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sysdb-fn-consumer-memberlist-writer
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fn-consumer-memberlist-writer
+subjects:
+  - kind: ServiceAccount
+    name: sysdb-serviceaccount
+    namespace: {{ .Values.namespace }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fn-consumer-memberlist-reader
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups: ["chroma.cluster"]
+    resources: ["memberlists"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: work-queue-service-fn-consumer-memberlist-reader
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fn-consumer-memberlist-reader
+subjects:
+  - kind: ServiceAccount
+    name: work-queue-service-serviceaccount
+    namespace: {{ .Values.namespace }}

--- a/k8s/distributed-chroma/templates/fn-consumer.yaml
+++ b/k8s/distributed-chroma/templates/fn-consumer.yaml
@@ -13,12 +13,11 @@ data:
 
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: fn-consumer
   namespace: {{ .Values.namespace }}
 spec:
-  serviceName: fn-consumer-headless
   replicas: {{ .Values.fnConsumer.replicaCount }}
   selector:
     matchLabels:
@@ -105,22 +104,6 @@ metadata:
   name: fn-consumer
   namespace: {{ .Values.namespace }}
 spec:
-  selector:
-    app: fn-consumer
-  ports:
-    - name: grpc
-      port: 50051
-      targetPort: 50051
-
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: fn-consumer-headless
-  namespace: {{ .Values.namespace }}
-spec:
-  clusterIP: None
   selector:
     app: fn-consumer
   ports:

--- a/k8s/distributed-chroma/templates/fn-consumer.yaml
+++ b/k8s/distributed-chroma/templates/fn-consumer.yaml
@@ -18,7 +18,7 @@ metadata:
   name: fn-consumer
   namespace: {{ .Values.namespace }}
 spec:
-  serviceName: fn-consumer
+  serviceName: fn-consumer-headless
   replicas: {{ .Values.fnConsumer.replicaCount }}
   selector:
     matchLabels:
@@ -103,6 +103,21 @@ apiVersion: v1
 kind: Service
 metadata:
   name: fn-consumer
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: fn-consumer
+  ports:
+    - name: grpc
+      port: 50051
+      targetPort: 50051
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: fn-consumer-headless
   namespace: {{ .Values.namespace }}
 spec:
   clusterIP: None

--- a/k8s/distributed-chroma/templates/fn-consumer.yaml
+++ b/k8s/distributed-chroma/templates/fn-consumer.yaml
@@ -105,6 +105,7 @@ metadata:
   name: fn-consumer
   namespace: {{ .Values.namespace }}
 spec:
+  clusterIP: None
   selector:
     app: fn-consumer
   ports:

--- a/k8s/distributed-chroma/templates/fn-consumer.yaml
+++ b/k8s/distributed-chroma/templates/fn-consumer.yaml
@@ -13,11 +13,12 @@ data:
 
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: fn-consumer
   namespace: {{ .Values.namespace }}
 spec:
+  serviceName: fn-consumer
   replicas: {{ .Values.fnConsumer.replicaCount }}
   selector:
     matchLabels:
@@ -26,6 +27,7 @@ spec:
     metadata:
       labels:
         app: fn-consumer
+        member-type: fn-consumer
     spec:
       serviceAccountName: fn-consumer-service-account
       volumes:
@@ -62,6 +64,10 @@ spec:
               # TODO properly use flow control here to check which type of value we need.
 {{ .value | nindent 14 }}
             {{ end }}
+            - name: CHROMA_FN_CONSUMER_SERVICE__MY_MEMBER_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           {{ if .Values.fnConsumer.resources }}
           resources:
             limits:
@@ -71,6 +77,25 @@ spec:
               cpu: {{ .Values.fnConsumer.resources.requests.cpu }}
               memory: {{ .Values.fnConsumer.resources.requests.memory }}
           {{ end }}
+      {{if .Values.fnConsumer.tolerations}}
+      tolerations:
+        {{ toYaml .Values.fnConsumer.tolerations | nindent 8 }}
+      {{ end }}
+      {{if .Values.fnConsumer.nodeSelector}}
+      nodeSelector:
+        {{ toYaml .Values.fnConsumer.nodeSelector | nindent 8 }}
+      {{ end }}
+      {{if .Values.fnConsumer.affinity}}
+      affinity:
+        {{ toYaml .Values.fnConsumer.affinity | nindent 8 }}
+      {{ end }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              member-type: fn-consumer
 
 ---
 

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -98,6 +98,7 @@ shuttle = { workspace = true }
 rand = { workspace = true }
 rand_xorshift = { workspace = true }
 tempfile = { workspace = true }
+kube = { version = "0.87.2", features = ["runtime"] }
 
 chroma-benchmark = { workspace = true }
 

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -241,6 +241,14 @@ work_queue_service:
   otel_filters:
     - crate_name: "worker"
       filter_level: "trace"
+  memberlist_provider:
+    custom_resource:
+      kube_namespace: "chroma"
+      memberlist_name: "fn-consumer-memberlist"
+      queue_size: 100
+  assignment_policy:
+    rendezvous_hashing:
+      hasher: Murmur3
   sysdb:
     grpc:
       host: "sysdb.chroma"

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -240,6 +240,14 @@ work_queue_service:
   otel_filters:
     - crate_name: "worker"
       filter_level: "trace"
+  memberlist_provider:
+    custom_resource:
+      kube_namespace: "chroma"
+      memberlist_name: "fn-consumer-memberlist"
+      queue_size: 100
+  assignment_policy:
+    rendezvous_hashing:
+      hasher: Murmur3
   sysdb:
     grpc:
       host: "sysdb.chroma"

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -240,6 +240,14 @@ work_queue_service:
   otel_filters:
     - crate_name: "worker"
       filter_level: "trace"
+  memberlist_provider:
+    custom_resource:
+      kube_namespace: "chroma2"
+      memberlist_name: "fn-consumer-memberlist"
+      queue_size: 100
+  assignment_policy:
+    rendezvous_hashing:
+      hasher: Murmur3
   sysdb:
     grpc:
       host: "sysdb.chroma2"

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 const DEFAULT_CONFIG_PATH: &str = "./chroma_config.yaml";
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 /// # Description
 /// The primary config for the work queue service.
 pub struct WorkQueueServiceConfig {
@@ -45,6 +45,14 @@ pub struct WorkQueueServiceConfig {
     /// The configuration for the work queue.
     #[serde(default)]
     pub work_queue: crate::work_queue::config::WorkQueueConfig,
+
+    /// The fn-consumer memberlist used to assign queued functions to consumers.
+    #[serde(default = "WorkQueueServiceConfig::default_memberlist_provider")]
+    pub memberlist_provider: chroma_memberlist::config::MemberlistProviderConfig,
+
+    /// The policy used to assign attached functions to fn-consumer members.
+    #[serde(default)]
+    pub assignment_policy: assignment::config::AssignmentPolicyConfig,
 }
 
 impl WorkQueueServiceConfig {
@@ -65,6 +73,32 @@ impl WorkQueueServiceConfig {
 
     fn default_my_port() -> u16 {
         50051
+    }
+
+    fn default_memberlist_provider() -> chroma_memberlist::config::MemberlistProviderConfig {
+        chroma_memberlist::config::MemberlistProviderConfig::CustomResource(
+            chroma_memberlist::config::CustomResourceMemberlistProviderConfig {
+                kube_namespace: "chroma".to_string(),
+                memberlist_name: "fn-consumer-memberlist".to_string(),
+                queue_size: 100,
+            },
+        )
+    }
+}
+
+impl Default for WorkQueueServiceConfig {
+    fn default() -> Self {
+        Self {
+            service_name: Self::default_service_name(),
+            otel_endpoint: Self::default_otel_endpoint(),
+            otel_filters: Self::default_otel_filters(),
+            my_port: Self::default_my_port(),
+            sysdb: SysDbConfig::default(),
+            storage: chroma_storage::config::StorageConfig::default(),
+            work_queue: crate::work_queue::config::WorkQueueConfig::default(),
+            memberlist_provider: Self::default_memberlist_provider(),
+            assignment_policy: assignment::config::AssignmentPolicyConfig::default(),
+        }
     }
 }
 
@@ -553,5 +587,20 @@ impl CompactionServiceConfig {
 
     fn default_my_port() -> u16 {
         50051
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn work_queue_defaults_to_fn_consumer_memberlist() {
+        let config = WorkQueueServiceConfig::default();
+        let chroma_memberlist::config::MemberlistProviderConfig::CustomResource(provider) =
+            config.memberlist_provider;
+
+        assert_eq!(provider.kube_namespace, "chroma");
+        assert_eq!(provider.memberlist_name, "fn-consumer-memberlist");
     }
 }

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -603,4 +603,22 @@ mod tests {
         assert_eq!(provider.kube_namespace, "chroma");
         assert_eq!(provider.memberlist_name, "fn-consumer-memberlist");
     }
+
+    #[test]
+    fn work_queue_multiregion_configs_use_their_own_namespace() {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+
+        for (file_name, expected_namespace) in [
+            ("chroma_mcmr.yaml", "chroma"),
+            ("chroma_mcmr2.yaml", "chroma2"),
+        ] {
+            let config_path = manifest_dir.join(file_name);
+            let config = RootConfig::load_from_path(config_path.to_str().unwrap());
+            let chroma_memberlist::config::MemberlistProviderConfig::CustomResource(provider) =
+                config.work_queue_service.memberlist_provider;
+
+            assert_eq!(provider.kube_namespace, expected_namespace);
+            assert_eq!(provider.memberlist_name, "fn-consumer-memberlist");
+        }
+    }
 }

--- a/rust/worker/src/work_queue/server.rs
+++ b/rust/worker/src/work_queue/server.rs
@@ -1,8 +1,12 @@
 use crate::config::RootConfig;
 use crate::work_queue::work_queue_manager::{WorkQueueManager, WorkQueueReadyMessage};
 use crate::work_queue::work_queue_server::WorkQueueServer;
+use chroma_config::assignment::assignment_policy::RendezvousHashingAssignmentPolicy;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
+use chroma_memberlist::memberlist_provider::{
+    CustomResourceMemberlistProvider, MemberlistProvider,
+};
 use chroma_storage::Storage;
 use chroma_sysdb::SysDb;
 use chroma_types::chroma_proto::work_queue_service_server::WorkQueueServiceServer;
@@ -53,10 +57,45 @@ pub async fn service_entrypoint() {
         }
     };
 
+    let assignment_policy = match RendezvousHashingAssignmentPolicy::try_from_config(
+        &service_config.assignment_policy,
+        &registry,
+    )
+    .await
+    {
+        Ok(policy) => Box::new(policy),
+        Err(err) => {
+            eprintln!("Failed to create work queue assignment policy: {:?}", err);
+            return;
+        }
+    };
+
+    let mut memberlist_provider = match CustomResourceMemberlistProvider::try_from_config(
+        &service_config.memberlist_provider,
+        &registry,
+    )
+    .await
+    {
+        Ok(provider) => provider,
+        Err(err) => {
+            eprintln!(
+                "Failed to create fn-consumer memberlist provider: {:?}",
+                err
+            );
+            return;
+        }
+    };
+
     // Create and start work queue manager
-    let work_queue_manager =
-        WorkQueueManager::new(storage, work_queue_config.clone(), sysdb.clone());
+    let work_queue_manager = WorkQueueManager::new(
+        storage,
+        work_queue_config.clone(),
+        sysdb.clone(),
+        assignment_policy,
+    );
     let work_queue_handle = system.start_component(work_queue_manager);
+    memberlist_provider.subscribe(work_queue_handle.receiver());
+    let _memberlist_provider_handle = system.start_component(memberlist_provider);
 
     // Create and start gRPC server
     let work_queue_server = WorkQueueServer::new(work_queue_handle.clone(), sysdb);

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -370,6 +370,7 @@ impl QueueState {
         self.dedup_index.contains_key(&(*fn_id, *input_coll_id))
     }
 
+    #[cfg(test)]
     pub(crate) fn get_live_work(
         &self,
         limit: usize,

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -11,6 +11,8 @@ mod tests {
     use std::sync::Arc;
     use uuid::Uuid;
 
+    const TEST_FN_CONSUMER_SHARD_ID: &str = "fn-consumer-0";
+
     struct TestContext {
         work_queue_client: WorkQueueClient,
         sysdb: SysDb,
@@ -224,7 +226,7 @@ mod tests {
 
             let dlq_filtered = ctx
                 .work_queue_client
-                .get_work_with_failure_limit("test_shard".to_string(), 10, 3)
+                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, 3)
                 .await
                 .expect("Failed to fetch DLQ-filtered work");
             assert!(dlq_filtered
@@ -234,7 +236,7 @@ mod tests {
 
             let visible = ctx
                 .work_queue_client
-                .get_work_with_failure_limit("test_shard".to_string(), 10, 4)
+                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, 4)
                 .await
                 .expect("Failed to fetch work above DLQ threshold");
             assert!(visible
@@ -274,7 +276,7 @@ mod tests {
             // Get work
             let work_items = ctx
                 .work_queue_client
-                .get_work_with_failure_limit("test_shard".to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work");
 
@@ -305,7 +307,7 @@ mod tests {
             // Get work again - should not contain our function
             let work_items = ctx
                 .work_queue_client
-                .get_work_with_failure_limit("test_shard".to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work after finish");
 
@@ -356,7 +358,7 @@ mod tests {
             // Get work - should return in FIFO order
             let retrieved = ctx
                 .work_queue_client
-                .get_work_with_failure_limit("test_shard".to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work");
 
@@ -405,7 +407,7 @@ mod tests {
             // Get work again - should filter out completed items
             let filtered = ctx
                 .work_queue_client
-                .get_work_with_failure_limit("test_shard".to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get filtered work");
 
@@ -500,7 +502,7 @@ mod tests {
             // Get work - this branch still re-enqueues repair work into the queue.
             let work_items = ctx
                 .work_queue_client
-                .get_work_with_failure_limit("test_shard".to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work after repair");
 

--- a/rust/worker/src/work_queue/tests/integration.rs
+++ b/rust/worker/src/work_queue/tests/integration.rs
@@ -8,16 +8,42 @@ mod tests {
         CheckInvocationStatusRequest, InvocationCheckItem, InvocationStatus,
     };
     use chroma_types::{AttachedFunctionUuid, CollectionUuid, DatabaseName, SegmentFlushInfo};
+    use kube::core::{ApiResource, DynamicObject, GroupVersionKind};
+    use kube::{Api, Client};
     use std::sync::Arc;
     use uuid::Uuid;
-
-    const TEST_FN_CONSUMER_SHARD_ID: &str = "fn-consumer-0";
 
     struct TestContext {
         work_queue_client: WorkQueueClient,
         sysdb: SysDb,
         tenant_id: String,
         database_name: String,
+        fn_consumer_shard_id: String,
+    }
+
+    async fn get_fn_consumer_shard_id() -> Result<String, Box<dyn std::error::Error>> {
+        let client = Client::try_default().await?;
+        let gvk = GroupVersionKind::gvk("chroma.cluster", "v1", "MemberList");
+        let api_resource = ApiResource::from_gvk(&gvk);
+        let memberlists: Api<DynamicObject> = Api::namespaced_with(client, "chroma", &api_resource);
+
+        for _ in 0..30 {
+            let memberlist = memberlists.get("fn-consumer-memberlist").await?;
+            if let Some(member_id) = memberlist
+                .data
+                .get("spec")
+                .and_then(|spec| spec.get("members"))
+                .and_then(|members| members.as_array())
+                .and_then(|members| members.first())
+                .and_then(|member| member.get("member_id"))
+                .and_then(|member_id| member_id.as_str())
+            {
+                return Ok(member_id.to_string());
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+
+        Err("fn-consumer memberlist was not populated within 30 seconds".into())
     }
 
     async fn setup_test_context() -> Result<TestContext, Box<dyn std::error::Error>> {
@@ -39,12 +65,14 @@ mod tests {
         // Use pre-existing tenant and database
         let tenant_id = "default_tenant".to_string();
         let database_name = "default_database".to_string();
+        let fn_consumer_shard_id = get_fn_consumer_shard_id().await?;
 
         Ok(TestContext {
             work_queue_client,
             sysdb,
             tenant_id,
             database_name,
+            fn_consumer_shard_id,
         })
     }
 
@@ -226,7 +254,7 @@ mod tests {
 
             let dlq_filtered = ctx
                 .work_queue_client
-                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, 3)
+                .get_work_with_failure_limit(ctx.fn_consumer_shard_id.clone(), 10, 3)
                 .await
                 .expect("Failed to fetch DLQ-filtered work");
             assert!(dlq_filtered
@@ -236,7 +264,7 @@ mod tests {
 
             let visible = ctx
                 .work_queue_client
-                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, 4)
+                .get_work_with_failure_limit(ctx.fn_consumer_shard_id.clone(), 10, 4)
                 .await
                 .expect("Failed to fetch work above DLQ threshold");
             assert!(visible
@@ -276,7 +304,7 @@ mod tests {
             // Get work
             let work_items = ctx
                 .work_queue_client
-                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit(ctx.fn_consumer_shard_id.clone(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work");
 
@@ -307,7 +335,7 @@ mod tests {
             // Get work again - should not contain our function
             let work_items = ctx
                 .work_queue_client
-                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit(ctx.fn_consumer_shard_id.clone(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work after finish");
 
@@ -358,7 +386,7 @@ mod tests {
             // Get work - should return in FIFO order
             let retrieved = ctx
                 .work_queue_client
-                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit(ctx.fn_consumer_shard_id.clone(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work");
 
@@ -407,7 +435,7 @@ mod tests {
             // Get work again - should filter out completed items
             let filtered = ctx
                 .work_queue_client
-                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit(ctx.fn_consumer_shard_id.clone(), 10, i32::MAX)
                 .await
                 .expect("Failed to get filtered work");
 
@@ -502,7 +530,7 @@ mod tests {
             // Get work - this branch still re-enqueues repair work into the queue.
             let work_items = ctx
                 .work_queue_client
-                .get_work_with_failure_limit(TEST_FN_CONSUMER_SHARD_ID.to_string(), 10, i32::MAX)
+                .get_work_with_failure_limit(ctx.fn_consumer_shard_id.clone(), 10, i32::MAX)
                 .await
                 .expect("Failed to get work after repair");
 

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -1,10 +1,10 @@
-// V1: WorkDistributor import commented out
-// use crate::work_queue::distribution::WorkDistributor;
 use crate::work_queue::state::QueueState;
 use crate::work_queue::types::{FinishResult, WorkQueueError, WorkQueueRecord};
 
 use async_trait::async_trait;
+use chroma_config::assignment::assignment_policy::AssignmentPolicy;
 use chroma_error::ChromaError;
+use chroma_memberlist::memberlist_provider::Memberlist;
 use chroma_storage::{GetOptions, PutMode, PutOptions, Storage};
 use chroma_sysdb::SysDb;
 use chroma_system::{Component, ComponentContext, ComponentRuntime, Handler};
@@ -37,7 +37,6 @@ pub struct FinishWorkMessage {
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct GetWorkMessage {
-    #[allow(dead_code)]
     pub shard_id: String,
     pub limit: usize,
     pub max_failure_count: i32,
@@ -75,6 +74,7 @@ pub(crate) struct WorkQueueManager {
     storage_path: String,
     sysdb: SysDb,
     config: crate::work_queue::config::WorkQueueConfig,
+    assignment_policy: Box<dyn AssignmentPolicy>,
     // Pending responses waiting for persistence (push work responses)
     pending_push_responses: Vec<oneshot::Sender<Result<(), WorkQueueError>>>,
     // Pending responses for finish work
@@ -89,6 +89,7 @@ impl WorkQueueManager {
         storage: Storage,
         config: crate::work_queue::config::WorkQueueConfig,
         sysdb: SysDb,
+        assignment_policy: Box<dyn AssignmentPolicy>,
     ) -> Self {
         Self {
             state: QueueState::new(),
@@ -96,15 +97,72 @@ impl WorkQueueManager {
             storage_path: config.storage_path.clone(),
             sysdb,
             config,
+            assignment_policy,
             pending_push_responses: Vec::new(),
             pending_finish_responses: Vec::new(),
         }
     }
 
-    // V1: Memberlist methods commented out
-    // pub fn set_memberlist(&mut self, members: Vec<chroma_memberlist::memberlist_provider::Member>) {
-    //     self.distributor = Some(WorkDistributor::new(members));
-    // }
+    fn set_memberlist(&mut self, memberlist: Memberlist) {
+        self.assignment_policy.set_members(
+            memberlist
+                .into_iter()
+                .map(|member| member.member_id)
+                .collect(),
+        );
+    }
+
+    fn get_work_for_shard(
+        &self,
+        shard_id: &str,
+        limit: usize,
+        max_failure_count: i32,
+    ) -> (Vec<WorkQueueRecord>, usize) {
+        let members = self.assignment_policy.get_members();
+        if members.is_empty() {
+            tracing::warn!("Fn-consumer memberlist is empty; returning no work");
+            return (Vec::new(), 0);
+        }
+        if !members.iter().any(|member| member == shard_id) {
+            tracing::warn!(
+                shard_id,
+                member_count = members.len(),
+                "Unknown fn-consumer shard requested work"
+            );
+            return (Vec::new(), 0);
+        }
+
+        let mut work = Vec::with_capacity(limit);
+        let mut failure_count_filtered = 0;
+        for item in self
+            .state
+            .pending_work
+            .iter()
+            .filter(|item| self.state.contains_entry(&item.fn_id, &item.input_coll_id))
+        {
+            let assigned_member = match self.assignment_policy.assign_one(&item.fn_id.to_string()) {
+                Ok(member) => member,
+                Err(error) => {
+                    tracing::error!(
+                        fn_id = %item.fn_id,
+                        error = %error,
+                        "Failed to assign queued function to an fn-consumer"
+                    );
+                    continue;
+                }
+            };
+            if assigned_member != shard_id {
+                continue;
+            }
+            if item.failure_count >= max_failure_count {
+                failure_count_filtered += 1;
+            } else if work.len() < limit {
+                work.push(item.clone());
+            }
+        }
+
+        (work, failure_count_filtered)
+    }
 
     #[tracing::instrument(name = "WorkQueueManager::load_state", skip(self))]
     async fn load_state(&mut self) -> Result<(), WorkQueueError> {
@@ -402,8 +460,9 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
         // With eager stale-row removal on push, the queue's dedup index is the
         // source of truth for whether a row is still live.
         let (filtered, failure_count_filtered) =
-            self.state.get_live_work(msg.limit, msg.max_failure_count);
+            self.get_work_for_shard(&msg.shard_id, msg.limit, msg.max_failure_count);
         tracing::info!(
+            shard_id = %msg.shard_id,
             returned_items = filtered.len(),
             failure_count_filtered,
             max_failure_count = msg.max_failure_count,
@@ -413,6 +472,19 @@ impl Handler<GetWorkMessage> for WorkQueueManager {
         if msg.response_tx.send(Ok(filtered)).is_err() {
             tracing::warn!("Failed to send get work response - receiver dropped");
         }
+    }
+}
+
+#[async_trait]
+impl Handler<Memberlist> for WorkQueueManager {
+    type Result = ();
+
+    async fn handle(&mut self, memberlist: Memberlist, _ctx: &ComponentContext<WorkQueueManager>) {
+        tracing::info!(
+            member_count = memberlist.len(),
+            "Updating fn-consumer memberlist"
+        );
+        self.set_memberlist(memberlist);
     }
 }
 
@@ -496,6 +568,8 @@ impl Handler<PeriodicPersistMessage> for WorkQueueManager {
 mod tests {
     use super::*;
     use crate::work_queue::state::QueueState;
+    use chroma_config::assignment::assignment_policy::RendezvousHashingAssignmentPolicy;
+    use chroma_memberlist::memberlist_provider::Member;
     use chroma_storage::local::LocalStorage;
     use tempfile::TempDir;
     use uuid::Uuid;
@@ -514,13 +588,20 @@ mod tests {
         SysDb::Test(chroma_sysdb::test_sysdb::TestSysDb::new())
     }
 
+    fn create_test_assignment_policy() -> Box<dyn AssignmentPolicy> {
+        Box::new(RendezvousHashingAssignmentPolicy::default())
+    }
+
     async fn create_test_manager() -> (WorkQueueManager, TempDir) {
         let temp_dir = TempDir::new().unwrap();
         let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
         let mut config = create_test_config();
         config.storage_path = "queue.parquet".to_string(); // Use relative path within temp dir
         let sysdb = create_test_sysdb();
-        (WorkQueueManager::new(storage, config, sysdb), temp_dir)
+        (
+            WorkQueueManager::new(storage, config, sysdb, create_test_assignment_policy()),
+            temp_dir,
+        )
     }
 
     #[test]
@@ -611,6 +692,90 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn test_get_work_returns_only_functions_assigned_to_shard() {
+        let (mut manager, _temp_dir) = create_test_manager().await;
+        manager.set_memberlist(vec![
+            Member {
+                member_id: "fn-consumer-a".to_string(),
+                member_ip: "10.0.0.1".to_string(),
+                member_node_name: "node-a".to_string(),
+            },
+            Member {
+                member_id: "fn-consumer-b".to_string(),
+                member_ip: "10.0.0.2".to_string(),
+                member_node_name: "node-b".to_string(),
+            },
+        ]);
+
+        let fn_for_a = (1..1000)
+            .map(|value| AttachedFunctionUuid(Uuid::from_u128(value)))
+            .find(|fn_id| {
+                manager
+                    .assignment_policy
+                    .assign_one(&fn_id.to_string())
+                    .unwrap()
+                    == "fn-consumer-a"
+            })
+            .expect("expected to find a function assigned to shard a");
+        let fn_for_b = (1..1000)
+            .map(|value| AttachedFunctionUuid(Uuid::from_u128(value)))
+            .find(|fn_id| {
+                manager
+                    .assignment_policy
+                    .assign_one(&fn_id.to_string())
+                    .unwrap()
+                    == "fn-consumer-b"
+            })
+            .expect("expected to find a function assigned to shard b");
+
+        // Put shard b first to prove the shard filter scans past other shards
+        // before applying the response limit.
+        manager
+            .state
+            .push_work(fn_for_b, CollectionUuid(Uuid::new_v4()), 10, 10);
+        manager
+            .state
+            .push_work(fn_for_a, CollectionUuid(Uuid::new_v4()), 20, 20);
+        manager
+            .state
+            .push_work(fn_for_a, CollectionUuid(Uuid::new_v4()), 30, 30);
+
+        let (work_for_a, _) = manager.get_work_for_shard("fn-consumer-a", 1, i32::MAX);
+        assert_eq!(work_for_a.len(), 1);
+        assert_eq!(work_for_a[0].fn_id, fn_for_a);
+
+        let (all_work_for_a, _) = manager.get_work_for_shard("fn-consumer-a", 10, i32::MAX);
+        assert_eq!(all_work_for_a.len(), 2);
+        assert!(all_work_for_a.iter().all(|item| item.fn_id == fn_for_a));
+
+        let (work_for_b, _) = manager.get_work_for_shard("fn-consumer-b", 10, i32::MAX);
+        assert_eq!(work_for_b.len(), 1);
+        assert_eq!(work_for_b[0].fn_id, fn_for_b);
+    }
+
+    #[tokio::test]
+    async fn test_get_work_returns_nothing_for_empty_or_unknown_memberlist() {
+        let (mut manager, _temp_dir) = create_test_manager().await;
+        manager.state.push_work(
+            AttachedFunctionUuid(Uuid::new_v4()),
+            CollectionUuid(Uuid::new_v4()),
+            10,
+            10,
+        );
+
+        let (without_members, _) = manager.get_work_for_shard("fn-consumer-a", 10, i32::MAX);
+        assert!(without_members.is_empty());
+
+        manager.set_memberlist(vec![Member {
+            member_id: "fn-consumer-a".to_string(),
+            member_ip: "10.0.0.1".to_string(),
+            member_node_name: "node-a".to_string(),
+        }]);
+        let (unknown_member, _) = manager.get_work_for_shard("fn-consumer-unknown", 10, i32::MAX);
+        assert!(unknown_member.is_empty());
+    }
+
     #[test]
     fn test_get_work_skips_dlq_items_before_applying_limit() {
         let mut state = QueueState::new();
@@ -643,7 +808,12 @@ mod tests {
         {
             let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
             let sysdb = create_test_sysdb();
-            let mut manager = WorkQueueManager::new(storage, config.clone(), sysdb);
+            let mut manager = WorkQueueManager::new(
+                storage,
+                config.clone(),
+                sysdb,
+                create_test_assignment_policy(),
+            );
             manager.state.push_work(fn_id_1, coll_id_1, 100, 100);
             manager.state.push_work(fn_id_2, coll_id_2, 200, 200);
             manager.persist().await.unwrap();
@@ -653,7 +823,8 @@ mod tests {
         {
             let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
             let sysdb = create_test_sysdb();
-            let mut manager = WorkQueueManager::new(storage, config, sysdb);
+            let mut manager =
+                WorkQueueManager::new(storage, config, sysdb, create_test_assignment_policy());
             manager.load_state().await.unwrap();
             assert_eq!(manager.state.pending_work.len(), 2);
             assert_eq!(manager.state.pending_work[0].completion_offset, 100);


### PR DESCRIPTION
## Summary
- add fn-consumer membership reconciliation to SysDB
- subscribe WQS to the fn-consumer MemberList
- assign attached functions with rendezvous hashing on `fn_id`
- return work only to the requesting active shard
- use each Deployment pod's Kubernetes name as its unique member ID
- configure each local/multi-region WQS to watch its own namespace
- add the MemberList, scoped RBAC, topology spreading, and Tilt wiring
- bump the distributed chart to 0.1.93

## Scope
Atomic SysDB, WQS, Helm, and Tilt support for fn-consumer sharding. These pieces are kept together so the runtime and Kubernetes integration tests never run without the membership resources they require.

## Risk
- membership changes can reassign queued or in-flight work; delivery remains at-least-once and functions must tolerate retries
- Deployment rollouts change member IDs and therefore rebalance assignments
- empty or unknown shards intentionally receive no work until membership is populated
- WQS scans the queue and computes rendezvous ownership per item; this is acceptable for the initial rollout but should be observed at larger queue depths

## Validation
- `cargo test -p worker work_queue::work_queue_manager::tests --lib`
- `cargo test -p worker config::tests::work_queue_defaults_to_fn_consumer_memberlist --lib`
- `cargo test -p worker config::tests::work_queue_multiregion_configs_use_their_own_namespace --lib`
- `cargo check -p worker --tests`
- `cargo clippy -p worker --lib -- -D warnings`
- generated-proto `go test ./pkg/sysdb/grpc -run TestMemberlistManagerConfigsIncludesFnConsumer`
- generated-proto `go test ./cmd/coordinator`
- `go vet ./pkg/sysdb/grpc ./cmd/coordinator`
- `helm lint k8s/distributed-chroma`
- `helm template distributed-chroma k8s/distributed-chroma`
- `tilt alpha tiltfile-result`
- `git diff --check`
