### PR TITLE
[BUG](python): Release GIL during metadata I/O

### DIFF
--- a/chromadb/test/test_rust_bindings_gil.py
+++ b/chromadb/test/test_rust_bindings_gil.py
@@ -1,0 +1,129 @@
+import multiprocessing
+from multiprocessing.synchronize import Event
+from pathlib import Path
+import sqlite3
+import sys
+import threading
+import time
+from typing import Callable
+
+import chromadb_rust_bindings
+import pytest
+
+from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT
+
+
+def _hold_sqlite_lock(path: str, locked: Event, release: Event) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute("BEGIN EXCLUSIVE")
+        locked.set()
+        # A separate process must eventually unlock even if Python's GIL is held.
+        released_by_thread = release.wait(5)
+        connection.rollback()
+    sys.exit(0 if released_by_thread else 1)
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "initialize",
+        "create_database",
+        "get_database",
+        "delete_database",
+        "list_databases",
+        "create_tenant",
+        "get_tenant",
+        "count_collections",
+        "list_collections",
+        "create_collection",
+        "get_collection",
+        "get_collection_by_id",
+        "update_collection",
+        "delete_collection",
+    ],
+)
+def test_sqlite_wait_releases_gil(tmp_path: Path, operation: str) -> None:
+    db_path = str(tmp_path / "chroma.sqlite3")
+
+    def initialize() -> chromadb_rust_bindings.Bindings:
+        return chromadb_rust_bindings.Bindings(
+            allow_reset=True,
+            sqlite_db_config=chromadb_rust_bindings.SqliteDBConfig(
+                url=db_path,
+                hash_type=chromadb_rust_bindings.MigrationHash.MD5,
+                migration_mode=chromadb_rust_bindings.MigrationMode.Apply,
+            ),
+            persist_path=str(tmp_path),
+            hnsw_cache_size=16,
+        )
+
+    bindings = initialize()
+    collection = bindings.create_collection("gil_test")
+    bindings.create_database("test_database", DEFAULT_TENANT)
+    operations: dict[str, Callable[[], object]] = {
+        "initialize": initialize,
+        "create_database": lambda: bindings.create_database(
+            "new_database", DEFAULT_TENANT
+        ),
+        "get_database": lambda: bindings.get_database("test_database", DEFAULT_TENANT),
+        "delete_database": lambda: bindings.delete_database(
+            "test_database", DEFAULT_TENANT
+        ),
+        "list_databases": lambda: bindings.list_databases(tenant=DEFAULT_TENANT),
+        "create_tenant": lambda: bindings.create_tenant("new_tenant"),
+        "get_tenant": lambda: bindings.get_tenant(DEFAULT_TENANT),
+        "count_collections": lambda: bindings.count_collections(
+            DEFAULT_TENANT, DEFAULT_DATABASE
+        ),
+        "list_collections": bindings.list_collections,
+        "create_collection": lambda: bindings.create_collection("new_collection"),
+        "get_collection": lambda: bindings.get_collection(
+            "gil_test", DEFAULT_TENANT, DEFAULT_DATABASE
+        ),
+        "get_collection_by_id": lambda: bindings.get_collection_by_id(
+            str(collection.id)
+        ),
+        "update_collection": lambda: bindings.update_collection(
+            str(collection.id), new_name="renamed_collection"
+        ),
+        "delete_collection": lambda: bindings.delete_collection(
+            "gil_test", DEFAULT_TENANT, DEFAULT_DATABASE
+        ),
+    }
+    if operation == "initialize":
+        bindings.close()
+
+    context = multiprocessing.get_context("spawn")
+    locked, release = context.Event(), context.Event()
+    holder = context.Process(target=_hold_sqlite_lock, args=(db_path, locked, release))
+    holder.start()
+
+    def release_from_python_thread() -> None:
+        # Let the native call reach its SQLite wait before trying to run Python.
+        time.sleep(0.2)
+        release.set()
+
+    thread = threading.Thread(target=release_from_python_thread)
+    try:
+        assert locked.wait(30), "SQLite lock holder did not start"
+        thread.start()
+        result = operations[operation]()
+        assert (
+            release.is_set()
+        ), "Operation completed without waiting for the SQLite lock"
+        if operation == "initialize":
+            assert isinstance(result, chromadb_rust_bindings.Bindings)
+            result.close()
+        holder.join(5)
+        assert (
+            holder.exitcode == 0
+        ), "SQLite wait prevented another Python thread from running"
+    finally:
+        release.set()
+        if thread.ident is not None:
+            thread.join(5)
+        holder.join(5)
+        if holder.is_alive():
+            holder.terminate()
+            holder.join(5)
+        bindings.close()

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -444,6 +444,7 @@ impl Bindings {
     #[new]
     #[pyo3(signature = (allow_reset, sqlite_db_config, hnsw_cache_size, persist_path=None))]
     pub fn py_new(
+        py: Python<'_>,
         allow_reset: bool,
         sqlite_db_config: SqliteDBConfig,
         hnsw_cache_size: usize,
@@ -512,8 +513,11 @@ impl Bindings {
             enable_transactions: false,
         };
 
-        let frontend = runtime.block_on(async {
-            Frontend::try_from_config(&(frontend_config, system.clone()), &registry).await
+        // SQLite initialization can wait for another connection's writer lock.
+        let frontend = py.allow_threads(|| {
+            runtime.block_on(async {
+                Frontend::try_from_config(&(frontend_config, system.clone()), &registry).await
+            })
         })?;
         let sqlite_db = registry.get::<SqliteDb>()?;
         let compactor_handle = registry.get::<ComponentHandle<LocalCompactionManager>>()?;
@@ -548,15 +552,17 @@ impl Bindings {
 
     ////////////////////////////// Admin API //////////////////////////////
 
-    fn create_database(&self, name: String, tenant: String, _py: Python<'_>) -> ChromaPyResult<()> {
+    fn create_database(&self, name: String, tenant: String, py: Python<'_>) -> ChromaPyResult<()> {
         let database_name = DatabaseName::new(name).ok_or_else(|| {
             InvalidDatabaseNameError("database name must be at least 3 characters".to_string())
         })?;
         let request = CreateDatabaseRequest::try_new(tenant, database_name)?;
         let mut frontend = self.frontend.clone();
 
-        self.runtime
-            .block_on(async { frontend.create_database(request).await })?;
+        py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.create_database(request).await })
+        })?;
 
         Ok(())
     }
@@ -565,7 +571,7 @@ impl Bindings {
         &self,
         name: String,
         tenant: String,
-        _py: Python<'_>,
+        py: Python<'_>,
     ) -> ChromaPyResult<Database> {
         let database_name = DatabaseName::new(name).ok_or_else(|| {
             InvalidDatabaseNameError("database name must be at least 3 characters".to_string())
@@ -573,18 +579,21 @@ impl Bindings {
         let request = GetDatabaseRequest::try_new(tenant, database_name)?;
 
         let mut frontend = self.frontend.clone();
-        let database = self
-            .runtime
-            .block_on(async { frontend.get_database(request).await })?;
+        let database = py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.get_database(request).await })
+        })?;
 
         Ok(database)
     }
 
-    fn delete_database(&self, name: String, tenant: String) -> ChromaPyResult<()> {
+    fn delete_database(&self, name: String, tenant: String, py: Python<'_>) -> ChromaPyResult<()> {
         let request = DeleteDatabaseRequest::try_new(tenant, name)?;
         let mut frontend = self.frontend.clone();
-        self.runtime
-            .block_on(async { frontend.delete_database(request).await })?;
+        py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.delete_database(request).await })
+        })?;
 
         Ok(())
     }
