### PR TITLE
[BUG](types): Fix configuration assignment

### DIFF
--- a/chromadb/test/test_collection_model.py
+++ b/chromadb/test/test_collection_model.py
@@ -1,0 +1,30 @@
+from uuid import uuid4
+
+from chromadb.api.collection_configuration import CollectionConfiguration
+from chromadb.types import Collection
+
+
+def test_setitem_updates_collection_configuration() -> None:
+    collection = Collection(
+        id=uuid4(),
+        name="test",
+        configuration_json={},
+        serialized_schema=None,
+        metadata=None,
+        dimension=None,
+        tenant="tenant",
+        database="database",
+    )
+    configuration = CollectionConfiguration(
+        hnsw=None,
+        spann=None,
+        embedding_function=None,
+    )
+
+    collection["configuration"] = configuration
+
+    assert collection.configuration_json == {
+        "hnsw": None,
+        "spann": None,
+        "embedding_function": {"type": "legacy"},
+    }

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -130,7 +130,7 @@ class Collection(
         # For the model attributes we allow the user to access them directly
         if key == "configuration":
             self.set_configuration(value)
-        if key in self.get_model_fields():
+        elif key in self.get_model_fields():
             setattr(self, key, value)
         else:
             raise KeyError(


### PR DESCRIPTION
## Description of changes

Assigning `collection["configuration"]` calls `set_configuration`, then falls through to the model-field check and raises `KeyError` because `configuration` is a virtual compatibility key.

Make the model-field branch mutually exclusive so configuration assignment completes successfully. A focused regression test verifies that the configuration is serialized into `configuration_json`.

## Testing

- Added `test_setitem_updates_collection_configuration`.
- Black check on the new test.
- Compiled both changed Python files with `compileall`.