### PR TITLE
[BUG](embedding-functions): concurrent first use races on the onnx model download

### DIFF
--- a/chromadb/test/ef/test_onnx_mini_lm_l6_v2.py
+++ b/chromadb/test/ef/test_onnx_mini_lm_l6_v2.py
@@ -1,6 +1,10 @@
+import io
 import os
+import tarfile
 import tempfile
-from typing import Dict, Any
+import threading
+import time
+from typing import Dict, Any, List
 
 import numpy as np
 from numpy.typing import NDArray
@@ -202,3 +206,92 @@ class TestONNXMiniLM_L6_V2:
 
         # The similarity between text1 and text2 should be higher than between text1 and text3
         assert sim_1_2 > sim_1_3
+
+    def test_concurrent_first_use_downloads_once(self) -> None:
+        """Threads racing on first use must serialize the model download.
+
+        Without serialization, every thread sees the model files missing and
+        downloads/extracts the shared archive concurrently, corrupting the
+        cache. With the lock, the download happens exactly once and later
+        threads take the fast path.
+        """
+        num_threads = 4
+        start_barrier = threading.Barrier(num_threads)
+        download_calls = 0
+        calls_lock = threading.Lock()
+
+        def fake_download(
+            self: ONNXMiniLM_L6_V2, url: str, fname: str, chunk_size: int = 1024
+        ) -> None:
+            nonlocal download_calls
+            with calls_lock:
+                download_calls += 1
+            # Keep the model files missing long enough that, without the fix,
+            # every racing thread passes the existence check and enters the
+            # download step.
+            time.sleep(1.0)
+            buf = io.BytesIO()
+            with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+                for name in (
+                    "config.json",
+                    "model.onnx",
+                    "special_tokens_map.json",
+                    "tokenizer_config.json",
+                    "tokenizer.json",
+                    "vocab.txt",
+                ):
+                    data = b"{}" if name.endswith(".json") else b"fake-model"
+                    # The real archive stores its members under the extracted
+                    # folder name, mirror that layout here.
+                    info = tarfile.TarInfo(
+                        name=os.path.join(ONNXMiniLM_L6_V2.EXTRACTED_FOLDER_NAME, name)
+                    )
+                    info.size = len(data)
+                    tar.addfile(info, io.BytesIO(data))
+            with open(fname, "wb") as f:
+                f.write(buf.getvalue())
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(ONNXMiniLM_L6_V2, "DOWNLOAD_PATH", temp_dir), patch(
+                "chromadb.utils.embedding_functions.onnx_mini_lm_l6_v2._verify_sha256",
+                return_value=True,
+            ), patch.object(ONNXMiniLM_L6_V2, "_download", fake_download):
+                ef = ONNXMiniLM_L6_V2()
+                errors: List[BaseException] = []
+
+                def first_use() -> None:
+                    try:
+                        start_barrier.wait(timeout=30)
+                        ef._download_model_if_not_exists()
+                    except BaseException as exc:  # noqa: BLE001
+                        errors.append(exc)
+
+                threads = [
+                    threading.Thread(target=first_use) for _ in range(num_threads)
+                ]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join(timeout=60)
+                    assert not thread.is_alive()
+
+                assert errors == []
+                assert download_calls == 1
+
+                # All model files are extracted, and a subsequent call takes
+                # the fast path without downloading again.
+                for name in (
+                    "config.json",
+                    "model.onnx",
+                    "special_tokens_map.json",
+                    "tokenizer_config.json",
+                    "tokenizer.json",
+                    "vocab.txt",
+                ):
+                    assert os.path.exists(
+                        os.path.join(
+                            temp_dir, ONNXMiniLM_L6_V2.EXTRACTED_FOLDER_NAME, name
+                        )
+                    )
+                ef._download_model_if_not_exists()
+                assert download_calls == 1

--- a/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
+++ b/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
@@ -4,6 +4,7 @@ import logging
 import os
 import tarfile
 import sys
+import threading
 from functools import cached_property
 from pathlib import Path
 from typing import List, Dict, Any, Optional, cast
