### PR TITLE
[BUG](foundation-api): Configurably skip currents on init

### DIFF
--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -83,6 +83,10 @@ pub struct FoundationConfig {
     /// (its output is the currents collection).
     #[serde(default = "FoundationConfig::default_currents_function_name")]
     pub currents_function_name: String,
+    /// Whether `/api/init` attaches the configured wiki-to-currents function.
+    /// Disabled by default while Currents is not enabled for a deployment.
+    #[serde(default)]
+    pub enable_currents_function: bool,
     /// Modal endpoint the attached function POSTs to. Threaded into the
     /// attach `params` as `endpoint_url`. Required — there is intentionally
     /// no default, so a deploy can't silently fall back to a hardcoded
@@ -181,6 +185,7 @@ impl Default for FoundationConfig {
             indexed_source_collections: Self::default_indexed_source_collections(),
             function_name: Self::default_function_name(),
             currents_function_name: Self::default_currents_function_name(),
+            enable_currents_function: false,
             function_endpoint_url: None,
             function_batch_size: Self::default_function_batch_size(),
             min_records_for_invocation: Self::default_min_records_for_invocation(),
@@ -223,6 +228,7 @@ mod tests {
                 ],
                 function_name: "http_generate".to_string(),
                 currents_function_name: "http_currents".to_string(),
+                enable_currents_function: false,
                 function_endpoint_url: None,
                 function_batch_size: 500_000,
                 min_records_for_invocation: 100,

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -136,14 +136,15 @@ pub async fn foundation_init(
         foundation_cfg,
     )
     .await?;
-    ensure_currents_function(
-        &mut sysdb,
-        tenant.clone(),
-        wiki.collection_id,
-        foundation_cfg,
-    )
-    .await?;
-
+    if foundation_cfg.enable_currents_function {
+        ensure_currents_function(
+            &mut sysdb,
+            tenant.clone(),
+            wiki.collection_id,
+            foundation_cfg,
+        )
+        .await?;
+    }
     // Private (per-user) collections — namespaced by user_id so each team
     // member gets their own isolated collection for uploads and traces.
     let file_uploads_name = format!("{}_{}", foundation_cfg.file_uploads_collection, user_id);


### PR DESCRIPTION
## Summary
- add `foundation.enable_currents_function`, disabled by default
- attach `http_currents` during `/api/init` only when that flag is enabled
- preserve the existing Currents helper and configuration

## Validation
- pre-commit hooks run during commit
- local Rust build intentionally skipped; CI will validate