### PR TITLE
[BUG](sqlite): $contains never uses the FTS trigram index

### DIFF
--- a/rust/segment/src/sqlite_metadata.rs
+++ b/rust/segment/src/sqlite_metadata.rs
@@ -680,16 +680,25 @@ impl IntoSqliteExpr for DocumentExpression {
             .from(EmbeddingFulltextSearch::Table)
             .and_where(match self.operator {
                 DocumentOperator::Contains | DocumentOperator::NotContains => {
-                    Expr::col(EmbeddingFulltextSearch::StringValue).like(
-                        LikeExpr::new(format!(
-                            "%{}%",
-                            self.pattern
-                                .replace("\\", "\\\\") // escape user-provided backslashes
-                                .replace("%", "\\%") // escape % characters
-                                .replace("_", "\\_") // escape _ characters
-                        ))
-                        .escape('\\'),
-                    )
+                    // SQLite will not serve a LIKE from the trigram index if
+                    // the expression carries an ESCAPE clause. LIKE has no
+                    // default escape character, so a pattern with no wildcard
+                    // needs no escaping and can use the index.
+                    if self.pattern.contains('%') || self.pattern.contains('_') {
+                        Expr::col(EmbeddingFulltextSearch::StringValue).like(
+                            LikeExpr::new(format!(
+                                "%{}%",
+                                self.pattern
+                                    .replace("\\", "\\\\") // escape user-provided backslashes
+                                    .replace("%", "\\%") // escape % characters
+                                    .replace("_", "\\_") // escape _ characters
+                            ))
+                            .escape('\\'),
+                        )
+                    } else {
+                        Expr::col(EmbeddingFulltextSearch::StringValue)
+                            .like(format!("%{}%", self.pattern))
+                    }
                 }
                 DocumentOperator::Regex | DocumentOperator::NotRegex => Expr::cust_with_exprs(
                     "? REGEXP ?",
@@ -3186,5 +3195,106 @@ mod tests {
         let plan = make_get_plan(&cas, Some(contains_arr));
         let result = reader.get(plan).await.expect("get");
         assert_eq!(result.result.records.len(), 0);
+    }
+
+    /// Render the SQL a `$contains` filter lowers to.
+    fn contains_sql(pattern: &str) -> String {
+        use super::IntoSqliteExpr;
+        let expr = chroma_types::DocumentExpression {
+            pattern: pattern.to_string(),
+            operator: DocumentOperator::Contains,
+        }
+        .eval();
+        sea_query::Query::select()
+            .expr(expr)
+            .to_string(sea_query::SqliteQueryBuilder)
+    }
+
+    #[test]
+    fn test_contains_plain_pattern_omits_escape_clause() {
+        // An ESCAPE clause would stop SQLite using the trigram index.
+        for pattern in ["wvk", "Lucky Strike", "back\\slash", "100$"] {
+            let sql = contains_sql(pattern);
+            assert!(
+                !sql.contains("ESCAPE"),
+                "pattern {pattern:?} should lower to a bare LIKE, got: {sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_contains_wildcard_pattern_keeps_escape_clause() {
+        // Wildcards must still be escaped so they match literally (#4402).
+        for pattern in ["50%", "a_b", "%_%"] {
+            let sql = contains_sql(pattern);
+            assert!(
+                sql.contains("ESCAPE"),
+                "pattern {pattern:?} must keep the ESCAPE clause, got: {sql}"
+            );
+        }
+    }
+
+    fn doc_log(offset: u64, id: &str, document: &str) -> LogRecord {
+        LogRecord {
+            log_offset: offset as i64,
+            record: OperationRecord {
+                id: id.to_string(),
+                metadata: None,
+                document: Some(document.to_string()),
+                operation: Operation::Add,
+                embedding: None,
+                encoding: None,
+            },
+        }
+    }
+
+    async fn contains_ids(
+        reader: &SqliteMetadataReader,
+        cas: &CollectionAndSegments,
+        pattern: &str,
+    ) -> Vec<String> {
+        let plan = make_get_plan(
+            cas,
+            Some(Where::Document(chroma_types::DocumentExpression {
+                pattern: pattern.to_string(),
+                operator: DocumentOperator::Contains,
+            })),
+        );
+        let mut ids: Vec<String> = reader
+            .get(plan)
+            .await
+            .expect("get")
+            .result
+            .records
+            .into_iter()
+            .map(|r| r.id)
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    #[tokio::test]
+    async fn test_contains_matches_wildcards_literally() {
+        // Guards both directions of the ESCAPE branch.
+        let logs = vec![
+            doc_log(0, "id0", "discount of 50% off"),
+            doc_log(1, "id1", "discount of 5000 off"),
+            doc_log(2, "id2", "a_b marker"),
+            doc_log(3, "id3", "axb marker"),
+            doc_log(4, "id4", "plain sentinel wvk"),
+        ];
+        let (reader, cas) = setup_with_logs(logs).await;
+
+        // `%` and `_` are literals, not wildcards.
+        assert_eq!(contains_ids(&reader, &cas, "50%").await, vec!["id0"]);
+        assert_eq!(contains_ids(&reader, &cas, "a_b").await, vec!["id2"]);
+
+        // Patterns with no wildcards take the bare-LIKE branch.
+        assert_eq!(contains_ids(&reader, &cas, "wvk").await, vec!["id4"]);
+        assert_eq!(
+            contains_ids(&reader, &cas, "marker").await,
+            vec!["id2", "id3"]
+        );
+        assert!(contains_ids(&reader, &cas, "nonexistent").await.is_empty());
     }
 }


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - `$contains` on the local (SQLite) metadata segment never uses the
    `embedding_fulltext_search` trigram index, because the `LIKE` it emits always
    carries an `ESCAPE` clause. Emit a bare `LIKE` when the pattern contains no
    SQLite wildcard, so the index can serve it.
- New functionality
  - None

### Background

`embedding_fulltext_search` is an FTS5 table declared with `tokenize='trigram'`
(`00003-full-text-tokenize.sqlite.sql`). That tokenizer lets SQLite answer
`LIKE '%needle%'` from the index whenever the pattern holds a run of at least
three non-wildcard characters.

SQLite applies that optimization only when the `LIKE` expression carries no
`ESCAPE` clause. `DocumentExpression::eval` has emitted one unconditionally
since #4402, so the optimization never fires and every `$contains` scans the
whole table — regardless of how long the search term is.

`EXPLAIN QUERY PLAN` over a 400k-document collection (chromadb 1.5.9, SQLite
3.43.1). FTS5 appends `L0` to its plan string when it has accepted the `LIKE`
constraint for a trigram lookup:

| form | plan | time |
| --- | --- | --- |
| `LIKE '%wvk%'` | `VIRTUAL TABLE INDEX 0:L0` | 0.02 ms |
| `LIKE ?` | `VIRTUAL TABLE INDEX 0:L0` | 0.02 ms |
| `LIKE '%wvk%' ESCAPE '\'` | `VIRTUAL TABLE INDEX 0:` | 69.59 ms |
| `LIKE ? ESCAPE '\'` — what we emit | `VIRTUAL TABLE INDEX 0:` | 70.62 ms |

Same predicate, same five matching rows, four spellings.

### The fix

SQLite's `LIKE` has no default escape character, so a pattern containing neither
`%` nor `_` is already matched literally and needs no escaping. Emit a bare
`LIKE` for those, and keep the escaped form for patterns that do contain a
wildcard — preserving the literal-match semantics #4402 introduced, and paying
for the scan only in that case.

Measured on the full `get()` statement the segment builds, run with and without
the `ESCAPE` clause (400k documents, 5 matching):

| term | with `ESCAPE` | without |
| --- | --- | --- |
| `wvk` (3 chars) | 99.93 ms | 26.63 ms |

Patterns shorter than three characters are unaffected — the trigram index cannot
serve those either way.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

New unit tests in `rust/segment/src/sqlite_metadata.rs`:

- `test_contains_plain_pattern_omits_escape_clause` — patterns without wildcards
  lower to a bare `LIKE`. Verified to fail before this change.
- `test_contains_wildcard_pattern_keeps_escape_clause` — patterns containing `%`
  or `_` keep the `ESCAPE` clause.
- `test_contains_matches_wildcards_literally` — end to end through the reader:
  `50%` and `a_b` still match literally (the #4402 guarantee), and patterns with
  no wildcards still match.

Ran `cargo test -p chroma-segment --lib sqlite_metadata` — 24 passed, including
the existing `test_get` / `test_count` proptests. The change is confined to the
Rust SQLite segment; the Python and JS suites were not run.

## Migration plan

None. This changes the shape of a generated query only — no schema or data
changes, and no change to results.

## Observability plan

None.

## Documentation Changes

None.
