### PR TITLE
fix(sysdb): serialize collection deletion with writes

### DIFF
--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -604,6 +604,10 @@ impl SqliteSysDb {
             .begin()
             .await
             .map_err(|e| DeleteCollectionError::Internal(e.into()))?;
+        self.db
+            .begin_immediate(&mut *tx)
+            .await
+            .map_err(|e| DeleteCollectionError::Internal(e.into()))?;
 
         let was_found = self
             .delete_collection_with_conn(&mut *tx, tenant, database, collection_id, segment_ids)


### PR DESCRIPTION
## Summary

`delete_collection` used a deferred SQLite transaction while `create_collection` already acquired the write lock immediately. Under concurrent create/delete operations, the delete could read stale state and both requests could report success.

This change applies the existing `begin_immediate` helper to collection deletion, serializing the read-modify-write sequence with other collection mutations.

## Validation

- `cargo fmt --check`
- `git diff --check`
- The focused Rust test command was attempted, but dependency resolution was blocked by an unavailable git submodule (`googleapis/googleapis`) required by `gcloud-gax`.

Related issue: #7375
