### PR TITLE
[BUG] Migrate Gemini example to google-genai SDK

### DIFF
--- a/examples/gemini/README.md
+++ b/examples/gemini/README.md
@@ -15,7 +15,7 @@ The basic flow is as follows:
 
 ## Running the example
 
-You will need an Google API key to run this demo.
+You will need a Google API key to run this demo. Export it as the `GEMINI_API_KEY` environment variable, or you will be prompted for it when running the scripts.
 
 Install dependencies and run the example:
 

--- a/examples/gemini/load_data.py
+++ b/examples/gemini/load_data.py
@@ -5,7 +5,6 @@ from tqdm import tqdm
 
 import chromadb
 from chromadb.utils import embedding_functions
-import google.generativeai as genai
 
 
 def main(
@@ -34,18 +33,12 @@ def main(
     # Learn more at docs.trychroma.com
     client = chromadb.PersistentClient(path=persist_directory)
 
-    google_api_key = None
-    if "GOOGLE_API_KEY" not in os.environ:
-        gapikey = input("Please enter your Google API Key: ")
-        genai.configure(api_key=gapikey)
-        google_api_key = gapikey
-    else:
-        google_api_key = os.environ["GOOGLE_API_KEY"]
+    # Check if the GEMINI_API_KEY environment variable is set. Prompt the user to set it if not.
+    if "GEMINI_API_KEY" not in os.environ:
+        os.environ["GEMINI_API_KEY"] = input("Please enter your Google API Key: ")
 
     # create embedding function
-    embedding_function = embedding_functions.GoogleGenerativeAiEmbeddingFunction(
-        api_key=google_api_key
-    )
+    embedding_function = embedding_functions.GoogleGeminiEmbeddingFunction()
 
     # If the collection already exists, we just return it. This allows us to add more
     # data to an existing collection.

--- a/examples/gemini/main.py
+++ b/examples/gemini/main.py
@@ -2,11 +2,11 @@ import argparse
 import os
 from typing import List
 
-import google.generativeai as genai
+from google import genai
 import chromadb
 from chromadb.utils import embedding_functions
 
-model = genai.GenerativeModel("gemini-pro")
+MODEL_NAME = "gemini-2.5-flash"
 
 
 def build_prompt(query: str, context: List[str]) -> str:
@@ -43,11 +43,12 @@ def build_prompt(query: str, context: List[str]) -> str:
     return system
 
 
-def get_gemini_response(query: str, context: List[str]) -> str:
+def get_gemini_response(client: genai.Client, query: str, context: List[str]) -> str:
     """
     Queries the Gemini API to get a response to the question.
 
     Args:
+    client (genai.Client): The Google GenAI client.
     query (str): The original query.
     context (List[str]): The context of the query, returned by embedding search.
 
@@ -55,7 +56,9 @@ def get_gemini_response(query: str, context: List[str]) -> str:
     A response to the question.
     """
 
-    response = model.generate_content(build_prompt(query, context))
+    response = client.models.generate_content(
+        model=MODEL_NAME, contents=build_prompt(query, context)
+    )
 
     return response.text
 
@@ -63,14 +66,13 @@ def get_gemini_response(query: str, context: List[str]) -> str:
 def main(
     collection_name: str = "documents_collection", persist_directory: str = "."
 ) -> None:
-    # Check if the GOOGLE_API_KEY environment variable is set. Prompt the user to set it if not.
-    google_api_key = None
-    if "GOOGLE_API_KEY" not in os.environ:
-        gapikey = input("Please enter your Google API Key: ")
-        genai.configure(api_key=gapikey)
-        google_api_key = gapikey
-    else:
-        google_api_key = os.environ["GOOGLE_API_KEY"]
+    # Check if the GEMINI_API_KEY environment variable is set. Prompt the user to set it if not.
+    if "GEMINI_API_KEY" not in os.environ:
+        os.environ["GEMINI_API_KEY"] = input("Please enter your Google API Key: ")
+    google_api_key = os.environ["GEMINI_API_KEY"]
+
+    # Create a Google GenAI client for generating responses.
+    genai_client = genai.Client(api_key=google_api_key)
 
     # Instantiate a persistent chroma client in the persist_directory.
     # This will automatically load any previously saved collections.
@@ -78,8 +80,8 @@ def main(
     client = chromadb.PersistentClient(path=persist_directory)
 
     # create embedding function
-    embedding_function = embedding_functions.GoogleGenerativeAiEmbeddingFunction(
-        api_key=google_api_key, task_type="RETRIEVAL_QUERY"
+    embedding_function = embedding_functions.GoogleGeminiEmbeddingFunction(
+        task_type="RETRIEVAL_QUERY"
     )
 
     # Get the collection.
@@ -109,7 +111,9 @@ def main(
         )
 
         # Get the response from Gemini
-        response = get_gemini_response(query, results["documents"][0])  # type: ignore
+        response = get_gemini_response(
+            genai_client, query, results["documents"][0]
+        )  # type: ignore
 
         # Output, with sources
         print(response)

--- a/examples/gemini/requirements.txt
+++ b/examples/gemini/requirements.txt
@@ -1,3 +1,3 @@
 chromadb>=0.4.18
-google.generativeai
+google-genai
 tqdm


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Migrates `examples/gemini` off the deprecated `google.generativeai` SDK (superseded by `google-genai`) and the shut-down `gemini-pro` model. As-is, the example fails for anyone following the README.
  - `main.py` / `load_data.py` now use `google.genai.Client` with `gemini-2.5-flash` for response generation, and the `google-genai`-based `GoogleGeminiEmbeddingFunction` for embeddings. The API key is read from `GEMINI_API_KEY` (the embedding function's default env var), keeping the interactive prompt fallback.
  - `requirements.txt`: `google.generativeai` → `google-genai`; README updated to mention `GEMINI_API_KEY`.
- New functionality
  - None

## Test plan

The examples are not covered by the test suite, so I verified directly:

- [x] Installed the example requirements in a fresh venv (`google-genai` 2.20.0, `chromadb` 1.5.9): both scripts import cleanly.
- [x] `genai.Client(api_key=...)` and `embedding_functions.GoogleGeminiEmbeddingFunction(task_type="RETRIEVAL_QUERY")` construct successfully, matching how the example uses them.
- [x] Aligns with the library's own direction: `chromadb/utils/embedding_functions/google_embedding_function.py` already targets the `google-genai` SDK.

## Migration plan

Example-only change; no library code or public API is touched. The deprecated `GoogleGenerativeAiEmbeddingFunction` remains exported for backward compatibility and is unchanged.

## Observability plan

N/A (example change).

## Documentation Changes

`examples/gemini/README.md` updated to reference the `GEMINI_API_KEY` environment variable.