@@ -592,6 +601,7 @@ impl Bindings {
     #[pyo3(signature = (limit = None, offset = None, tenant = "DEFAULT_TENANT".to_string()))]
     fn list_databases(
         &self,
+        py: Python<'_>,
         limit: Option<u32>,
         offset: Option<u32>,
         tenant: String,
@@ -599,46 +609,57 @@ impl Bindings {
         let request = ListDatabasesRequest::try_new(tenant, limit, offset.unwrap_or(0))?;
         let mut frontend = self.frontend.clone();
 
-        let databases = self
-            .runtime
-            .block_on(async { frontend.list_databases(request).await })?;
+        let databases = py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.list_databases(request).await })
+        })?;
         Ok(databases)
     }
 
-    fn create_tenant(&self, name: String) -> ChromaPyResult<()> {
+    fn create_tenant(&self, name: String, py: Python<'_>) -> ChromaPyResult<()> {
         let request = CreateTenantRequest::try_new(name)?;
         let mut frontend = self.frontend.clone();
 
-        self.runtime
-            .block_on(async { frontend.create_tenant(request).await })?;
+        py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.create_tenant(request).await })
+        })?;
         Ok(())
     }
 
-    fn get_tenant(&self, name: String) -> ChromaPyResult<GetTenantResponse> {
+    fn get_tenant(&self, name: String, py: Python<'_>) -> ChromaPyResult<GetTenantResponse> {
         let request = GetTenantRequest::try_new(name)?;
         let mut frontend = self.frontend.clone();
 
-        let tenant = self
-            .runtime
-            .block_on(async { frontend.get_tenant(request).await })?;
+        let tenant = py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.get_tenant(request).await })
+        })?;
         Ok(tenant)
     }
 
     ////////////////////////////// Base API //////////////////////////////
