### PR TITLE
fix(auth): read auth files as utf-8

### DIFF
--- a/chromadb/auth/__init__.py
+++ b/chromadb/auth/__init__.py
@@ -121,7 +121,7 @@ class ServerAuthenticationProvider(Component):
         if _creds:
             return [c for c in _creds.split("\n") if c]
         elif _creds_file:
-            with open(_creds_file, "r") as f:
+            with open(_creds_file, "r", encoding="utf-8") as f:
                 return f.readlines()
         raise ValueError("Should never happen")
 
@@ -232,6 +232,6 @@ class ServerAuthorizationProvider(Component):
         if _config:
             return [c for c in _config.split("\n") if c]
         elif _config_file:
-            with open(_config_file, "r") as f:
+            with open(_config_file, "r", encoding="utf-8") as f:
                 return f.readlines()
         raise ValueError("Should never happen")


### PR DESCRIPTION
## Problem
Server auth credential and authorization config files are text files, but `read_creds_or_creds_file()` and `read_config_or_config_file()` read them with the platform default encoding.

On systems where the default locale is not UTF-8, auth files containing non-ASCII user IDs, comments, or role metadata can fail to load even though the same files work on UTF-8 systems.

## Before / after
Before, Chroma used bare text-mode `open(..., "r")` for authn credential files and authz config files.

After, both file-read paths use explicit UTF-8 decoding. Inline credentials/config strings are unchanged.

## Verification
- `python -m py_compile chromadb/auth/__init__.py`
- `git diff --check`