### PR TITLE
[CHORE] Pin minikube to 1.39.0 in tilt prebuild CI

### DIFF
--- a/.github/actions/tilt-setup-prebuild/action.yaml
+++ b/.github/actions/tilt-setup-prebuild/action.yaml
@@ -68,4 +68,6 @@ runs:
     - name: Start minikube
       uses: medyagh/setup-minikube@latest
       with:
+        minikube-version: "1.39.0"
         driver: none # uses Docker engine on host instead of Docker-in-Docker
+        container-runtime: docker # v1.39 defaults to containerd, but CI images are loaded into Docker


### PR DESCRIPTION
## Description of changes

Pin the minikube version to 1.39.0 and force the Docker container
runtime in the tilt-setup-prebuild action. v1.39 defaults to
containerd, but CI images are loaded into Docker, so the runtime must be
set explicitly.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
