### PR TITLE
fix: preserve async TLS verification default

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -138,12 +138,15 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
                 + " (https://github.com/chroma-core/chroma)"
             )
 
-            self._clients[loop_hash] = httpx.AsyncClient(
-                timeout=None,
-                headers=headers,
-                verify=self._settings.chroma_server_ssl_verify or False,
-                limits=self.http_limits,
-            )
+            client_kwargs = {
+                "timeout": None,
+                "headers": headers,
+                "limits": self.http_limits,
+            }
+            if self._settings.chroma_server_ssl_verify is not None:
+                client_kwargs["verify"] = self._settings.chroma_server_ssl_verify
+
+            self._clients[loop_hash] = httpx.AsyncClient(**client_kwargs)
 
         return self._clients[loop_hash]
 

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -6,6 +6,7 @@ from chromadb.config import Settings, System
 from chromadb.api import ClientAPI
 import chromadb.server.fastapi
 from chromadb.api.fastapi import FastAPI
+from chromadb.api.async_fastapi import AsyncFastAPI
 import pytest
 import tempfile
 import os
@@ -197,6 +198,36 @@ def test_fastapi_uses_http_limits_from_settings() -> None:
     assert limits.max_keepalive_connections == 16
     assert captured["timeout"] is None
     assert captured["verify"] is True
+
+
+@pytest.mark.parametrize("ssl_verify", [None, False, True, "/path/to/ca.pem"])
+def test_async_fastapi_passes_ssl_verify_only_when_configured(ssl_verify: Any) -> None:
+    settings = Settings(
+        chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=9000,
+        chroma_server_ssl_verify=ssl_verify,
+    )
+    system = System(settings)
+    captured: Dict[str, Any] = {}
+
+    def factory(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return MagicMock()
+
+    AsyncFastAPI._clients.clear()
+    with patch.object(AsyncFastAPI, "require", side_effect=[MagicMock(), MagicMock()]):
+        with patch("chromadb.api.async_fastapi.httpx.AsyncClient", side_effect=factory):
+            api = AsyncFastAPI(system)
+            api._get_client()
+
+    assert captured["timeout"] is None
+    assert captured["headers"]["Content-Type"] == "application/json"
+    if ssl_verify is None:
+        assert "verify" not in captured
+    else:
+        assert captured["verify"] == ssl_verify
+    AsyncFastAPI._clients.clear()
 
 
 def test_persistent_client_close() -> None:

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -216,18 +216,24 @@ def test_async_fastapi_passes_ssl_verify_only_when_configured(ssl_verify: Any) -
         return MagicMock()
 
     AsyncFastAPI._clients.clear()
-    with patch.object(AsyncFastAPI, "require", side_effect=[MagicMock(), MagicMock()]):
-        with patch("chromadb.api.async_fastapi.httpx.AsyncClient", side_effect=factory):
-            api = AsyncFastAPI(system)
-            api._get_client()
+    try:
+        with patch.object(
+            AsyncFastAPI, "require", side_effect=[MagicMock(), MagicMock()]
+        ):
+            with patch(
+                "chromadb.api.async_fastapi.httpx.AsyncClient", side_effect=factory
+            ):
+                api = AsyncFastAPI(system)
+                api._get_client()
 
-    assert captured["timeout"] is None
-    assert captured["headers"]["Content-Type"] == "application/json"
-    if ssl_verify is None:
-        assert "verify" not in captured
-    else:
-        assert captured["verify"] == ssl_verify
-    AsyncFastAPI._clients.clear()
+        assert captured["timeout"] is None
+        assert captured["headers"]["Content-Type"] == "application/json"
+        if ssl_verify is None:
+            assert "verify" not in captured
+        else:
+            assert captured["verify"] == ssl_verify
+    finally:
+        AsyncFastAPI._clients.clear()
 
 
 def test_persistent_client_close() -> None:

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -7,6 +7,7 @@ from chromadb.api import ClientAPI
 import chromadb.server.fastapi
 from chromadb.api.fastapi import FastAPI
 from chromadb.api.async_fastapi import AsyncFastAPI
+from pathlib import Path
 import pytest
 import tempfile
 import os
@@ -232,6 +233,34 @@ def test_async_fastapi_passes_ssl_verify_only_when_configured(ssl_verify: Any) -
             assert "verify" not in captured
         else:
             assert captured["verify"] == ssl_verify
+    finally:
+        AsyncFastAPI._clients.clear()
+
+
+def test_async_fastapi_rejects_missing_ssl_verify_path() -> None:
+    missing_ca_path = Path(__file__).with_name(
+        "__missing_ca_for_async_fastapi_test__.pem"
+    )
+    assert not missing_ca_path.exists()
+    settings = Settings(
+        chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=9000,
+        chroma_server_ssl_verify=str(missing_ca_path),
+    )
+    system = System(settings)
+
+    AsyncFastAPI._clients.clear()
+    try:
+        with patch.object(
+            AsyncFastAPI, "require", side_effect=[MagicMock(), MagicMock()]
+        ):
+            api = AsyncFastAPI(system)
+
+        with pytest.raises(FileNotFoundError):
+            api._get_client()
+
+        assert not AsyncFastAPI._clients
     finally:
         AsyncFastAPI._clients.clear()
 


### PR DESCRIPTION
## Summary

`AsyncFastAPI` previously converted the default `None` value of `chroma_server_ssl_verify` to `verify=False`, disabling TLS certificate verification. This makes the async client match the synchronous client's behavior while preserving explicit boolean and CA-path settings.

## Testing

- `pytest -q chromadb/test/test_client.py -k async_fastapi_passes_ssl_verify --tb=short`
- `python -m black --check chromadb/api/async_fastapi.py chromadb/test/test_client.py`
- `git diff --check`

Related issue: #7511

Fixes #7511
