### PR TITLE
[BUG](fn-consumer): Replay from checkpoints

### DIFF
--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -163,6 +163,10 @@ pub struct MaterializedLogRecord {
     // If log has [Upsert] and the record does not exist in storage then final
     // operation is Insert.
     final_operation: MaterializedLogOperation,
+    // True when a logical checkpoint replaced the physical segment value.
+    // Subsequent visible updates must hydrate from the checkpointed log state
+    // without merging fields from the older physical snapshot.
+    logical_baseline_overwrites_segment: bool,
     // The log entry that produced the final materialized operation.
     operation_log_index: Option<usize>,
     // This is the metadata obtained by combining all the operations
@@ -193,6 +197,7 @@ impl MaterializedLogRecord {
             offset_id: AtomicU32::new(offset_id),
             user_id_at_log_index: None,
             final_operation: MaterializedLogOperation::Initial,
+            logical_baseline_overwrites_segment: false,
             operation_log_index: None,
             metadata_to_be_merged: None,
             metadata_to_be_deleted: None,
@@ -241,6 +246,7 @@ impl MaterializedLogRecord {
             offset_id: AtomicU32::new(offset_id),
             user_id_at_log_index: Some(log_index),
             final_operation: MaterializedLogOperation::AddNew,
+            logical_baseline_overwrites_segment: false,
             operation_log_index: Some(log_index),
             metadata_to_be_merged: merged_metadata,
             metadata_to_be_deleted: deleted_metadata,
@@ -413,8 +419,11 @@ impl<'log_data, 'segment_data: 'log_data> HydratedMaterializedLogRecord<'log_dat
             return self.document_ref_from_log();
         }
 
-        if self.materialized_log_record.final_operation
-            == MaterializedLogOperation::OverwriteExisting
+        if self
+            .materialized_log_record
+            .logical_baseline_overwrites_segment
+            || self.materialized_log_record.final_operation
+                == MaterializedLogOperation::OverwriteExisting
             || self.materialized_log_record.final_operation == MaterializedLogOperation::AddNew
         {
             None
@@ -426,8 +435,11 @@ impl<'log_data, 'segment_data: 'log_data> HydratedMaterializedLogRecord<'log_dat
     /// Performs a deep copy of the metadata so only use this if really needed.
     pub fn merged_metadata(&self) -> HashMap<String, MetadataValue> {
         let mut final_metadata;
-        if self.materialized_log_record.final_operation
-            == MaterializedLogOperation::OverwriteExisting
+        if self
+            .materialized_log_record
+            .logical_baseline_overwrites_segment
+            || self.materialized_log_record.final_operation
+                == MaterializedLogOperation::OverwriteExisting
             || self.materialized_log_record.final_operation == MaterializedLogOperation::AddNew
         {
             final_metadata = HashMap::new();
@@ -475,8 +487,11 @@ impl<'log_data, 'segment_data: 'log_data> HydratedMaterializedLogRecord<'log_dat
             return self.embeddings_ref_from_log().unwrap();
         }
 
-        if self.materialized_log_record.final_operation
-            == MaterializedLogOperation::OverwriteExisting
+        if self
+            .materialized_log_record
+            .logical_baseline_overwrites_segment
+            || self.materialized_log_record.final_operation
+                == MaterializedLogOperation::OverwriteExisting
             || self.materialized_log_record.final_operation == MaterializedLogOperation::AddNew
         {
             panic!("Expected at least once source of embedding")
@@ -496,10 +511,15 @@ impl<'log_data, 'segment_data: 'log_data> HydratedMaterializedLogRecord<'log_dat
     pub fn compute_metadata_delta(&self) -> MetadataDelta<'_> {
         let mut metadata_delta = MetadataDelta::new();
         let mut base_metadata: HashMap<&str, &MetadataValue> = HashMap::new();
-        if let Some(data_record) = &self.segment_data_record {
-            if let Some(meta) = &data_record.metadata {
-                for (meta_key, meta_val) in meta {
-                    base_metadata.insert(meta_key, meta_val);
+        if !self
+            .materialized_log_record
+            .logical_baseline_overwrites_segment
+        {
+            if let Some(data_record) = &self.segment_data_record {
+                if let Some(meta) = &data_record.metadata {
+                    for (meta_key, meta_val) in meta {
+                        base_metadata.insert(meta_key, meta_val);
+                    }
                 }
             }
         }
@@ -757,6 +777,34 @@ static TOTAL_LOGS_POST_MATERIALIZED: std::sync::LazyLock<opentelemetry::metrics:
             .build()
     });
 
+fn checkpoint_materialized_state<'log>(
+    existing: &mut HashMap<&'log str, MaterializedLogRecord>,
+    new: &mut HashMap<&'log str, MaterializedLogRecord>,
+) {
+    // Convert the state reconstructed from the hidden prefix into the logical
+    // baseline for visible operations. Deleted records become absent, while
+    // prefix-created records become existing records whose values still point
+    // into the shared log chunk.
+    existing.retain(|_, record| {
+        if record.final_operation == MaterializedLogOperation::DeleteExisting {
+            return false;
+        }
+        if record.final_operation == MaterializedLogOperation::OverwriteExisting {
+            record.logical_baseline_overwrites_segment = true;
+        }
+        record.final_operation = MaterializedLogOperation::Initial;
+        record.operation_log_index = None;
+        true
+    });
+
+    for (user_id, mut record) in new.drain() {
+        record.logical_baseline_overwrites_segment = true;
+        record.final_operation = MaterializedLogOperation::Initial;
+        record.operation_log_index = None;
+        existing.insert(user_id, record);
+    }
+}
+
 /// Materializes a chunk of log records.
 /// - `record_segment_reader` can be `None` if the record segment is uninitialized.
 /// - `next_offset_id` must be provided if the log was partitioned and `materialize_logs()` is called for each partition: if it is not provided, generated offset IDs will conflict between partitions. When it is not provided, it is initialized from the max offset ID in the record segment.
@@ -766,6 +814,23 @@ pub async fn materialize_logs(
     logs: Chunk<LogRecord>,
     next_offset_id: Option<Arc<AtomicU32>>,
     plan: &RecordSegmentReaderOptions,
+) -> Result<MaterializeLogsResult, LogMaterializerError> {
+    materialize_logs_with_cutoff(record_segment_reader, logs, next_offset_id, plan, None).await
+}
+
+/// Materializes logs against a physical snapshot while optionally treating a
+/// later log offset as the logical baseline for the returned operations.
+///
+/// Logs at or below `visibility_cutoff` are applied to reconstruct state, but
+/// are not returned. Logs above the cutoff are materialized relative to that
+/// reconstructed state. This lets callers replay from an older collection
+/// snapshot without re-emitting work that a consumer has already completed.
+pub async fn materialize_logs_with_cutoff(
+    record_segment_reader: &Option<RecordSegmentReaderShard<'_>>,
+    logs: Chunk<LogRecord>,
+    next_offset_id: Option<Arc<AtomicU32>>,
+    plan: &RecordSegmentReaderOptions,
+    visibility_cutoff: Option<i64>,
 ) -> Result<MaterializeLogsResult, LogMaterializerError> {
     // Trace the total_len since len() iterates over the entire chunk
     // and we don't want to do that just to trace the length.
@@ -823,13 +888,25 @@ pub async fn materialize_logs(
     }
 
     let mut has_backfill = false;
+    let mut checkpoint_applied = visibility_cutoff.is_none();
     // Populate updates to these and fresh records that are being
     // inserted for the first time.
     async {
         for (log_record, log_index) in logs.iter() {
+            if !checkpoint_applied
+                && visibility_cutoff.is_some_and(|cutoff| log_record.log_offset > cutoff)
+            {
+                checkpoint_materialized_state(
+                    &mut existing_id_to_materialized,
+                    &mut new_id_to_materialized,
+                );
+                checkpoint_applied = true;
+            }
             match log_record.record.operation {
                 Operation::BackfillFn => {
-                    has_backfill = true;
+                    if checkpoint_applied {
+                        has_backfill = true;
+                    }
                     continue;
                 }
                 Operation::Add => {
@@ -913,7 +990,9 @@ pub async fn materialize_logs(
                         record_from_map.final_embedding_at_log_index = None;
                         record_from_map.metadata_to_be_merged = None;
                         record_from_map.metadata_to_be_deleted = None;
-                        record_from_map.user_id_at_log_index = None;
+                        if record_from_map.offset_id_exists_in_segment {
+                            record_from_map.user_id_at_log_index = None;
+                        }
                     }
                 }
                 Operation::Update => {
@@ -1090,6 +1169,12 @@ pub async fn materialize_logs(
                     }
                 }
             }
+        }
+        if !checkpoint_applied {
+            checkpoint_materialized_state(
+                &mut existing_id_to_materialized,
+                &mut new_id_to_materialized,
+            );
         }
         Ok(())
     }.instrument(Span::current()).await?;
@@ -1658,6 +1743,256 @@ mod tests {
     use chroma_storage::{local::LocalStorage, Storage};
     use chroma_types::{CollectionUuid, DatabaseUuid, OperationRecord, SegmentShard, SegmentUuid};
     use std::{collections::HashMap, str::FromStr};
+
+    fn test_log(
+        log_offset: i64,
+        id: &str,
+        operation: Operation,
+        document: Option<&str>,
+    ) -> LogRecord {
+        LogRecord {
+            log_offset,
+            record: OperationRecord {
+                id: id.to_string(),
+                embedding: matches!(operation, Operation::Add | Operation::Upsert)
+                    .then_some(vec![1.0, 2.0, 3.0]),
+                encoding: None,
+                metadata: None,
+                document: document.map(str::to_string),
+                operation,
+            },
+        }
+    }
+
+    #[test]
+    fn checkpoint_preserves_overwrite_as_log_backed_baseline() {
+        let logs = [test_log(10, "record", Operation::Add, Some("replacement"))];
+        let mut record = MaterializedLogRecord::from_log_record(1, 0, &logs[0]).unwrap();
+        record.offset_id_exists_in_segment = true;
+        record.final_operation = MaterializedLogOperation::OverwriteExisting;
+        let mut existing = HashMap::from([("record", record)]);
+        let mut new = HashMap::new();
+
+        checkpoint_materialized_state(&mut existing, &mut new);
+
+        let checkpointed = existing.get("record").unwrap();
+        assert_eq!(
+            checkpointed.final_operation,
+            MaterializedLogOperation::Initial
+        );
+        assert!(checkpointed.logical_baseline_overwrites_segment);
+    }
+
+    #[tokio::test]
+    async fn materialization_cutoff_hides_prefix_and_uses_it_as_baseline() {
+        let logs = Chunk::new(
+            vec![
+                test_log(10, "record", Operation::Add, Some("before")),
+                test_log(11, "record", Operation::Update, Some("after")),
+            ]
+            .into(),
+        );
+
+        let result = materialize_logs_with_cutoff(
+            &None,
+            logs,
+            None,
+            &RecordSegmentReaderOptions::default(),
+            Some(10),
+        )
+        .await
+        .unwrap();
+
+        let records = result.iter().collect::<Vec<_>>();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].get_operation(),
+            MaterializedLogOperation::UpdateExisting
+        );
+        let hydrated = records[0].hydrate(None).await.unwrap();
+        assert_eq!(hydrated.get_user_id(), "record");
+        assert_eq!(hydrated.merged_document_ref(), Some("after"));
+        assert_eq!(hydrated.get_operation_log_offset().unwrap(), 11);
+    }
+
+    #[tokio::test]
+    async fn materialization_cutoff_emits_delete_for_prefix_created_record() {
+        let logs = Chunk::new(
+            vec![
+                test_log(10, "record", Operation::Add, Some("before")),
+                test_log(11, "record", Operation::Delete, None),
+            ]
+            .into(),
+        );
+
+        let result = materialize_logs_with_cutoff(
+            &None,
+            logs,
+            None,
+            &RecordSegmentReaderOptions::default(),
+            Some(10),
+        )
+        .await
+        .unwrap();
+
+        let records = result.iter().collect::<Vec<_>>();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].get_operation(),
+            MaterializedLogOperation::DeleteExisting
+        );
+        let hydrated = records[0].hydrate(None).await.unwrap();
+        assert_eq!(hydrated.get_user_id(), "record");
+        assert_eq!(hydrated.get_operation_log_offset().unwrap(), 11);
+    }
+
+    #[tokio::test]
+    async fn materialization_cutoff_hides_prefix_only_changes() {
+        let logs = Chunk::new(vec![test_log(10, "record", Operation::Add, Some("before"))].into());
+
+        let result = materialize_logs_with_cutoff(
+            &None,
+            logs,
+            None,
+            &RecordSegmentReaderOptions::default(),
+            Some(10),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn materialization_cutoff_preserves_prefix_fields_for_suffix_update() {
+        let mut initial_metadata = HashMap::new();
+        initial_metadata.insert(
+            "kept".to_string(),
+            UpdateMetadataValue::Str("initial".to_string()),
+        );
+        let mut updated_metadata = HashMap::new();
+        updated_metadata.insert(
+            "added".to_string(),
+            UpdateMetadataValue::Str("suffix".to_string()),
+        );
+        let logs = Chunk::new(
+            vec![
+                LogRecord {
+                    log_offset: 10,
+                    record: OperationRecord {
+                        id: "record".to_string(),
+                        embedding: Some(vec![1.0, 2.0, 3.0]),
+                        encoding: None,
+                        metadata: Some(initial_metadata),
+                        document: Some("prefix-document".to_string()),
+                        operation: Operation::Add,
+                    },
+                },
+                LogRecord {
+                    log_offset: 11,
+                    record: OperationRecord {
+                        id: "record".to_string(),
+                        embedding: None,
+                        encoding: None,
+                        metadata: Some(updated_metadata),
+                        document: None,
+                        operation: Operation::Update,
+                    },
+                },
+            ]
+            .into(),
+        );
+
+        let result = materialize_logs_with_cutoff(
+            &None,
+            logs,
+            None,
+            &RecordSegmentReaderOptions::default(),
+            Some(10),
+        )
+        .await
+        .unwrap();
+
+        let record = result.iter().next().unwrap();
+        let hydrated = record.hydrate(None).await.unwrap();
+        assert_eq!(hydrated.merged_document_ref(), Some("prefix-document"));
+        assert_eq!(hydrated.merged_embeddings_ref(), &[1.0, 2.0, 3.0]);
+        assert_eq!(
+            hydrated.merged_metadata(),
+            HashMap::from([
+                (
+                    "kept".to_string(),
+                    MetadataValue::Str("initial".to_string())
+                ),
+                (
+                    "added".to_string(),
+                    MetadataValue::Str("suffix".to_string())
+                ),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn materialization_cutoff_readds_after_visible_delete() {
+        let logs = Chunk::new(
+            vec![
+                test_log(10, "record", Operation::Add, Some("prefix")),
+                test_log(11, "record", Operation::Delete, None),
+                test_log(12, "record", Operation::Add, Some("suffix")),
+            ]
+            .into(),
+        );
+
+        let result = materialize_logs_with_cutoff(
+            &None,
+            logs,
+            None,
+            &RecordSegmentReaderOptions::default(),
+            Some(10),
+        )
+        .await
+        .unwrap();
+
+        let record = result.iter().next().unwrap();
+        assert_eq!(
+            record.get_operation(),
+            MaterializedLogOperation::OverwriteExisting
+        );
+        let hydrated = record.hydrate(None).await.unwrap();
+        assert_eq!(hydrated.merged_document_ref(), Some("suffix"));
+        assert_eq!(hydrated.get_operation_log_offset().unwrap(), 12);
+    }
+
+    #[tokio::test]
+    async fn materialization_cutoff_ignores_completed_backfill_marker() {
+        let logs = Chunk::new(
+            vec![LogRecord {
+                log_offset: 10,
+                record: OperationRecord {
+                    id: "backfill".to_string(),
+                    embedding: None,
+                    encoding: None,
+                    metadata: None,
+                    document: None,
+                    operation: Operation::BackfillFn,
+                },
+            }]
+            .into(),
+        );
+
+        let result = materialize_logs_with_cutoff(
+            &None,
+            logs,
+            None,
+            &RecordSegmentReaderOptions::default(),
+            Some(10),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.has_backfill());
+        assert!(result.is_empty());
+    }
 
     #[tokio::test]
     async fn test_materializer_add_delete_upsert() {

--- a/rust/worker/src/execution/operators/get_async_fn_fetch_boundaries.rs
+++ b/rust/worker/src/execution/operators/get_async_fn_fetch_boundaries.rs
@@ -24,6 +24,7 @@ pub(crate) struct GetAsyncFnFetchBoundariesInput {
     pub collection: Collection,
     pub record_segment: Segment,
     pub completion_offset: i64,
+    pub target_log_offset: i64,
     pub max_compaction_size: usize,
     pub blockfile_provider: BlockfileProvider,
 }
@@ -79,6 +80,7 @@ impl Operator<GetAsyncFnFetchBoundariesInput, GetAsyncFnFetchBoundariesOutput>
         resolve_boundary_plan_from_version_file(
             version_file.as_ref(),
             input.completion_offset,
+            input.target_log_offset,
             input.max_compaction_size,
             &input.record_segment,
         )

--- a/rust/worker/src/execution/operators/materialize_logs.rs
+++ b/rust/worker/src/execution/operators/materialize_logs.rs
@@ -4,7 +4,7 @@ use chroma_segment::blockfile_record::{
     RecordSegmentReader, RecordSegmentReaderOptions, RecordSegmentReaderShardCreationError,
 };
 use chroma_segment::types::{
-    materialize_logs, LogMaterializerError, PartitionedMaterializeLogsResult,
+    materialize_logs_with_cutoff, LogMaterializerError, PartitionedMaterializeLogsResult,
 };
 use chroma_system::Operator;
 use chroma_types::{Chunk, LogRecord};
@@ -53,6 +53,7 @@ pub struct MaterializeLogInput {
     record_reader: Option<RecordSegmentReader<'static>>,
     offset_ids: Vec<Arc<AtomicU32>>,
     plan: RecordSegmentReaderOptions,
+    visibility_cutoff: Option<i64>,
 }
 
 impl MaterializeLogInput {
@@ -67,7 +68,13 @@ impl MaterializeLogInput {
             record_reader,
             offset_ids,
             plan,
+            visibility_cutoff: None,
         }
+    }
+
+    pub fn with_visibility_cutoff(mut self, visibility_cutoff: Option<i64>) -> Self {
+        self.visibility_cutoff = visibility_cutoff;
+        self
     }
 }
 
@@ -108,9 +115,15 @@ impl Operator<MaterializeLogInput, MaterializeLogOutput> for MaterializeLogOpera
             // Get offset_id for this shard, or None if not available
             let offset_id = input.offset_ids.get(shard_idx).cloned();
 
-            let result = materialize_logs(shard_reader, logs, offset_id, &input.plan)
-                .await
-                .map_err(MaterializeLogOperatorError::LogMaterializationFailed)?;
+            let result = materialize_logs_with_cutoff(
+                shard_reader,
+                logs,
+                offset_id,
+                &input.plan,
+                input.visibility_cutoff,
+            )
+            .await
+            .map_err(MaterializeLogOperatorError::LogMaterializationFailed)?;
 
             // Calculate logical size delta for this shard
             let mut shard_delta = 0i64;

--- a/rust/worker/src/execution/orchestration/async_function_boundary.rs
+++ b/rust/worker/src/execution/orchestration/async_function_boundary.rs
@@ -4,6 +4,7 @@ use chroma_types::Segment;
 #[derive(Debug, Clone)]
 pub(crate) struct AsyncFnBoundaryPlan {
     pub(crate) historical_record_segment: Option<Segment>,
+    pub(crate) snapshot_log_position: i64,
     pub(crate) target_log_position: i64,
 }
 
@@ -18,33 +19,27 @@ impl AsyncFnBoundaryPlan {
 pub(crate) fn resolve_boundary_plan_from_version_file(
     version_file: Option<&CollectionVersionFile>,
     completion_offset: i64,
+    target_log_offset: i64,
     max_compaction_size: usize,
     live_record_segment: &Segment,
 ) -> Result<AsyncFnBoundaryPlan, String> {
-    let Some(version_file) = version_file else {
+    if target_log_offset <= completion_offset {
         return Err(format!(
-            "async fn completion offset {} has no next compaction boundary",
-            completion_offset
+            "async fn target offset {} must exceed completion offset {}",
+            target_log_offset, completion_offset
         ));
-    };
+    }
+    if max_compaction_size == 0 {
+        return Err("async fn max_compaction_size must be greater than zero".to_string());
+    }
 
-    let version_history = match version_file.version_history.as_ref() {
-        Some(history) => history,
-        None => {
-            return Err(format!(
-                "async fn completion offset {} has no next compaction boundary",
-                completion_offset
-            ));
-        }
-    };
-
-    let version_infos = version_history
-        .versions
-        .iter()
-        // GC only marks versions for deletion after a newer version supersedes them.
-        // Fn-consumers should only resolve boundaries against the still-live versions
-        // whose segment files are expected to remain readable. GC makes sure to
-        // keep at least one version live below the completion offset.
+    // Version history is only needed to find the newest readable snapshot at
+    // or before the function checkpoint. The execution target comes from the
+    // queued work frontier and does not need to be a compaction boundary.
+    let historical_version = version_file
+        .and_then(|version_file| version_file.version_history.as_ref())
+        .into_iter()
+        .flat_map(|history| history.versions.iter())
         .filter(|version| !version.marked_for_deletion)
         .filter_map(|version| {
             version
@@ -52,72 +47,33 @@ pub(crate) fn resolve_boundary_plan_from_version_file(
                 .as_ref()
                 .map(|mutable| (version, mutable.current_log_position))
         })
-        .collect::<Vec<_>>();
+        .filter(|(_, log_position)| *log_position <= completion_offset)
+        .max_by_key(|(_, log_position)| *log_position);
 
-    // Walk versions newest -> oldest. Boundaries above the completion offset
-    // are visited furthest-first, so the first one whose window fits
-    // max_compaction_size is the widest eligible target. Tracking the nearest
-    // boundary as well preserves the oversized-window error below when no
-    // boundary fits.
-    let mut historical_version = None;
-    let mut next_boundary = None;
-    let mut furthest_fitting_boundary = None;
-    for (version, log_position) in version_infos.into_iter().rev() {
-        if log_position <= completion_offset {
-            historical_version = Some((version, log_position));
-            break;
-        }
-
-        if furthest_fitting_boundary.is_none()
-            && usize::try_from(log_position - completion_offset)
-                .is_ok_and(|window| window <= max_compaction_size)
-        {
-            furthest_fitting_boundary = Some(log_position);
-        }
-        next_boundary = Some(log_position);
+    if historical_version.is_none() && completion_offset > 0 {
+        return Err(format!(
+            "async fn completion offset {} has no live snapshot at or before it",
+            completion_offset
+        ));
     }
 
+    let snapshot_log_position = historical_version
+        .as_ref()
+        .map(|(_, log_position)| *log_position)
+        .unwrap_or_else(|| completion_offset.min(0));
     let historical_record_segment = match historical_version {
-        Some((_, log_position)) if completion_offset > 0 && log_position < completion_offset => {
-            return Err(format!(
-                "Invariant violation: async fn completion offset {} does not align to a compaction boundary",
-                completion_offset
-            ));
-        }
         Some((version, _)) => Some(
             live_record_segment.historical_segment_for_version(version, live_record_segment.id)?,
         ),
         None => None,
     };
 
-    // Prefer the furthest boundary that fits: one run then covers every
-    // compaction between the completion offset and that boundary, instead of
-    // draining a backlog one small compaction window at a time. Skipped
-    // intermediate boundaries are safe — the completion offset advances to a
-    // real boundary either way, and the work queue retires stale entries by
-    // offset comparison.
-    let target_log_position = furthest_fitting_boundary.or(next_boundary).ok_or_else(|| {
-        format!(
-            "async fn completion offset {} has no next compaction boundary",
-            completion_offset
-        )
-    })?;
-    let log_window_size =
-        usize::try_from(target_log_position - completion_offset).map_err(|_| {
-            format!(
-                "Invariant violation: next compaction boundary {} precedes completion offset {}",
-                target_log_position, completion_offset
-            )
-        })?;
-    if log_window_size > max_compaction_size {
-        return Err(format!(
-            "next compaction boundary window {} exceeds max_compaction_size {}",
-            log_window_size, max_compaction_size
-        ));
-    }
+    let max_window = i64::try_from(max_compaction_size).unwrap_or(i64::MAX);
+    let target_log_position = target_log_offset.min(completion_offset.saturating_add(max_window));
 
     Ok(AsyncFnBoundaryPlan {
         historical_record_segment,
+        snapshot_log_position,
         target_log_position,
     })
 }
@@ -175,204 +131,80 @@ mod tests {
     }
 
     #[test]
-    fn no_version_file_means_no_executable_boundary() {
+    fn initial_checkpoint_uses_empty_state_without_version_file() {
         let record_segment = test_record_segment();
-        let err =
-            resolve_boundary_plan_from_version_file(None, -1, 1024, &record_segment).unwrap_err();
-        assert!(err.contains("no next compaction boundary"));
-    }
-
-    #[test]
-    fn resolves_exact_boundary_and_next_boundary() {
-        let record_segment = test_record_segment();
-        let version_file = CollectionVersionFile {
-            version_history: Some(CollectionVersionHistory {
-                versions: vec![
-                    version_info(1, 100, record_segment.id, "record/v100"),
-                    version_info(2, 150, record_segment.id, "record/v150"),
-                ],
-            }),
-            ..Default::default()
-        };
-
-        let plan = resolve_boundary_plan_from_version_file(
-            Some(&version_file),
-            100,
-            1024,
-            &record_segment,
-        )
-        .unwrap();
-
-        assert_eq!(plan.target_log_position, 150);
-        assert_eq!(
-            plan.historical_record_segment.unwrap().file_path["offset_id_to_data"],
-            vec!["record/v100".to_string()]
-        );
-    }
-
-    #[test]
-    fn completion_offset_zero_uses_empty_state_and_widest_fitting_boundary() {
-        let record_segment = test_record_segment();
-        let version_file = CollectionVersionFile {
-            version_history: Some(CollectionVersionHistory {
-                versions: vec![
-                    version_info(1, 100, record_segment.id, "record/v100"),
-                    version_info(2, 150, record_segment.id, "record/v150"),
-                ],
-            }),
-            ..Default::default()
-        };
-
         let plan =
-            resolve_boundary_plan_from_version_file(Some(&version_file), 0, 1024, &record_segment)
-                .unwrap();
+            resolve_boundary_plan_from_version_file(None, -1, 75, 1024, &record_segment).unwrap();
 
-        assert_eq!(plan.target_log_position, 150);
-        assert!(
-            plan.historical_record_segment.is_none(),
-            "completion offset zero should use the empty pre-compaction state"
-        );
+        assert_eq!(plan.snapshot_log_position, -1);
+        assert_eq!(plan.target_log_position, 75);
+        assert!(plan.historical_record_segment.is_none());
     }
 
     #[test]
-    fn picks_furthest_boundary_that_fits_max_compaction_size() {
+    fn positive_checkpoint_requires_a_live_snapshot() {
+        let record_segment = test_record_segment();
+        let err = resolve_boundary_plan_from_version_file(None, 25, 75, 1024, &record_segment)
+            .unwrap_err();
+
+        assert!(err.contains("no live snapshot"));
+    }
+
+    #[test]
+    fn target_does_not_need_a_compaction_boundary() {
         let record_segment = test_record_segment();
         let version_file = CollectionVersionFile {
             version_history: Some(CollectionVersionHistory {
-                versions: vec![
-                    version_info(1, 100, record_segment.id, "record/v100"),
-                    version_info(2, 150, record_segment.id, "record/v150"),
-                    version_info(3, 200, record_segment.id, "record/v200"),
-                ],
+                versions: vec![version_info(1, 100, record_segment.id, "record/v100")],
             }),
             ..Default::default()
         };
 
         let plan = resolve_boundary_plan_from_version_file(
-            Some(&version_file),
-            100,
-            1024,
-            &record_segment,
-        )
-        .unwrap();
-
-        assert_eq!(plan.target_log_position, 200);
-        assert_eq!(
-            plan.historical_record_segment.unwrap().file_path["offset_id_to_data"],
-            vec!["record/v100".to_string()]
-        );
-    }
-
-    #[test]
-    fn skips_boundaries_wider_than_max_compaction_size() {
-        let record_segment = test_record_segment();
-        let version_file = CollectionVersionFile {
-            version_history: Some(CollectionVersionHistory {
-                versions: vec![
-                    version_info(1, 100, record_segment.id, "record/v100"),
-                    version_info(2, 150, record_segment.id, "record/v150"),
-                    version_info(3, 200, record_segment.id, "record/v200"),
-                    version_info(4, 5000, record_segment.id, "record/v5000"),
-                ],
-            }),
-            ..Default::default()
-        };
-
-        let plan = resolve_boundary_plan_from_version_file(
-            Some(&version_file),
-            100,
-            1000,
-            &record_segment,
-        )
-        .unwrap();
-
-        assert_eq!(plan.target_log_position, 200);
-    }
-
-    #[test]
-    fn errors_when_no_boundary_fits_max_compaction_size() {
-        let record_segment = test_record_segment();
-        let version_file = CollectionVersionFile {
-            version_history: Some(CollectionVersionHistory {
-                versions: vec![
-                    version_info(1, 100, record_segment.id, "record/v100"),
-                    version_info(2, 5000, record_segment.id, "record/v5000"),
-                ],
-            }),
-            ..Default::default()
-        };
-
-        let err = resolve_boundary_plan_from_version_file(
-            Some(&version_file),
-            100,
-            1000,
-            &record_segment,
-        )
-        .unwrap_err();
-
-        assert!(err.contains("exceeds max_compaction_size"));
-    }
-
-    #[test]
-    fn deleted_versions_are_not_widened_targets() {
-        let record_segment = test_record_segment();
-        let mut deleted_version = version_info(2, 150, record_segment.id, "record/v150");
-        deleted_version.marked_for_deletion = true;
-
-        let version_file = CollectionVersionFile {
-            version_history: Some(CollectionVersionHistory {
-                versions: vec![
-                    version_info(1, 100, record_segment.id, "record/v100"),
-                    deleted_version,
-                    version_info(3, 5000, record_segment.id, "record/v5000"),
-                ],
-            }),
-            ..Default::default()
-        };
-
-        // The only live boundary above the offset (5000) does not fit, and the
-        // deleted 150 boundary must not be picked in its place.
-        let err = resolve_boundary_plan_from_version_file(
-            Some(&version_file),
-            100,
-            1000,
-            &record_segment,
-        )
-        .unwrap_err();
-
-        assert!(err.contains("exceeds max_compaction_size"));
-    }
-
-    #[test]
-    fn rejects_non_boundary_completion_offsets_after_first_compaction() {
-        let record_segment = test_record_segment();
-        let version_file = CollectionVersionFile {
-            version_history: Some(CollectionVersionHistory {
-                versions: vec![
-                    version_info(1, 100, record_segment.id, "record/v100"),
-                    version_info(2, 150, record_segment.id, "record/v150"),
-                ],
-            }),
-            ..Default::default()
-        };
-
-        let err = resolve_boundary_plan_from_version_file(
             Some(&version_file),
             125,
+            175,
             1024,
             &record_segment,
         )
-        .unwrap_err();
+        .unwrap();
 
-        assert!(err.contains("does not align to a compaction boundary"));
+        assert_eq!(plan.snapshot_log_position, 100);
+        assert_eq!(plan.target_log_position, 175);
+        assert_eq!(
+            plan.historical_record_segment.unwrap().file_path["offset_id_to_data"],
+            vec!["record/v100".to_string()]
+        );
     }
 
     #[test]
-    fn ignores_deleted_versions_when_finding_next_boundary() {
+    fn caps_target_by_max_compaction_size_without_a_boundary() {
+        let record_segment = test_record_segment();
+        let version_file = CollectionVersionFile {
+            version_history: Some(CollectionVersionHistory {
+                versions: vec![version_info(1, 100, record_segment.id, "record/v100")],
+            }),
+            ..Default::default()
+        };
+
+        let plan = resolve_boundary_plan_from_version_file(
+            Some(&version_file),
+            125,
+            5000,
+            1000,
+            &record_segment,
+        )
+        .unwrap();
+
+        assert_eq!(plan.snapshot_log_position, 100);
+        assert_eq!(plan.target_log_position, 1125);
+    }
+
+    #[test]
+    fn chooses_newest_live_snapshot_at_or_before_checkpoint() {
         let record_segment = test_record_segment();
         let mut deleted_version = version_info(2, 150, record_segment.id, "record/v150");
         deleted_version.marked_for_deletion = true;
-
         let version_file = CollectionVersionFile {
             version_history: Some(CollectionVersionHistory {
                 versions: vec![
@@ -386,45 +218,32 @@ mod tests {
 
         let plan = resolve_boundary_plan_from_version_file(
             Some(&version_file),
-            100,
+            175,
+            190,
             1024,
             &record_segment,
         )
         .unwrap();
 
-        assert_eq!(plan.target_log_position, 200);
-        assert_eq!(
-            plan.historical_record_segment.unwrap().file_path["offset_id_to_data"],
-            vec!["record/v100".to_string()]
-        );
+        assert_eq!(plan.snapshot_log_position, 100);
+        assert_eq!(plan.target_log_position, 190);
     }
 
     #[test]
-    fn rejects_completion_offsets_that_only_match_deleted_versions() {
+    fn rejects_non_advancing_target() {
         let record_segment = test_record_segment();
-        let mut deleted_version = version_info(2, 150, record_segment.id, "record/v150");
-        deleted_version.marked_for_deletion = true;
+        let err = resolve_boundary_plan_from_version_file(None, 25, 25, 1024, &record_segment)
+            .unwrap_err();
 
-        let version_file = CollectionVersionFile {
-            version_history: Some(CollectionVersionHistory {
-                versions: vec![
-                    version_info(1, 100, record_segment.id, "record/v100"),
-                    deleted_version,
-                    version_info(3, 200, record_segment.id, "record/v200"),
-                ],
-            }),
-            ..Default::default()
-        };
+        assert!(err.contains("must exceed completion offset"));
+    }
 
-        let err = resolve_boundary_plan_from_version_file(
-            Some(&version_file),
-            150,
-            1024,
-            &record_segment,
-        )
-        .unwrap_err();
+    #[test]
+    fn rejects_zero_sized_windows() {
+        let record_segment = test_record_segment();
+        let err =
+            resolve_boundary_plan_from_version_file(None, -1, 25, 0, &record_segment).unwrap_err();
 
-        assert!(err.contains("Invariant violation"));
-        assert!(err.contains("does not align to a compaction boundary"));
+        assert!(err.contains("must be greater than zero"));
     }
 }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -192,6 +192,7 @@ pub struct CompactionContext {
     pub shard_size: Option<u64>,
     pub work_queue_client: Option<WorkQueueClient>,
     pub log_start_offset: Option<i64>,
+    pub log_end_offset: Option<i64>,
     #[cfg(test)]
     pub poison_offset: Option<u32>,
 }
@@ -220,6 +221,7 @@ impl Clone for CompactionContext {
             shard_size: self.shard_size,
             work_queue_client: self.work_queue_client.clone(),
             log_start_offset: self.log_start_offset,
+            log_end_offset: self.log_end_offset,
             #[cfg(test)]
             poison_offset: self.poison_offset,
         }
@@ -276,6 +278,7 @@ impl CompactionContext {
             shard_size: self.shard_size,
             work_queue_client: self.work_queue_client.clone(),
             log_start_offset: self.log_start_offset,
+            log_end_offset: self.log_end_offset,
             #[cfg(test)]
             poison_offset: self.poison_offset,
         }
@@ -414,6 +417,7 @@ impl CompactionContext {
             shard_size,
             work_queue_client,
             log_start_offset: None,
+            log_end_offset: None,
             #[cfg(test)]
             poison_offset: None,
         }
@@ -557,6 +561,7 @@ impl CompactionContext {
             self.work_queue_client.clone(),
             self.is_fn_consumer,
             self.log_start_offset,
+            self.log_end_offset,
             attached_function_id_filter,
         );
 
@@ -4992,7 +4997,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_k8s_integration_async_attached_function() {
+    async fn test_async_attached_function_boundaries() {
         // Setup test environment
         let config = RootConfig::default();
         let system = System::default();
@@ -5060,11 +5065,11 @@ mod tests {
             .await
             .expect("Should be able to update log_position");
 
-        // Add 300 records with zero-based offsets.  The in-memory log test
+        // Add 350 records with zero-based offsets.  The in-memory log test
         // double treats requested log offsets as storage indices, so the
         // logical `LogRecord.log_offset` values must stay aligned with the
         // contiguous internal offsets.
-        for i in 0..300 {
+        for i in 0..350 {
             let log_record = chroma_types::LogRecord {
                 log_offset: i,
                 record: OperationRecord {
@@ -5209,6 +5214,62 @@ mod tests {
         }
 
         Box::pin(fn_consumer_context.cleanup()).await;
+
+        // A function checkpoint beyond the latest compaction must replay from
+        // that snapshot while hiding records already covered by the function.
+        // The latest snapshot is at 299, the function is at 325, and the queued
+        // work frontier is the non-boundary offset 349.
+        let mut unaligned_context = CompactionContext::new_with_log_offset(
+            None,
+            50,
+            10,
+            1000,
+            50,
+            log.clone(),
+            sysdb.clone(),
+            test_segments.blockfile_provider.clone(),
+            test_segments.hnsw_provider.clone(),
+            test_segments.spann_provider.clone(),
+            dispatcher_handle.clone(),
+            false,
+            true,
+            None,
+            None,
+            None,
+            None,
+            325,
+        );
+        unaligned_context.log_end_offset = Some(349);
+
+        let unaligned_response = unaligned_context
+            .run_get_logs(
+                collection_id,
+                database_name.clone(),
+                system.clone(),
+                false,
+                None,
+            )
+            .await
+            .expect("unaligned fn-consumer log fetch should succeed");
+
+        match unaligned_response {
+            LogFetchOrchestratorResponse::Success(success) => {
+                assert_eq!(success.collection_info.pulled_log_offset, 349);
+                let total_materialized_records: usize = success
+                    .materialized
+                    .iter()
+                    .map(|batch| batch.result.len())
+                    .sum();
+                assert_eq!(
+                    total_materialized_records, 24,
+                    "records at or below the function checkpoint must only rebuild state, \
+                     and the target need not be a compaction boundary"
+                );
+            }
+            other => panic!("expected successful unaligned fetch, got {other:?}"),
+        }
+
+        Box::pin(unaligned_context.cleanup()).await;
 
         // Repeat from the first boundary with a max_compaction_size of exactly
         // one window (100) to prove the cap forces the fetch back to the

--- a/rust/worker/src/execution/orchestration/function_execution.rs
+++ b/rust/worker/src/execution/orchestration/function_execution.rs
@@ -69,7 +69,9 @@ impl FunctionExecutionContext {
         system: System,
         use_compacted_logs: bool,
         attached_function_id: AttachedFunctionUuid,
+        target_log_offset: i64,
     ) -> Result<LogFetchOrchestratorResponse, CompactionError> {
+        log_fetch_context.log_end_offset = Some(target_log_offset);
         Ok(log_fetch_context
             .run_get_logs(
                 collection_id,
@@ -87,6 +89,7 @@ impl FunctionExecutionContext {
         attached_function_id: AttachedFunctionUuid,
         database_name: DatabaseName,
         system: System,
+        target_log_offset: i64,
     ) -> Result<FunctionInputCollectionData, CompactionError> {
         match Self::fetch_function_input_logs(
             log_fetch_context,
@@ -95,6 +98,7 @@ impl FunctionExecutionContext {
             system,
             true,
             attached_function_id,
+            target_log_offset,
         )
         .await?
         {
@@ -118,6 +122,7 @@ impl FunctionExecutionContext {
         attached_function_id: AttachedFunctionUuid,
         database_name: DatabaseName,
         system: System,
+        target_log_offset: i64,
     ) -> Result<FunctionInputCollectionData, CompactionError> {
         let log_fetch_context = compaction_context;
         let result = match Self::fetch_function_input_logs(
@@ -127,6 +132,7 @@ impl FunctionExecutionContext {
             system.clone(),
             false,
             attached_function_id,
+            target_log_offset,
         )
         .await
         {
@@ -138,6 +144,7 @@ impl FunctionExecutionContext {
                     attached_function_id,
                     database_name,
                     system,
+                    target_log_offset,
                 ))
                 .await;
             }
@@ -157,6 +164,7 @@ impl FunctionExecutionContext {
                     attached_function_id,
                     database_name,
                     system,
+                    target_log_offset,
                 ))
                 .await
             }
@@ -387,6 +395,7 @@ impl FunctionExecutionContext {
                 attached_function_id,
                 shared_database_name.clone(),
                 system.clone(),
+                input.queue_compaction_offset,
             ))
             .await?;
 

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -304,6 +304,8 @@ pub(crate) struct LogFetchOrchestrator {
     has_backfill: bool,
     resolved_attached_functions: Option<Vec<AttachedFunction>>,
     attached_function_id_filter: Option<AttachedFunctionUuid>,
+    materialization_visibility_cutoff: Option<i64>,
+    target_log_offset: Option<i64>,
 }
 
 #[async_trait]
@@ -368,6 +370,7 @@ impl LogFetchOrchestrator {
         collection: &chroma_types::Collection,
         record_segment: &chroma_types::Segment,
         completion_offset: i64,
+        target_log_offset: i64,
         max_compaction_size: usize,
         blockfile_provider: BlockfileProvider,
     ) -> Result<AsyncFnBoundaryPlan, LogFetchOrchestratorError> {
@@ -376,6 +379,7 @@ impl LogFetchOrchestrator {
                 collection: collection.clone(),
                 record_segment: record_segment.clone(),
                 completion_offset,
+                target_log_offset,
                 max_compaction_size,
                 blockfile_provider,
             })
@@ -403,6 +407,7 @@ impl LogFetchOrchestrator {
         work_queue_client: Option<WorkQueueClient>,
         is_fn_consumer: bool,
         log_start_offset: Option<i64>,
+        target_log_offset: Option<i64>,
         attached_function_id_filter: Option<AttachedFunctionUuid>,
     ) -> Self {
         let mut context = CompactionContext::new(
@@ -437,6 +442,8 @@ impl LogFetchOrchestrator {
             has_backfill: false,
             resolved_attached_functions: None,
             attached_function_id_filter,
+            materialization_visibility_cutoff: None,
+            target_log_offset,
         }
     }
 
@@ -547,7 +554,8 @@ impl LogFetchOrchestrator {
                 record_reader.clone(),
                 next_max_offset_ids.clone(),
                 option,
-            );
+            )
+            .with_visibility_cutoff(self.materialization_visibility_cutoff);
             let task = wrap(
                 operator,
                 input,
@@ -619,6 +627,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
         let mut record_segment_for_reader = output.record_segment.clone();
         let mut pulled_log_offset = collection.log_position;
         let mut log_upper_bound_offset = None;
+        let mut maximum_fetch_count = self.context.max_compaction_size as u32;
 
         // Compacted-state backfill reads the whole live segment and is not
         // constrained by the incremental max_compaction_size window.
@@ -656,14 +665,28 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                     }
                 },
             };
-            self.context.log_start_offset = Some(completion_offset);
-
             let max_compaction_size = self.context.max_compaction_size;
+            let target_log_offset = match (self.target_log_offset, self.attached_function_id_filter)
+            {
+                (Some(offset), _) => offset,
+                (None, Some(_)) => {
+                    self.terminate_with_result(
+                        Err(LogFetchOrchestratorError::InvariantViolation(
+                            "fn-consumer log fetch requires a queued target offset",
+                        )),
+                        ctx,
+                    )
+                    .await;
+                    return;
+                }
+                (None, None) => collection.log_position,
+            };
             let blockfile_provider = self.context.blockfile_provider.clone();
             let boundary_plan = match LogFetchOrchestrator::get_async_fn_fetch_boundaries(
                 &collection,
                 &output.record_segment,
                 completion_offset,
+                target_log_offset,
                 max_compaction_size,
                 blockfile_provider,
             )
@@ -679,15 +702,33 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
             tracing::info!(
                 collection_id = %collection.collection_id,
                 completion_offset,
+                snapshot_log_position = boundary_plan.snapshot_log_position,
                 target_log_position = boundary_plan.target_log_position,
                 uses_pre_compaction_state = boundary_plan.historical_record_segment.is_none(),
-                "Resolved async function execution boundary"
+                "Resolved async function replay window"
             );
 
             record_segment_for_reader =
                 boundary_plan.record_segment_for_reader(&output.record_segment);
+            self.context.log_start_offset = Some(boundary_plan.snapshot_log_position);
+            self.materialization_visibility_cutoff = Some(completion_offset);
             pulled_log_offset = boundary_plan.target_log_position;
             log_upper_bound_offset = Some((boundary_plan.target_log_position + 1) as u64);
+            maximum_fetch_count = match u32::try_from(
+                boundary_plan.target_log_position - boundary_plan.snapshot_log_position,
+            ) {
+                Ok(count) => count,
+                Err(_) => {
+                    self.terminate_with_result(
+                        Err(LogFetchOrchestratorError::InvariantViolation(
+                            "fn-consumer replay window does not fit in u32",
+                        )),
+                        ctx,
+                    )
+                    .await;
+                    return;
+                }
+            };
         }
 
         // Create RecordSegmentReader for MaterializeLogOperator
@@ -797,7 +838,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                         Some(offset) => u64::try_from(offset + 1).unwrap_or_default(),
                         None => u64::try_from(collection.log_position + 1).unwrap_or_default(),
                     },
-                    maximum_fetch_count: Some(self.context.max_compaction_size as u32),
+                    maximum_fetch_count: Some(maximum_fetch_count),
                     collection_uuid: collection.collection_id,
                     tenant: collection.tenant.clone(),
                     database_name,


### PR DESCRIPTION
## Description of changes

- Remove the requirement that an async function completion offset align with a collection snapshot.
- Fetch logs beginning after the latest live snapshot at or before the function checkpoint.
- Reconstruct materialized state through the function checkpoint, then expose only later mutations to the attached function.
- Preserve overwrite, delete/re-add, metadata, document, embedding, and completed-backfill semantics across the hidden replay prefix.
- Use the queued work frontier as the execution target, capped to one configured chunk, without requiring the target to be a compaction boundary.
- Leave partially completed work queued so large gaps drain incrementally across fn-consumer runs.

## Test plan

- [x] `cargo test -p chroma-segment materialization_cutoff --no-default-features -- --nocapture`
- [x] `cargo test -p chroma-segment checkpoint_preserves_overwrite_as_log_backed_baseline --no-default-features -- --nocapture`
- [x] `cargo test -p worker async_function_boundary -- --nocapture`
- [x] `cargo test -p worker test_async_attached_function_boundaries -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p worker -p chroma-segment --all-targets -- -D warnings`

## Migration plan

No data migration or API change is required. Existing aligned checkpoints continue through the same path; unaligned checkpoints now replay from the preceding live snapshot and may finish at any queued log offset.

## Observability plan

The existing async-function replay log includes the selected snapshot position, function completion offset, and target log offset so replay windows can be inspected in production.

## Documentation Changes

None. This changes internal fn-consumer execution semantics and does not alter user-facing APIs.
