### PR TITLE
[TYP] database/tenant APIs: align docstring param names with signatures

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -715,7 +715,7 @@ class AdminAPI(ABC):
         """Create a new database. Raises an error if the database already exists.
 
         Args:
-            database: The name of the database to create.
+            name: The name of the database to create.
 
         """
         pass
@@ -725,7 +725,7 @@ class AdminAPI(ABC):
         """Get a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to get.
+            name: The name of the database to get.
             tenant: The tenant of the database to get.
 
         """
@@ -736,7 +736,7 @@ class AdminAPI(ABC):
         """Delete a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to delete.
+            name: The name of the database to delete.
             tenant: The tenant of the database to delete.
 
         """
@@ -762,7 +762,7 @@ class AdminAPI(ABC):
         """Create a new tenant. Raises an error if the tenant already exists.
 
         Args:
-            tenant: The name of the tenant to create.
+            name: The name of the tenant to create.
 
         """
         pass
@@ -772,7 +772,7 @@ class AdminAPI(ABC):
         """Get a tenant. Raises an error if the tenant does not exist.
 
         Args:
-            tenant: The name of the tenant to get.
+            name: The name of the tenant to get.
 
         """
         pass

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -667,7 +667,7 @@ class AsyncAdminAPI(ABC):
         """Create a new database. Raises an error if the database already exists.
 
         Args:
-            database: The name of the database to create.
+            name: The name of the database to create.
 
         """
         pass
@@ -677,7 +677,7 @@ class AsyncAdminAPI(ABC):
         """Get a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to get.
+            name: The name of the database to get.
             tenant: The tenant of the database to get.
 
         """
@@ -688,7 +688,7 @@ class AsyncAdminAPI(ABC):
         """Delete a database. Raises an error if the database does not exist.
 
         Args:
-            database: The name of the database to delete.
+            name: The name of the database to delete.
             tenant: The tenant of the database to delete.
 
         """
@@ -714,7 +714,7 @@ class AsyncAdminAPI(ABC):
         """Create a new tenant. Raises an error if the tenant already exists.
 
         Args:
-            tenant: The name of the tenant to create.
+            name: The name of the tenant to create.
 
         """
         pass
@@ -724,7 +724,7 @@ class AsyncAdminAPI(ABC):
         """Get a tenant. Raises an error if the tenant does not exist.
 
         Args:
-            tenant: The name of the tenant to get.
+            name: The name of the tenant to get.
 
         """
         pass


### PR DESCRIPTION
Ten `Args:` blocks in the sync and async Segment APIs documented parameter names that don't exist:

- `create_database` / `get_database` / `delete_database` (sync + async): documented `:param database:`; the parameter is `name`
- `create_tenant` / `get_tenant` (sync + async): documented `:param tenant:`; the parameter is `name`

Docstrings only.