### PR TITLE
fix(sysdb): clean up embedding_metadata_array rows on collection deletion

### DIFF
--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -1012,6 +1012,20 @@ impl SqliteSysDb {
         .execute(&mut *conn)
         .await?;
 
+        // Delete embedding metadata array for the embedding ids matching the segment ids
+        sqlx::query(
+            r#"
+            DELETE FROM embedding_metadata_array
+            WHERE id IN (
+                SELECT id FROM embeddings
+                WHERE segment_id IN (SELECT id FROM segments WHERE collection = $1)
+            )
+            "#,
+        )
+        .bind(collection_id.to_string())
+        .execute(&mut *conn)
+        .await?;
+
         // Delete embeddings fulltext search records
         sqlx::query(
             r#"


### PR DESCRIPTION
## Summary

Fixes #7594.

`delete_collection` cleans up `embedding_metadata` (scalar metadata) but
omits `embedding_metadata_array` (list-valued metadata). Orphaned array
rows are keyed by the embedding's internal integer id, which new records
in a replacement collection reuse. The first record in the replacement
collection silently inherits every list-valued metadata field that
belonged to the deleted collection's first record.

## Root Cause

In `delete_collection_with_conn` (`rust/sysdb/src/sqlite.rs`), seven
tables are cleaned:
`embedding_metadata`, `embedding_fulltext_search`, `embeddings`,
`segment_metadata`, `max_seq_id`, `segments`, and
`collection_metadata`. `embedding_metadata_array` is missing.

Per-record deletion correctly cleans both tables (`sqlite_metadata.rs`
line 2616), so the defect is specific to `delete_collection`.

## Reproduction

```python
import chromadb
client = chromadb.PersistentClient(path="/tmp/chroma-ghost")
col = client.get_or_create_collection("demo")
col.add(ids=["id-1"], embeddings=[[0.1, 0.2, 0.3]],
        metadatas=[{"listy": ["ghost"]}])
client.delete_collection("demo")

col = client.get_or_create_collection("demo")
col.add(ids=["id-1"], embeddings=[[0.1, 0.2, 0.3]],
        metadatas=[{"scalar": "new"}])
# Before fix: {'listy': ['ghost'], 'scalar': 'new'}
# After fix:  {'scalar': 'new'}
```

## Fix

Add `DELETE FROM embedding_metadata_array` in `delete_collection_with_conn`
using the same `segment_id` subquery as the existing
`embedding_metadata` cleanup.

## Impact

Found by an Obsidian RAG user: 1,647 of 38,622 chunks (in 531 of 8,390
files) inherited tags and links from previously-deleted collections
after index rebuild. `where` filters returned wrong documents because
the inherited metadata matched filter conditions.

## Changes

- `rust/sysdb/src/sqlite.rs`: 14 insertions