### PR TITLE
[BLD]: fix maturin strip/include-debuginfo conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,10 @@ packages = ["chromadb"]
 chromadb = ["*.yml"]
 
 [tool.maturin]
-strip = true
+# The workspace [profile.release] sets debug = 2 with split-debuginfo =
+# "unpacked", so maturin auto-passes --include-debuginfo, which conflicts
+# with --strip. Leave stripping to the release profile instead.
+strip = false
 features = ["pyo3/extension-module"]
 manifest-path = "rust/python_bindings/Cargo.toml"
 python-packages = ["chromadb"]


### PR DESCRIPTION
## Summary
`maturin dev` fails locally with:
```
Caused by: --include-debuginfo cannot be used with --strip
```

Root cause: the workspace `[profile.release]` sets `debug = 2` with
`split-debuginfo = "unpacked"`, which makes maturin automatically pass
`--include-debuginfo`. That collides with `strip = true` under
`[tool.maturin]` in `pyproject.toml`.

Fix: disable `strip` in `[tool.maturin]` so it no longer conflicts with the
release profile's own debug-info settings.

Fixes #6536

## Test plan
- [x] `maturin dev` no longer errors with the strip/include-debuginfo conflict locally
- [ ] CI build/test suite