### PR TITLE
[BUG](python): Apply auth on AsyncFastAPI

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -7,7 +7,7 @@ import logging
 import httpx
 from overrides import override
 from chromadb import __version__
-from chromadb.auth import UserIdentity
+from chromadb.auth import ClientAuthProvider, UserIdentity
 from chromadb.api.async_api import AsyncServerAPI
 from chromadb.api.base_http_client import BaseHTTPClient
 from chromadb.api.collection_configuration import (
@@ -86,6 +86,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         self._opentelemetry_client = self.require(OpenTelemetryClient)
         self._product_telemetry_client = self.require(ProductTelemetryClient)
         self._settings = system.settings
+        self._auth_headers: Dict[str, str] = {}
 
         self._api_url = AsyncFastAPI.resolve_url(
             chroma_server_host=str(system.settings.chroma_server_host),
@@ -93,6 +94,11 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
             chroma_server_ssl_enabled=system.settings.chroma_server_ssl_enabled,
             default_api_path=system.settings.chroma_server_api_default_path,
         )
+
+        if system.settings.chroma_client_auth_provider:
+            self._auth_provider = self.require(ClientAuthProvider)
+            for header, value in self._auth_provider.authenticate().items():
+                self._auth_headers[header] = value.get_secret_value()
 
     async def __aenter__(self) -> "AsyncFastAPI":
         self._get_client()
@@ -137,6 +143,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
                 + __version__
                 + " (https://github.com/chroma-core/chroma)"
             )