-    fn count_collections(&self, tenant: String, database: String) -> ChromaPyResult<u32> {
+    fn count_collections(
+        &self,
+        tenant: String,
+        database: String,
+        py: Python<'_>,
+    ) -> ChromaPyResult<u32> {
         let database_name =
             DatabaseName::new(database.clone()).ok_or(InvalidDatabaseNameError(database))?;
         let request = CountCollectionsRequest::try_new(tenant, database_name)?;
         let mut frontend = self.frontend.clone();
-        let count = self
-            .runtime
-            .block_on(async { frontend.count_collections(request).await })?;
+        let count = py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.count_collections(request).await })
+        })?;
         Ok(count)
     }
 
     #[pyo3(signature = (limit = None, offset = 0, tenant = DEFAULT_TENANT.to_string(), database = DEFAULT_DATABASE.to_string()))]
     fn list_collections(
         &self,
+        py: Python<'_>,
         limit: Option<u32>,
         offset: Option<u32>,
         tenant: String,
@@ -649,9 +670,10 @@ impl Bindings {
         let request =
             ListCollectionsRequest::try_new(tenant, database_name, limit, offset.unwrap_or(0))?;
         let mut frontend = self.frontend.clone();
-        let collections = self
-            .runtime
-            .block_on(async { frontend.list_collections(request).await })?;
+        let collections = py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.list_collections(request).await })
+        })?;
         Ok(collections)
     }
 
@@ -661,6 +683,7 @@ impl Bindings {
     )]
     fn create_collection(
         &self,
+        py: Python<'_>,
         name: String,
         configuration_json_str: Option<String>,
         schema_str: Option<String>,
@@ -716,15 +739,17 @@ impl Bindings {
         )?;
 
         let mut frontend = self.frontend.clone();
-        let collection = self
-            .runtime
-            .block_on(async { frontend.create_collection(request).await })?;
+        let collection = py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.create_collection(request).await })
+        })?;
 
         Ok(collection)
     }
 
     fn get_collection(
         &self,
+        py: Python<'_>,
         name: String,
         tenant: String,
         database: String,
@@ -733,15 +758,17 @@ impl Bindings {
             DatabaseName::new(database.clone()).ok_or(InvalidDatabaseNameError(database))?;
         let request = GetCollectionRequest::try_new(tenant, database_name, name)?;
         let mut frontend = self.frontend.clone();
-        let collection = self
-            .runtime
-            .block_on(async { frontend.get_collection(request).await })?;
+        let collection = py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.get_collection(request).await })
+        })?;
         Ok(collection)
     }
 
     #[pyo3(signature = (collection_id, tenant = DEFAULT_TENANT.to_string(), database = DEFAULT_DATABASE.to_string()))]
     fn get_collection_by_id(
         &self,
+        py: Python<'_>,
         collection_id: String,
         tenant: String,
         database: String,
@@ -750,9 +777,10 @@ impl Bindings {
             DatabaseName::new(database.clone()).ok_or(InvalidDatabaseNameError(database))?;
         let request = GetCollectionByIdRequest::try_new(collection_id, tenant, database_name)?;
         let mut frontend = self.frontend.clone();
-        let collection = self
-            .runtime
-            .block_on(async { frontend.get_collection_by_id(request).await })?;
+        let collection = py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.get_collection_by_id(request).await })
+        })?;
         Ok(collection)
     }
 
@@ -761,6 +789,7 @@ impl Bindings {
     )]
     fn update_collection(
         &self,
+        py: Python<'_>,
         collection_id: String,
         new_name: Option<String>,
         new_metadata: Option<UpdateMetadata>,
@@ -796,22 +825,27 @@ impl Bindings {
         )?;
 
         let mut frontend = self.frontend.clone();
-        self.runtime
-            .block_on(async { frontend.update_collection(request).await })?;
+        py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.update_collection(request).await })
+        })?;
 
         Ok(())
     }
 
     fn delete_collection(
         &self,
+        py: Python<'_>,
         name: String,
         tenant: String,
         database: String,
     ) -> ChromaPyResult<()> {
         let request = DeleteCollectionRequest::try_new(tenant, database, name)?;
         let mut frontend = self.frontend.clone();
-        self.runtime
-            .block_on(async { frontend.delete_collection(request).await })?;
+        py.allow_threads(move || {
+            self.runtime
+                .block_on(async { frontend.delete_collection(request).await })
+        })?;
         Ok(())
     }
 
