### PR TITLE
[TYP] add APIs: document embeddings/metadatas, the actual _add parameters

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -179,8 +179,8 @@ class BaseAPI(ABC):
         Args:
             ids: The ids to associate with the embeddings.
             collection_id: The UUID of the collection to add the embeddings to.
-            embedding: The sequence of embeddings to add.
-            metadata: The metadata to associate with the embeddings. Defaults to None.
+            embeddings: The sequence of embeddings to add.
+            metadatas: The metadata to associate with the embeddings. Defaults to None.
             documents: The documents to associate with the embeddings. Defaults to None.
             uris: URIs of data sources for each embedding. Defaults to None.
 

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -132,8 +132,8 @@ class AsyncBaseAPI(ABC):
         Args:
             ids: The ids to associate with the embeddings.
             collection_id: The UUID of the collection to add the embeddings to.
-            embedding: The sequence of embeddings to add.
-            metadata: The metadata to associate with the embeddings. Defaults to None.
+            embeddings: The sequence of embeddings to add.
+            metadatas: The metadata to associate with the embeddings. Defaults to None.
             documents: The documents to associate with the embeddings. Defaults to None.
             uris: URIs of data sources for each embedding. Defaults to None.
 


### PR DESCRIPTION
`_add(ids, collection_id, embeddings, metadatas=None, documents=None, uris=None)`'s docstring (sync and async) documented `embedding:` and `metadata:` — the parameters are the plurals `embeddings` / `metadatas`. Four lines fixed across the two APIs. Docs-only.