### PR TITLE
[DOC](api): align AdminAPI and _add docstring parameter names with signatures

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -179,8 +179,8 @@ class BaseAPI(ABC):
         Args:
             ids: The ids to associate with the embeddings.
             collection_id: The UUID of the collection to add the embeddings to.
-            embedding: The sequence of embeddings to add.
-            metadata: The metadata to associate with the embeddings. Defaults to None.
+            embeddings: The sequence of embeddings to add.
+            metadatas: The metadata to associate with the embeddings. Defaults to None.
             documents: The documents to associate with the embeddings. Defaults to None.
             uris: URIs of data sources for each embedding. Defaults to None.
 
@@ -715,7 +715,7 @@ class AdminAPI(ABC):
         """Create a new database. Raises an error if the database already exists.
 
         Args:
-            database: The name of the database to create.
+            name: The name of the database to create.
 
         """
         pass
@@ -725,7 +725,7 @@ class AdminAPI(ABC):
         """Get a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to get.
+            name: The name of the database to get.
             tenant: The tenant of the database to get.
 
         """
@@ -736,7 +736,7 @@ class AdminAPI(ABC):
         """Delete a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to delete.
+            name: The name of the database to delete.
             tenant: The tenant of the database to delete.
 
         """
@@ -762,7 +762,7 @@ class AdminAPI(ABC):
         """Create a new tenant. Raises an error if the tenant already exists.
 
         Args:
-            tenant: The name of the tenant to create.
+            name: The name of the tenant to create.
 
         """
         pass
@@ -772,7 +772,7 @@ class AdminAPI(ABC):
         """Get a tenant. Raises an error if the tenant does not exist.
 
         Args:
-            tenant: The name of the tenant to get.
+            name: The name of the tenant to get.
 
         """
         pass

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -132,8 +132,8 @@ class AsyncBaseAPI(ABC):
         Args:
             ids: The ids to associate with the embeddings.
             collection_id: The UUID of the collection to add the embeddings to.
-            embedding: The sequence of embeddings to add.
-            metadata: The metadata to associate with the embeddings. Defaults to None.
+            embeddings: The sequence of embeddings to add.
+            metadatas: The metadata to associate with the embeddings. Defaults to None.
             documents: The documents to associate with the embeddings. Defaults to None.
             uris: URIs of data sources for each embedding. Defaults to None.
 
@@ -667,7 +667,7 @@ class AsyncAdminAPI(ABC):
         """Create a new database. Raises an error if the database already exists.
 
         Args:
-            database: The name of the database to create.
+            name: The name of the database to create.
 
         """
         pass
@@ -677,7 +677,7 @@ class AsyncAdminAPI(ABC):
         """Get a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to get.
+            name: The name of the database to get.
             tenant: The tenant of the database to get.
 
         """
@@ -688,7 +688,7 @@ class AsyncAdminAPI(ABC):
         """Delete a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to delete.
+            name: The name of the database to delete.
             tenant: The tenant of the database to delete.
 
         """
@@ -714,7 +714,7 @@ class AsyncAdminAPI(ABC):
         """Create a new tenant. Raises an error if the tenant already exists.
 
         Args:
-            tenant: The name of the tenant to create.
+            name: The name of the tenant to create.
 
         """
         pass
@@ -724,7 +724,7 @@ class AsyncAdminAPI(ABC):
         """Get a tenant. Raises an error if the tenant does not exist.
 
         Args:
-            tenant: The name of the tenant to get.
+            name: The name of the tenant to get.
 
         """
         pass


### PR DESCRIPTION
## Description of changes

Docstring-only fix: 14 documented parameter names in `chromadb/api/__init__.py` and `chromadb/api/async_api.py` didn't match the actual signatures:

- `AdminClient`/`AsyncAdminClient` `create_database`, `get_database`, `delete_database` documented `database:` — the parameter is `name`
- `create_tenant`, `get_tenant` documented `tenant:` — the parameter is `name`
- sync/async `_add` documented `embedding:`/`metadata:` — the parameters are `embeddings`/`metadatas`

These docstrings feed IDE hints and the generated API reference.

## Test plan

- [x] Docstring-only change; `python -m compileall` on both files passes; no behavior change.
- [ ] CI test suites

## Migration plan

None.

## Observability plan

None.

## Documentation Changes

This is the documentation change.