@@ -1455,8 +1489,11 @@ mod tests {
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
         };
-        let bindings = Bindings::py_new(true, sqlite_db_config, 16, Some(persist_path))
-            .expect("persistent bindings");
+        pyo3::prepare_freethreaded_python();
+        let bindings = Python::with_gil(|py| {
+            Bindings::py_new(py, true, sqlite_db_config, 16, Some(persist_path))
+                .expect("persistent bindings")
+        });
 
         (temp_dir, bindings)
     }


### PR DESCRIPTION
## Why this matters

I found this while investigating event-loop stalls in [MindRoom](https://github.com/mindroom-ai/mindroom), an asyncio-based multi-agent application using Chroma through Agno.

One observed stall lasted **474.5 seconds**, while the main process consumed only **2.2 seconds of CPU**. The event loop and Python watchdog stopped making progress during background index cleanup, and resumed about 0.1 seconds after cleanup finished. A blocked native stack was not captured during that incident, so attributing that specific stall to this bug remains a hypothesis, not a proven stack trace. The smaller reproduction below establishes the GIL problem independently.

This is relevant even when applications already offload synchronous database calls:

- MindRoom [resolves knowledge in `asyncio.to_thread`](https://github.com/mindroom-ai/mindroom/blob/73d64b2dcd1d6310cedec20bdcc4594b7171fa4b/src/mindroom/knowledge/utils.py#L227-L243).
- Its [cached-index check still calls `vector_db.exists()`](https://github.com/mindroom-ai/mindroom/blob/73d64b2dcd1d6310cedec20bdcc4594b7171fa4b/src/mindroom/knowledge/registry.py#L497-L501). Agno's [`ChromaDb.exists()` calls `client.get_collection()`](https://github.com/agno-agi/agno/blob/f7f078bec1544f887723d48e1115150a4a598a0d/libs/agno/agno/vectordb/chroma/chromadb.py#L1454-L1465).
- Concurrently, MindRoom [publishes a replacement index and retires superseded collections](https://github.com/mindroom-ai/mindroom/blob/73d64b2dcd1d6310cedec20bdcc4594b7171fa4b/src/mindroom/knowledge/manager.py#L2042-L2066).

A SQLite lock wait in the lookup can therefore prevent unrelated conversations, timers, and health checks from running—not just delay the caller.

## Reproduction

Using Chroma 1.5.8 and a tiny, disposable local database: a separate process holds `BEGIN EXCLUSIVE` for three seconds; the operation runs through `asyncio.to_thread`; an unrelated Python thread records a heartbeat every 20 ms.

| Operation | Journal | Call duration | Largest heartbeat gap |
| --- | --- | ---: | ---: |
| New Chroma client | DELETE | 2.977 s | 2.951 s |
| Cached Chroma `get_collection` | DELETE | 2.932 s | 2.931 s |
| Standard-library SQLite read (control) | DELETE | 2.931 s | 0.020 s |
| Cached Chroma `get_collection` | WAL | 0.001 s | 0.020 s |
| New Chroma client | WAL | 2.976 s | 2.951 s |

The cached-client case consumed only 0.004 CPU seconds. A native faulthandler timer captured the worker in Chroma's Rust binding initialization while the main thread showed `selector.poll`.

So moving work to a thread is insufficient, and WAL alone does not fix initialization. Chroma's [SQLite busy timeout is 1,000 seconds](https://github.com/chroma-core/chroma/blob/34f8e76bae6195b91160e78b2e47a397055aa3ab/rust/sqlite/src/config.rs#L97-L108), making GIL retention during contention particularly costly.

## Change and verification

Release the GIL around initialization and the 13 tenant/database/collection metadata operations, following the existing `get`/`query` pattern. No API or database-format changes. Individual contended calls still wait; unrelated Python threads can run. Other GIL-held record operations are outside this PR's scope.

The [regression test](https://github.com/chroma-core/chroma/pull/7692/files) holds a real SQLite lock in a separate process and requires a Python thread to release it before the fallback deadline:

- All 14 cases fail on a locally built, unmodified main branch at `34f8e76ba` and pass after rebuilding with this fix.
- API/client/concurrency suites: 282 passed, 7 skipped.
- Rust binding lifecycle tests: 3 passed.
- Pre-commit and Rust formatting checks pass.
