### PR TITLE
docs: fix typos across docs, examples and wal3 design notes

### DIFF
--- a/clients/js/packages/chromadb-client/README.md
+++ b/clients/js/packages/chromadb-client/README.md
@@ -2,7 +2,7 @@
 
 Chroma is the open-source data infrastructure for AI. Chroma makes it easy to build LLM apps by making knowledge, facts, and skills pluggable for LLMs.
 
-**Note:** JS client version 3._ is only compatible with chromadb v1.0.6 and newer or Chroma Cloud. For prior version compatiblity, please use JS client version 2._.
+**Note:** JS client version 3._ is only compatible with chromadb v1.0.6 and newer or Chroma Cloud. For prior version compatibility, please use JS client version 2._.
 
 **This package provides embedding libraries as peer dependencies**, allowing you to manage your own versions of embedding libraries and keep your dependency tree lean by not bundling dependencies you don't use. For a thick client with bundled embedding functions, install `chromadb`.
 

--- a/docs/mintlify/docs/cli/update.mdx
+++ b/docs/mintlify/docs/cli/update.mdx
@@ -5,4 +5,4 @@ description: "Check for CLI updates."
 
 The `chroma update` command will inform you if you should update your CLI installation.
 
-If you run the CLI via our Python or JavaScript packages, the `update` command will inform you if a new `chromadb` version is availble. When you update your `chromadb` package, you will also get the latest version of the CLI bundled with it.
+If you run the CLI via our Python or JavaScript packages, the `update` command will inform you if a new `chromadb` version is available. When you update your `chromadb` package, you will also get the latest version of the CLI bundled with it.

--- a/docs/mintlify/docs/overview/migration.mdx
+++ b/docs/mintlify/docs/overview/migration.mdx
@@ -210,7 +210,7 @@ CHROMA_SERVER_AUTH_PROVIDER="chromadb.auth.basic.BasicAuthServerProvider"
 
 _Note: Only one of `AUTH_CREDENTIALS` and `AUTH_CREDENTIALS_FILE` can be set, but this guide shows how to migrate both._
 
-And your corresponding client configation:
+And your corresponding client configuration:
 
 ```yaml
 CHROMA_CLIENT_AUTH_PROVIDER="chromadb.auth.token.TokenAuthClientProvider"
@@ -246,7 +246,7 @@ CHROMA_SERVER_AUTH_TOKEN_TRANSPORT_HEADER="AUTHORIZATION"
 
 _Note: Only one of `AUTH_CREDENTIALS` and `AUTH_CREDENTIALS_FILE` can be set, but this guide shows how to migrate both._
 
-And your corresponding client configation:
+And your corresponding client configuration:
 
 ```yaml
 CHROMA_CLIENT_AUTH_PROVIDER="chromadb.auth.token.TokenAuthClientProvider"

--- a/docs/mintlify/integrations/frameworks/openlit.mdx
+++ b/docs/mintlify/integrations/frameworks/openlit.mdx
@@ -43,7 +43,7 @@ With the LLM Observability data now being collected by OpenLIT, the next step is
 
 To begin exploring your LLM Application's performance data within the OpenLIT UI, please see the [Quickstart Guide](https://docs.openlit.io/latest/quickstart).
 
