### PR TITLE
[ENH](sysdb): Label AttachFunction conflict sites

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -323,7 +323,7 @@ def test_functions_allow_one_sync_and_one_async_per_collection(
     # A second sync function should fail because the sync slot is already occupied.
     with pytest.raises(
         ChromaError,
-        match="collection already has an attached function with the same execution mode: name=task_1, function=record_counter, output_collection=output_1",
+        match=r"collection already has an attached function with the same execution mode \(pre-lock validation\): name=task_1, function=record_counter, output_collection=output_1",
     ):
         collection.attach_function(
             function=RECORD_COUNTER_FUNCTION,
@@ -346,7 +346,7 @@ def test_functions_allow_one_sync_and_one_async_per_collection(
     # A second async function should fail because the async slot is now occupied.
     with pytest.raises(
         ChromaError,
-        match="collection already has an attached function with the same execution mode: name=task_async, function=dummy_async, output_collection=output_async",
+        match=r"collection already has an attached function with the same execution mode \(pre-lock validation\): name=task_async, function=dummy_async, output_collection=output_async",
     ):
         collection.attach_function(
             function=DUMMY_ASYNC_FUNCTION,

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -478,8 +478,14 @@ func (s *Coordinator) insertAttachedFunctionForInputCollection(
 		}
 
 		if existingFunction.IsAsync == requestedFunction.IsAsync {
+			// "post-lock validation" distinguishes this refusal from the
+			// pre-lock one in AttachFunction when querying traces (CHR-527):
+			// this site runs under the collection lock, so hitting it with a
+			// request that matches the existing row means two identical
+			// attaches raced. Keep the message prefix stable — trace queries
+			// and tests match on "same execution mode".
 			return false, status.Errorf(codes.AlreadyExists,
-				"collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s",
+				"collection already has an attached function with the same execution mode (post-lock validation): name=%s, function=%s, output_collection=%s",
 				attachedFunction.Name,
 				existingFunction.Name,
 				attachedFunction.OutputCollectionName)
@@ -590,14 +596,14 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 				return common.ErrFunctionNotFound
 			}
 			if existingFunction.IsAsync == function.IsAsync {
-				log.Error("AttachFunction: collection already has an attached function with the same execution mode",
+				log.Error("AttachFunction: collection already has an attached function with the same execution mode (pre-lock validation)",
 					zap.String("name", attachedFunction.Name),
 					zap.String("existing_function", existingFunction.Name),
 					zap.String("requested_function", function.Name),
 					zap.Bool("is_async", function.IsAsync),
 					zap.Bool("is_ready", attachedFunction.IsReady))
 				return status.Errorf(codes.AlreadyExists,
-					"collection already has an attached function with the same execution mode: name=%s, function=%s, output_collection=%s",
+					"collection already has an attached function with the same execution mode (pre-lock validation): name=%s, function=%s, output_collection=%s",
 					attachedFunction.Name,
 					existingFunction.Name,
 					attachedFunction.OutputCollectionName)


### PR DESCRIPTION
The two AlreadyExists refusals in the attach path emit byte-identical
messages, so Honeycomb traces (sysdb-service, rpc.message) cannot
distinguish a legitimate pre-lock conflict from the post-lock refusal
that only fires when two identical attach requests race (CHR-527).
The shared helper's message also surfaces under
AddAttachedFunctionInput spans, compounding the ambiguity.

Append the validation site to each message, keeping the shared
prefix stable for existing queries and tests that match on
"same execution mode".

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
