### PR TITLE
[BUG](client): Give AsyncClient a way to release its System reference

### DIFF
--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -1,4 +1,5 @@
 import httpx
+from types import TracebackType
 from typing import Optional, Sequence
 from uuid import UUID
 from overrides import override
@@ -52,6 +53,8 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
 
     # An internal admin client for verifying that databases and tenants exist
     _admin_client: AsyncAdminAPI
+
+    _closed: bool = False
 
     tenant: str = DEFAULT_TENANT
     database: str = DEFAULT_DATABASE
@@ -124,6 +127,58 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         raise NotImplementedError(
             "AsyncClient cannot be created synchronously. Use .from_system_async() instead."
         )
+
+    async def close(self) -> None:
+        """Close the client and release all resources.
+
+        This method decrements the reference count for the underlying System.
+        When the last client using a shared System calls close(), the System
+        is stopped and all resources (database connections, etc.) are released.
+
+        This is particularly important for a persistent backend, to avoid
+        SQLite file locking issues.
+
+        Note: If multiple clients share the same System, the System will only
+        be stopped when the last client is closed. This allows safe use of
+        context managers with multiple clients.
+
+        Example:
+            >>> client = await chromadb.AsyncHttpClient()
+            >>> # ... use client ...
+            >>> await client.close()
+
+            Or using an async context manager:
+            >>> async with await chromadb.AsyncHttpClient() as client:
+            ...     # ... use client ...
+        """
+        # Make close() idempotent - a second call is a safe no-op
+        if self._closed:
+            return
+        self._closed = True
+
+        # Release the internal admin client's reference first, since it also
+        # incremented the refcount for the shared system on creation. It is
+        # absent when create() never ran, and typed as the AsyncAdminAPI
+        # interface, which does not itself carry an identifier.
+        admin_client = getattr(self, "_admin_client", None)
+        if isinstance(admin_client, SharedSystemClient):
+            SharedSystemClient._release_system(admin_client._identifier)
+
+        # Release our own reference; stops system if this was the last client
+        SharedSystemClient._release_system(self._identifier)
+
+    async def __aenter__(self) -> "AsyncClient":
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """Async context manager exit."""
+        await self.close()
 
     @override
     async def get_user_identity(self) -> UserIdentity:

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 import chromadb
 from chromadb.config import Settings, System
 from chromadb.api import ClientAPI
+from chromadb.api.async_client import AsyncClient
+from chromadb.api.shared_system_client import SharedSystemClient
 import chromadb.server.fastapi
 from chromadb.api.fastapi import FastAPI
 import pytest
@@ -343,3 +345,65 @@ def test_rust_bindings_api_stop_closes_bindings() -> None:
     bindings.close.assert_called_once_with()
     assert hasattr(api, "bindings") is False
     assert api._running is False
+
+
+def _total_refcount() -> int:
+    """Every reference currently held on a shared System."""
+    return sum(SharedSystemClient._identifier_to_refcount.values())
+
+
+def test_async_client_close_releases_system() -> None:
+    """close() gives back the reference AsyncClient took, as the sync client does."""
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY"):
+        pytest.skip("Integration test only")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        settings = Settings(is_persistent=True, persist_directory=tmpdir)
+
+        before = _total_refcount()
+        client = AsyncClient(settings=settings)
+        assert _total_refcount() > before
+
+        system = client._system
+        _run_async(client.close())
+
+        assert _total_refcount() == before
+        assert system._running is False
+
+
+def test_async_client_close_idempotent() -> None:
+    """A second close() is a safe no-op, not a KeyError."""
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY"):
+        pytest.skip("Integration test only")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        settings = Settings(is_persistent=True, persist_directory=tmpdir)
+        client = AsyncClient(settings=settings)
+
+        async def close_three_times() -> None:
+            await client.close()
+            await client.close()
+            await client.close()
+
+        _run_async(close_three_times())
+        client.clear_system_cache()
+
+
+def test_async_client_context_manager() -> None:
+    """`async with` releases the reference on exit."""
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY"):
+        pytest.skip("Integration test only")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        settings = Settings(is_persistent=True, persist_directory=tmpdir)
+        before = _total_refcount()
+
+        async def use_client() -> System:
+            async with AsyncClient(settings=settings) as client:
+                assert _total_refcount() > before
+                return client._system
+
+        system = _run_async(use_client())
+
+        assert _total_refcount() == before
+        assert system._running is False


### PR DESCRIPTION
Closes #7694.

## Problem

`AsyncClient` inherits `SharedSystemClient.__init__`, which calls `_increment_refcount`, but defined no counterpart — no `close()`, no `__aenter__`/`__aexit__`. The sync `Client` has all three. So an `AsyncClient` takes a reference to the shared `System` and there is no supported way to give it back.

Reproduced on this branch's parent, using the issue's script:

```
sync : 0 -> 2 -> 0
async: 0 -> 1
AsyncClient defines: []
```

The sync control returning to baseline is what shows the refcount mechanism itself is fine — only the async class was missing the way back.

As the issue says plainly, a single long-lived `AsyncClient` is unaffected in practice; this is not a leak that brings a server down. The defect is that there was no correct way to release the reference even when you want to.

## Fix

Mirrors `Client.close()`: guard on `_closed` so a second call is a safe no-op, release the internal admin client's reference, then release its own. Plus `__aenter__`/`__aexit__` so `async with` works the way `with` already does.

**One deliberate difference from the sync version, worth a look.** `Client.close()` reaches `self._admin_client._identifier` behind a `hasattr` guard, which `mypy --strict` flags — `client.py:122` and `client.py:765` both error with `"AdminAPI" has no attribute "_identifier"` on master today, since the attribute is typed as the interface. Rather than add a third instance of an existing error, this narrows with `isinstance(admin_client, SharedSystemClient)`, which is where `_identifier` is actually declared, and covers the "admin client absent" case in the same expression. Happy to switch to a literal copy of the sync form if you'd rather the two read identically.

## Tests

Three, next to the existing sync `close`/context-manager tests and following their shape:

- `test_async_client_close_releases_system` — the refcount returns to its starting value and the System is stopped.
- `test_async_client_close_idempotent` — three `close()` calls in a row, matching `test_client_close_idempotent`.
- `test_async_client_context_manager` — `async with` releases on exit.

All three fail on master with `AttributeError: 'AsyncClient' object has no attribute 'close'`.

Worth noting what else showed up while running them on Windows: before the fix, the failing tests *also* raised `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: ...\chroma.sqlite3` when `TemporaryDirectory` tried to clean up — the System was still holding the SQLite file open. That is the exact case `Client.close()`'s own docstring warns about ("particularly important for PersistentClient to avoid SQLite file locking issues"), reached through the async path. It disappears with the fix.

## Verification

- `chromadb/test/test_client.py`: **18 passed** (15 before + 3 new).
- `black`, `flake8` and `mypy --strict` at the pinned pre-commit versions and flags: no new findings. `async_client.py` is clean under mypy; the pre-existing counts elsewhere (15 in `test_client.py`, and black's one reformat of `_begin_conditional_transaction` at `async_client.py:540`) are identical before and after, and I left those lines alone.

## Not fixed here, flagged for you

`AsyncClient.create()` has no equivalent of the sync `Client.__init__`'s `try/except` that releases the refcount when init fails partway. If `create()` raises after `cls(settings=settings)`, the reference leaks and the caller never receives an object to call the new `close()` on. Same defect class, but it is not what the issue asks for, so I have left it — say the word and I will add it here or in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxphSQWkGcC4sgncbRU64C
