### PR TITLE
[BUG](types): Name whitespace error names the cause

### DIFF
--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -70,8 +70,17 @@ pub fn validate_name(name: impl AsRef<str>) -> Result<(), ValidationError> {
         return Ok(());
     }
 
+    if name_str != name_str.trim() {
+        return Err(ValidationError::new("name").with_message(
+            format!(
+                "Expected a name without leading or trailing whitespace. Got: {name_str:?}"
+            )
+            .into(),
+        ));
+    }
+
     if !ALNUM_RE.is_match(name_str) {
-        return Err(ValidationError::new("name").with_message(format!("Expected a name containing 3-512 characters from [a-zA-Z0-9._-], starting and ending with a character in [a-zA-Z0-9]. Got: {name_str}").into()));
+        return Err(ValidationError::new("name").with_message(format!("Expected a name containing 3-512 characters from [a-zA-Z0-9._-], starting and ending with a character in [a-zA-Z0-9]. Got: {name_str:?}").into()));
     }
 
     if DP_RE.is_match(name_str) {
@@ -423,6 +432,31 @@ mod tests {
     fn invalid_simple_name_ip_address() {
         assert!(validate_name("192.168.0.1").is_err());
         assert!(validate_name("127.0.0.1").is_err());
+    }
+
+    #[test]
+    fn invalid_simple_name_surrounding_whitespace_names_the_cause() {
+        for name in [" testDB", "testDB ", " testDB ", "\ttestDB", "testDB\n"] {
+            let err = validate_name(name).expect_err("surrounding whitespace must be rejected");
+            let message = err.to_string();
+            assert!(
+                message.contains("whitespace"),
+                "message must name whitespace as the cause, got: {message}"
+            );
+            assert!(
+                message.contains(&format!("{name:?}")),
+                "message must quote the raw value so the whitespace is visible, got: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_simple_name_quotes_the_rejected_value() {
+        let err = validate_name("test DB").expect_err("interior space must be rejected");
+        assert!(
+            err.to_string().contains("\"test DB\""),
+            "rejected value must be quoted, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

Creating a database whose name has a leading or trailing space failed the alphanumeric check, and the error interpolated the raw value, so `" testDB"` rendered as

```
Expected a name containing 3-512 characters from [a-zA-Z0-9._-], starting and ending with a character in [a-zA-Z0-9]. Got: testDB
```

`testDB` on its own satisfies that rule, so the message told the user their valid name was invalid and the actual cause, the invisible space, never appeared

This rejects surrounding whitespace with its own message and quotes the rejected value in both messages, so whitespace is visible wherever a name is refused

```
Expected a name without leading or trailing whitespace. Got: " testDB"
```

I kept validation strict rather than trimming silently. Trimming would accept a name the caller did not type, and a name that differs from what the user sees is worse than a clear refusal. Interior spaces still fall through to the alphanumeric check, now quoted

- *Improvements & Bug fixes*
  - Name validation reports surrounding whitespace as its own error instead of a misleading character-set error
  - Rejected names are quoted in validation messages so invisible characters are visible

- *New functionality*
  - None

## Test plan

`cargo test -p chroma-types --lib validators`, 20 passed

Two tests cover this. `invalid_simple_name_surrounding_whitespace_names_the_cause` walks leading, trailing, both, tab, and newline forms, asserting the message names whitespace and quotes the raw value. `invalid_simple_name_quotes_the_rejected_value` pins the quoting on the alphanumeric path with an interior space

I checked both tests fail without the fix rather than assuming they cover it. Removing the whitespace guard and keeping the tests gives

```
---- validators::tests::invalid_simple_name_surrounding_whitespace_names_the_cause stdout ----
panicked at rust/types/src/validators.rs:433:13:
message must name whitespace as the cause, got: Expected a name containing 3-512 characters
from [a-zA-Z0-9._-], starting and ending with a character in [a-zA-Z0-9]. Got: " testDB"

test result: FAILED. 19 passed; 1 failed
```

Restoring the guard returns 20 passed

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

None. The change is to validation error text, not to a documented API surface