-If you want to integrate and send metrics and traces to your existing observability tools like Promethues+Jaeger, Grafana or more, refer to the [Official Documentation for OpenLIT Connections](https://docs.openlit.io/latest/connections/intro) for detailed instructions.
+If you want to integrate and send metrics and traces to your existing observability tools like Prometheus+Jaeger, Grafana or more, refer to the [Official Documentation for OpenLIT Connections](https://docs.openlit.io/latest/connections/intro) for detailed instructions.
 
 
 ## Support

--- a/docs/mintlify/reference/overview.mdx
+++ b/docs/mintlify/reference/overview.mdx
@@ -5,7 +5,7 @@ title: "Overview"
 ## SDKs
 
 Chroma currently maintains first party clients for Python, Typescript, and Rust.
-For other languages, the Chroma community built and maintains open source clients.
+For other languages, the Chroma community builds and maintains open source clients.
 
 <Columns cols={3}>
   <Card title="Python" icon="python" iconType="brands" href="/reference/python/client">

--- a/docs/mintlify/reference/overview.mdx
+++ b/docs/mintlify/reference/overview.mdx
@@ -5,7 +5,7 @@ title: "Overview"
 ## SDKs
 
 Chroma currently maintains first party clients for Python, Typescript, and Rust.
-For other languages, the Chroma community built and mantains open source clients.
+For other languages, the Chroma community built and maintains open source clients.
 
 <Columns cols={3}>
   <Card title="Python" icon="python" iconType="brands" href="/reference/python/client">

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,7 @@ folder structure
 
 ### Basic Functionality
 - [x] Examples of using different embedding models
-- [x] Local persistance demo
+- [x] Local persistence demo
 - [x] Where filtering demo
 
 ### Advanced Functionality
@@ -37,7 +37,7 @@ folder structure
 #### LLM Application Code
 - [ ] Langchain
 - [ ] LlamaIndex
-- [ ] Semantic Kernal
+- [ ] Semantic Kernel
 
 #### App Frameworks
 - [ ] Streamlit

--- a/examples/deployments/systemd-service/systemd-service.md
+++ b/examples/deployments/systemd-service/systemd-service.md
@@ -1,6 +1,6 @@
 # Running Chroma as a systemd service
 
-You can run Chroma as a systemd service which wil allow you to automatically start Chroma on boot and restart it if it
+You can run Chroma as a systemd service which will allow you to automatically start Chroma on boot and restart it if it
 crashes.
 
 ### Docker Compose

--- a/rust/wal3/README.md
+++ b/rust/wal3/README.md
@@ -124,7 +124,7 @@ Invariants of the manifest:
 - snapshot.start < snapshot.limit for all snapshots.
 - snapshot.start is strictly increasing.
 - The range (snapshot.start, snapshot.limit) is disjoint for all snapshots in a manifest.  No other
-  snapshot will have overlap with log position.  Children of the snapshot will be wholely contained
+  snapshot will have overlap with log position.  Children of the snapshot will be wholly contained
   within the snapshot.
 
 ### Cursor Structure
@@ -377,7 +377,7 @@ The direct way to handle this would be to write a snapshot every N writes and em
    └──────────────────┘
 ```
 
-This requires writing a new snapshot everytime a new manifest that exceeds the size is written.
+This requires writing a new snapshot every time a new manifest that exceeds the size is written.
 This would be the straight-forward way to handle this, except that it requires writing SNAPSHOT.x
 before writing MANIFEST and a naive implementation would introduce latency.  The manifest writer
 is a hot path and we don't want to introduce an extra round trip.
@@ -406,7 +406,7 @@ two levels of interior nodes, and a level of leaves.  The root will point to the
 first level of interior nodes point to the second level, and that level points to the leaves.
 
 This is, strictly speaking, an optimization, but one that will allow us to scale the log to beyond
-all forseeable current requirements.  20-25 pointers in the root, or 2kB are all that's needed to
+all foreseeable current requirements.  20-25 pointers in the root, or 2kB are all that's needed to
 capture a log that's more than a petabyte in size if the log is written at maximum batch size.
 Compare that to 5k pointers or 329kB for a single manifest.  We're dealing with kilobytes per
 manifest for a log that's petabytes, but when each manifest targets < 1MB in size, the difference at
@@ -548,7 +548,7 @@ recovered.  This will be a human endeavor.
 ## Dropped Async Tasks
 
 In Rust, web servers and the like will drop tasks associated with dropped file handles.  If that
-task were one that was driving the log foward, such an abort would cause the log to hang.  This is
+task were one that was driving the log forward, such an abort would cause the log to hang.  This is
 unacceptable, so every file write that can block other writes if it's cancelled is carefully
 scheduled on a background, uncancellable task.
 

--- a/rust/wal3/README.md
+++ b/rust/wal3/README.md
@@ -10,7 +10,7 @@ This log is designed to provide high throughput with a single writer and multipl
 
 # Design
 
-wal3 is designed to work on object storage.  It is intended to to be lightweight, to allow a single
+wal3 is designed to work on object storage.  It is intended to be lightweight, to allow a single
 machine to multiplex many logs simultaneously over a variety of paths.
 
 At a high level wal3's logged records are in a large number of immutable files on object storage ("fragments"), and wal3 maintains multiple files that track which files compose the log and in which order. Those files are organized in a tree for performance. The root is the "manifest" (mutable) and the interior nodes are the "snapshots" (immutable).


### PR DESCRIPTION
Fourteen corrections, one word each, spread across four areas:

- **docs/mintlify** — `mantains`, `availble`, `Promethues` (Prometheus), and `configation` twice on the migration page
- **examples/** — `persistance`, `Kernal` (Semantic Kernel), and `wil` in the systemd deployment guide
- **clients/js** — `compatiblity` in the chromadb-client README
- **rust/wal3** — `wholely`, `everytime`, `forseeable`, `foward` in the design notes, plus a repeated word in "It is intended to to be lightweight"

No wording or content changes beyond the corrections.