### PR TITLE
[ENH] Accept batch arrays on put-back-and-drain

### DIFF
--- a/rust/mdac-service/README.md
+++ b/rust/mdac-service/README.md
@@ -99,6 +99,20 @@ Use `excess: 0` for a drain and `need: 0` for a refund. Requests larger than 1 K
 are rejected; malformed bodies, unknown fields, and out-of-range values are
 rejected before changing the balance.
 
+The same endpoint also accepts an array of those objects:
+
+```json
+[{"name":"tenant-a/reads","excess":0,"need":10},{"name":"tenant-b/reads","excess":0,"need":1}]
+```
+
+Array requests return HTTP 200 with an array of results in request order. Each
+result contains `admitted` and a numeric `status` (200, 429, or 404), for example
+`[{"admitted":true,"status":200},{"admitted":false,"status":429}]`.
+An empty array returns `[]`. Updates run in order and continue after failures;
+they are not atomic as a group, and other requests may interleave. Repeated names
+observe earlier updates in the array. The entire body is validated before any
+updates are applied, and the same 1 KiB body limit applies to the whole array.
+
 ## Deployment semantics
 
 All clients of one process share one registry of named buckets. State is in memory:

--- a/rust/mdac-service/config/modal-main.yaml
+++ b/rust/mdac-service/config/modal-main.yaml
@@ -1,12 +1,42 @@
 listen_address: "0.0.0.0:8000"
 stdout_tracing: true
+# Independent limits for each foundation-research provider, summed over all models.
+# Each provider gets 6,000,000 input tokens/minute, 50,000 output tokens/minute,
+# and 200 requests/minute, with one minute of burst capacity.
 buckets:
-  bucket-0:
-    capacity: 100
-    interval_ns: 100000000
-  bucket-1:
-    capacity: 100
-    interval_ns: 100000000
-  bucket-2:
-    capacity: 100
-    interval_ns: 100000000
+  "foundation/baseten/input-tokens":
+    capacity: 6000000
+    interval_ns: 10000
+  "foundation/baseten/output-tokens":
+    capacity: 50000
+    interval_ns: 1200000
+  "foundation/baseten/requests":
+    capacity: 200
+    interval_ns: 300000000
+  "foundation/fireworks/input-tokens":
+    capacity: 6000000
+    interval_ns: 10000
+  "foundation/fireworks/output-tokens":
+    capacity: 50000
+    interval_ns: 1200000
+  "foundation/fireworks/requests":
+    capacity: 200
+    interval_ns: 300000000
+  "foundation/anthropic/input-tokens":
+    capacity: 6000000
+    interval_ns: 10000
+  "foundation/anthropic/output-tokens":
+    capacity: 50000
+    interval_ns: 1200000
+  "foundation/anthropic/requests":
+    capacity: 200
+    interval_ns: 300000000
+  "foundation/openai/input-tokens":
+    capacity: 6000000
+    interval_ns: 10000
+  "foundation/openai/output-tokens":
+    capacity: 50000
+    interval_ns: 1200000
+  "foundation/openai/requests":
+    capacity: 200
+    interval_ns: 300000000

--- a/rust/mdac-service/src/lib.rs
+++ b/rust/mdac-service/src/lib.rs
@@ -132,10 +132,33 @@ pub struct UpdateRequest {
     pub need: u32,
 }
 
+/// Refund and drain either one bucket or a sequence of buckets in request order.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum UpdatesRequest {
+    Single(UpdateRequest),
+    Multiple(Vec<UpdateRequest>),
+}
+
 /// For configured names, the refund is applied regardless of whether the drain was admitted.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct UpdateResponse {
     pub admitted: bool,
+}
+
+/// The outcome of one update in an array, including its individual HTTP status.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BatchUpdateResponse {
+    pub admitted: bool,
+    pub status: u16,
+}
+
+/// Response shape follows whether the request contained an object or an array.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum UpdatesResponse {
+    Single(UpdateResponse),
+    Multiple(Vec<BatchUpdateResponse>),
 }
 
 /// Build embeddable routes around a registry. Router clones share the same named buckets.
@@ -148,23 +171,42 @@ pub fn router(buckets: Arc<TokenBuckets>) -> Router {
     chroma_tracing::add_tracing_middleware(app)
 }
 
-async fn update(
-    State(buckets): State<Arc<TokenBuckets>>,
-    Json(request): Json<UpdateRequest>,
-) -> (StatusCode, Json<UpdateResponse>) {
+fn apply_update(buckets: &TokenBuckets, request: UpdateRequest) -> (StatusCode, UpdateResponse) {
     let Some(admitted) = buckets.put_back_and_drain(&request.name, request.excess, request.need)
     else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(UpdateResponse { admitted: false }),
-        );
+        return (StatusCode::NOT_FOUND, UpdateResponse { admitted: false });
     };
     let status = if admitted {
         StatusCode::OK
     } else {
         StatusCode::TOO_MANY_REQUESTS
     };
