### PR TITLE
[DOC](cli): Clarify vacuum erasure limits

### DIFF
--- a/docs/mintlify/docs/cli/vacuum.mdx
+++ b/docs/mintlify/docs/cli/vacuum.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Vacuum"
-description: "Shrink and optimize your Chroma database."
+description: "Reclaim SQLite space in a local persistent Chroma database."
 ---
 
-Vacuuming shrinks and optimizes your database.
+Vacuuming reclaims unused space in a local persistent database's SQLite file and enables automatic write-ahead log (WAL) pruning.
 
 Vacuuming after upgrading from a version of Chroma below v0.5.6 will greatly reduce the size of your database and enable continuous database pruning. A warning is logged during server startup if this is necessary.
 
@@ -14,7 +14,17 @@ Vacuuming blocks all reads and writes to your database while it's running, so we
 To vacuum your database, run:
 
 ```bash
-chroma utils vacuum --path <your-data-directory>
+chroma vacuum --path <your-data-directory>
 ```
 
 For large databases, expect this to take up to a few minutes.
+
+## What vacuum does not erase
+
+Vacuum prunes WAL entries only after the collection's segments have persisted the corresponding progress. It does not force pending vector-index changes to persist, so a quiet collection can still have WAL entries after vacuum completes.
+
+Vacuum does **not** rebuild or compact the HNSW vector index. Deleting a record removes it from collection reads and queries, but its vector bytes can remain in the index files. A smaller SQLite file or a successful vacuum is not proof that those bytes have been erased.
+
+<Warning>
+Vacuum is a space-reclamation command, not a secure-erasure operation. It does not erase all stored copies of deleted records, including copies in backups or storage snapshots. Do not delete individual files from a live persistent directory to try to remove this data; doing so can corrupt the database.
+</Warning>

--- a/docs/mintlify/docs/collections/delete-data.mdx
+++ b/docs/mintlify/docs/collections/delete-data.mdx
@@ -5,7 +5,9 @@ description: "Learn how to delete data from Chroma collections."
 
 import { Danger } from '/snippets/callout.mdx';
 
-Chroma supports deleting items from a collection by `id` using `.delete`. The embeddings, documents, and metadata associated with each item will be deleted.
+Chroma supports deleting items from a collection by `id` using `.delete`. The embeddings, documents, and metadata associated with each item will be deleted from the collection.
+
+For local persistent databases, deletion removes records from reads and queries but does not guarantee immediate physical erasure of their bytes from storage. See [Vacuum](/docs/cli/vacuum#what-vacuum-does-not-erase) for the limits of WAL pruning and vector-index cleanup.
 
 <Danger>
 Naturally, this is a destructive operation, and cannot be undone.


### PR DESCRIPTION
## Description of changes

Fixes #7662's documentation gap. The vacuum reference now distinguishes SQLite space reclamation and progress-gated WAL pruning from physical erasure of HNSW vectors. It states that successful vacuum is not a secure-erasure guarantee, links this limitation from Delete Data, and uses the current `chroma vacuum` command.

No storage behavior changes. This PR does not implement vector erasure or claim to remove copies in backups or snapshots.

## Test plan

- `npm exec --yes --package=mint@4.2.876 -- mint validate`: passed.
- `git diff --check`: passed.
- Reproduced on CPU with the reported `chromadb==1.5.9`, Python 3.12, macOS arm64, a fresh persistent directory, and explicitly supplied embeddings. Added 2,000 records, deleted 100, stopped the client, then ran `chroma vacuum --path <temporary-directory> --force`:

```text
Count after delete: 1900
Deleted IDs returned: []
Deleted vectors in HNSW before vacuum: 100
vacuum exit: 0
Deleted vectors in HNSW after vacuum: 100
```

The byte check searched `data_level0.bin` for each deleted record's eight-float vector. `chroma vacuum --help` also confirms the documented CLI syntax. Current `rust/cli/src/commands/vacuum.rs` purges logs at persisted segment offsets and executes SQLite `VACUUM`; it does not rebuild the HNSW index.

No GPU, model download, cloud service, or runtime code test is needed for this documentation-only change. The behavior reproduction used the released wheel, not a locally rebuilt Rust extension.

## Migration plan

None. Documentation only.

## Observability plan

None. No runtime behavior changes.

## Documentation Changes

Updated the vacuum reference and linked its retention limitations from Delete Data.
