### PR TITLE
[BUG]: Defer home path resolution

### DIFF
--- a/chromadb/telemetry/product/__init__.py
+++ b/chromadb/telemetry/product/__init__.py
@@ -48,7 +48,7 @@ class ProductTelemetryEvent:
 
 
 class ProductTelemetryClient(Component):
-    USER_ID_PATH = str(Path.home() / ".cache" / "chroma" / "telemetry_user_id")
+    USER_ID_PATH = ""
     UNKNOWN_USER_ID = "UNKNOWN"
     SERVER_CONTEXT: ServerContext = ServerContext.NONE
     _curr_user_id = None
@@ -83,14 +83,17 @@ class ProductTelemetryClient(Component):
         # File access may fail due to permissions or other reasons. We don't want to
         # crash so we catch all exceptions.
         try:
-            if not os.path.exists(self.USER_ID_PATH):
-                os.makedirs(os.path.dirname(self.USER_ID_PATH), exist_ok=True)
-                with open(self.USER_ID_PATH, "w") as f:
+            user_id_path = self.USER_ID_PATH or str(
+                Path.home() / ".cache" / "chroma" / "telemetry_user_id"
+            )
+            if not os.path.exists(user_id_path):
+                os.makedirs(os.path.dirname(user_id_path), exist_ok=True)
+                with open(user_id_path, "w") as f:
                     new_user_id = str(uuid.uuid4())
                     f.write(new_user_id)
                 self._curr_user_id = new_user_id
             else:
-                with open(self.USER_ID_PATH, "r") as f:
+                with open(user_id_path, "r") as f:
                     self._curr_user_id = f.read()
         except Exception:
             self._curr_user_id = self.UNKNOWN_USER_ID

--- a/chromadb/test/test_import.py
+++ b/chromadb/test/test_import.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+
+
+def test_import_without_home_directory() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from unittest.mock import patch; "
+            "patcher = patch('pathlib.Path.home', "
+            "side_effect=RuntimeError('no home')); "
+            "patcher.start(); import chromadb",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
+++ b/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
@@ -36,7 +36,7 @@ def _verify_sha256(fname: str, expected_sha256: str) -> bool:
 # and verify the ONNX model.
 class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
     MODEL_NAME = "all-MiniLM-L6-v2"
-    DOWNLOAD_PATH = Path.home() / ".cache" / "chroma" / "onnx_models" / MODEL_NAME
+    DOWNLOAD_PATH = cast(Path, None)
     EXTRACTED_FOLDER_NAME = "onnx"
     ARCHIVE_FILENAME = "onnx.tar.gz"
     MODEL_DOWNLOAD_URL = (
@@ -64,6 +64,11 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
             raise ValueError("Preferred providers must be unique")
 
         self._preferred_providers = preferred_providers
+
+        if self.DOWNLOAD_PATH is None:
+            self.DOWNLOAD_PATH = (
+                Path.home() / ".cache" / "chroma" / "onnx_models" / self.MODEL_NAME
+            )
 
         try:
             # Equivalent to import onnxruntime


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Defer the default ONNX model cache path until the embedding function is instantiated.
  - Defer the telemetry user ID path until it is used, inside its existing failure-safe block.
  - Keep both class attributes available so callers and tests can still override their paths.

This fixes #1962. A plain `import chromadb` currently raises when the process has no resolvable home directory, as can happen with systemd dynamic users and distroless containers, even when neither the ONNX embedding function nor telemetry storage is used.

## Test plan

- [x] New subprocess regression fails on the upstream base with `RuntimeError: no home` and passes with this patch.
- [x] `pytest -q chromadb/test/test_import.py` (`1 passed`)
- [x] `black==23.3.0 --check` on the three changed files
- [x] `python -m compileall` on the three changed files

The initial editable build could not run in this environment because its Rust build requires a system `cc` linker. The focused test was run against the source tree with the Python dependencies installed separately.

## Migration plan

No migration or compatibility action is required. Explicit `DOWNLOAD_PATH` and `USER_ID_PATH` overrides continue to take precedence.

## Observability plan

No new runtime instrumentation is needed; this only moves path resolution from import time to first use.

## Documentation Changes

None. No user-facing API changes.

This contribution was AI-assisted and manually reviewed. The reproduction and reported test results were run locally.
