### PR TITLE
[BUG](log): Cap the log client's encode size at the log server's decode limit

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -5493,6 +5493,27 @@ mod tests {
         assert_eq!(100, config.grpc.max_concurrent_streams);
     }
 
+    /// A client must never be able to send a message this server will refuse to decode.
+    ///
+    /// The write path is asymmetric: the frontend encodes a whole batch of log records into one
+    /// `PushLogsRequest` and this server decodes it. If the client's encode ceiling were the
+    /// larger of the two, an oversized batch would leave the frontend successfully and die at
+    /// decode here, far from the code that built it. Keeping the client's ceiling at or below the
+    /// server's makes the frontend reject it locally instead, with the offending size in the error.
+    #[test]
+    fn log_client_encode_limit_fits_server_decode_limit() {
+        let server = LogServerConfig::default();
+        let server_decode_limit = server
+            .max_decoding_message_size
+            .unwrap_or(server.grpc.max_decoding_message_size);
+        let client_encode_limit = GrpcLogConfig::default().max_encoding_message_size;
+        assert!(
+            client_encode_limit <= server_decode_limit,
+            "log client would encode up to {client_encode_limit} bytes but the log server \
+             decodes at most {server_decode_limit} bytes",
+        );
+    }
+
     #[test]
     fn opentelemetry_config_defaults() {
         let config = OpenTelemetryConfig {

--- a/rust/log/src/config.rs
+++ b/rust/log/src/config.rs
@@ -7,6 +7,11 @@ pub struct GrpcLogConfig {
     pub connect_timeout_ms: u64,
     #[serde(default = "GrpcLogConfig::default_request_timeout_ms")]
     pub request_timeout_ms: u64,
+    /// Largest `PushLogsRequest` this client will put on the wire.
+    ///
+    /// Must stay at or below the log service's decode limit, otherwise an oversized batch leaves
+    /// the client fine and is rejected on arrival, with nothing in the error naming the request
+    /// that caused it.
     #[serde(default = "GrpcLogConfig::default_max_encoding_message_size")]
     pub max_encoding_message_size: usize,
     #[serde(default = "GrpcLogConfig::default_max_decoding_message_size")]
@@ -28,6 +33,7 @@ impl GrpcLogConfig {
         5000
     }
 
+    /// Matches the log service's default decode limit.
     fn default_max_encoding_message_size() -> usize {
         32_000_000
     }

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -341,7 +341,8 @@ impl Configurable<(GrpcLogConfig, System)> for GrpcLog {
             my_config.connect_timeout_ms,
             my_config.request_timeout_ms,
             my_config.port,
-            ClientOptions::new(Some(my_config.max_decoding_message_size)),
+            ClientOptions::new(Some(my_config.max_decoding_message_size))
+                .with_max_encoding_message_size(Some(my_config.max_encoding_message_size)),
         );
         let client_manager_handle = system.start_component(client_manager);
 


### PR DESCRIPTION
## What this fixes

When a client writes records to Chroma, the frontend does not write them to storage itself. It batches the records into a single gRPC message and forwards that message to a separate log service, which durably appends it. A whole conditional commit travels as one message, so a large write is one large message rather than many small ones.

Both ends of a gRPC hop set their own size ceilings. The receiver sets a **decode limit** — the largest message it will accept off the wire. The sender sets an **encode limit** — the largest message it will put on the wire. These are independent settings, and the sender's is unlimited unless you set it.

The log service sets a decode limit of 32 MB (`LogServerConfig::default_max_decoding_message_size` in `rust/log-service/src/lib.rs`, applied to the server in `LogServerWrapper::run`). Nothing in the repo overrides it.

The frontend's log client set only the decode limit, and left the encode limit unset (`rust/log/src/grpc_log.rs`, building `ClientOptions` from `rust/memberlist/src/client_manager.rs`). Its send ceiling was therefore unlimited.

## What that causes

An oversized write leaves the frontend looking healthy and dies on arrival. The frontend serializes the batch, opens a stream, sends 35 MB, and the log service rejects it during decode. The error the client gets back names a decode failure on a gRPC stream, not the write that caused it — there is no collection id, no record count, no size in it. Diagnosing one means correlating the failure back to a request by hand.

The gap is reachable in production. The frontend accepts HTTP request bodies up to 40 MB (`default_max_payload_size_bytes` in `rust/frontend/src/config.rs`), so a write between roughly 33 and 40 MB clears the HTTP layer and then fails at the internal hop.

## The fix

`GrpcLogConfig`, the log client's configuration, already carried a `max_encoding_message_size` field defaulting to 32 MB — the same number the log service decodes at. The field was simply never passed to the client. This wires it through:

```rust
ClientOptions::new(Some(my_config.max_decoding_message_size))
    .with_max_encoding_message_size(Some(my_config.max_encoding_message_size)),
```

Now the frontend refuses the write before sending it, and tonic's local error names the actual byte count and the limit. No new constant is introduced, and the value stays configurable through the same config key it always had.

## Why match the server rather than raise it

Raising the log service's decode limit would move the failure, not remove it. Some ceiling always exists, and whatever it is, a client that will send past it produces the same undiagnosable far-side failure. Matching makes the client refuse locally, where the request that caused it is still in hand.

32 MB is also the log service's real capacity decision — it bounds a single buffered append. Raising it to admit larger writes is a capacity change to argue on its own merits, not a fix for an error-reporting problem.

## Other gRPC clients

I checked every `ClientOptions` construction in the repo:

- **Frontend to query/compaction services** (`rust/frontend/src/executor/distributed.rs`) — sets both limits. This is the pattern the log client now follows.
- **Heap service client** (`rust/s3heap-service/src/client/grpc.rs`) — has the same asymmetry, and its config declares an unused `max_encoding_message_size` default of 32 MB, exactly like the log client did. Left alone: the heap service has no server implementation in this repo yet and the client defaults to disabled, so there is no decode limit to match against. It is worth fixing when that server lands.
- **Garbage collector's Tilt log helper** (`rust/garbage_collector/src/helper.rs`) — same asymmetry, but it is local integration-test scaffolding, not a production path.

## Testing

Added `log_client_encode_limit_fits_server_decode_limit` to the log service's config tests. It asserts the log client's default encode ceiling is at or below the log service's effective decode ceiling, computed the same way the server computes it. The two numbers live in different crates, and this is what keeps them from drifting apart again.

`cargo check`, `cargo clippy -- -D warnings`, and `cargo fmt --check` pass for `chroma-log` and `chroma-log-service`. The new test passes. I did not exercise the oversized-write path against a running log service.
