### PR TITLE
[BUG](sqlite): get() fails with "too many SQL variables" above 32766 records

### DIFF
--- a/rust/segment/src/sqlite_metadata.rs
+++ b/rust/segment/src/sqlite_metadata.rs
@@ -36,6 +36,11 @@ use thiserror::Error;
 
 const SUBQ_ALIAS: &str = "filter_limit_subq";
 
+/// Maximum number of ids bound into a single `IN (...)` list. SQLite rejects
+/// statements with more than `SQLITE_MAX_VARIABLE_NUMBER` bind parameters
+/// (32766 in the bundled build `sqlx` links against).
+const MAX_IDS_PER_QUERY: usize = 10_000;
+
 #[derive(Debug, Error)]
 pub enum SqliteMetadataError {
     #[error("Invalid log offset: {0}")]
@@ -1099,32 +1104,36 @@ impl SqliteMetadataReader {
         // into the records we already have.
         if metadata && !records.is_empty() {
             let offset_ids: Vec<u32> = records.keys().copied().collect();
-            let (arr_sql, arr_vals) = Query::select()
-                .columns([
-                    EmbeddingMetadataArray::Id,
-                    EmbeddingMetadataArray::Key,
-                    EmbeddingMetadataArray::StringValue,
-                    EmbeddingMetadataArray::IntValue,
-                    EmbeddingMetadataArray::FloatValue,
-                    EmbeddingMetadataArray::BoolValue,
-                ])
-                .from(EmbeddingMetadataArray::Table)
-                .and_where(
-                    Expr::col(EmbeddingMetadataArray::Id)
-                        .is_in(offset_ids.iter().copied().map(|id| id as i64)),
-                )
-                .build_sqlx(SqliteQueryBuilder);
+            // One bind parameter per matched record, so this must be chunked
+            // or large reads fail with "too many SQL variables".
+            for id_chunk in offset_ids.chunks(MAX_IDS_PER_QUERY) {
+                let (arr_sql, arr_vals) = Query::select()
+                    .columns([
+                        EmbeddingMetadataArray::Id,
+                        EmbeddingMetadataArray::Key,
+                        EmbeddingMetadataArray::StringValue,
+                        EmbeddingMetadataArray::IntValue,
+                        EmbeddingMetadataArray::FloatValue,
+                        EmbeddingMetadataArray::BoolValue,
+                    ])
+                    .from(EmbeddingMetadataArray::Table)
+                    .and_where(
+                        Expr::col(EmbeddingMetadataArray::Id)
+                            .is_in(id_chunk.iter().copied().map(|id| id as i64)),
+                    )
+                    .build_sqlx(SqliteQueryBuilder);
 
-            let arr_rows = sqlx::query_with(&arr_sql, arr_vals)
-                .fetch_all(self.db.get_conn())
-                .await?;
+                let arr_rows = sqlx::query_with(&arr_sql, arr_vals)
+                    .fetch_all(self.db.get_conn())
+                    .await?;
 
-            for row in arr_rows {
-                let offset_id: u32 = row.try_get(0)?;
-                let key: String = row.try_get(1)?;
-                if let Some(record) = records.get_mut(&offset_id) {
-                    if let Some(md) = record.metadata.as_mut() {
-                        Self::accumulate_array_value(md, &key, &row)?;
+                for row in arr_rows {
+                    let offset_id: u32 = row.try_get(0)?;
+                    let key: String = row.try_get(1)?;
+                    if let Some(record) = records.get_mut(&offset_id) {
+                        if let Some(md) = record.metadata.as_mut() {
+                            Self::accumulate_array_value(md, &key, &row)?;
+                        }
                     }
                 }
             }
@@ -3186,5 +3195,76 @@ mod tests {
         let plan = make_get_plan(&cas, Some(contains_arr));
         let result = reader.get(plan).await.expect("get");
         assert_eq!(result.result.records.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_exceeding_sqlite_variable_limit() {
+        // Without chunking, a read matching more than
+        // SQLITE_MAX_VARIABLE_NUMBER records fails with "too many SQL
+        // variables" -- including a plain unfiltered `get()`.
+        const N: usize = 33_000;
+
+        let mut logs = Vec::with_capacity(N);
+        for i in 0..N {
+            let mut meta = HashMap::new();
+            meta.insert("idx".to_string(), UpdateMetadataValue::Int(i as i64));
+            // One record carries array metadata to exercise the merge path.
+            if i == 0 {
+                meta.insert(
+                    "tags".to_string(),
+                    UpdateMetadataValue::StringArray(vec![
+                        "action".to_string(),
+                        "comedy".to_string(),
+                    ]),
+                );
+            }
+            logs.push(LogRecord {
+                log_offset: i as i64,
+                record: OperationRecord {
+                    id: format!("id{i}"),
+                    metadata: Some(meta),
+                    document: None,
+                    operation: Operation::Add,
+                    embedding: None,
+                    encoding: None,
+                },
+            });
+        }
+
+        let (reader, cas) = setup_with_logs(logs).await;
+        let plan = make_get_plan(&cas, None);
+        let result = reader
+            .get(plan)
+            .await
+            .expect("get must not exceed SQLite's bind parameter limit");
+
+        assert_eq!(result.result.records.len(), N);
+
+        // The chunked merge still attaches array metadata to the right record.
+        let first = result
+            .result
+            .records
+            .iter()
+            .find(|r| r.id == "id0")
+            .expect("id0 present");
+        match first.metadata.as_ref().and_then(|md| md.get("tags")) {
+            Some(MetadataValue::StringArray(arr)) => {
+                let mut sorted = arr.clone();
+                sorted.sort();
+                assert_eq!(sorted, vec!["action", "comedy"]);
+            }
+            other => panic!("Expected StringArray for 'tags', got {:?}", other),
+        }
+
+        // And records without array metadata are untouched.
+        let last = result
+            .result
+            .records
+            .iter()
+            .find(|r| r.id == format!("id{}", N - 1))
+            .expect("last record present");
+        let md = last.metadata.as_ref().expect("metadata present");
+        assert_eq!(md.get("tags"), None);
+        assert_eq!(md.get("idx"), Some(&MetadataValue::Int(N as i64 - 1)));
     }
 }


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Fix `too many SQL variables` on any read that matches more than
    `SQLITE_MAX_VARIABLE_NUMBER` records in the local (SQLite) metadata segment,
    by chunking the array-metadata id lookup.
- New functionality
  - None

### Background

`SqliteMetadataReader::get` merges array metadata in with a second query that
binds one parameter per matched record:

```rust
.and_where(
    Expr::col(EmbeddingMetadataArray::Id)
        .is_in(offset_ids.iter().copied().map(|id| id as i64)),
)
```

SQLite rejects a statement carrying more than `SQLITE_MAX_VARIABLE_NUMBER` bind
parameters — 32766 in the bundled build `sqlx` links against — so any read
matching more records than that fails outright.

Repro with `PersistentClient` on a 400k-document collection (chromadb 1.5.9):

```python
col.get()                        # InternalError: too many SQL variables
col.get(limit=32766)             # ok
col.get(limit=32767)             # InternalError: too many SQL variables
col.get(include=["documents"])   # ok, 400,000 ids
```

Three things worth calling out:

- It is not filter-specific. Only the number of matched records matters, so a
  plain unfiltered `get()` fails on any collection larger than 32766.
- `include=["documents"]` and `include=[]` succeed, because the block is gated on
  the `metadata` projection flag.
- It fires even when the collection has no array metadata at all. The guard is
  `if metadata && !records.is_empty()`, which never checks whether there is any
  array metadata to fetch — the repro collection above has 0 rows in
  `embedding_metadata_array`.

Introduced in #6355; before that commit the projection path bound no id list.
This is the same failure class as #1101, #1861 and #4802, and the still-open
#2762, all of which were in the older Python segment path.

### The fix

Chunk the id list so the bind count stays bounded no matter how many records
match. `MAX_IDS_PER_QUERY` is 10,000 — comfortably under the 32766 limit, while
keeping the number of round trips low for large reads.

Two adjacent items I deliberately left out of this PR, happy to follow up:

- The array fetch could be skipped entirely when the collection schema declares
  no array-typed keys.
- `Filter::query_ids` binds the caller's id list the same way, so
  `get(ids=[...])` with more than 32766 ids hits the same limit.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

New unit test in `rust/segment/src/sqlite_metadata.rs`:

- `test_get_exceeding_sqlite_variable_limit` — writes 33,000 records and reads
  them back with an unfiltered `get()`, asserting the array metadata on one
  record is still merged onto the right record and that records without array
  metadata are untouched.

Verified the test reproduces the reported failure before the fix — reverting the
chunking gives:

```
panicked at rust/segment/src/sqlite_metadata.rs:3248:14:
get must not exceed SQLite's bind parameter limit:
  Sqlx(Database(SqliteError { code: 1, message: "too many SQL variables" }))
```

Ran `cargo test -p chroma-segment --lib sqlite_metadata` — 22 passed. The change
is confined to the Rust SQLite segment; the Python and JS suites were not run.

## Migration plan

None. No schema or data changes; the same rows are returned, fetched over
several statements instead of one.

## Observability plan

None.

## Documentation Changes

None.