@@ -17,6 +18,17 @@ from chromadb.api.types import Documents, Embeddings, EmbeddingFunction, Space
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 
 logger = logging.getLogger(__name__)
+
+# The model archive lives in a shared cache directory that every instance of
+# this embedding function (and the process-wide DefaultEmbeddingFunction
+# singleton) points at. First use from multiple threads therefore races:
+# two threads can see the model files missing, download the archive to the
+# same path concurrently (interleaved writes corrupt it and the SHA256 check
+# then fails with a bogus "Corrupted download or malicious file" error), and
+# extract the same tarball on top of itself, exposing half-written model
+# files to the tokenizer/model loaders. Serialize the download+extract so
+# only one thread ever populates the cache.
+_MODEL_POPULATE_LOCK = threading.Lock()
 
 
 def _verify_sha256(fname: str, expected_sha256: str) -> bool:
@@ -291,13 +303,23 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
             "vocab.txt",
         ]
         extracted_folder = os.path.join(self.DOWNLOAD_PATH, self.EXTRACTED_FOLDER_NAME)
-        onnx_files_exist = True
-        for f in onnx_files:
-            if not os.path.exists(os.path.join(extracted_folder, f)):
-                onnx_files_exist = False
-                break
-        # Model is not downloaded yet
-        if not onnx_files_exist:
+
+        def model_files_exist() -> bool:
+            for f in onnx_files:
+                if not os.path.exists(os.path.join(extracted_folder, f)):
+                    return False
+            return True
+
+        # Fast path: the model is already cached, no need to take the lock.
+        if model_files_exist():
+            return
+
+        # Double-checked locking: threads that arrive while another thread is
+        # populating the cache wait here, then re-check and return without
+        # downloading again.
+        with _MODEL_POPULATE_LOCK:
+            if model_files_exist():
+                return
             os.makedirs(self.DOWNLOAD_PATH, exist_ok=True)
             if not os.path.exists(
                 os.path.join(self.DOWNLOAD_PATH, self.ARCHIVE_FILENAME)


### PR DESCRIPTION
## Description of changes

Hit this with a small FastAPI service that shares one `PersistentClient` across request threads. On a cold start the first few requests all go through the default embedding function at once, and every thread sees the model cache as empty. They all start downloading `onnx.tar.gz` into the same path, and more than once a normal request came back with "Downloaded file ... does not match expected SHA256 hash. Corrupted download or malicious file." Not a great look.

`_download_model_if_not_exists` is completely unsynchronized. The existence check, the download, and the extraction can interleave across threads:

- two threads writing the archive at the same time corrupt it, which is where the spurious SHA failure (or a tarfile ReadError on a half-written file) comes from
- `extractall` running concurrently can also expose half-extracted files to the tokenizer/model loaders

The fix serializes just the populate step with a module-level lock, double-checked so the common path (model already cached) stays lock-free. One thread downloads and extracts, the rest wait and then return through the fast path.

- Improvements & Bug fixes
  - `ONNXMiniLM_L6_V2` model download/extract is thread-safe; concurrent first use downloads exactly once
- New functionality
  - none

## Test plan

Added `test_concurrent_first_use_downloads_once`: 4 threads hit `_download_model_if_not_exists` simultaneously, with `_download` mocked so the model files stay missing long enough to force the race. On unfixed code this fails with a tarfile `ReadError` from the interleaved writes; with the fix it passes and asserts the download ran exactly once and the extracted files land where the tokenizer/model loaders expect them. Local run:

```
pytest chromadb/test/ef/test_onnx_mini_lm_l6_v2.py -k "download or initialization or concurrent"
3 passed, 13 deselected
```

black and flake8 (with the repo's args from .pre-commit-config.yaml) are clean on both changed files.

## Migration plan

No data migration. Existing model caches are untouched; the lock only affects the first-use populate path.

## Observability plan

Nothing new to instrument. The existing SHA256 verification on the downloaded archive still runs as before.

## Documentation Changes

None. Behavior is unchanged except that concurrent first use no longer races.
