### PR TITLE
[ENH](wqs): Add queue metrics

### DIFF
--- a/rust/worker/src/work_queue/metrics.rs
+++ b/rust/worker/src/work_queue/metrics.rs
@@ -1,0 +1,76 @@
+use opentelemetry::metrics::{Counter, Gauge};
+
+#[derive(Debug, Clone)]
+pub(crate) struct WorkQueueMetrics {
+    depth: Gauge<u64>,
+    items_with_failures: Gauge<u64>,
+    failure_count: Gauge<u64>,
+    snapshot_size_bytes: Gauge<u64>,
+    push_count: Counter<u64>,
+    finish_count: Counter<u64>,
+    persist_failure_count: Counter<u64>,
+}
+
+impl Default for WorkQueueMetrics {
+    fn default() -> Self {
+        let meter = opentelemetry::global::meter("chroma.work_queue");
+
+        Self {
+            depth: meter
+                .u64_gauge("work_queue_depth")
+                .with_description("Number of entries currently in the work queue")
+                .build(),
+            items_with_failures: meter
+                .u64_gauge("work_queue_items_with_failures")
+                .with_description("Number of queued entries with at least one failure")
+                .build(),
+            failure_count: meter
+                .u64_gauge("work_queue_failure_count")
+                .with_description("Sum of failure counts across queued entries")
+                .build(),
+            snapshot_size_bytes: meter
+                .u64_gauge("work_queue_snapshot_size_bytes")
+                .with_description("Size of the latest durable work queue snapshot")
+                .build(),
+            push_count: meter
+                .u64_counter("work_queue_push_count")
+                .with_description("Number of PushWork requests handled")
+                .build(),
+            finish_count: meter
+                .u64_counter("work_queue_finish_count")
+                .with_description("Number of FinishWork requests completed successfully")
+                .build(),
+            persist_failure_count: meter
+                .u64_counter("work_queue_persist_failure_count")
+                .with_description("Number of work queue snapshot persistence failures")
+                .build(),
+        }
+    }
+}
+
+impl WorkQueueMetrics {
+    pub(crate) fn record_state(
+        &self,
+        depth: u64,
+        items_with_failures: u64,
+        failure_count: u64,
+        snapshot_size_bytes: u64,
+    ) {
+        self.depth.record(depth, &[]);
+        self.items_with_failures.record(items_with_failures, &[]);
+        self.failure_count.record(failure_count, &[]);
+        self.snapshot_size_bytes.record(snapshot_size_bytes, &[]);
+    }
+
+    pub(crate) fn record_push(&self) {
+        self.push_count.add(1, &[]);
+    }
+
+    pub(crate) fn record_finish(&self) {
+        self.finish_count.add(1, &[]);
+    }
+
+    pub(crate) fn record_persist_failure(&self) {
+        self.persist_failure_count.add(1, &[]);
+    }
+}

--- a/rust/worker/src/work_queue/mod.rs
+++ b/rust/worker/src/work_queue/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod config;
+mod metrics;
 pub mod server;
 pub(crate) mod state;
 #[cfg(test)]

--- a/rust/worker/src/work_queue/state.rs
+++ b/rust/worker/src/work_queue/state.rs
@@ -50,6 +50,20 @@ impl QueueState {
         }
     }
 
