### PR TITLE
fix(cli): bound update release check

### DIFF
--- a/chromadb/cli/cli.py
+++ b/chromadb/cli/cli.py
@@ -22,7 +22,7 @@ def build_cli_args(**kwargs):
 def update():
     try:
         url = f"https://api.github.com/repos/chroma-core/chroma/releases"
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         response.raise_for_status()
         releases = response.json()
 

--- a/chromadb/test/test_cli.py
+++ b/chromadb/test/test_cli.py
@@ -18,6 +18,29 @@ import numpy as np
 from chromadb.test.property import invariants
 
 
+def test_update_bounds_release_request(monkeypatch, capsys) -> None:
+    captured_kwargs = {}
+
+    class Response:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> list[dict[str, str]]:
+            return [{"tag_name": "999.0.0"}]
+
+    def mock_get(url: str, **kwargs):
+        captured_kwargs.update(kwargs)
+        return Response()
+
+    monkeypatch.setattr(cli.requests, "get", mock_get)
+    monkeypatch.setattr(cli.chromadb, "__version__", "0.0.1")
+
+    cli.update()
+
+    assert captured_kwargs == {"timeout": 30}
+    assert "A new version of Chroma is available!" in capsys.readouterr().out
+
+
 def wait_for_server(
         host: str, port: int,
     max_retries: int = 5, initial_delay: float = 1.0


### PR DESCRIPTION
## Summary
- add an explicit timeout to the `chroma update` GitHub releases request
- add a focused CLI test that asserts the release request is bounded

## Verification
- `python -m py_compile chromadb/cli/cli.py chromadb/test/test_cli.py`
- `git diff --check`

I could not run `python -m pytest chromadb/test/test_cli.py -k update_bounds_release_request -q` in my local checkout because test collection imports `chromadb` and this environment is missing the repo dependency `overrides`.
