### PR TITLE
[BLD](ci): Pin minikube to 1.38.1 in tilt-setup-prebuild

### DIFF
--- a/.github/actions/tilt-setup-prebuild/action.yaml
+++ b/.github/actions/tilt-setup-prebuild/action.yaml
@@ -69,3 +69,9 @@ runs:
       uses: medyagh/setup-minikube@latest
       with:
         driver: none # uses Docker engine on host instead of Docker-in-Docker
+        # minikube 1.39.0 fails to start the none driver on GitHub runners
+        # (picks the containerd runtime and dies with "unknown service
+        # runtime.v1.RuntimeService" from crictl); 1.38.1 is the last known
+        # good. Unpinned, this broke every hosted-chroma tilt CI job on
+        # 2026-09-02.
+        minikube-version: 1.38.1


### PR DESCRIPTION
## Description

`tilt-setup-prebuild` uses `medyagh/setup-minikube@latest` with no `minikube-version`, so the minikube version resolves at run time. minikube **1.39.0** (picked up starting 2026-09-02) fails to start the `none` driver on GitHub runners: it selects the containerd runtime and setup dies with

```
X Exiting due to RUNTIME_ENABLE: Failed to start container runtime: Temporary Error: sudo /usr/local/bin/crictl version: exit status 1
validate CRI v1 runtime API for endpoint "unix:///run/containerd/containerd.sock": rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService
```

This broke every hosted-chroma tilt CI job today (this repo's own tilt jobs consume the same action). The last job to pass used **1.38.1** (2026-09-01); the first to fail used **1.39.0** — reruns reproduce it deterministically.

## Change

Pin `minikube-version: 1.38.1` (last known good). We can unpin or bump once minikube's none-driver regression is fixed upstream.

## Validation

- Failing hosted runs: [js](https://github.com/chroma-core/hosted-chroma/actions/runs/33689852042/job/100458949827), [JS (E2E)](https://github.com/chroma-core/hosted-chroma/actions/runs/33689855589/job/100445983133) — both die in minikube setup before any test runs.
- Passing 1.38.1 run for contrast: [JS (E2E) on hosted #8324](https://github.com/chroma-core/hosted-chroma/actions/runs/33554882211/job/100013319088).
- This PR's own CI exercises the pinned action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)