### PR TITLE
[BUG](types): Reject non-finite metadata floats

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1047,6 +1047,14 @@ def validate_ids(ids: IDs) -> IDs:
     return ids
 
 
+def _validate_metadata_float_value(key: str, value: float) -> None:
+    """Validates that a float metadata value is finite."""
+    if not math.isfinite(value):
+        raise ValueError(
+            f"Expected metadata value for key '{key}' to be a finite float, got {value}"
+        )
+
+
 def _validate_metadata_list_value(key: str, value: list) -> None:
     """Validates a list metadata value: must be non-empty and homogeneously typed."""
     if len(value) == 0:
@@ -1064,6 +1072,8 @@ def _validate_metadata_list_value(key: str, value: list) -> None:
                 f"Expected metadata list value for key '{key}' to contain only str, int, float, or bool "
                 f"and all elements must be the same type, got {value}"
             )
+        if item_type is float:
+            _validate_metadata_float_value(key, item)
 
 
 def validate_metadata(metadata: Metadata) -> Metadata:
@@ -1099,6 +1109,8 @@ def validate_metadata(metadata: Metadata) -> Metadata:
             raise ValueError(
                 f"Expected metadata value to be a str, int, float, bool, SparseVector, list, or None, got {value} which is a {type(value).__name__}"
             )
+        elif isinstance(value, float):
+            _validate_metadata_float_value(key, value)
     return metadata
 
 
@@ -1127,6 +1139,8 @@ def validate_update_metadata(metadata: UpdateMetadata) -> UpdateMetadata:
             raise ValueError(
                 f"Expected metadata value to be a str, int, float, bool, SparseVector, list, or None, got {value}"
             )
+        elif isinstance(value, float):
+            _validate_metadata_float_value(key, value)
     return metadata
 
 

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -2078,6 +2078,21 @@ def test_sparse_vector_in_metadata_validation():
     validate_metadata(metadata_large)
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_metadata_is_rejected(value: float) -> None:
+    """Non-finite metadata floats cannot be stored, so they are rejected up front."""
+    from chromadb.api.types import validate_metadata, validate_update_metadata
+
+    for metadata in [{"score": value}, {"scores": [1.0, value]}]:
+        with pytest.raises(ValueError, match="finite float"):
+            validate_metadata(metadata)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="finite float"):
+            validate_update_metadata(metadata)  # type: ignore[arg-type]
+
+    validate_metadata({"score": 1.5, "scores": [1.0, 2.5]})  # type: ignore[arg-type]
+    validate_update_metadata({"score": 1.5, "scores": [1.0, 2.5]})  # type: ignore[arg-type]
+
+
 def test_sparse_vector_dict_format_normalization():
     """Test that dict-format sparse vectors are normalized to SparseVector instances."""
     from chromadb.api.types import normalize_metadata, validate_metadata

--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -103,16 +103,45 @@ fn validate_metadata_key(key: &str) -> Result<(), ValidationError> {
     }
 }
 
