### PR TITLE
[BUG](errors): restore missing separators in concatenated error messages

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -790,7 +790,7 @@ class CollectionCommon(Generic[ClientT]):
             return schema_embedding_function(input=input)
         if self._embedding_function is None:
             raise ValueError(
-                "You must provide an embedding function to compute embeddings."
+                "You must provide an embedding function to compute embeddings. "
                 "https://docs.trychroma.com/guides/embeddings"
             )
         if is_query:

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -228,7 +228,7 @@ class LocalHnswSegment(VectorReader):
         else:
             if dim != self._dimensionality:
                 raise InvalidDimensionException(
-                    f"Dimensionality of ({dim}) does not match index"
+                    f"Dimensionality of ({dim}) does not match index "
                     + f"dimensionality ({self._dimensionality})"
                 )
 


### PR DESCRIPTION
## Description of changes

Two error messages built from concatenated string literals were missing the joining space:

- `chromadb/segment/impl/vector/local_hnsw.py` — rendered as `Dimensionality of (384) does not match indexdimensionality (128)` (fires on real dimension mismatches).
- `chromadb/api/models/CollectionCommon.py` — rendered as `You must provide an embedding function to compute embeddings.https://docs.trychroma.com/guides/embeddings` (fires whenever no embedding function is configured).

One-character fixes; message text only, no behavior change.

## Test plan

- [x] Message-only change; no existing test asserts the exact strings (grepped `chromadb/test`).
- [ ] CI test suites

## Migration plan

None.

## Observability plan

None — the messages themselves become readable.

## Documentation Changes

None.
