### PR TITLE
[BUG](fn-consumer): Retry unpublished boundary

### DIFF
--- a/idl/chromadb/proto/workqueue.proto
+++ b/idl/chromadb/proto/workqueue.proto
@@ -30,6 +30,13 @@ message FailFunctionRequest {
     string input_coll_id = 2;
 }
 
+// Moves work that is not ready yet behind other queued work without recording
+// an execution failure.
+message DeferWorkRequest {
+    string fn_id = 1;
+    string input_coll_id = 2;
+}
+
 // Sets the failure count for one queued attached-function invocation.
 message SetFunctionFailureCountRequest {
     string fn_id = 1;
@@ -58,6 +65,7 @@ service WorkQueueService {
     rpc PushWork(PushWorkRequest) returns (google.protobuf.Empty);
     rpc FinishWork(FinishWorkRequest) returns (google.protobuf.Empty);
     rpc FailFunction(FailFunctionRequest) returns (google.protobuf.Empty);
+    rpc DeferWork(DeferWorkRequest) returns (google.protobuf.Empty);
     rpc SetFunctionFailureCount(SetFunctionFailureCountRequest) returns (google.protobuf.Empty);
     rpc GetWork(GetWorkRequest) returns (GetWorkResponse);
 }

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -3,7 +3,7 @@ use chroma_log::grpc_log::GrpcPullLogsError;
 use chroma_sysdb::GetCollectionsOptions;
 use chroma_system::{Operator, System};
 use chroma_types::{AttachedFunction, AttachedFunctionUuid, CollectionUuid, DatabaseName};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::error::Error;
 use uuid::Uuid;
 
@@ -14,7 +14,7 @@ use crate::execution::operators::{
 };
 
 use super::{
-    compact::{CollectionCompactInfo, CompactionContext, CompactionError, CompactionResponse},
+    compact::{CollectionCompactInfo, CompactionContext, CompactionError},
     log_fetch_orchestrator::LogFetchOrchestratorResponse,
 };
 
@@ -51,8 +51,21 @@ pub struct FunctionExecutionContext {
     compaction_context: CompactionContext,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FunctionExecutionOutcome {
+    Completed,
+    RetryLater,
+}
+
 fn has_reached_queue_frontier(completion_offset: i64, queue_compaction_offset: i64) -> bool {
     completion_offset >= queue_compaction_offset
+}
+
+fn is_compaction_frontier_visible(
+    collection_log_position: i64,
+    queue_compaction_offset: i64,
+) -> bool {
+    collection_log_position >= queue_compaction_offset
 }
 
 impl FunctionExecutionContext {
@@ -277,7 +290,7 @@ impl FunctionExecutionContext {
         compaction_context: CompactionContext,
         attached_function_id: AttachedFunctionUuid,
         fn_inputs: &[FunctionExecutionInput],
-    ) -> Result<(Option<DatabaseName>, Vec<FunctionExecutionInput>), CompactionError> {
+    ) -> Result<(Option<DatabaseName>, Vec<FunctionExecutionInput>, bool), CompactionError> {
         if fn_inputs.is_empty() {
             return Err(CompactionError::InvariantViolation(
                 "Function execution requires at least one input collection",
@@ -296,9 +309,9 @@ impl FunctionExecutionContext {
             .map_err(|_| {
                 CompactionError::InvariantViolation("Failed to resolve function input collections")
             })?;
-        let live_collection_ids: HashSet<_> = collections
+        let live_collections: HashMap<_, _> = collections
             .iter()
-            .map(|collection| collection.collection_id)
+            .map(|collection| (collection.collection_id, collection))
             .collect();
         let shared_database_name = collections
             .first()
@@ -310,26 +323,45 @@ impl FunctionExecutionContext {
             .transpose()?;
         let mut live_inputs = Vec::with_capacity(fn_inputs.len());
         let mut stale_work_items = Vec::new();
+        let mut should_retry_later = false;
 
         for input in fn_inputs.iter().cloned() {
-            if live_collection_ids.contains(&input.collection_id) {
-                live_inputs.push(input);
-            } else {
-                tracing::info!(
-                    collection_id = %input.collection_id,
-                    attached_function_id = %attached_function_id,
-                    "Finishing stale fn-consumer work for deleted input collection"
-                );
-                stale_work_items.push(FinishAsyncWorkItem {
-                    input_collection_id: input.collection_id,
-                    completion_offset: input.queue_compaction_offset,
-                });
+            match live_collections.get(&input.collection_id) {
+                Some(collection)
+                    if is_compaction_frontier_visible(
+                        collection.log_position,
+                        input.queue_compaction_offset,
+                    ) =>
+                {
+                    live_inputs.push(input);
+                }
+                Some(collection) => {
+                    tracing::debug!(
+                        collection_id = %input.collection_id,
+                        attached_function_id = %attached_function_id,
+                        visible_compaction_offset = collection.log_position,
+                        queue_compaction_offset = input.queue_compaction_offset,
+                        "Fn-consumer input compaction boundary is not visible yet; retrying later"
+                    );
+                    should_retry_later = true;
+                }
+                None => {
+                    tracing::info!(
+                        collection_id = %input.collection_id,
+                        attached_function_id = %attached_function_id,
+                        "Finishing stale fn-consumer work for deleted input collection"
+                    );
+                    stale_work_items.push(FinishAsyncWorkItem {
+                        input_collection_id: input.collection_id,
+                        completion_offset: input.queue_compaction_offset,
+                    });
+                }
             }
         }
 
         Self::purge_deleted(compaction_context, attached_function_id, stale_work_items).await?;
 
-        Ok((shared_database_name, live_inputs))
+        Ok((shared_database_name, live_inputs, should_retry_later))
     }
 
     #[tracing::instrument(skip(self, system))]
@@ -338,7 +370,7 @@ impl FunctionExecutionContext {
         attached_function_id: AttachedFunctionUuid,
         fn_inputs: Vec<FunctionExecutionInput>,
         system: System,
-    ) -> Result<CompactionResponse, CompactionError> {
+    ) -> Result<FunctionExecutionOutcome, CompactionError> {
         if fn_inputs.is_empty() {
             return Err(CompactionError::InvariantViolation(
                 "Function execution requires at least one input collection",
@@ -346,16 +378,18 @@ impl FunctionExecutionContext {
         }
 
         let base_context = self.compaction_context;
-        let (shared_database_name, live_inputs) = Box::pin(Self::partition_live_and_stale_inputs(
-            base_context.clone(),
-            attached_function_id,
-            &fn_inputs,
-        ))
-        .await?;
+        let (shared_database_name, live_inputs, should_retry_later) =
+            Box::pin(Self::partition_live_and_stale_inputs(
+                base_context.clone(),
+                attached_function_id,
+                &fn_inputs,
+            ))
+            .await?;
+        if should_retry_later {
+            return Ok(FunctionExecutionOutcome::RetryLater);
+        }
         if live_inputs.is_empty() {
-            return Ok(CompactionResponse::Success {
-                job_id: attached_function_id.into(),
-            });
+            return Ok(FunctionExecutionOutcome::Completed);
         }
         let shared_database_name =
             shared_database_name.ok_or(CompactionError::InvariantViolation(
@@ -413,9 +447,7 @@ impl FunctionExecutionContext {
         }
 
         if input_collection_data.is_empty() {
-            return Ok(CompactionResponse::Success {
-                job_id: attached_function_id.into(),
-            });
+            return Ok(FunctionExecutionOutcome::Completed);
         }
 
         let mut compaction_context = base_context;
@@ -438,15 +470,15 @@ impl FunctionExecutionContext {
                 .await?;
         }
 
-        Ok(CompactionResponse::Success {
-            job_id: attached_function_id.into(),
-        })
+        Ok(FunctionExecutionOutcome::Completed)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{has_reached_queue_frontier, FunctionExecutionContext};
+    use super::{
+        has_reached_queue_frontier, is_compaction_frontier_visible, FunctionExecutionContext,
+    };
     use crate::execution::{
         operators::fetch_log::FetchLogError,
         orchestration::{
@@ -483,6 +515,17 @@ mod tests {
     #[test]
     fn zero_queue_frontier_treats_equality_as_complete() {
         assert!(has_reached_queue_frontier(0, 0));
+    }
+
+    #[test]
+    fn compaction_frontier_behind_queue_retries_later() {
+        assert!(!is_compaction_frontier_visible(22162, 22173));
+    }
+
+    #[test]
+    fn compaction_frontier_at_or_ahead_of_queue_is_visible() {
+        assert!(is_compaction_frontier_visible(22173, 22173));
+        assert!(is_compaction_frontier_visible(22180, 22173));
     }
 
     #[test]

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -285,6 +285,7 @@ impl FnConsumerManager {
                 Ok(FnDispatchOutcome::Completed)
             }
             Ok(FunctionExecutionOutcome::RetryLater) => {
+                defer_batch(&mut work_queue_client, fn_id, &batch).await;
                 tracing::debug!(
                     fn_id = %fn_id,
                     batch_size = batch.len(),
@@ -463,6 +464,26 @@ async fn report_batch_failure(
                 input_coll_id = %item.collection_id,
                 error = %report_error,
                 "Failed to report attached function execution failure"
+            );
+        }
+    }
+}
+
+async fn defer_batch(
+    work_queue_client: &mut WorkQueueClient,
+    fn_id: AttachedFunctionUuid,
+    batch: &[FunctionExecutionInput],
+) {
+    for item in batch {
+        if let Err(defer_error) = work_queue_client
+            .defer_work(fn_id.to_string(), item.collection_id.to_string())
+            .await
+        {
+            tracing::warn!(
+                fn_id = %fn_id,
+                input_coll_id = %item.collection_id,
+                error = %defer_error,
+                "Failed to defer attached function work"
             );
         }
     }

--- a/rust/worker/src/fn_consumer/fn_consumer_manager.rs
+++ b/rust/worker/src/fn_consumer/fn_consumer_manager.rs
@@ -22,7 +22,7 @@ use tracing::{instrument, span};
 use crate::compactor::config::CompactorConfig;
 use crate::execution::orchestration::compact::CompactionContext;
 use crate::execution::orchestration::function_execution::{
-    FunctionExecutionContext, FunctionExecutionInput,
+    FunctionExecutionContext, FunctionExecutionInput, FunctionExecutionOutcome,
 };
 use crate::fn_consumer::config::FnConsumerConfig;
 use crate::work_queue::work_queue_client::WorkQueueClient;
@@ -58,6 +58,12 @@ pub enum DispatchError {
     DispatchPanicked,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FnDispatchOutcome {
+    Completed,
+    RetryLater,
+}
+
 impl ChromaError for DispatchError {
     fn code(&self) -> ErrorCodes {
         match self {
@@ -68,7 +74,7 @@ impl ChromaError for DispatchError {
     }
 }
 
-type FnDispatchOutput = Result<(), DispatchError>;
+type FnDispatchOutput = Result<FnDispatchOutcome, DispatchError>;
 type FnDispatchFuture = Pin<Box<dyn Future<Output = FnDispatchOutput> + Send>>;
 
 struct FnDispatchTask {
@@ -270,13 +276,21 @@ impl FnConsumerManager {
                 .await;
 
         match result {
-            Ok(_response) => {
+            Ok(FunctionExecutionOutcome::Completed) => {
                 tracing::info!(
                     fn_id = %fn_id,
                     batch_size = batch.len(),
                     "Function consumer workflow completed successfully"
                 );
-                Ok(())
+                Ok(FnDispatchOutcome::Completed)
+            }
+            Ok(FunctionExecutionOutcome::RetryLater) => {
+                tracing::debug!(
+                    fn_id = %fn_id,
+                    batch_size = batch.len(),
+                    "Function consumer work is not ready; retrying on a later poll"
+                );
+                Ok(FnDispatchOutcome::RetryLater)
             }
             Err(e) => {
                 tracing::error!(
@@ -296,11 +310,18 @@ impl FnConsumerManager {
             self.in_progress.remove(&completion.fn_id);
 
             match completion.result {
-                Ok(()) => {
+                Ok(FnDispatchOutcome::Completed) => {
                     tracing::debug!(
                         fn_id = %completion.fn_id,
                         batch_size = completion.batch_size,
                         "Successfully completed work batch"
+                    );
+                }
+                Ok(FnDispatchOutcome::RetryLater) => {
+                    tracing::debug!(
+                        fn_id = %completion.fn_id,
+                        batch_size = completion.batch_size,
+                        "Work batch will be retried on a later poll"
                     );
                 }
                 Err(e) => {
@@ -572,7 +593,7 @@ mod tests {
                 future: Box::pin(async move {
                     let _ = slow_started_tx.send(());
                     let _ = release_slow_rx.await;
-                    Ok(())
+                    Ok(FnDispatchOutcome::Completed)
                 }),
                 work_queue_client: None,
                 batch: Vec::new(),
@@ -584,7 +605,7 @@ mod tests {
         task_tx
             .send(FnDispatchTask {
                 fn_id: fast_fn_id,
-                future: Box::pin(async { Ok(()) }),
+                future: Box::pin(async { Ok(FnDispatchOutcome::Completed) }),
                 work_queue_client: None,
                 batch: Vec::new(),
             })

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -416,6 +416,31 @@ impl QueueState {
         true
     }
 
+    /// Move an existing queue entry to the back without changing its failure count.
+    pub fn defer_work(
+        &mut self,
+        fn_id: &AttachedFunctionUuid,
+        input_coll_id: &CollectionUuid,
+    ) -> bool {
+        let Some(index) = self
+            .pending_work
+            .iter()
+            .position(|record| record.fn_id == *fn_id && record.input_coll_id == *input_coll_id)
+        else {
+            return false;
+        };
+
+        let mut record = self
+            .pending_work
+            .remove(index)
+            .expect("queue entry found by position");
+        record.insertion_order = self.next_insertion_order;
+        self.next_insertion_order += 1;
+        self.pending_work.push_back(record);
+        self.dirty = true;
+        true
+    }
+
     /// Sets the failure count for a queued entry.
     ///
     /// `None` means the entry is absent. `Some(false)` means the entry was
@@ -616,6 +641,31 @@ mod tests {
         assert_eq!(state.set_failure_count(&fn_id, &coll_id, 3), Some(true));
         assert!(state.dirty);
         assert_eq!(state.pending_work[0].failure_count, 3);
+    }
+
+    #[test]
+    fn test_defer_work_moves_blocked_head_behind_ready_work() {
+        let mut state = QueueState::new();
+        let fn_id = AttachedFunctionUuid(Uuid::new_v4());
+        let blocked_coll_id = CollectionUuid(Uuid::new_v4());
+        let ready_coll_id = CollectionUuid(Uuid::new_v4());
+
+        assert!(state.push_work(fn_id, blocked_coll_id, 10, 20));
+        assert!(state.push_work(fn_id, ready_coll_id, 30, 30));
+        assert!(state.update_failure_count(&fn_id, &blocked_coll_id, 2));
+        state.dirty = false;
+
+        let (before, _) = state.get_live_work(1, i32::MAX);
+        assert_eq!(before[0].input_coll_id, blocked_coll_id);
+
+        assert!(state.defer_work(&fn_id, &blocked_coll_id));
+
+        let (after, _) = state.get_live_work(1, i32::MAX);
+        assert_eq!(after[0].input_coll_id, ready_coll_id);
+        let deferred = state.pending_work.back().expect("deferred work");
+        assert_eq!(deferred.input_coll_id, blocked_coll_id);
+        assert_eq!(deferred.failure_count, 2);
+        assert!(state.dirty);
     }
 
     #[test]

--- a/rust/worker/src/work_queue/work_queue_client.rs
+++ b/rust/worker/src/work_queue/work_queue_client.rs
@@ -1,8 +1,9 @@
 use crate::fn_consumer::config::GrpcWorkQueueConfig;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::chroma_proto::{
-    work_queue_service_client::WorkQueueServiceClient, FailFunctionRequest, FinishWorkRequest,
-    GetWorkRequest, GetWorkResponse, PushWorkRequest, SetFunctionFailureCountRequest,
+    work_queue_service_client::WorkQueueServiceClient, DeferWorkRequest, FailFunctionRequest,
+    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest,
+    SetFunctionFailureCountRequest,
 };
 use std::time::Duration;
 use tonic::transport::Endpoint;
@@ -114,6 +115,21 @@ impl WorkQueueClient {
     ) -> Result<(), Box<dyn ChromaError>> {
         self.client
             .fail_function(Request::new(FailFunctionRequest {
+                fn_id,
+                input_coll_id,
+            }))
+            .await
+            .map_err(|e| Box::new(WorkQueueClientError::RequestError(e)) as Box<dyn ChromaError>)?;
+        Ok(())
+    }
+
+    pub async fn defer_work(
+        &mut self,
+        fn_id: String,
+        input_coll_id: String,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        self.client
+            .defer_work(Request::new(DeferWorkRequest {
                 fn_id,
                 input_coll_id,
             }))

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -35,6 +35,13 @@ pub struct FinishWorkMessage {
 }
 
 #[derive(Debug)]
+pub struct DeferWorkMessage {
+    pub fn_id: AttachedFunctionUuid,
+    pub input_coll_id: CollectionUuid,
+    pub response_tx: oneshot::Sender<()>,
+}
+
+#[derive(Debug)]
 #[allow(dead_code)]
 pub struct GetWorkMessage {
     #[allow(dead_code)]
@@ -390,6 +397,18 @@ impl Handler<FinishWorkMessage> for WorkQueueManager {
 
         if self.should_persist() {
             let _ = self.persist().await;
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<DeferWorkMessage> for WorkQueueManager {
+    type Result = ();
+
+    async fn handle(&mut self, msg: DeferWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
+        self.state.defer_work(&msg.fn_id, &msg.input_coll_id);
+        if msg.response_tx.send(()).is_err() {
+            tracing::warn!("Failed to acknowledge deferred work - receiver dropped");
         }
     }
 }

--- a/rust/worker/src/work_queue/work_queue_server.rs
+++ b/rust/worker/src/work_queue/work_queue_server.rs
@@ -1,15 +1,16 @@
 use crate::work_queue::types::{FinishResult, WorkQueueError};
 use crate::work_queue::work_queue_manager::{
-    FinishWorkMessage, GetWorkMessage, PushWorkMessage, SetFunctionFailureCountMessage,
-    UpdateFunctionFailureCountMessage, WorkQueueManager,
+    DeferWorkMessage, FinishWorkMessage, GetWorkMessage, PushWorkMessage,
+    SetFunctionFailureCountMessage, UpdateFunctionFailureCountMessage, WorkQueueManager,
 };
 use chroma_sysdb::SysDb;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     work_queue_service_server::{WorkQueueService, WorkQueueServiceServer},
-    FailAttachedFunctionRequest, FailFunctionRequest, FinalizeAsyncAttachedFunctionRepairRequest,
-    FinishWorkRequest, GetWorkRequest, GetWorkResponse, PushWorkRequest,
-    SetAttachedFunctionFailureCountRequest, SetFunctionFailureCountRequest, WorkItemResult,
+    DeferWorkRequest, FailAttachedFunctionRequest, FailFunctionRequest,
+    FinalizeAsyncAttachedFunctionRepairRequest, FinishWorkRequest, GetWorkRequest, GetWorkResponse,
+    PushWorkRequest, SetAttachedFunctionFailureCountRequest, SetFunctionFailureCountRequest,
+    WorkItemResult,
 };
 use chroma_types::{AttachedFunctionUuid, CollectionUuid};
 use std::str::FromStr;
@@ -175,6 +176,33 @@ impl WorkQueueService for WorkQueueServer {
         response_rx.await.map_err(|e| {
             Status::internal(format!("Failed to receive failure count update: {}", e))
         })?;
+
+        Ok(Response::new(()))
+    }
+
+    async fn defer_work(&self, request: Request<DeferWorkRequest>) -> Result<Response<()>, Status> {
+        let req = request.into_inner();
+        let fn_id = AttachedFunctionUuid::from_str(&req.fn_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid fn_id: {}", e)))?;
+        let input_coll_id = CollectionUuid::from_str(&req.input_coll_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid collection_id: {}", e)))?;
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        self.manager
+            .receiver()
+            .send(
+                DeferWorkMessage {
+                    fn_id,
+                    input_coll_id,
+                    response_tx,
+                },
+                None,
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Failed to defer work: {}", e)))?;
+        response_rx
+            .await
+            .map_err(|e| Status::internal(format!("Failed to receive defer response: {}", e)))?;
 
         Ok(Response::new(()))
     }


### PR DESCRIPTION
## Summary

- gate fn-consumer execution on the committed collection compaction frontier
- return a non-error RetryLater outcome while queued work is ahead of SysDB
- defer temporarily unready work to the back of the FIFO queue without incrementing its failure count
- allow ready work behind a deferred FIFO head to continue instead of being starved
- wait for all inputs of a multi-input batch rather than executing a partial invocation

## Why

Compaction durably enqueues async function work before registration publishes the corresponding version-file boundary. Fn-consumer can therefore observe a queued frontier while collection.log_position still points to the previous boundary. This is an expected race, but the existing path attempts boundary resolution, reports a workflow error, and increments the attached function failure count.

Simply returning RetryLater leaves the same item at the FIFO head. If its boundary remains unpublished, fixed-size GetWork polls can repeatedly return that item and starve ready work behind it. RetryLater now asks the work queue to move the item to the back while preserving its offsets and failure count.

Production example: completion offset 22162 was queued with compaction offset 22173. The first consumer attempt ran before registration and failed; the next poll succeeded after 22173 became visible.

Failure trace: https://ui.honeycomb.io/chroma-/environments/production-aws--us-east-1/result/ty3EKNUCQPh/trace?trace_id=edd7bbf6f794a3186a2533b8d6bd9097

## Validation

- cargo fmt --all -- --check
- cargo test -p worker function_execution --lib
- cargo test -p worker fn_consumer_manager::tests --lib
- cargo test -p worker work_queue::state::tests --lib
- cargo clippy -p worker --lib -- -D warnings