+            headers.update(self._auth_headers)
 
             self._clients[loop_hash] = httpx.AsyncClient(
                 timeout=None,
@@ -149,7 +156,9 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
 
     @override
     def get_request_headers(self) -> Mapping[str, str]:
-        return dict(self._get_client().headers)
+        headers = httpx.Headers(self._get_client().headers)
+        headers.update(self._auth_headers)
+        return dict(headers)
 
     @override
     def get_api_url(self) -> str:
@@ -168,6 +177,11 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         # Unlike requests, httpx does not automatically escape the path
         escaped_path = urllib.parse.quote(path, safe="/", encoding=None, errors=None)
         url = self._api_url + escaped_path
+
+        if self._auth_headers:
+            request_headers = dict(kwargs.get("headers") or {})
+            request_headers.update(self._auth_headers)
+            kwargs["headers"] = request_headers
 
         response = await self._get_client().request(method, url, **cast(Any, kwargs))
         BaseHTTPClient._raise_chroma_error(response)

--- a/chromadb/test/api/test_async_fastapi_auth.py
+++ b/chromadb/test/api/test_async_fastapi_auth.py
@@ -1,0 +1,147 @@
+import base64
+from typing import Any, AsyncGenerator, Dict, Mapping, Optional
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from chromadb.api.async_fastapi import AsyncFastAPI
+from chromadb.config import Settings, System
+
+BASIC_CREDENTIALS = "admin:admin"
+EXPECTED_BASIC_AUTHORIZATION = "Basic " + base64.b64encode(
+    BASIC_CREDENTIALS.encode("utf-8")
+).decode("utf-8")
+TOKEN_CREDENTIALS = "test-token"
+EXPECTED_BEARER_AUTHORIZATION = f"Bearer {TOKEN_CREDENTIALS}"
+
+
+@pytest.fixture(autouse=True)
+async def clear_async_clients() -> AsyncGenerator[None, None]:
+    AsyncFastAPI._clients.clear()
+    yield
+    clients = list(AsyncFastAPI._clients.values())
+    AsyncFastAPI._clients.clear()
+    for client in clients:
+        await client.aclose()
+
+
+def _make_async_api(**settings_kwargs: Any) -> AsyncFastAPI:
+    settings = Settings(
+        chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=8000,
+        **settings_kwargs,
+    )
+    return AsyncFastAPI(System(settings))
+
+
+def _header(headers: Mapping[str, str], name: str) -> Optional[str]:
+    target = name.lower()
+    for key, value in headers.items():
+        if key.lower() == target:
+            return value
+    return None
+
+
+async def _capture_heartbeat_headers(api: AsyncFastAPI) -> Dict[str, str]:
+    captured: Dict[str, Any] = {}
+
+    async def fake_request(method: str, url: str, **kwargs: Any) -> httpx.Response:
+        captured["headers"] = kwargs.get("headers") or {}
+        request = httpx.Request(method, str(url))
+        return httpx.Response(
+            200,
+            json={"nanosecond heartbeat": 1},
+            request=request,
+        )
+
+    with patch.object(api._get_client(), "request", side_effect=fake_request):
+        await api.heartbeat()
+
+    headers = captured.get("headers") or {}
+    return dict(headers)
+
+
+def test_async_fastapi_applies_basic_auth_headers() -> None:
+    api = _make_async_api(
+        chroma_client_auth_provider="chromadb.auth.basic_authn.BasicAuthClientProvider",
+        chroma_client_auth_credentials=BASIC_CREDENTIALS,
+    )
+
+    assert _header(api.get_request_headers(), "Authorization") == (
+        EXPECTED_BASIC_AUTHORIZATION
+    )
+
+
+def test_async_fastapi_applies_token_auth_headers() -> None:
+    api = _make_async_api(
+        chroma_client_auth_provider="chromadb.auth.token_authn.TokenAuthClientProvider",
+        chroma_client_auth_credentials=TOKEN_CREDENTIALS,
+    )
+
+    assert _header(api.get_request_headers(), "Authorization") == (
+        EXPECTED_BEARER_AUTHORIZATION
+    )
+
+
+def test_async_fastapi_applies_x_chroma_token_auth_headers() -> None:
+    api = _make_async_api(
+        chroma_client_auth_provider="chromadb.auth.token_authn.TokenAuthClientProvider",
+        chroma_client_auth_credentials=TOKEN_CREDENTIALS,
+        chroma_auth_token_transport_header="X-Chroma-Token",
+    )
+
+    headers = api.get_request_headers()
+    assert _header(headers, "X-Chroma-Token") == TOKEN_CREDENTIALS
+    assert _header(headers, "Authorization") is None
+
+
+def test_async_fastapi_preserves_custom_headers_with_auth() -> None:
+    api = _make_async_api(
+        chroma_server_headers={"X-Custom": "present"},
+        chroma_client_auth_provider="chromadb.auth.basic_authn.BasicAuthClientProvider",
+        chroma_client_auth_credentials=BASIC_CREDENTIALS,
+    )
+
+    headers = api.get_request_headers()
+    assert _header(headers, "X-Custom") == "present"
+    assert _header(headers, "Authorization") == EXPECTED_BASIC_AUTHORIZATION
+
+
+def test_async_fastapi_omits_auth_headers_when_unconfigured() -> None:
+    api = _make_async_api()
+
+    headers = api.get_request_headers()
+    assert _header(headers, "Authorization") is None
+    assert _header(headers, "X-Chroma-Token") is None
+
+
+@pytest.mark.asyncio
+async def test_async_fastapi_sends_auth_on_request() -> None:
+    api = _make_async_api(
+        chroma_client_auth_provider="chromadb.auth.basic_authn.BasicAuthClientProvider",
+        chroma_client_auth_credentials=BASIC_CREDENTIALS,
+    )
+
+    request_headers = await _capture_heartbeat_headers(api)
+    assert _header(request_headers, "Authorization") == EXPECTED_BASIC_AUTHORIZATION
+
+
+@pytest.mark.asyncio
+async def test_async_fastapi_sends_auth_when_loop_client_already_cached() -> None:
+    unauthenticated = _make_async_api()
+    unauthenticated._get_client()
+
+    authenticated = _make_async_api(
+        chroma_client_auth_provider="chromadb.auth.basic_authn.BasicAuthClientProvider",
+        chroma_client_auth_credentials=BASIC_CREDENTIALS,
+    )
+
+    assert authenticated._get_client() is unauthenticated._get_client()
+    assert _header(authenticated.get_request_headers(), "Authorization") == (
+        EXPECTED_BASIC_AUTHORIZATION
+    )
+
+    request_headers = await _capture_heartbeat_headers(authenticated)
+    assert _header(request_headers, "Authorization") == EXPECTED_BASIC_AUTHORIZATION


### PR DESCRIPTION
## Summary

Fixes #2488.

`AsyncHttpClient` accepts `chroma_client_auth_provider` / `chroma_client_auth_credentials`, but `AsyncFastAPI` never loaded `ClientAuthProvider`. Sync `FastAPI` applies those headers; the async client sent unauthenticated requests (`Authorization header not found` / 403).

This was previously attempted in #2489 (auth + headers + SSL) and closed as stale. Custom `chroma_server_headers` already land on the async httpx client. SSL verification default is tracked separately in #7511. This PR is the remaining auth gap only.

## Changes

- Resolve `ClientAuthProvider` in `AsyncFastAPI.__init__`, matching sync `FastAPI`.
- Merge auth headers into each new per-loop httpx client.
- Overlay them on every `_make_request` so a shared class-level transport created without auth still sends credentials.
- Overlay them in `get_request_headers()` so callers observe the same headers the request uses.

## Test plan

- [x] `python -m pytest chromadb/test/api/test_async_fastapi_auth.py -v --noconftest` — 7 passed
- [x] Black 23.3.0 check on changed files — unchanged
- [x] `git diff --check` — passed

Coverage:

- basic auth `Authorization: Basic ...`
- token auth `Authorization: Bearer ...`
- `X-Chroma-Token` transport header
- custom headers preserved alongside auth
- no auth headers when unconfigured
- auth attached to the actual request
- auth still sent when another `AsyncFastAPI` already cached the per-loop client