+    pub(crate) fn metric_values(&self) -> (u64, u64, u64) {
+        self.pending_work.iter().fold(
+            (0_u64, 0_u64, 0_u64),
+            |(depth, items_with_failures, failure_count), record| {
+                let record_failure_count = record.failure_count.max(0) as u64;
+                (
+                    depth.saturating_add(1),
+                    items_with_failures.saturating_add(u64::from(record_failure_count > 0)),
+                    failure_count.saturating_add(record_failure_count),
+                )
+            },
+        )
+    }
+
     /// Serialize state to Parquet bytes
     #[allow(dead_code)]
     pub fn to_parquet_bytes(&self) -> Result<Bytes, WorkQueueError> {
@@ -505,6 +519,23 @@ impl QueueState {
 mod tests {
     use super::*;
     use uuid::Uuid;
+
+    #[test]
+    fn metric_values_summarize_queue_failures() {
+        let mut state = QueueState::new();
+        for failure_count in [0, 2, 5, -1] {
+            state.pending_work.push_back(WorkQueueRecord {
+                fn_id: AttachedFunctionUuid(Uuid::new_v4()),
+                input_coll_id: CollectionUuid(Uuid::new_v4()),
+                completion_offset: 100,
+                compaction_offset: 100,
+                insertion_order: state.pending_work.len() as u64,
+                failure_count,
+            });
+        }
+
+        assert_eq!(state.metric_values(), (4, 2, 7));
+    }
 
     #[test]
     fn test_queue_state_serialization() {

--- a/rust/worker/src/work_queue/work_queue_manager.rs
+++ b/rust/worker/src/work_queue/work_queue_manager.rs
@@ -1,3 +1,4 @@
+use crate::work_queue::metrics::WorkQueueMetrics;
 use crate::work_queue::state::QueueState;
 use crate::work_queue::types::{FinishResult, WorkQueueError, WorkQueueRecord};
 
@@ -82,6 +83,8 @@ pub(crate) struct WorkQueueManager {
     sysdb: SysDb,
     config: crate::work_queue::config::WorkQueueConfig,
     assignment_policy: Box<dyn AssignmentPolicy>,
+    metrics: WorkQueueMetrics,
+    snapshot_size_bytes: u64,
     // Pending responses waiting for persistence (push work responses)
     pending_push_responses: Vec<oneshot::Sender<Result<(), WorkQueueError>>>,
     // Pending responses for finish work
@@ -105,9 +108,21 @@ impl WorkQueueManager {
             sysdb,
             config,
             assignment_policy,
+            metrics: WorkQueueMetrics::default(),
+            snapshot_size_bytes: 0,
             pending_push_responses: Vec::new(),
             pending_finish_responses: Vec::new(),
         }
+    }
+
+    fn record_metrics(&self) {
+        let (depth, items_with_failures, failure_count) = self.state.metric_values();
+        self.metrics.record_state(
+            depth,
+            items_with_failures,
+            failure_count,
+            self.snapshot_size_bytes,
+        );
     }
 
     fn set_memberlist(&mut self, memberlist: Memberlist) {
@@ -179,25 +194,30 @@ impl WorkQueueManager {
             .await
         {
             Ok((bytes, Some(etag))) => {
+                self.snapshot_size_bytes = bytes.len() as u64;
                 self.state = QueueState::from_parquet_bytes(&bytes)?;
                 self.state.current_etag = Some(etag);
                 tracing::info!(
                     "Loaded work queue state with {} items",
                     self.state.pending_work.len()
                 );
+                self.record_metrics();
                 Ok(())
             }
             Ok((bytes, None)) => {
+                self.snapshot_size_bytes = bytes.len() as u64;
                 self.state = QueueState::from_parquet_bytes(&bytes)?;
                 self.state.current_etag = None;
                 tracing::info!(
                     "Loaded work queue state with {} items (no ETag support)",
                     self.state.pending_work.len()
                 );
+                self.record_metrics();
                 Ok(())
             }
             Err(chroma_storage::StorageError::NotFound { .. }) => {
                 tracing::info!("No existing work queue state found, starting fresh");
+                self.record_metrics();
                 Ok(())
             }
             Err(e) => Err(WorkQueueError::Storage(e.to_string())),
@@ -207,11 +227,19 @@ impl WorkQueueManager {
     #[tracing::instrument(name = "WorkQueueManager::persist", skip(self), level = "debug")]
     async fn persist(&mut self) -> Result<(), WorkQueueError> {
         if !self.state.dirty {
+            self.record_metrics();
             self.notify_pending_responses();
             return Ok(());
         }
 
-        let bytes = self.state.to_parquet_bytes()?;
+        let bytes = match self.state.to_parquet_bytes() {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                self.metrics.record_persist_failure();
+                return Err(err);
+            }
+        };
+        let snapshot_size_bytes = bytes.len() as u64;
 
         let put_options = if let Some(etag) = &self.state.current_etag {
             PutOptions::default().with_mode(PutMode::IfMatch(etag.clone()))
@@ -228,6 +256,8 @@ impl WorkQueueManager {
                 let has_etag = etag_opt.is_some();
                 self.state.current_etag = etag_opt;
                 self.state.dirty = false;
+                self.snapshot_size_bytes = snapshot_size_bytes;
+                self.record_metrics();
 
                 let etag_msg = if has_etag { "" } else { " (no ETag)" };
                 let total_pending =
@@ -243,10 +273,12 @@ impl WorkQueueManager {
             }
             Err(e) => match e {
                 chroma_storage::StorageError::Precondition { .. } => {
+                    self.metrics.record_persist_failure();
                     tracing::error!("ETag mismatch - another instance is active");
                     panic!("Work queue ETag mismatch - shutting down");
                 }
                 _ => {
+                    self.metrics.record_persist_failure();
                     let err = WorkQueueError::Storage(e.to_string());
                     self.notify_pending_responses_error(&err);
                     Err(err)
@@ -306,6 +338,8 @@ impl WorkQueueManager {
         let _ = self
             .state
             .push_work(fn_id, input_coll_id, completion_offset, compaction_offset);
+        self.metrics.record_push();
+        self.record_metrics();
 
         // TODO(tanujnay112): Can optimize the case where we push work
         // that gets deduplicated. That would require epoch tracking
@@ -447,6 +481,8 @@ impl Handler<FinishWorkMessage> for WorkQueueManager {
         // Use the queued compaction frontier to decide whether to remove or advance the entry.
         self.state
             .finish_work_success(&msg.fn_id, &msg.input_coll_id, msg.new_completion_offset);
+        self.metrics.record_finish();
+        self.record_metrics();
 
         // Send immediate success response
         if msg.response_tx.send(Ok(finish_result)).is_err() {
@@ -465,6 +501,7 @@ impl Handler<DeferWorkMessage> for WorkQueueManager {
 
     async fn handle(&mut self, msg: DeferWorkMessage, _ctx: &ComponentContext<WorkQueueManager>) {
         self.state.defer_work(&msg.fn_id, &msg.input_coll_id);
+        self.record_metrics();
         if msg.response_tx.send(()).is_err() {
             tracing::warn!("Failed to acknowledge deferred work - receiver dropped");
         }
@@ -518,6 +555,7 @@ impl Handler<UpdateFunctionFailureCountMessage> for WorkQueueManager {
     ) {
         self.state
             .update_failure_count(&msg.fn_id, &msg.input_coll_id, msg.failure_count);
+        self.record_metrics();
         if msg.response_tx.send(()).is_err() {
             tracing::warn!(
                 "Failed to acknowledge function failure count update - receiver dropped"
@@ -540,7 +578,10 @@ impl Handler<SetFunctionFailureCountMessage> for WorkQueueManager {
                 .state
                 .set_failure_count(&msg.fn_id, &msg.input_coll_id, msg.failure_count)
             {
-                Some(_) => self.persist().await.map(|_| true),
+                Some(_) => {
+                    self.record_metrics();
+                    self.persist().await.map(|_| true)
+                }
                 None => Ok(false),
             };
         if msg.response_tx.send(result).is_err() {


### PR DESCRIPTION
## Summary

- publish low-cardinality gauges for queue depth, failed entries, aggregate
  failure count, and durable snapshot bytes
- publish counters for PushWork, successful FinishWork, and persistence
  failures
- refresh state gauges on queue mutations and the existing periodic
  persistence cycle
- avoid function and collection IDs as metric attributes

## Validation

- `cargo test -p worker work_queue::state::tests` (9 passed)
- `cargo test -p worker work_queue::work_queue_manager::tests` (12 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

## Rollout

Deploy this service change together with
[chroma-core/k8s#3206](https://github.com/chroma-core/k8s/pull/3206) before
applying the Honeycomb board in
[chroma-core/hosted-chroma#8328](https://github.com/chroma-core/hosted-chroma/pull/8328).