### PR TITLE
[BUG](tracing): Ignore blank OTEL endpoint

### DIFF
--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use tokio::runtime::Handle;
 use tracing_subscriber::fmt;
+use tracing_subscriber::layer::Identity;
 use tracing_subscriber::Registry;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
@@ -131,6 +132,11 @@ pub fn init_otel_layer(
     service_name: &String,
     otel_endpoint: &String,
 ) -> Box<dyn Layer<Registry> + Send + Sync> {
+    if otel_endpoint.trim().is_empty() {
+        tracing::info!("OpenTelemetry is disabled because its endpoint is empty");
+        return Box::new(Identity::new());
+    }
+
     install_rustls_crypto_provider();
 
     tracing::info!(
@@ -405,4 +411,18 @@ pub fn init_otel_tracing(
     ];
     init_tracing(layers);
     init_panic_tracing_hook();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_otel_endpoint_does_not_initialize_exporters() {
+        let service_name = "test-service".to_string();
+
+        for endpoint in ["", "   ", "\t\n"] {
+            let _layer = init_otel_layer(&service_name, &endpoint.to_string());
+        }
+    }
 }


### PR DESCRIPTION
## Description

Treat empty and whitespace-only OpenTelemetry endpoints as disabled instead of passing them to the OTLP exporter and panicking on an invalid URI.

The tracing layer now returns an identity layer for blank endpoints, so stdout tracing can continue without attempting OTLP exporter initialization.

Closes #4609

## Test plan

- `cargo test -p chroma-tracing`
- `cargo test -p chroma-tracing --doc`
- `cargo clippy -p chroma-tracing --tests -- -D warnings`
- `cargo fmt --all -- --check`
