### PR TITLE
[DOC]: fix malformed URLs and dead links/anchors across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://discord.gg/MMeYNTmh3x" target="_blank">
       <img src="https://img.shields.io/discord/1073293645303795742?cacheSeconds=3600" alt="Discord">
   </a> |
-  <a href="https://github.com/chroma-core/chroma/blob/master/LICENSE" target="_blank">
+  <a href="https://github.com/chroma-core/chroma/blob/main/LICENSE" target="_blank">
       <img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License">
   </a> |
   <a href="https://docs.trychroma.com/" target="_blank">

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -37,4 +37,4 @@ results = collection.query(
 ```
 ## License
 
-[Apache 2.0](./LICENSE)
+[Apache 2.0](https://github.com/chroma-core/chroma/blob/main/LICENSE)

--- a/docs/mintlify/cloud/schema/schema-basics.mdx
+++ b/docs/mintlify/cloud/schema/schema-basics.mdx
@@ -44,7 +44,7 @@ Chroma uses two reserved key names:
 **`K.EMBEDDING`** (`#embedding`) stores dense vector embeddings with Vector Index enabled, sourcing from `K.DOCUMENT`. This enables semantic similarity search.
 
 <Callout>
-Use `K.DOCUMENT` and `K.EMBEDDING` in your code (they correspond to internal keys `#document` and `#embedding`). These special keys are automatically configured and cannot be manually modified. See the [Search API field reference](../search-api/pagination-selection#available-fields) for more details.
+Use `K.DOCUMENT` and `K.EMBEDDING` in your code (they correspond to internal keys `#document` and `#embedding`). These special keys are automatically configured and cannot be manually modified. See the [Search API field reference](../search-api/pagination-selection#selectable-fields) for more details.
 </Callout>
 
 ### Example: Using Defaults

--- a/docs/mintlify/cloud/search-api/search-basics.mdx
+++ b/docs/mintlify/cloud/search-api/search-basics.mdx
@@ -80,7 +80,7 @@ The Search class accepts four optional parameters:
   - Types: `Select` object, `dict`, `list`, `set`, or `None`
   - Default: `None` (returns IDs only)
   - Available fields: `#id`, `#document`, `#embedding`, `#metadata`, `#score`, or any custom metadata field
-  - See [field selection](./pagination-selection#field-selection) for details
+  - See [field selection](./pagination-selection#field-selection-with-select) for details
 
 ## Builder Pattern
 
@@ -89,8 +89,8 @@ The Search class provides a fluent interface with method chaining. Each method r
 For detailed usage of each builder method, see the respective sections:
 - `.where()` - See [Filter expressions](./filtering)
 - `.rank()` - See [Ranking and scoring](./ranking)
-- `.limit()` - See [Pagination](./pagination-selection#pagination)
-- `.select()` and `.select_all()` - See [Field selection](./pagination-selection#field-selection)
+- `.limit()` - See [Pagination](./pagination-selection#pagination-with-limit)
+- `.select()` and `.select_all()` - See [Field selection](./pagination-selection#field-selection-with-select)
 
 <CodeGroup>
 ```python Python

--- a/docs/mintlify/docs/cli/login.mdx
+++ b/docs/mintlify/docs/cli/login.mdx
@@ -7,7 +7,7 @@ The Chroma CLI allows you to perform various operations with your Chroma Cloud a
 
 Use the `login` command, to authenticate the CLI with your Chroma Cloud account, to enable these features.
 
-First, in your browser [create](https://trychroma.com/signup?utm_source=docs-cli-login) a Chroma Cloud account or [login](https:trychroma.com/login) into your existing account.
+First, in your browser [create](https://trychroma.com/signup?utm_source=docs-cli-login) a Chroma Cloud account or [login](https://trychroma.com/login) into your existing account.
 
 Then, in your terminal, run
 

--- a/docs/mintlify/reference/architecture/distributed.mdx
+++ b/docs/mintlify/reference/architecture/distributed.mdx
@@ -7,7 +7,7 @@ Distributed Chroma is designed for large-scale production workloads. Its compone
 
 ## Core Components
 
-Regardless of deployment mode, Chroma is composed of five core components. Each plays a distinct role in the system and operates over the shared [Chroma data model](#chroma-data-model).
+Regardless of deployment mode, Chroma is composed of five core components. Each plays a distinct role in the system and operates over the shared [Chroma data model](./overview#chroma-data-model).
 
 <img className="block dark:hidden" src="/images/system-diagram-light.png" alt="Chroma system architecture" />
 <img className="hidden dark:block" src="/images/system-diagram-dark.png" alt="Chroma system architecture" />


### PR DESCRIPTION
## Description of changes

Batch of small docs link fixes, each verified against the repo tree / actual headings:

- `docs/mintlify/docs/cli/login.mdx`: `https:trychroma.com/login` → `https://trychroma.com/login` (missing `//` made it a relative link)
- `README.md`: license badge pointed to `blob/master/LICENSE`; the default branch is `main`
- `clients/python/README.md`: `./LICENSE` does not exist under `clients/python/`; point at the root LICENSE
- `docs/mintlify/cloud/search-api/search-basics.mdx` + `docs/mintlify/cloud/schema/schema-basics.mdx`: anchors `#field-selection`, `#pagination`, `#available-fields` don't exist on `pagination-selection`; updated to the real heading slugs (`#field-selection-with-select`, `#pagination-with-limit`, `#selectable-fields`)
- `docs/mintlify/reference/architecture/distributed.mdx`: same-page anchor `#chroma-data-model` is actually a heading in `architecture/overview.mdx`; link updated

## Test plan

- [x] Docs-only change; all link targets verified to exist in-repo (`git ls-files` / heading slugs).
- [ ] Docs preview build

## Migration plan

None.

## Observability plan

None.

## Documentation Changes

This PR is the documentation change.
