### PR TITLE
[BUG] segment: treat limit=0 as 'no records', not unlimited

### DIFF
--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -125,7 +125,9 @@ class SqliteMetadataSegment(MetadataReader):
             "embeddings", "embedding_metadata", "embedding_fulltext_search"
         )
 
-        limit = limit or 2**63 - 1
+        # `limit if limit is not None` (not `or`): limit=0 is a valid request
+        # meaning "no records", but `0 or default` treated it as unlimited.
+        limit = limit if limit is not None else 2**63 - 1
         offset = offset or 0
 
         if limit < 0:


### PR DESCRIPTION
## Summary

`SegmentAPI`'s metadata query used the falsy-zero idiom `limit = limit or 2**63 - 1`. A caller passing `limit=0` — a valid request meaning "no records" — got **every record in the collection** instead.

Concrete failure: a pagination loop computing `limit = total - offset` hits 0 at the end and silently dumps the whole table (memory blow-up / over-fetch). The HTTP path (`chromadb/server/fastapi/types.py`) accepts `limit: Optional[int]` without a `ge=` guard (contrast `DeleteEmbedding`'s `ge=0`), so the zero reaches this segment unchanged.

`None` still means 'no limit' via the explicit `is not None` check.

## Test plan

The change is a one-line falsy-zero correction; `limit < 0` validation continues to raise. Manual verification: `limit=0` now yields an empty result set; `limit=None` unchanged.