### PR TITLE
[BUG](ingest): decode INT32 vectors as int32, not float32

### DIFF
--- a/chromadb/ingest/__init__.py
+++ b/chromadb/ingest/__init__.py
@@ -29,7 +29,7 @@ def decode_vector(vector: bytes, encoding: ScalarEncoding) -> Vector:
     if encoding == ScalarEncoding.FLOAT32:
         return np.frombuffer(vector, dtype=np.float32)
     elif encoding == ScalarEncoding.INT32:
-        return np.frombuffer(vector, dtype=np.float32)
+        return np.frombuffer(vector, dtype=np.int32)
     else:
         raise ValueError(f"Unsupported encoding: {encoding.value}")
 

--- a/chromadb/test/db/test_ingest.py
+++ b/chromadb/test/db/test_ingest.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+from chromadb.ingest import decode_vector, encode_vector
+from chromadb.types import ScalarEncoding
+
+
+@pytest.mark.parametrize("encoding", [ScalarEncoding.FLOAT32, ScalarEncoding.INT32])
+def test_encode_decode_roundtrip(encoding: ScalarEncoding) -> None:
+    vector = np.array([1, 2, 3], dtype=np.int32 if encoding == ScalarEncoding.INT32 else np.float32)
+    decoded = decode_vector(encode_vector(vector, encoding), encoding)
+    np.testing.assert_array_equal(decoded, vector)
+    assert decoded.dtype == vector.dtype
+
+
+def test_decode_int32_preserves_dtype() -> None:
+    encoded = np.array([7, -3, 11], dtype=np.int32).tobytes()
+    decoded = decode_vector(encoded, ScalarEncoding.INT32)
+    assert decoded.dtype == np.int32
+    np.testing.assert_array_equal(decoded, np.array([7, -3, 11], dtype=np.int32))

--- a/chromadb/test/db/test_ingest.py
+++ b/chromadb/test/db/test_ingest.py
@@ -7,7 +7,8 @@ from chromadb.types import ScalarEncoding
 
 @pytest.mark.parametrize("encoding", [ScalarEncoding.FLOAT32, ScalarEncoding.INT32])
 def test_encode_decode_roundtrip(encoding: ScalarEncoding) -> None:
-    vector = np.array([1, 2, 3], dtype=np.int32 if encoding == ScalarEncoding.INT32 else np.float32)
+    dtype = np.int32 if encoding == ScalarEncoding.INT32 else np.float32
+    vector = np.array([1, 2, 3], dtype=dtype)
     decoded = decode_vector(encode_vector(vector, encoding), encoding)
     np.testing.assert_array_equal(decoded, vector)
     assert decoded.dtype == vector.dtype


### PR DESCRIPTION
## Description of changes

`decode_vector()` in `chromadb/ingest/__init__.py` used `np.float32` in its `INT32` branch, so a round trip through the embeddings queue (`encode_vector(..., INT32)` → store → `decode_vector(..., INT32)`, `chromadb/db/mixins/embeddings_queue.py:382`) reinterpreted int32 bytes as float32 and returned garbage. This brings the decode dtype in line with the sibling `encode_vector()`, which correctly uses `np.int32`, and adds a round-trip regression test.

## Test plan

- [x] `pytest chromadb/test/db/test_ingest.py` — new round-trip test passes for both encodings (3 passed locally); the INT32 assertions fail on the unfixed code.
- [ ] CI test suites

## Migration plan

None — one-line dtype fix; no persisted format change (stored bytes were already int32).

## Observability plan

None needed.

## Documentation Changes

None.