+/// Validate that a float metadata value is finite
+///
+/// Non-finite floats are rejected when metadata is read back off the log, so
+/// accepting them on write leaves records that can never be decoded again.
+fn validate_metadata_floats(
+    key: &str,
+    values: impl IntoIterator<Item = f64>,
+) -> Result<(), ValidationError> {
+    for value in values {
+        if !value.is_finite() {
+            return Err(ValidationError::new("metadata_non_finite").with_message(
+                format!(
+                    "Metadata value for key '{}' must not be NaN or Infinity",
+                    key
+                )
+                .into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Validate metadata
 pub fn validate_metadata(metadata: &Metadata) -> Result<(), ValidationError> {
     for (key, value) in metadata {
         validate_metadata_key(key)?;
 
-        if let MetadataValue::SparseVector(sv) = value {
-            sv.validate().map_err(|e| {
-                ValidationError::new("sparse_vector")
-                    .with_message(format!("Invalid sparse vector: {}", e).into())
-            })?;
+        match value {
+            MetadataValue::SparseVector(sv) => {
+                sv.validate().map_err(|e| {
+                    ValidationError::new("sparse_vector")
+                        .with_message(format!("Invalid sparse vector: {}", e).into())
+                })?;
+            }
+            MetadataValue::Float(value) => validate_metadata_floats(key, [*value])?,
+            MetadataValue::FloatArray(values) => {
+                validate_metadata_floats(key, values.iter().copied())?
+            }
+            _ => {}
         }
     }
     Ok(())
@@ -123,11 +152,18 @@ pub fn validate_update_metadata(metadata: &UpdateMetadata) -> Result<(), Validat
     for (key, value) in metadata {
         validate_metadata_key(key)?;
 
-        if let UpdateMetadataValue::SparseVector(sv) = value {
-            sv.validate().map_err(|e| {
-                ValidationError::new("sparse_vector")
-                    .with_message(format!("Invalid sparse vector: {}", e).into())
-            })?;
+        match value {
+            UpdateMetadataValue::SparseVector(sv) => {
+                sv.validate().map_err(|e| {
+                    ValidationError::new("sparse_vector")
+                        .with_message(format!("Invalid sparse vector: {}", e).into())
+                })?;
+            }
+            UpdateMetadataValue::Float(value) => validate_metadata_floats(key, [*value])?,
+            UpdateMetadataValue::FloatArray(values) => {
+                validate_metadata_floats(key, values.iter().copied())?
+            }
+            _ => {}
         }
     }
     Ok(())
@@ -517,6 +553,41 @@ mod tests {
             MetadataValue::SparseVector(invalid_sparse),
         );
         assert!(validate_metadata(&metadata).is_err());
+    }
+
+    #[test]
+    fn test_metadata_rejects_non_finite_floats() {
+        for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let mut metadata = Metadata::new();
+            metadata.insert("score".to_string(), MetadataValue::Float(value));
+            assert!(validate_metadata(&metadata).is_err());
+
+            let mut metadata = Metadata::new();
+            metadata.insert(
+                "scores".to_string(),
+                MetadataValue::FloatArray(vec![1.0, value]),
+            );
+            assert!(validate_metadata(&metadata).is_err());
+
+            let mut metadata = UpdateMetadata::new();
+            metadata.insert("score".to_string(), UpdateMetadataValue::Float(value));
+            assert!(validate_update_metadata(&metadata).is_err());
+
+            let mut metadata = UpdateMetadata::new();
+            metadata.insert(
+                "scores".to_string(),
+                UpdateMetadataValue::FloatArray(vec![1.0, value]),
+            );
+            assert!(validate_update_metadata(&metadata).is_err());
+        }
+
+        let mut metadata = Metadata::new();
+        metadata.insert("score".to_string(), MetadataValue::Float(0.5));
+        metadata.insert(
+            "scores".to_string(),
+            MetadataValue::FloatArray(vec![0.5, 1.5]),
+        );
+        assert!(validate_metadata(&metadata).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

Metadata floats that are `NaN` or `±Infinity` are accepted on write, but the
conversion that reads a metadata value back out (`MetadataValueConversionError::InvalidValue`
in `rust/types/src/metadata.rs`) rejects them, so such a record can never be
decoded again. The failure mode depends on the shape:

- a scalar is silently dropped — `add(metadatas=[{"f": float("nan"), "ok": 1}])`
  reads back as `{"ok": 1}`, and a metadata-only record reads back as `None`;
- a float **list** breaks compaction for the whole collection, and every later
  operation on it fails, including in new processes against a persistent path:

  ```
  healthy add ok, count: 1
  nan add: InvalidArgumentError Error in compaction: Failed to pull logs from the log store
  # fresh process, same persist_directory:
  count: InvalidArgumentError Error executing plan: Error sending backfill request to compactor: ...
  get:   InvalidArgumentError Error executing plan: Failed to pull logs from the log store
  ```

Embeddings are already guarded (`validate_embeddings`, "Embeddings must not
contain NaN or Infinity values"); metadata was not.

- Improvements & Bug fixes
  - `rust/types/src/validators.rs`: `validate_metadata` / `validate_update_metadata`
    reject non-finite `Float` and `FloatArray` values. These run for add, update
    and upsert requests, so the guard covers the Rust client, the frontend server
    and the Python bindings.
  - `chromadb/api/types.py`: the Python client's own metadata validation rejects
    non-finite scalars and non-finite items in list values, so the caller gets a
    `ValueError` naming the offending key before the request is built.

Removals/no-ops: none. Finite values, ints, bools, strings and sparse vectors
behave exactly as before; the only newly rejected inputs are ones that could not
be stored and read back.

## Test plan

- [x] Tests pass locally with `pytest` for python, `cargo test` for rust
  - `cargo test -p chroma-types --lib validators` — 19 passed, includes the new
    `test_metadata_rejects_non_finite_floats` (scalar + array, metadata + update
    metadata, all three non-finite values, plus a finite case that stays valid).
  - `pytest chromadb/test/test_api.py -k "non_finite or sparse_vector"` — 7 passed.
    The new `test_non_finite_metadata_is_rejected` fails on `main`
    (3 failed: nan/inf/-inf) and passes with the fix.
  - `cargo clippy -p chroma-types --lib --all-targets` clean, `cargo fmt --check`
    and `black --check` clean.

## Migration plan

Input that used to be accepted and silently corrupted now raises an error, so a
caller writing `NaN`/`Infinity` metadata today (for example an unguarded
`float("nan")` from a scoring pipeline) sees a validation error instead of losing
the field or bricking the collection. No stored-data or wire-format change.

## Observability plan

No new instrumentation: the rejection surfaces through the existing validation
error path (HTTP 422 / `InvalidArgumentError`) with a message naming the key.

## Documentation Changes

None needed — no public API surface changes; the metadata docs already describe
values as `str`, `int`, `float`, `bool` without promising non-finite support.
