### PR TITLE
[BUG](utils): Fix RWLock writer starvation

### DIFF
--- a/chromadb/test/utils/test_read_write_lock.py
+++ b/chromadb/test/utils/test_read_write_lock.py
@@ -1,0 +1,108 @@
+import threading
+import time
+
+from chromadb.utils.read_write_lock import ReadWriteLock
+
+
+def _wait_until(predicate, timeout=5.0, interval=0.01):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_pending_writer_blocks_new_readers():
+    """Regression test for writer starvation.
+
+    A steady stream of new readers must not be able to keep a waiting
+    writer starved forever: once a writer starts waiting for readers to
+    drain, any *new* reader must itself wait until that writer has run
+    and released the lock.
+    """
+    lock = ReadWriteLock()
+
+    # An existing reader holds the lock, so the writer below will have to
+    # wait.
+    lock.acquire_read()
+
+    writer_acquired = threading.Event()
+
+    def writer():
+        lock.acquire_write()
+        writer_acquired.set()
+        lock.release_write()
+
+    writer_thread = threading.Thread(target=writer)
+    writer_thread.start()
+
+    # Wait for the writer to register that it's waiting.
+    assert _wait_until(lambda: lock._writers_waiting > 0), (
+        "writer never started waiting"
+    )
+
+    # A brand new reader arrives while the writer is waiting. It must be
+    # blocked by the fix, not slip in ahead of the writer.
+    new_reader_acquired = threading.Event()
+
+    def new_reader():
+        lock.acquire_read()
+        new_reader_acquired.set()
+        lock.release_read()
+
+    new_reader_thread = threading.Thread(target=new_reader)
+    new_reader_thread.start()
+
+    # The new reader should NOT be able to acquire while the writer is
+    # still waiting for the original reader to release.
+    time.sleep(0.2)
+    assert not new_reader_acquired.is_set(), (
+        "a new reader acquired the lock while a writer was waiting -- "
+        "this starves the writer"
+    )
+    assert not writer_acquired.is_set()
+
+    # Release the original reader: the writer should now be able to run.
+    lock.release_read()
+
+    assert _wait_until(writer_acquired.is_set), "writer was never able to acquire"
+    writer_thread.join(timeout=5.0)
+
+    # And now that the writer has finished, the new reader should proceed.
+    assert _wait_until(new_reader_acquired.is_set), (
+        "new reader never acquired after the writer finished"
+    )
+    new_reader_thread.join(timeout=5.0)
+
+
+def test_multiple_readers_can_acquire_concurrently():
+    lock = ReadWriteLock()
+    lock.acquire_read()
+    lock.acquire_read()
+    assert lock._readers == 2
+    lock.release_read()
+    lock.release_read()
+    assert lock._readers == 0
+
+
+def test_write_lock_is_exclusive():
+    lock = ReadWriteLock()
+    lock.acquire_write()
+    try:
+        second_writer_acquired = threading.Event()
+
+        def second_writer():
+            lock.acquire_write()
+            second_writer_acquired.set()
+            lock.release_write()
+
+        t = threading.Thread(target=second_writer)
+        t.start()
+        time.sleep(0.2)
+        assert not second_writer_acquired.is_set()
+    finally:
+        lock.release_write()
+
+    assert _wait_until(second_writer_acquired.is_set)
+    t.join(timeout=5.0)

--- a/chromadb/utils/read_write_lock.py
+++ b/chromadb/utils/read_write_lock.py
@@ -10,12 +10,21 @@ class ReadWriteLock:
     def __init__(self) -> None:
         self._read_ready = threading.Condition(threading.RLock())
         self._readers = 0
+        # Number of writers currently waiting for readers to drain (0 or 1,
+        # since acquire_write() holds the underlying lock for its whole
+        # critical section, so at most one thread can be in that phase at a
+        # time). Used to stop new readers from continually renewing
+        # `_readers > 0` and starving a waiting writer.
+        self._writers_waiting = 0
 
     def acquire_read(self) -> None:
         """Acquire a read lock. Blocks only if a thread has
-        acquired the write lock."""
+        acquired the write lock, or a thread is waiting to acquire
+        the write lock."""
         self._read_ready.acquire()
         try:
+            while self._writers_waiting > 0:
+                self._read_ready.wait()
             self._readers += 1
         finally:
             self._read_ready.release()
@@ -32,13 +41,21 @@ class ReadWriteLock:
 
     def acquire_write(self) -> None:
         """Acquire a write lock. Blocks until there are no
-        acquired read or write locks."""
+        acquired read or write locks. Once a thread starts waiting
+        here, new readers are blocked so they cannot starve it."""
         self._read_ready.acquire()
-        while self._readers > 0:
-            self._read_ready.wait()
+        self._writers_waiting += 1
+        try:
+            while self._readers > 0:
+                self._read_ready.wait()
+        finally:
+            self._writers_waiting -= 1
 
     def release_write(self) -> None:
         """Release a write lock."""
+        # Wake any readers parked in acquire_read() because a writer was
+        # waiting; without this they'd never be notified and would hang.
+        self._read_ready.notify_all()
         self._read_ready.release()
 
 


### PR DESCRIPTION
## Description of changes

`ReadWriteLock` (`chromadb/utils/read_write_lock.py`) is susceptible to writer starvation under sustained read load. It guards the local HNSW vector segment (`local_hnsw.py`, `local_persistent_hnsw.py`), so this can stall index writes (inserts/updates) indefinitely under continuous query traffic.

### Root cause

`acquire_write()` waits for `_readers` to reach zero via `Condition.wait()`, which temporarily releases the underlying lock while waiting. `acquire_read()` had no way to know a writer was already waiting, so a continuous stream of *new* readers could keep sneaking in during those release windows, continually renewing `_readers > 0` and never letting the writer proceed.

I verified this empirically against the current code:

```python
lock = ReadWriteLock()
lock.acquire_read()                     # reader1 holds it

# writer starts waiting (readers > 0)
threading.Thread(target=lambda: (lock.acquire_write(), writer_done.set(), lock.release_write())).start()
time.sleep(0.1)

# a brand new reader arrives while the writer is still waiting
threading.Thread(target=lambda: (lock.acquire_read(), new_reader_ok.set(), lock.release_read())).start()
time.sleep(0.3)

print(new_reader_ok.is_set())  # True on current main -- the writer is starved
```

### Fix

Track the number of writers currently waiting (`_writers_waiting`). New readers now check this and block until it drops back to zero, so once a writer registers intent, no further readers can be admitted ahead of it. `release_write()` calls `notify_all()` so any readers parked on that check are woken (a plain lock release doesn't wake `Condition.wait()`ers).

This preserves the original mutual-exclusion mechanism (the writer still holds the underlying `RLock` across its whole critical section) — the change only affects when *new* readers are admitted.

## Test plan

- Added `chromadb/test/utils/test_read_write_lock.py`:
  - `test_pending_writer_blocks_new_readers`: reproduces the starvation scenario and asserts a new reader blocks until the waiting writer has run.
  - `test_multiple_readers_can_acquire_concurrently`: unchanged behavior sanity check.
  - `test_write_lock_is_exclusive`: unchanged behavior sanity check.
- Verified the starvation test fails against the original code (new reader acquires while the writer is still starved) and passes against the fix.
- Verified no deadlock is introduced: released readers correctly wake and proceed once the writer finishes.