-    (status, Json(UpdateResponse { admitted }))
+    (status, UpdateResponse { admitted })
+}
+
+async fn update(
+    State(buckets): State<Arc<TokenBuckets>>,
+    Json(request): Json<UpdatesRequest>,
+) -> (StatusCode, Json<UpdatesResponse>) {
+    match request {
+        UpdatesRequest::Single(request) => {
+            let (status, response) = apply_update(&buckets, request);
+            (status, Json(UpdatesResponse::Single(response)))
+        }
+        UpdatesRequest::Multiple(requests) => {
+            let responses = requests
+                .into_iter()
+                .map(|request| {
+                    let (status, response) = apply_update(&buckets, request);
+                    BatchUpdateResponse {
+                        admitted: response.admitted,
+                        status: status.as_u16(),
+                    }
+                })
+                .collect();
+            (StatusCode::OK, Json(UpdatesResponse::Multiple(responses)))
+        }
+    }
 }
 
 /// Serve configured buckets and finish in-flight requests on graceful shutdown.

--- a/rust/mdac-service/tests/http.rs
+++ b/rust/mdac-service/tests/http.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use mdac_service::{BucketConfig, Config, UpdateRequest, UpdateResponse};
+use mdac_service::{BatchUpdateResponse, BucketConfig, Config, UpdateRequest, UpdateResponse};
 use reqwest::{Client, StatusCode};
 use tokio::{net::TcpListener, sync::oneshot};
 
@@ -44,6 +44,29 @@ async fn http_clients_share_named_buckets() {
         .build()
         .unwrap();
     let endpoint = format!("{base}/api/v1/token-bucket/put-back-and-drain");
+
+    // Single objects preserve the existing response and status.
+    for (name, need, expected) in [
+        ("shared", 0, StatusCode::OK),
+        ("shared", 6, StatusCode::TOO_MANY_REQUESTS),
+        ("unknown", 0, StatusCode::NOT_FOUND),
+    ] {
+        let response = client
+            .post(&endpoint)
+            .json(&UpdateRequest {
+                name: name.into(),
+                excess: 0,
+                need,
+            })
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), expected);
+        assert_eq!(
+            response.json::<UpdateResponse>().await.unwrap().admitted,
+            expected == StatusCode::OK
+        );
+    }
 
     let mut requests = Vec::new();
     for _ in 0..20 {
@@ -222,6 +245,68 @@ async fn http_clients_share_named_buckets() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // Decode the whole array before mutating any buckets.
+    for body in [
+        r#"[{"name":"shared","excess":5,"need":0},{"name":"shared","need":1}]"#,
+        r#"[{"name":"shared","excess":5,"need":0,"unexpected":true}]"#,
+        r#"null"#,
+    ] {
+        let response = client
+            .post(&endpoint)
+            .header("content-type", "application/json")
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    // Mixed outcomes preserve order and continue after failures. Repeated names observe
+    // earlier refunds and drains; invalid arrays above must not have refunded this bucket.
+    let requests: Vec<_> = [
+        ("shared", 0, 1),
+        ("unknown", 5, 0),
+        ("shared", 2, 3),
+        ("shared", 0, 2),
+        ("shared", 0, 1),
+    ]
+    .into_iter()
+    .map(|(name, excess, need)| UpdateRequest {
+        name: name.into(),
+        excess,
+        need,
+    })
+    .collect();
+    let response = client.post(&endpoint).json(&requests).send().await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let results = response.json::<Vec<BatchUpdateResponse>>().await.unwrap();
+    assert_eq!(
+        results
+            .iter()
+            .map(|r| (r.status, r.admitted))
+            .collect::<Vec<_>>(),
+        vec![
+            (429, false),
+            (404, false),
+            (429, false),
+            (200, true),
+            (429, false)
+        ]
+    );
+
+    let response = client
+        .post(&endpoint)
+        .json(&Vec::<UpdateRequest>::new())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response
+        .json::<Vec<BatchUpdateResponse>>()
+        .await
+        .unwrap()
+        .is_empty());
 
     shutdown_tx.send(()).unwrap();
     tokio::time::timeout(Duration::from_secs(5), server)


### PR DESCRIPTION
## Description of changes

The put-back-and-drain endpoint now accepts either a single update
object (unchanged) or an array of updates via an untagged UpdatesRequest
enum. Array requests return HTTP 200 with a per-item result carrying
admitted and a numeric status (200, 429, or 404) in request order.

The whole body is validated before any bucket is mutated, and updates
run in order and continue after failures rather than aborting as a
group. Repeated names observe earlier updates within the array. The
existing 1 KiB body limit applies to the entire array, and an empty
array returns [].

Also refresh config/modal-main.yaml with per-provider foundation-research
limits, document the array form in the README, and extend the HTTP tests
to cover single objects, validation failures, mixed outcomes, and the
empty array.

## Test plan

N/A

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
