### PR TITLE
fix(validation): provide clear error message on leading/trailing whitespace in names (fix #7609)

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -96,6 +96,10 @@ logger = logging.getLogger(__name__)
 
 # mimics s3 bucket requirements for naming
 def check_index_name(index_name: str) -> None:
+    if index_name != index_name.strip():
+        raise ValueError(
+            f"Expected collection name without leading or trailing whitespace, got {index_name!r}"
+        )
     msg = (
         "Expected collection name that "
         "(1) contains 3-63 characters, "

--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -43,6 +43,12 @@ pub(crate) fn validate_non_empty_metadata<V>(
 pub fn validate_name(name: impl AsRef<str>) -> Result<(), ValidationError> {
     let name_str = name.as_ref();
 
+    if name_str != name_str.trim() {
+        return Err(ValidationError::new("name").with_message(
+            format!("Expected a name without leading or trailing whitespace. Got: {name_str:?}").into(),
+        ));
+    }
+
     // A topology is a valid name.  A database name prefixed with a topology is a valid name.  The
     // conjunction must be separated by a single `+` and not exceed the database name limits.
     // Thus, we recurse after validating no more plusses.


### PR DESCRIPTION
Fixes #7609

### Problem
When creating a database or collection with accidental leading or trailing whitespace, validation failed with a generic regex mismatch error message that displayed the name without quotes, making invisible whitespace hard to diagnose.

### Solution
- In ust/types/src/validators.rs (alidate_name): Pre-check if 
ame_str != name_str.trim() and return an explicit error Expected a name without leading or trailing whitespace. Got: {name_str:?}.
- In chromadb/api/segment.py (check_index_name): Pre-check index_name != index_name.strip() and raise a clear ValueError with formatted representation.