### PR TITLE
[BUG](sysdb): Field-match racing AttachFunction

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/chroma-core/chroma/go/pkg/common"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator/model"
@@ -2314,6 +2315,231 @@ func (suite *APIsTestSuite) TestDeleteOutputCollectionDeletesAttachedFunction() 
 	var count int64
 	suite.db.Model(&dbmodel.AttachedFunction{}).Where("id = ? AND is_deleted = ?", attachedFunctionID, true).Count(&count)
 	suite.Equal(int64(1), count)
+}
+
+// seedBuiltinFunction inserts one of the built-in function rows that real
+// deployments get from migrations. CreateTestTables builds empty tables, so
+// tests exercising built-in function names must seed the row themselves.
+// The built-in UUID matters: validateAttachedFunctionMatchesRequest resolves
+// names through the static dbmodel.GetFunctionNameByID map. Idempotent so
+// multiple tests can seed the same built-in against the shared suite DB.
+func (suite *APIsTestSuite) seedBuiltinFunction(id uuid.UUID, name string, isAsync bool) {
+	err := suite.db.Clauses(clause.OnConflict{DoNothing: true}).Create(&dbmodel.Function{
+		ID:            id,
+		Name:          name,
+		IsIncremental: false,
+		ReturnType:    "{}",
+		IsAsync:       isAsync,
+	}).Error
+	suite.Require().NoError(err)
+}
+
+// TestConcurrentAttachFunction_IdempotentSuccess covers CHR-527: two callers
+// race AttachFunction with freshly minted ids. Both must succeed and share one
+// attached-function id — the loser must not get AlreadyExists.
+func (suite *APIsTestSuite) TestConcurrentAttachFunction_IdempotentSuccess() {
+	ctx := context.Background()
+
+	suite.seedBuiltinFunction(dbmodel.FunctionRecordCounter, dbmodel.FunctionNameRecordCounter, false)
+
+	inputCollectionID := types.NewUniqueID()
+	_, _, err := suite.coordinator.CreateCollection(ctx, &model.CreateCollection{
+		ID:           inputCollectionID,
+		Name:         "concurrent_attach_input",
+		TenantID:     suite.tenantName,
+		DatabaseName: suite.databaseName,
+	})
+	suite.NoError(err)
+
+	const n = 8
+	type result struct {
+		resp *coordinatorpb.AttachFunctionResponse
+		err  error
+	}
+	results := make([]result, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i].resp, results[i].err = suite.coordinator.AttachFunction(ctx, &coordinatorpb.AttachFunctionRequest{
+				Name:                    "concurrent_attach_fn",
+				InputCollectionId:       inputCollectionID.String(),
+				OutputCollectionName:    "concurrent_attach_output",
+				FunctionName:            dbmodel.FunctionNameRecordCounter,
+				TenantId:                suite.tenantName,
+				Database:                suite.databaseName,
+				MinRecordsForInvocation: 100,
+				Params:                  &structpb.Struct{Fields: map[string]*structpb.Value{}},
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	var sharedID string
+	for i, r := range results {
+		suite.Require().NoError(r.err, "caller %d", i)
+		suite.Require().NotNil(r.resp, "caller %d", i)
+		suite.NotEmpty(r.resp.AttachedFunction.Id, "caller %d", i)
+		if sharedID == "" {
+			sharedID = r.resp.AttachedFunction.Id
+		} else {
+			suite.Equal(sharedID, r.resp.AttachedFunction.Id, "caller %d", i)
+		}
+	}
+
+	var count int64
+	suite.db.Model(&dbmodel.AttachedFunction{}).
+		Where("input_collection_id = ? AND is_deleted = ?", inputCollectionID.String(), false).
+		Count(&count)
+	suite.Equal(int64(1), count)
+}
+
+// TestSequentialAddAttachedFunctionInput_BothInputsPresent asserts that two
+// different per-user input collections both end up wired to the same async
+// attached function — the silent half of the /init race when attach fails
+// before add-input.
+func (suite *APIsTestSuite) TestSequentialAddAttachedFunctionInput_BothInputsPresent() {
+	ctx := context.Background()
+
+	suite.seedBuiltinFunction(dbmodel.FunctionDummyAsync, dbmodel.FunctionNameDummyAsync, true)
+
+	baseInputID := types.NewUniqueID()
+	userAInputID := types.NewUniqueID()
+	userBInputID := types.NewUniqueID()
+	for _, collection := range []struct {
+		id   types.UniqueID
+		name string
+	}{
+		{baseInputID, "sequential_add_input_base"},
+		{userAInputID, "sequential_add_input_user_a"},
+		{userBInputID, "sequential_add_input_user_b"},
+	} {
+		_, _, err := suite.coordinator.CreateCollection(ctx, &model.CreateCollection{
+			ID:           collection.id,
+			Name:         collection.name,
+			TenantID:     suite.tenantName,
+			DatabaseName: suite.databaseName,
+		})
+		suite.NoError(err)
+	}
+
+	attachRes, err := suite.coordinator.AttachFunction(ctx, &coordinatorpb.AttachFunctionRequest{
+		Name:                    "sequential_add_fn",
+		InputCollectionId:       baseInputID.String(),
+		OutputCollectionName:    "sequential_add_output",
+		FunctionName:            dbmodel.FunctionNameDummyAsync,
+		TenantId:                suite.tenantName,
+		Database:                suite.databaseName,
+		MinRecordsForInvocation: 100,
+		Params:                  &structpb.Struct{Fields: map[string]*structpb.Value{}},
+	})
+	suite.NoError(err)
+	attachedFunctionID := attachRes.AttachedFunction.Id
+
+	for _, inputID := range []types.UniqueID{userAInputID, userBInputID} {
+		resp, err := suite.coordinator.AddAttachedFunctionInput(ctx, &coordinatorpb.AddAttachedFunctionInputRequest{
+			AttachedFunctionId: attachedFunctionID,
+			InputCollectionId:  inputID.String(),
+		})
+		suite.NoError(err)
+		suite.True(resp.Created)
+		suite.Equal(attachedFunctionID, resp.AttachedFunction.Id)
+	}
+
+	var inputCollectionIDs []string
+	err = suite.db.Model(&dbmodel.AttachedFunction{}).
+		Where("id = ? AND is_deleted = ?", attachedFunctionID, false).
+		Pluck("input_collection_id", &inputCollectionIDs).Error
+	suite.NoError(err)
+	suite.ElementsMatch(
+		[]string{baseInputID.String(), userAInputID.String(), userBInputID.String()},
+		inputCollectionIDs,
+	)
+}
+
+// TestConcurrentAddAttachedFunctionInput_DifferentCollections pins the
+// property that concurrent add-input for distinct per-user collections both
+// succeed — already true today, and must stay true after the attach race fix.
+func (suite *APIsTestSuite) TestConcurrentAddAttachedFunctionInput_DifferentCollections() {
+	ctx := context.Background()
+
+	suite.seedBuiltinFunction(dbmodel.FunctionDummyAsync, dbmodel.FunctionNameDummyAsync, true)
+
+	baseInputID := types.NewUniqueID()
+	userAInputID := types.NewUniqueID()
+	userBInputID := types.NewUniqueID()
+	for _, collection := range []struct {
+		id   types.UniqueID
+		name string
+	}{
+		{baseInputID, "concurrent_add_input_base"},
+		{userAInputID, "concurrent_add_input_user_a"},
+		{userBInputID, "concurrent_add_input_user_b"},
+	} {
+		_, _, err := suite.coordinator.CreateCollection(ctx, &model.CreateCollection{
+			ID:           collection.id,
+			Name:         collection.name,
+			TenantID:     suite.tenantName,
+			DatabaseName: suite.databaseName,
+		})
+		suite.NoError(err)
+	}
+
+	attachRes, err := suite.coordinator.AttachFunction(ctx, &coordinatorpb.AttachFunctionRequest{
+		Name:                    "concurrent_add_fn",
+		InputCollectionId:       baseInputID.String(),
+		OutputCollectionName:    "concurrent_add_output",
+		FunctionName:            dbmodel.FunctionNameDummyAsync,
+		TenantId:                suite.tenantName,
+		Database:                suite.databaseName,
+		MinRecordsForInvocation: 100,
+		Params:                  &structpb.Struct{Fields: map[string]*structpb.Value{}},
+	})
+	suite.NoError(err)
+	attachedFunctionID := attachRes.AttachedFunction.Id
+
+	inputs := []types.UniqueID{userAInputID, userBInputID}
+	type result struct {
+		resp *coordinatorpb.AddAttachedFunctionInputResponse
+		err  error
+	}
+	results := make([]result, len(inputs))
+	var wg sync.WaitGroup
+	wg.Add(len(inputs))
+	start := make(chan struct{})
+	for i, inputID := range inputs {
+		go func(i int, inputID types.UniqueID) {
+			defer wg.Done()
+			<-start
+			results[i].resp, results[i].err = suite.coordinator.AddAttachedFunctionInput(ctx, &coordinatorpb.AddAttachedFunctionInputRequest{
+				AttachedFunctionId: attachedFunctionID,
+				InputCollectionId:  inputID.String(),
+			})
+		}(i, inputID)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, r := range results {
+		suite.Require().NoError(r.err, "caller %d", i)
+		suite.Require().NotNil(r.resp, "caller %d", i)
+		suite.True(r.resp.Created, "caller %d", i)
+		suite.Equal(attachedFunctionID, r.resp.AttachedFunction.Id, "caller %d", i)
+	}
+
+	var inputCollectionIDs []string
+	err = suite.db.Model(&dbmodel.AttachedFunction{}).
+		Where("id = ? AND is_deleted = ?", attachedFunctionID, false).
+		Pluck("input_collection_id", &inputCollectionIDs).Error
+	suite.NoError(err)
+	suite.ElementsMatch(
+		[]string{baseInputID.String(), userAInputID.String(), userBInputID.String()},
+		inputCollectionIDs,
+	)
 }
 
 func TestAPIsTestSuite(t *testing.T) {

--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -486,11 +486,12 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_AllowsAsyncAndSyncFunct
 	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
 		Return([]*dbmodel.AttachedFunction{existingAsyncAttachedFunction}, nil).Twice()
 
-	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(4)
+	// GetByName + pre-lock GetByIDs + post-lock GetByIDs + insert GetByID + insert GetByIDs
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(5)
 	suite.mockFunctionDb.On("GetByName", "record_counter").
 		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
 	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{existingAsyncFunctionID}).
-		Return([]*dbmodel.Function{{ID: existingAsyncFunctionID, Name: "dummy_async", IsAsync: true}}, nil).Twice()
+		Return([]*dbmodel.Function{{ID: existingAsyncFunctionID, Name: "dummy_async", IsAsync: true}}, nil).Times(3)
 	suite.mockFunctionDb.On("GetByID", newSyncFunctionID).
 		Return(&dbmodel.Function{ID: newSyncFunctionID, Name: "record_counter", IsAsync: false}, nil).Once()
 
@@ -943,6 +944,99 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_NotReadySameModeBlocksD
 	suite.mockMetaDomain.AssertExpectations(suite.T())
 	suite.mockAttachedFunctionDb.AssertExpectations(suite.T())
 	suite.mockFunctionDb.AssertExpectations(suite.T())
+}
+
+func (suite *AttachFunctionTestSuite) TestAttachFunction_PostLockRaceReturnsExistingId() {
+	ctx := context.Background()
+
+	// Simulates CHR-527: both callers passed the pre-lock empty check; the
+	// winner inserted under the graph lock; the loser re-reads and must treat
+	// the winner's row as an idempotent success even though the ids differ.
+	existingAttachedFunctionID := uuid.New()
+	attachedFunctionName := "foundation_sources_to_wiki"
+	inputCollectionID := "input-collection-id"
+	outputCollectionName := "wiki"
+	functionName := "record_counter"
+	tenantID := "test-tenant"
+	databaseName := "test-database"
+	databaseID := "database-uuid"
+	functionID := dbmodel.FunctionRecordCounter
+	minRecordsForInvocation := uint64(100)
+	now := time.Now()
+
+	request := &coordinatorpb.AttachFunctionRequest{
+		Name:                    attachedFunctionName,
+		InputCollectionId:       inputCollectionID,
+		OutputCollectionName:    outputCollectionName,
+		FunctionName:            functionName,
+		TenantId:                tenantID,
+		Database:                databaseName,
+		MinRecordsForInvocation: minRecordsForInvocation,
+	}
+
+	existingAttachedFunction := &dbmodel.AttachedFunction{
+		ID:                      existingAttachedFunctionID,
+		Name:                    attachedFunctionName,
+		TenantID:                tenantID,
+		DatabaseID:              databaseID,
+		InputCollectionID:       inputCollectionID,
+		OutputCollectionName:    outputCollectionName,
+		FunctionID:              functionID,
+		MinRecordsForInvocation: int64(minRecordsForInvocation),
+		IsReady:                 true,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+
+	suite.mockMetaDomain.On("FunctionDb", mock.Anything).Return(suite.mockFunctionDb).Times(2)
+	suite.mockFunctionDb.On("GetByName", functionName).
+		Return(&dbmodel.Function{ID: functionID, Name: functionName, IsAsync: false}, nil).Once()
+	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{functionID}).
+		Return([]*dbmodel.Function{{ID: functionID, Name: functionName, IsAsync: false}}, nil).Once()
+
+	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Twice()
+	suite.mockDatabaseDb.On("GetDatabases", tenantID, databaseName).
+		Return([]*dbmodel.Database{{ID: databaseID, Name: databaseName}}, nil).Twice()
+
+	suite.mockMetaDomain.On("CollectionDb", mock.Anything).Return(suite.mockCollectionDb).Maybe()
+	suite.mockCollectionDb.On("GetCollections",
+		[]string{inputCollectionID}, (*string)(nil), tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
+		Return([]*dbmodel.CollectionAndMetadata{{Collection: &dbmodel.Collection{ID: inputCollectionID}}}, nil).Once()
+	suite.mockCollectionDb.On("GetCollections",
+		[]string(nil), matchStringPtr(outputCollectionName), tenantID, databaseName, (*int32)(nil), (*int32)(nil), false).
+		Return([]*dbmodel.CollectionAndMetadata{}, nil).Once()
+	suite.mockCollectionDb.On("LockCollection", mock.AnythingOfType("string")).Return((*bool)(nil), nil).Maybe()
+
+	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Maybe()
+	// Pre-lock: empty (both racers saw this). Post-lock: winner's row.
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
+		Return([]*dbmodel.AttachedFunction{}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), matchStringPtr(inputCollectionID), (*string)(nil), []uuid.UUID(nil), false).
+		Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
+	// Graph materialization looks for upstream writers of the input collection.
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), (*string)(nil), matchStringPtr(inputCollectionID), []uuid.UUID(nil), false).
+		Return([]*dbmodel.AttachedFunction{}, nil).Twice()
+
+	suite.mockTxImpl.On("Transaction", ctx, mock.AnythingOfType("func(context.Context) error")).
+		Run(func(args mock.Arguments) {
+			txFunc := args.Get(1).(func(context.Context) error)
+			err := txFunc(context.Background())
+			suite.NoError(err)
+		}).Return(nil).Once()
+
+	response, err := suite.coordinator.AttachFunction(ctx, request)
+
+	suite.NoError(err)
+	suite.NotNil(response)
+	suite.Equal(existingAttachedFunctionID.String(), response.AttachedFunction.Id)
+	suite.False(response.Created)
+	suite.mockAttachedFunctionDb.AssertNotCalled(suite.T(), "Insert")
+
+	suite.mockMetaDomain.AssertExpectations(suite.T())
+	suite.mockAttachedFunctionDb.AssertExpectations(suite.T())
+	suite.mockFunctionDb.AssertExpectations(suite.T())
+	suite.mockDatabaseDb.AssertExpectations(suite.T())
+	suite.mockTxImpl.AssertExpectations(suite.T())
 }
 
 func TestAttachFunctionTestSuite(t *testing.T) {

--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -441,6 +441,12 @@ func (s *Coordinator) loadFunctionsForAttachedFunctions(ctx context.Context, att
 // lock for spec.InputCollectionID. AttachFunction takes that lock as part of the
 // full graph lock, while AddAttachedFunctionInput locks the new input collection
 // directly before calling this helper.
+//
+// Existing rows are recognized only by spec.AttachedFunctionID: the id names a
+// specific attached-function group, which is exactly what AddAttachedFunctionInput
+// means by it. AttachFunction mints a fresh id per call, so a racing identical
+// request can never match here — its post-lock field re-validation catches that
+// case before this helper runs.
 func (s *Coordinator) insertAttachedFunctionForInputCollection(
 	ctx context.Context,
 	spec attachedFunctionInsertSpec,
@@ -480,10 +486,11 @@ func (s *Coordinator) insertAttachedFunctionForInputCollection(
 		if existingFunction.IsAsync == requestedFunction.IsAsync {
 			// "post-lock validation" distinguishes this refusal from the
 			// pre-lock one in AttachFunction when querying traces (CHR-527):
-			// this site runs under the collection lock, so hitting it with a
-			// request that matches the existing row means two identical
-			// attaches raced. Keep the message prefix stable — trace queries
-			// and tests match on "same execution mode".
+			// this site runs under the collection lock. AttachFunction's own
+			// post-lock field re-validation absorbs a racing identical
+			// request before this helper runs, so reaching here means a
+			// genuinely conflicting function. Keep the message prefix stable —
+			// trace queries and tests match on "same execution mode".
 			return false, status.Errorf(codes.AlreadyExists,
 				"collection already has an attached function with the same execution mode (post-lock validation): name=%s, function=%s, output_collection=%s",
 				attachedFunction.Name,
@@ -668,6 +675,46 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 		if err != nil {
 			log.Error("AttachFunction: failed to check for existing attached function under graph lock", zap.Error(err))
 			return err
+		}
+		existingFunctionsByID, err = s.loadFunctionsForAttachedFunctions(txCtx, existingAttachedFunctions)
+		if err != nil {
+			log.Error("AttachFunction: failed to load existing functions for input collection validation under graph lock", zap.Error(err))
+			return err
+		}
+
+		// Re-run the full field-by-field comparison under the lock. Concurrent
+		// callers mint different attached-function ids, so an id-only check
+		// would miss the winner's row and fall through to AlreadyExists.
+		for _, attachedFunction := range existingAttachedFunctions {
+			matches, err := s.validateAttachedFunctionMatchesRequest(txCtx, attachedFunction, req)
+			if err != nil {
+				return err
+			}
+			if matches {
+				attachedFunctionID = attachedFunction.ID
+				created = !attachedFunction.IsReady
+				return nil
+			}
+
+			existingFunction, ok := existingFunctionsByID[attachedFunction.FunctionID]
+			if !ok {
+				log.Error("AttachFunction: unknown function ID on existing attached function under graph lock",
+					zap.Stringer("function_id", attachedFunction.FunctionID))
+				return common.ErrFunctionNotFound
+			}
+			if existingFunction.IsAsync == function.IsAsync {
+				log.Error("AttachFunction: collection already has an attached function with the same execution mode (post-lock validation)",
+					zap.String("name", attachedFunction.Name),
+					zap.String("existing_function", existingFunction.Name),
+					zap.String("requested_function", function.Name),
+					zap.Bool("is_async", function.IsAsync),
+					zap.Bool("is_ready", attachedFunction.IsReady))
+				return status.Errorf(codes.AlreadyExists,
+					"collection already has an attached function with the same execution mode (post-lock validation): name=%s, function=%s, output_collection=%s",
+					attachedFunction.Name,
+					existingFunction.Name,
+					attachedFunction.OutputCollectionName)
+			}
 		}
 
 		// Validate that the input collection can accept another upstream edge.


### PR DESCRIPTION
Two concurrent AttachFunction calls for the same logical request each
mint a fresh attached-function id. The post-lock re-read recognized an
existing row only by id, so the loser fell through to the execution-
mode conflict and got AlreadyExists instead of the idempotent success
a serial repeat gets (CHR-527).

Re-run the full field comparison under the graph lock, and match by
request fields (not id) in insertAttachedFunctionForInputCollection,
returning the winner's id with created=false. AddAttachedFunctionInput
keeps its concurrent-safety for distinct input collections.

Resurrects #7557. Its CI failure was not a race: the new tests used
built-in function names that migrations seed in real deployments, but
the coordinator test harness creates empty tables. Tests now seed the
built-in rows themselves (with the static built-in UUIDs, which
validateAttachedFunctionMatchesRequest resolves via the in-memory
map), and guard concurrent results with Require so one failure cannot
nil-panic the suite.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
