### PR TITLE
[BUG](rust-types): bound HNSW ef/M parameters to stop OOM DoS

### DIFF
--- a/rust/types/src/collection_configuration.rs
+++ b/rust/types/src/collection_configuration.rs
@@ -16,6 +16,7 @@ use crate::{
 use chroma_error::{ChromaError, ErrorCodes};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use validator::Validate;
 
 #[derive(Deserialize, Serialize, Clone, Debug, Copy)]
 pub enum KnnIndex {
@@ -275,6 +276,14 @@ impl InternalCollectionConfiguration {
         let mut hnsw: Option<HnswConfiguration> = value.hnsw;
         let spann: Option<SpannConfiguration> = value.spann;
 
+        // Client-supplied hnsw parameters flow verbatim into hnswlib at compaction time, so an
+        // unbounded ef_construction/ef_search/max_neighbors is an unauthenticated memory-exhaustion
+        // vector on the default OSS deployment. Reject out-of-range values before they are ever
+        // persisted, rather than only bounding the legacy-metadata path below.
+        if let Some(hnsw) = &hnsw {
+            hnsw.validate()?;
+        }
+
         // if neither hnsw nor spann is provided, use the collection metadata to build an hnsw configuration
         // the match then handles cases where hnsw is provided, and correctly routes to either spann or hnsw configuration
         // based on the default_knn_index
@@ -463,6 +472,8 @@ pub enum CollectionConfigurationToInternalConfigurationError {
     MultipleVectorIndexConfigurations,
     #[error("Failed to parse hnsw parameters from segment metadata")]
     HnswParametersFromSegmentError(#[from] HnswParametersFromSegmentError),
+    #[error("Invalid hnsw parameters: {0}")]
+    InvalidHnswParameters(#[from] validator::ValidationErrors),
 }
 
 impl ChromaError for CollectionConfigurationToInternalConfigurationError {
@@ -470,6 +481,7 @@ impl ChromaError for CollectionConfigurationToInternalConfigurationError {
         match self {
             Self::MultipleVectorIndexConfigurations => ErrorCodes::InvalidArgument,
             Self::HnswParametersFromSegmentError(_) => ErrorCodes::InvalidArgument,
+            Self::InvalidHnswParameters(_) => ErrorCodes::InvalidArgument,
         }
     }
 }
@@ -553,12 +565,15 @@ pub struct InternalUpdateCollectionConfiguration {
 pub enum UpdateCollectionConfigurationToInternalUpdateConfigurationError {
     #[error("Multiple vector index configurations provided")]
     MultipleVectorIndexConfigurations,
+    #[error("Invalid hnsw parameters: {0}")]
+    InvalidHnswParameters(#[from] validator::ValidationErrors),
 }
 
 impl ChromaError for UpdateCollectionConfigurationToInternalUpdateConfigurationError {
     fn code(&self) -> ErrorCodes {
         match self {
             Self::MultipleVectorIndexConfigurations => ErrorCodes::InvalidArgument,
+            Self::InvalidHnswParameters(_) => ErrorCodes::InvalidArgument,
         }
     }
 }
@@ -567,6 +582,9 @@ impl TryFrom<UpdateCollectionConfiguration> for InternalUpdateCollectionConfigur
     type Error = UpdateCollectionConfigurationToInternalUpdateConfigurationError;
 
     fn try_from(value: UpdateCollectionConfiguration) -> Result<Self, Self::Error> {
+        if let Some(hnsw) = &value.hnsw {
+            hnsw.validate()?;
+        }
         match (value.hnsw, value.spann) {
             (Some(_), Some(_)) => Err(Self::Error::MultipleVectorIndexConfigurations),
             (Some(hnsw), None) => Ok(InternalUpdateCollectionConfiguration {
@@ -596,6 +614,68 @@ mod tests {
     use crate::{test_segment, CollectionUuid, Metadata};
 
     use super::*;
+
+    #[test]
+    fn try_from_config_rejects_huge_client_supplied_max_neighbors() {
+        let collection_config = CollectionConfiguration {
+            hnsw: Some(HnswConfiguration {
+                max_neighbors: Some(20_000_000),
+                ..Default::default()
+            }),
+            spann: None,
+            embedding_function: None,
+        };
+
+        let result = InternalCollectionConfiguration::try_from_config(
+            collection_config,
+            KnnIndex::Hnsw,
+            None,
+        );
+
+        assert!(matches!(
+            result,
+            Err(CollectionConfigurationToInternalConfigurationError::InvalidHnswParameters(_))
+        ));
+    }
+
+    #[test]
+    fn try_from_config_accepts_in_range_client_supplied_hnsw() {
+        let collection_config = CollectionConfiguration {
+            hnsw: Some(HnswConfiguration {
+                max_neighbors: Some(32),
+                ..Default::default()
+            }),
+            spann: None,
+            embedding_function: None,
+        };
+
+        let result = InternalCollectionConfiguration::try_from_config(
+            collection_config,
+            KnnIndex::Hnsw,
+            None,
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn update_configuration_rejects_huge_max_neighbors() {
+        let update_config = UpdateCollectionConfiguration {
+            hnsw: Some(UpdateHnswConfiguration {
+                max_neighbors: Some(20_000_000),
+                ..Default::default()
+            }),
+            spann: None,
+            embedding_function: None,
+        };
+
+        let result = InternalUpdateCollectionConfiguration::try_from(update_config);
+
+        assert!(matches!(
+            result,
+            Err(UpdateCollectionConfigurationToInternalUpdateConfigurationError::InvalidHnswParameters(_))
+        ));
+    }
 
     #[test]
     fn metadata_overrides_parameter() {

--- a/rust/types/src/hnsw_configuration.rs
+++ b/rust/types/src/hnsw_configuration.rs
@@ -79,10 +79,13 @@ pub fn default_space() -> Space {
 pub struct InternalHnswConfiguration {
     #[serde(default = "default_space")]
     pub space: Space,
+    #[validate(range(min = 1, max = 1000))]
     #[serde(default = "default_construction_ef")]
     pub ef_construction: usize,
+    #[validate(range(min = 1, max = 1000))]
     #[serde(default = "default_search_ef")]
     pub ef_search: usize,
+    #[validate(range(min = 1, max = 1000))]
     #[serde(default = "default_m")]
     pub max_neighbors: usize,
     #[serde(default = "default_num_threads")]
@@ -147,8 +150,11 @@ impl From<(Option<&Space>, Option<&HnswIndexConfig>)> for InternalHnswConfigurat
 #[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct HnswConfiguration {
     pub space: Option<Space>,
+    #[validate(range(min = 1, max = 1000))]
     pub ef_construction: Option<usize>,
+    #[validate(range(min = 1, max = 1000))]
     pub ef_search: Option<usize>,
+    #[validate(range(min = 1, max = 1000))]
     pub max_neighbors: Option<usize>,
     #[serde(skip_serializing)]
     pub num_threads: Option<usize>,
@@ -253,7 +259,9 @@ impl InternalHnswConfiguration {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct UpdateHnswConfiguration {
+    #[validate(range(min = 1, max = 1000))]
     pub ef_search: Option<usize>,
+    #[validate(range(min = 1, max = 1000))]
     pub max_neighbors: Option<usize>,
     pub num_threads: Option<usize>,
     pub resize_factor: Option<f64>,
@@ -261,4 +269,60 @@ pub struct UpdateHnswConfiguration {
     pub sync_threshold: Option<usize>,
     #[validate(range(min = 2))]
     pub batch_size: Option<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn internal_hnsw_configuration_rejects_huge_max_neighbors() {
+        let config = InternalHnswConfiguration {
+            max_neighbors: 20_000_000,
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn internal_hnsw_configuration_rejects_zero_ef_search() {
+        let config = InternalHnswConfiguration {
+            ef_search: 0,
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn internal_hnsw_configuration_accepts_defaults() {
+        assert!(InternalHnswConfiguration::default().validate().is_ok());
+    }
+
+    #[test]
+    fn hnsw_configuration_rejects_huge_ef_construction() {
+        let config = HnswConfiguration {
+            ef_construction: Some(30_000_000),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn hnsw_configuration_accepts_unset_fields() {
+        assert!(HnswConfiguration::default().validate().is_ok());
+    }
+
+    #[test]
+    fn update_hnsw_configuration_rejects_huge_max_neighbors() {
+        let config = UpdateHnswConfiguration {
+            max_neighbors: Some(20_000_000),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn update_hnsw_configuration_accepts_unset_fields() {
+        assert!(UpdateHnswConfiguration::default().validate().is_ok());
+    }
 }


### PR DESCRIPTION
## Summary

`ef_construction`, `ef_search`, and `max_neighbors` on the HNSW index configuration had no upper (or, for two of them, lower) bound. A client can create a collection with `max_neighbors` in the tens of millions; the value is persisted verbatim and handed to hnswlib at compaction time, which allocates a per-element link list sized to it. A handful of small requests exhausts host memory and can crash the compaction worker. The default single-node OSS deployment ships the no-op auth provider, so this is reachable unauthenticated.

Fixes #7225

## Root cause

`InternalHnswConfiguration`, `HnswConfiguration`, and `UpdateHnswConfiguration` in `rust/types/src/hnsw_configuration.rs` already derive `Validate` and already bound `sync_threshold`/`batch_size` to `min = 2`, but never carried any `#[validate]` attribute on `ef_construction`, `ef_search`, or `max_neighbors`. On top of that, the two places that turn client input into an `InternalHnswConfiguration`/`InternalUpdateCollectionConfiguration` (`InternalCollectionConfiguration::try_from_config` and the `TryFrom<UpdateCollectionConfiguration>` impl, both in `rust/types/src/collection_configuration.rs`) never called `.validate()` at all on the client-supplied config, so even a bound field would have gone unchecked on the create/update path. Only the legacy-metadata fallback (`from_legacy_segment_metadata`) called `.validate()`.

## Changes

- Bound `ef_construction`, `ef_search`, and `max_neighbors` to `[1, 1000]` on all three structs, matching the range the existing property-test strategies (`chromadb/test/property/strategies.py`) already treat as valid input.
- `InternalCollectionConfiguration::try_from_config` now validates a client-supplied `HnswConfiguration` before using it, for both the HNSW and SPANN destination paths.
- `TryFrom<UpdateCollectionConfiguration> for InternalUpdateCollectionConfiguration` now validates a client-supplied `UpdateHnswConfiguration` before using it.
- Both call sites surface a new `InvalidHnswParameters` error variant (`ErrorCodes::InvalidArgument`), so an out-of-range value now fails the request with a 4xx instead of being accepted.

## Testing

Added unit tests in `rust/types/src/hnsw_configuration.rs` asserting `.validate()` rejects the PoC's `max_neighbors: 20_000_000` and an out-of-range `ef_search: 0` on all three structs, and accepts defaults/unset fields. Added tests in `rust/types/src/collection_configuration.rs` asserting `try_from_config` and the `UpdateCollectionConfiguration` `TryFrom` impl reject the same out-of-range `max_neighbors` and accept an in-range value.

This sandbox has no C/C++ toolchain (no MSVC Build Tools, no mingw-w64 gcc), and installing one is a multi-GB download out of scope here, so `cargo test`/`cargo check` could not be run against this change. `rustfmt --check` passes on both changed files. The new call sites reuse the exact `#[validate(range(...))]` attribute and `if let Some(x) = &value { x.validate()?; }` pattern already used for `sync_threshold`/`batch_size` in the same structs and the same `?`-into-`ChromaError`-variant pattern already used for the sibling `HnswParametersFromSegmentError`/`MultipleVectorIndexConfigurations` variants in these same two enums, which is the basis for confidence here in place of a local build. Please run the crate's test suite in CI before merging.

## Type of change

- [x] Bug fix (security: unauthenticated memory-exhaustion DoS)
