### PR TITLE
fix(telemetry): replace deprecated asyncio.iscoroutinefunction with inspect.iscoroutinefunction

### DIFF
--- a/chromadb/telemetry/opentelemetry/__init__.py
+++ b/chromadb/telemetry/opentelemetry/__init__.py
@@ -1,4 +1,4 @@
-import asyncio
+import inspect
 import os
 from functools import wraps
 from enum import Enum
@@ -125,7 +125,7 @@ def trace_method(
     """A decorator that traces a method."""
 
     def decorator(f: T) -> T:
-        if asyncio.iscoroutinefunction(f):
+        if inspect.iscoroutinefunction(f):
 
             @wraps(f)
             async def async_wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]

--- a/chromadb/test/telemetry/test_opentelemetry.py
+++ b/chromadb/test/telemetry/test_opentelemetry.py
@@ -1,0 +1,28 @@
+import asyncio
+import inspect
+import pytest
+from chromadb.telemetry.opentelemetry import (
+    OpenTelemetryGranularity,
+    trace_method,
+)
+
+
+def test_trace_method_sync_function() -> None:
+    @trace_method("test_sync", OpenTelemetryGranularity.OPERATION)
+    def sample_sync(x: int, y: int) -> int:
+        return x + y
+
+    assert not inspect.iscoroutinefunction(sample_sync)
+    assert sample_sync(2, 3) == 5
+
+
+@pytest.mark.asyncio
+async def test_trace_method_async_function() -> None:
+    @trace_method("test_async", OpenTelemetryGranularity.OPERATION)
+    async def sample_async(x: int, y: int) -> int:
+        await asyncio.sleep(0.001)
+        return x * y
+
+    assert inspect.iscoroutinefunction(sample_async)
+    result = await sample_async(3, 4)
+    assert result == 12


### PR DESCRIPTION
Fixes #6729

### Description
`asyncio.iscoroutinefunction()` was deprecated in Python 3.12 and is slated for removal in Python 3.16. On Python 3.14+, this emits a `DeprecationWarning` on every invocation.

This PR replaces `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` in `chromadb/telemetry/opentelemetry/__init__.py` and adds unit tests covering sync and async functions.