### PR TITLE
fix(js): bound openapi transform fetch

### DIFF
--- a/clients/js/test_transform_openapi.py
+++ b/clients/js/test_transform_openapi.py
@@ -1,0 +1,42 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_transform_openapi():
+    module_path = Path(__file__).with_name("transform-openapi.py")
+    spec = importlib.util.spec_from_file_location("transform_openapi", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fetch_openapi_json_uses_timeout(monkeypatch):
+    module = _load_transform_openapi()
+    calls = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b'{"openapi": "3.0.0"}'
+
+    def fake_urlopen(url, **kwargs):
+        calls.append((url, kwargs))
+        return Response()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    assert module.fetch_openapi_json("http://localhost:8000/openapi.json") == {
+        "openapi": "3.0.0"
+    }
+    assert calls == [
+        (
+            "http://localhost:8000/openapi.json",
+            {"timeout": module.OPENAPI_FETCH_TIMEOUT_SECONDS},
+        )
+    ]

--- a/clients/js/transform-openapi.py
+++ b/clients/js/transform-openapi.py
@@ -7,11 +7,13 @@ import urllib.request
 from urllib.error import URLError
 from typing import Any
 
+OPENAPI_FETCH_TIMEOUT_SECONDS = 30
+
 
 def fetch_openapi_json(url: str) -> Any:
     """Fetch OpenAPI JSON from a URL"""
     try:
-        with urllib.request.urlopen(url) as response:
+        with urllib.request.urlopen(url, timeout=OPENAPI_FETCH_TIMEOUT_SECONDS) as response:
             data = response.read().decode("utf-8")
             return json.loads(data)
     except URLError as e:
@@ -185,7 +187,7 @@ def main() -> None:
     modify_version_endpoint_response(openapi_json)
 
     print(f"Writing transformed OpenAPI spec to {output_file}")
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         json.dump(openapi_json, f, indent=2)
 
     print("OpenAPI specification transformed successfully!")


### PR DESCRIPTION
## Summary
- add a timeout to the OpenAPI fetch in the JS client transform script
- write the generated OpenAPI JSON with explicit UTF-8 encoding
- cover the fetch helper so the timeout argument is preserved

## Tests
- `python -m pytest clients/js/test_transform_openapi.py -q`
- `python -m py_compile clients/js/transform-openapi.py clients/js/test_transform_openapi.py`
- `git diff --check`
