### PR TITLE
[DOC] fix two README links and a duplicated word

### DIFF
--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -59,7 +59,7 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
     are in the same process.
 
     This is because notification of new embeddings happens solely in-process: this
-    implementation does not actively listen to the the database for new records added by
+    implementation does not actively listen to the database for new records added by
     other processes.
     """
 

--- a/clients/new-js/packages/chromadb/README.md
+++ b/clients/new-js/packages/chromadb/README.md
@@ -49,7 +49,7 @@ const queryData = await collection.query({
 
 ## Local development
 
-[View the Development Readme](./DEVELOP.md)
+[View the Development Readme](../../DEVELOP.md)
 
 ## License
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -37,4 +37,4 @@ results = collection.query(
 ```
 ## License
 
-[Apache 2.0](./LICENSE)
+[Apache 2.0](../../../LICENSE)


### PR DESCRIPTION
- `clients/python/README.md`: license link `./LICENSE` — the file is at the repo root (`../../../LICENSE`)
- `clients/new-js/packages/chromadb/README.md`: dev-readme link `./DEVELOP.md` — it lives at `clients/new-js/DEVELOP.md` (`../../DEVELOP.md`)
- `chromadb/db/mixins/embeddings_queue.py`: "listen to **the the** database"

Docs/comment fixes; no behavior change.