### PR TITLE
[ENH]: Add fn-consumer memberlist chart

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -276,12 +276,15 @@ k8s_resource(
     'compaction-service-memberlist:MemberList:chroma',
     'garbage-collection-service-memberlist:MemberList:chroma',
     'rust-log-service-memberlist:MemberList:chroma',
+    'fn-consumer-memberlist:MemberList:chroma',
 
     'sysdb-serviceaccount:ServiceAccount:chroma',
     'sysdb-serviceaccount-rolebinding:RoleBinding:chroma',
     'sysdb-query-service-memberlist-binding:RoleBinding:chroma',
     'sysdb-compaction-service-memberlist-binding:RoleBinding:chroma',
     'sysdb-rust-log-service-memberlist-binding:RoleBinding:chroma',
+    'fn-consumer-memberlist-writer:Role:chroma',
+    'sysdb-fn-consumer-memberlist-writer:RoleBinding:chroma',
 
     'query-service-serviceaccount:ServiceAccount:chroma',
     'query-service-serviceaccount-rolebinding:RoleBinding:chroma',
@@ -298,6 +301,8 @@ k8s_resource(
     'fn-consumer-rust-log-service-memberlist-binding:RoleBinding:chroma',
     'fn-consumer-service-account:ServiceAccount:chroma',
     'fn-consumer-service-serviceaccount-rolebinding:RoleBinding:chroma',
+    'fn-consumer-memberlist-reader:Role:chroma',
+    'work-queue-service-fn-consumer-memberlist-reader:RoleBinding:chroma',
 
     'rust-frontend-service-serviceaccount:ServiceAccount:chroma',
     'rust-frontend-service-rolebinding:RoleBinding:chroma',
@@ -324,12 +329,15 @@ k8s_resource(
     'compaction-service-memberlist:MemberList:chroma2',
     'garbage-collection-service-memberlist:MemberList:chroma2',
     'rust-log-service-memberlist:MemberList:chroma2',
+    'fn-consumer-memberlist:MemberList:chroma2',
 
     'sysdb-serviceaccount:ServiceAccount:chroma2',
     'sysdb-serviceaccount-rolebinding:RoleBinding:chroma2',
     'sysdb-query-service-memberlist-binding:RoleBinding:chroma2',
     'sysdb-compaction-service-memberlist-binding:RoleBinding:chroma2',
     'sysdb-rust-log-service-memberlist-binding:RoleBinding:chroma2',
+    'fn-consumer-memberlist-writer:Role:chroma2',
+    'sysdb-fn-consumer-memberlist-writer:RoleBinding:chroma2',
 
     'query-service-serviceaccount:ServiceAccount:chroma2',
     'query-service-serviceaccount-rolebinding:RoleBinding:chroma2',
@@ -342,6 +350,9 @@ k8s_resource(
     'compaction-service-memberlist-readerwriter-binding:RoleBinding:chroma2',
     'compaction-service-serviceaccount:ServiceAccount:chroma2',
     'compaction-service-serviceaccount-rolebinding:RoleBinding:chroma2',
+
+    'fn-consumer-memberlist-reader:Role:chroma2',
+    'work-queue-service-fn-consumer-memberlist-reader:RoleBinding:chroma2',
 
     'rust-frontend-service-serviceaccount:ServiceAccount:chroma2',
     'rust-frontend-service-rolebinding:RoleBinding:chroma2',
@@ -367,7 +378,7 @@ k8s_resource('rust-frontend-service:deployment:chroma', resource_deps=['sysdb:de
 k8s_resource('query-service:statefulset:chroma', resource_deps=['sysdb:deployment:chroma'], labels=["chroma"], port_forwards='50053:50051')
 k8s_resource('compaction-service:statefulset:chroma', resource_deps=['sysdb:deployment:chroma'] + ['work-queue-service:statefulset:chroma'], labels=["chroma"], port_forwards="50057:50051")
 k8s_resource('work-queue-service:statefulset:chroma', resource_deps=['sysdb:deployment:chroma'], labels=["chroma"], port_forwards="50058:50051")
-k8s_resource('fn-consumer:deployment:chroma', resource_deps=['sysdb:deployment:chroma', 'work-queue-service:statefulset:chroma'], labels=["chroma"], port_forwards="50059:50051")
+k8s_resource('fn-consumer:statefulset:chroma', resource_deps=['sysdb:deployment:chroma', 'work-queue-service:statefulset:chroma'], labels=["chroma"], port_forwards="50059:50051")
 k8s_resource('garbage-collector:statefulset:chroma', resource_deps=['k8s_setup', 'minio-deployment', 'rust-log-service:statefulset:chroma'], labels=["chroma"], port_forwards='50055:50055')
 
 # Production Chroma 2
@@ -411,7 +422,7 @@ groups = {
     'query-service:statefulset:chroma',
     'compaction-service:statefulset:chroma',
     'work-queue-service:statefulset:chroma',
-    'fn-consumer:deployment:chroma',
+    'fn-consumer:statefulset:chroma',
     'garbage-collector:statefulset:chroma',
     'jaeger',
     'grafana',
@@ -432,7 +443,7 @@ groups = {
     'query-service:statefulset:chroma2',
     'compaction-service:statefulset:chroma2',
     'work-queue-service:statefulset:chroma2',
-    'fn-consumer:deployment:chroma2',
+    'fn-consumer:statefulset:chroma2',
     'garbage-collector:statefulset:chroma2',
     'spanner-deployment',
   ],

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.92
+version: 0.1.93
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/fn-consumer-memberlist-cr.yaml
+++ b/k8s/distributed-chroma/templates/fn-consumer-memberlist-cr.yaml
@@ -1,0 +1,64 @@
+apiVersion: chroma.cluster/v1
+kind: MemberList
+metadata:
+  name: fn-consumer-memberlist
+  namespace: {{ .Values.namespace }}
+spec:
+  members:
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fn-consumer-memberlist-writer
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups: ["chroma.cluster"]
+    resources: ["memberlists"]
+    resourceNames: ["fn-consumer-memberlist"]
+    verbs: ["get", "update", "patch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sysdb-fn-consumer-memberlist-writer
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fn-consumer-memberlist-writer
+subjects:
+  - kind: ServiceAccount
+    name: sysdb-serviceaccount
+    namespace: {{ .Values.namespace }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fn-consumer-memberlist-reader
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups: ["chroma.cluster"]
+    resources: ["memberlists"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: work-queue-service-fn-consumer-memberlist-reader
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fn-consumer-memberlist-reader
+subjects:
+  - kind: ServiceAccount
+    name: work-queue-service-serviceaccount
+    namespace: {{ .Values.namespace }}

--- a/k8s/distributed-chroma/templates/fn-consumer.yaml
+++ b/k8s/distributed-chroma/templates/fn-consumer.yaml
@@ -105,6 +105,7 @@ metadata:
   name: fn-consumer
   namespace: {{ .Values.namespace }}
 spec:
+  clusterIP: None
   selector:
     app: fn-consumer
   ports:

--- a/k8s/distributed-chroma/templates/fn-consumer.yaml
+++ b/k8s/distributed-chroma/templates/fn-consumer.yaml
@@ -13,11 +13,12 @@ data:
 
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: fn-consumer
   namespace: {{ .Values.namespace }}
 spec:
+  serviceName: fn-consumer
   replicas: {{ .Values.fnConsumer.replicaCount }}
   selector:
     matchLabels:
@@ -26,6 +27,7 @@ spec:
     metadata:
       labels:
         app: fn-consumer
+        member-type: fn-consumer
     spec:
       serviceAccountName: fn-consumer-service-account
       volumes:
@@ -62,6 +64,10 @@ spec:
               # TODO properly use flow control here to check which type of value we need.
 {{ .value | nindent 14 }}
             {{ end }}
+            - name: CHROMA_FN_CONSUMER_SERVICE__MY_MEMBER_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           {{ if .Values.fnConsumer.resources }}
           resources:
             limits:
@@ -71,6 +77,25 @@ spec:
               cpu: {{ .Values.fnConsumer.resources.requests.cpu }}
               memory: {{ .Values.fnConsumer.resources.requests.memory }}
           {{ end }}
+      {{if .Values.fnConsumer.tolerations}}
+      tolerations:
+        {{ toYaml .Values.fnConsumer.tolerations | nindent 8 }}
+      {{ end }}
+      {{if .Values.fnConsumer.nodeSelector}}
+      nodeSelector:
+        {{ toYaml .Values.fnConsumer.nodeSelector | nindent 8 }}
+      {{ end }}
+      {{if .Values.fnConsumer.affinity}}
+      affinity:
+        {{ toYaml .Values.fnConsumer.affinity | nindent 8 }}
+      {{ end }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              member-type: fn-consumer
 
 ---
 


### PR DESCRIPTION
## Summary
- deploy fn-consumer as a StatefulSet with stable member IDs and a headless governing Service
- label ready fn-consumer pods for SysDB membership reconciliation
- create the `fn-consumer-memberlist` resource
- grant scoped writer access to SysDB and reader access to WQS
- spread consumers across Kubernetes nodes when possible
- update Tilt resource identities and setup dependencies for both local namespaces
- bump the distributed chart to 0.1.93

## Scope
Distributed Chroma Helm chart and matching Tilt wiring only. This PR depends on the WQS/SysDB runtime PR in its base branch.

## Risk
The workload kind changes from Deployment to StatefulSet. During rollout, review rendered manifests and verify the old Deployment is removed before scaling beyond one replica.

## Validation
- `helm lint k8s/distributed-chroma`
- `helm template distributed-chroma k8s/distributed-chroma`
- `tilt alpha tiltfile-result`
- `git diff --check`

The current repo-wide Clippy failure is in unchanged `rust/types` code and is unrelated to this chart-only diff.