### PR TITLE
fix(sysdb): delete embedding_metadata_array rows on collection delete

### DIFF
--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -1012,6 +1012,24 @@ impl SqliteSysDb {
         .execute(&mut *conn)
         .await?;
 
+        // Delete list-valued ("array") embedding metadata for the embedding ids matching the
+        // segment ids. embeddings.id has no AUTOINCREMENT, so SQLite can reuse an id after the
+        // embeddings row is deleted; without this cleanup, a later collection's record can reuse
+        // the same id and its get() query joins in this orphaned row, resurfacing list metadata
+        // from a deleted collection.
+        sqlx::query(
+            r#"
+            DELETE FROM embedding_metadata_array
+            WHERE id IN (
+                SELECT id FROM embeddings
+                WHERE segment_id IN (SELECT id FROM segments WHERE collection = $1)
+            )
+            "#,
+        )
+        .bind(collection_id.to_string())
+        .execute(&mut *conn)
+        .await?;
+
         // Delete embeddings fulltext search records
         sqlx::query(
             r#"
@@ -1600,6 +1618,86 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_delete_collection_cleans_array_metadata() {
+        // Regression test: delete_collection_with_conn deleted embedding_metadata (scalar) but
+        // not embedding_metadata_array (list-valued). Since embeddings.id has no AUTOINCREMENT,
+        // SQLite can reuse an id after the embeddings row is deleted; a later collection's
+        // record can then reuse that id, and its get() query joins in the orphaned array row,
+        // resurfacing list metadata from a deleted collection (see GH #7594).
+        let db = get_new_sqlite_db().await;
+        let sysdb = SqliteSysDb::new(db, "default".to_string(), "default".to_string());
+
+        let collection_id = CollectionUuid::new();
+        let segment_id = SegmentUuid::new();
+        let segments = vec![Segment {
+            id: segment_id,
+            r#type: SegmentType::Sqlite,
+            scope: SegmentScope::METADATA,
+            collection: collection_id,
+            metadata: None,
+            file_path: HashMap::new(),
+        }];
+
+        sysdb
+            .create_collection(
+                "default_tenant".to_string(),
+                "default_database".to_string(),
+                collection_id,
+                "test_collection".to_string(),
+                segments.clone(),
+                Some(InternalCollectionConfiguration::default_hnsw()),
+                Some(Schema::new_default(KnnIndex::Hnsw)),
+                None,
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        // Insert an embedding row and a list-valued metadata row for it directly, mirroring
+        // what the metadata segment writer would produce for `{"tags": ["stale"]}`.
+        sqlx::query(
+            r#"
+            INSERT INTO embeddings (id, segment_id, embedding_id, seq_id)
+            VALUES (1, $1, 'id1', X'00')
+            "#,
+        )
+        .bind(segment_id.to_string())
+        .execute(sysdb.db.get_conn())
+        .await
+        .unwrap();
+
+        sqlx::query(
+            r#"
+            INSERT INTO embedding_metadata_array (id, key, string_value)
+            VALUES (1, 'tags', 'stale')
+            "#,
+        )
+        .execute(sysdb.db.get_conn())
+        .await
+        .unwrap();
+
+        sysdb
+            .delete_collection(
+                "default_tenant".to_string(),
+                "default_database".to_string(),
+                collection_id,
+                vec![segment_id],
+            )
+            .await
+            .unwrap();
+
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM embedding_metadata_array")
+            .fetch_one(sysdb.db.get_conn())
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining, 0,
+            "embedding_metadata_array rows must be cleaned up by delete_collection"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #7594

## Problem

After `delete_collection()`, a newly created collection's first record can silently inherit list-valued metadata from the deleted collection's first record. Scalar metadata is cleaned up correctly — only list-valued metadata leaks, and it happens whether or not the new collection reuses the deleted one's name, and survives a process restart (genuine on-disk state, not a cache).

## Root cause

`delete_collection_with_conn` in `rust/sysdb/src/sqlite.rs` deletes scalar `embedding_metadata` rows but never touches `embedding_metadata_array` — the separate table introduced in migration `00006-metadata-array-support.sqlite.sql` for list-valued metadata (one row per array element).

Combined with `embeddings.id` being declared `INTEGER PRIMARY KEY` **without** `AUTOINCREMENT` (migration `00001-embedding-metadata.sqlite.sql`), SQLite is free to reuse that rowid once the table empties out. So:

1. Original collection's first record gets `embeddings.id = 1`; its list metadata (e.g. `{"tags": ["stale"]}`) is written to `embedding_metadata_array` with `id = 1`.
2. `delete_collection` wipes the `embeddings` row (`id = 1` gone) but leaves the orphaned `embedding_metadata_array` row with `id = 1` behind.
3. A newly created collection's first inserted record can also get `embeddings.id = 1` (id space is reused once the table is empty/low).
4. The metadata segment's `get()` query (`rust/segment/src/sqlite_metadata.rs`) joins `embedding_metadata_array` purely on `id`, with no segment/collection scoping — it finds the orphaned row and merges the deleted collection's list metadata into the new record's result.

## Fix

Add the missing `DELETE FROM embedding_metadata_array` to `delete_collection_with_conn`, scoped and ordered identically to the existing `embedding_metadata` delete (must run before the `embeddings` rows are removed, since it resolves ids via a join against `embeddings`).

## Testing

Added `test_delete_collection_cleans_array_metadata` in `rust/sysdb/src/sqlite.rs`: inserts an `embeddings` row and an `embedding_metadata_array` row directly against a collection's segment, deletes the collection via `sysdb.delete_collection`, and asserts `embedding_metadata_array` is empty afterward.

Verified the test is a real regression guard, not a false positive — reverted the fix locally and confirmed the test fails (`left: 1, right: 0`) against the buggy code, then confirmed it passes once the fix is restored.

Full `chroma-sysdb` (19 tests) and `chroma-segment` (83 tests, including all existing array-metadata tests) suites pass with no regressions. `cargo fmt --check` and `cargo clippy -- -D warnings` are both clean.