### PR TITLE
[ENH](foundation-api): Accept a tenant and Foundation in the request path

### DIFF
--- a/rust/foundation-api/examples/trajectory-load-http.rs
+++ b/rust/foundation-api/examples/trajectory-load-http.rs
@@ -12,6 +12,11 @@
 //! Add `--incremental` to create each trajectory open, append pruned reasoning
 //! entries, finalize, and verify the finalized read through
 //! `GET /api/trajectories/{id}`. The default mode is wholesale.
+//!
+//! Pass `--tenant` and `--foundation` together to address one Foundation by
+//! name, which sends every request under `/api/f/{tenant}/{foundation}`.
+//! Without them the requests go to the bare `/api` paths, which the server
+//! resolves to the key's tenant and its default Foundation.
 
 use std::env;
 use std::error::Error;
@@ -40,6 +45,14 @@ struct Args {
     /// Chroma API token sent as x-chroma-token. Defaults to CHROMA_API_KEY.
     #[arg(long, value_name = "TOKEN")]
     token: Option<String>,
+
+    /// Tenant UUID to address. Requires --foundation.
+    #[arg(long, value_name = "TENANT", requires = "foundation")]
+    tenant: Option<String>,
+
+    /// Foundation (database) name to address. Requires --tenant.
+    #[arg(long, value_name = "FOUNDATION", requires = "tenant")]
+    foundation: Option<String>,
 
     /// Upload through open, append, and finalize routes instead of one-shot save.
     #[arg(long)]
@@ -83,8 +96,11 @@ async fn run(args: Args) -> Result<(), Box<dyn Error>> {
         return Err("--append-batch must be at least 1".into());
     }
 
-    let client =
-        FoundationTrajectoryClient::new(resolve_api_url(&args.api_url), resolve_token(&args)?)?;
+    let client = FoundationTrajectoryClient::new(
+        resolve_api_url(&args.api_url),
+        route_prefix(args.tenant.as_deref(), args.foundation.as_deref()),
+        resolve_token(&args)?,
+    )?;
     let paths = collect_input_paths(&args.paths)?;
     if paths.is_empty() {
         return Err("no trajectory JSON files matched the provided paths".into());
@@ -114,6 +130,16 @@ fn resolve_api_url(raw: &str) -> String {
     raw.trim_end_matches('/').to_string()
 }
 
+/// The path every route hangs off: the scoped prefix when the caller named a
+/// tenant and a Foundation, and the bare `/api` prefix otherwise. The two are
+/// the same routes on the same handlers, so only the prefix changes.
+fn route_prefix(tenant: Option<&str>, foundation: Option<&str>) -> String {
+    match (tenant, foundation) {
+        (Some(tenant), Some(foundation)) => format!("/api/f/{tenant}/{foundation}"),
+        _ => "/api".to_string(),
+    }
+}
+
 fn resolve_token(args: &Args) -> Result<String, Box<dyn Error>> {
     args.token
         .clone()
@@ -125,11 +151,12 @@ fn resolve_token(args: &Args) -> Result<String, Box<dyn Error>> {
 struct FoundationTrajectoryClient {
     client: reqwest::Client,
     api_url: String,
+    route_prefix: String,
     token: String,
 }
 
 impl FoundationTrajectoryClient {
-    fn new(api_url: String, token: String) -> Result<Self, Box<dyn Error>> {
+    fn new(api_url: String, route_prefix: String, token: String) -> Result<Self, Box<dyn Error>> {
         if api_url.is_empty() {
             return Err("foundation-api URL cannot be empty".into());
         }
@@ -137,6 +164,7 @@ impl FoundationTrajectoryClient {
         Ok(Self {
             client: reqwest::Client::new(),
             api_url,
+            route_prefix,
             token,
         })
     }
@@ -145,7 +173,7 @@ impl FoundationTrajectoryClient {
         &self,
         file: &ReasoningTrajectoryFile,
     ) -> Result<TrajectoryWriteResponse, Box<dyn Error>> {
-        self.send_json(Method::POST, "/api/trajectories/save", file)
+        self.send_json(Method::POST, "/trajectories/save", file)
             .await
     }
 
@@ -153,7 +181,7 @@ impl FoundationTrajectoryClient {
         &self,
         file: &ReasoningTrajectoryFile,
     ) -> Result<TrajectoryWriteResponse, Box<dyn Error>> {
-        self.send_json(Method::POST, "/api/trajectories/open", file)
+        self.send_json(Method::POST, "/trajectories/open", file)
             .await
     }
 
@@ -164,7 +192,7 @@ impl FoundationTrajectoryClient {
     ) -> Result<TrajectoryWriteResponse, Box<dyn Error>> {
         self.send_json(
             Method::POST,
-            &format!("/api/trajectories/{id}/entries"),
+            &format!("/trajectories/{id}/entries"),
             request,
         )
         .await
@@ -176,7 +204,7 @@ impl FoundationTrajectoryClient {
     ) -> Result<TrajectoryWriteResponse, Box<dyn Error>> {
         self.send_json(
             Method::POST,
-            &format!("/api/trajectories/{}/finalize", file.trajectory.id),
+            &format!("/trajectories/{}/finalize", file.trajectory.id),
             file,
         )
         .await
@@ -185,7 +213,7 @@ impl FoundationTrajectoryClient {
     async fn get_finalized(&self, id: Uuid) -> Result<ReasoningTrajectoryFile, Box<dyn Error>> {
         self.request_json(
             Method::GET,
-            &format!("/api/trajectories/{id}?require_finalized=true"),
+            &format!("/trajectories/{id}?require_finalized=true"),
         )
         .await
     }
@@ -200,7 +228,7 @@ impl FoundationTrajectoryClient {
         Body: Serialize + ?Sized,
         Response: DeserializeOwned,
     {
-        let url = format!("{}{}", self.api_url, path);
+        let url = format!("{}{}{}", self.api_url, self.route_prefix, path);
         let response = self
             .client
             .request(method, &url)
@@ -219,7 +247,7 @@ impl FoundationTrajectoryClient {
     where
         Response: DeserializeOwned,
     {
-        let url = format!("{}{}", self.api_url, path);
+        let url = format!("{}{}{}", self.api_url, self.route_prefix, path);
         let response = self
             .client
             .request(method, &url)

--- a/rust/foundation-api/src/config.rs
+++ b/rust/foundation-api/src/config.rs
@@ -123,6 +123,10 @@ pub struct FoundationConfig {
     /// omit `url`.
     #[serde(default)]
     pub foundation_ui_origin: Option<String>,
+    /// Whether a request that writes must name its Foundation in the path.
+    /// While false a bare write resolves to the configured default Foundation.
+    #[serde(default)]
+    pub require_scope_for_writes: bool,
 }
 
 impl FoundationConfig {
@@ -199,6 +203,7 @@ impl Default for FoundationConfig {
             api_public_origin: None,
             mcp_authorization_server_url: None,
             foundation_ui_origin: None,
+            require_scope_for_writes: false,
         }
     }
 }
@@ -243,6 +248,7 @@ mod tests {
                 api_public_origin: None,
                 mcp_authorization_server_url: None,
                 foundation_ui_origin: None,
+                require_scope_for_writes: false,
             }
         );
     }

--- a/rust/foundation-api/src/foundation_chroma.rs
+++ b/rust/foundation-api/src/foundation_chroma.rs
@@ -520,10 +520,10 @@ mod tests {
 
     #[tokio::test]
     async fn a_resolved_collection_from_another_database_is_not_cached() {
-        // A model the served-from-cache check rejects is one this call would
-        // never hand back, so caching it buys nothing and costs every later
-        // request a warning, an invalidation and a fresh resolve that writes the
-        // same unusable entry back.
+        // A model the cache-read check rejects can never be served from cache,
+        // so storing it buys nothing and costs every later request a warning, an
+        // invalidation and a fresh resolve that writes the same unusable entry
+        // back.
         let mock_server = MockServer::start_async().await;
         let body = serde_json::to_value(collection_in("wiki", "t1", "other_foundation"))
             .expect("a collection should serialize");

--- a/rust/foundation-api/src/foundation_chroma.rs
+++ b/rust/foundation-api/src/foundation_chroma.rs
@@ -146,12 +146,17 @@ impl FoundationChromaClient {
     /// Invariants:
     /// 1. A cached entry is served only when its own tenant and database match
     ///    the request. The Chroma client builds its data-plane URL from the
-    ///    cached collection model, so handing back an entry that belongs
-    ///    elsewhere would read and write the wrong Foundation.
-    /// 2. Only a model that would pass that check is cached. A model the check
-    ///    rejects can never be served, so storing it costs every later request
-    ///    a warning, an invalidation and a fresh resolve while the entry is
-    ///    written back unchanged.
+    ///    collection model rather than from the pair the caller asked for, so an
+    ///    entry that belongs elsewhere addresses the wrong Foundation.
+    /// 2. Only a model that would pass that check is cached, so the cache never
+    ///    holds an entry it would refuse to serve. Nothing is written back on a
+    ///    mismatch, where the old entry would be evicted and rewritten unchanged
+    ///    on every request.
+    ///
+    /// A freshly resolved model that fails the check is still returned, so the
+    /// mismatch reaches the caller rather than being converted to an error here.
+    /// No known path produces one: the frontend answers a get-collection call
+    /// with the row stored under the tenant and database in the request URL.
     pub async fn collection(
         &self,
         tenant: &str,

--- a/rust/foundation-api/src/foundation_chroma.rs
+++ b/rust/foundation-api/src/foundation_chroma.rs
@@ -47,6 +47,25 @@ pub enum FoundationChromaClientError {
     /// The caller's `x-chroma-token` is not a valid HTTP header value.
     #[error("invalid x-chroma-token header value: {0}")]
     InvalidToken(String),
+    /// The frontend answered with a collection that lives somewhere other than
+    /// the Foundation the request addressed.
+    #[error(
+        "collection '{collection}' resolved to tenant '{resolved_tenant}' database \
+         '{resolved_database}', but the request addressed tenant '{requested_tenant}' \
+         database '{requested_database}'"
+    )]
+    ForeignCollection {
+        /// Name the request asked to resolve.
+        collection: String,
+        /// Tenant the request addressed.
+        requested_tenant: String,
+        /// Database the request addressed.
+        requested_database: String,
+        /// Tenant the answered collection belongs to.
+        resolved_tenant: String,
+        /// Database the answered collection belongs to.
+        resolved_database: String,
+    },
     /// The downstream Chroma client/FE returned an error.
     #[error("chroma client error: {0}")]
     Client(#[from] ChromaHttpClientError),
@@ -58,6 +77,7 @@ impl ChromaError for FoundationChromaClientError {
             FoundationChromaClientError::MissingIngressUrl
             | FoundationChromaClientError::InvalidIngressUrl { .. } => ErrorCodes::Internal,
             FoundationChromaClientError::InvalidToken(_) => ErrorCodes::InvalidArgument,
+            FoundationChromaClientError::ForeignCollection { .. } => ErrorCodes::Internal,
             FoundationChromaClientError::Client(_) => ErrorCodes::Internal,
         }
     }
@@ -148,15 +168,17 @@ impl FoundationChromaClient {
     ///    the request. The Chroma client builds its data-plane URL from the
     ///    collection model rather than from the pair the caller asked for, so an
     ///    entry that belongs elsewhere addresses the wrong Foundation.
-    /// 2. Only a model that would pass that check is cached, so the cache never
-    ///    holds an entry it would refuse to serve. Nothing is written back on a
-    ///    mismatch, where the old entry would be evicted and rewritten unchanged
-    ///    on every request.
+    /// 2. A freshly resolved model is subject to the same check, and a model
+    ///    that fails it is refused rather than handed back. A handle built from
+    ///    it would address the Foundation the model names, so returning one
+    ///    would answer a request that reached the wrong Foundation with a
+    ///    success — the one misaddressing failure that announces nothing.
+    /// 3. Only a model that passed the check is cached, so the cache never holds
+    ///    an entry it would refuse to serve.
     ///
-    /// A freshly resolved model that fails the check is still returned, so the
-    /// mismatch reaches the caller rather than being converted to an error here.
-    /// No known path produces one: the frontend answers a get-collection call
-    /// with the row stored under the tenant and database in the request URL.
+    /// No path is known to produce a mismatched model: the frontend answers a
+    /// get-collection call with the row stored under the tenant and database the
+    /// request URL names. The refusal is what keeps it that way.
     pub async fn collection(
         &self,
         tenant: &str,
@@ -181,23 +203,29 @@ impl FoundationChromaClient {
         }
         let collection = client.get_collection(collection_name).await?;
         let resolved = collection.to_collection_model();
-        if belongs_to(&resolved, tenant, database) {
-            self.cache.put(
-                tenant.to_string(),
-                database.to_string(),
-                collection_name.to_string(),
-                resolved,
-            );
-        } else {
+        if !belongs_to(&resolved, tenant, database) {
             tracing::warn!(
                 requested_tenant = %tenant,
                 requested_database = %database,
                 resolved_tenant = %resolved.tenant,
                 resolved_database = %resolved.database,
                 collection = %collection_name,
-                "resolved foundation collection belongs to another tenant or database; not caching it"
+                "resolved foundation collection belongs to another tenant or database; refusing it"
             );
+            return Err(FoundationChromaClientError::ForeignCollection {
+                collection: collection_name.to_string(),
+                requested_tenant: tenant.to_string(),
+                requested_database: database.to_string(),
+                resolved_tenant: resolved.tenant,
+                resolved_database: resolved.database,
+            });
         }
+        self.cache.put(
+            tenant.to_string(),
+            database.to_string(),
+            collection_name.to_string(),
+            resolved,
+        );
         Ok(collection)
     }
 
@@ -524,13 +552,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_resolved_collection_from_another_database_is_not_cached() {
-        // A model the cache-read check rejects can never be served from cache,
-        // so storing it buys nothing and costs every later request a warning, an
-        // invalidation and a fresh resolve that writes the same unusable entry
-        // back.
+    async fn a_resolved_collection_from_another_database_is_refused_and_not_cached() {
+        // A handle is built from the model's own pair, so returning one for a
+        // model that names another Foundation would answer a misaddressed
+        // request with a success and read and write that other Foundation. The
+        // refusal names both pairs, and nothing is cached that the next read
+        // would reject.
         let mock_server = MockServer::start_async().await;
         let body = serde_json::to_value(collection_in("wiki", "t1", "other_foundation"))
+            .expect("a collection should serialize");
+        let resolve = mock_server
+            .mock_async(move |when, then| {
+                when.method("GET").path(format!(
+                    "/api/v2/tenants/t1/databases/{DB}/collections/wiki"
+                ));
+                then.status(200).json_body(body.clone());
+            })
+            .await;
+        let config = FoundationConfig {
+            frontend_ingress_url: Some(mock_server.base_url()),
+            ..FoundationConfig::default()
+        };
+        let client = FoundationChromaClient::from_config(&config).expect("valid url");
+
+        let err = client
+            .collection("t1", DB, "ck-token", "wiki")
+            .await
+            .expect_err("a collection from another Foundation must not be handed back");
+
+        match err {
+            FoundationChromaClientError::ForeignCollection {
+                collection,
+                requested_database,
+                resolved_database,
+                ..
+            } => {
+                assert_eq!(collection, "wiki");
+                assert_eq!(requested_database, DB);
+                assert_eq!(resolved_database, "other_foundation");
+            }
+            other => panic!("expected a foreign-collection refusal, got {other:?}"),
+        }
+        assert_eq!(resolve.calls(), 1);
+        assert!(
+            client.cache.get("t1", DB, "wiki").is_none(),
+            "a model that could never be served must not be cached"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_resolved_collection_from_the_addressed_database_is_served_and_cached() {
+        // The refusal above must turn on the pair disagreeing, not on every
+        // resolve, so the matching case has to answer and populate the cache.
+        let mock_server = MockServer::start_async().await;
+        let body = serde_json::to_value(collection_in("wiki", "t1", DB))
             .expect("a collection should serialize");
         let resolve = mock_server
             .mock_async(move |when, then| {
@@ -549,13 +624,14 @@ mod tests {
         client
             .collection("t1", DB, "ck-token", "wiki")
             .await
-            .expect("the frontend answered, so the resolve succeeds");
+            .expect("a collection in the addressed Foundation should resolve");
 
         assert_eq!(resolve.calls(), 1);
-        assert!(
-            client.cache.get("t1", DB, "wiki").is_none(),
-            "a model that could never be served must not be cached"
-        );
+        let cached = client
+            .cache
+            .get("t1", DB, "wiki")
+            .expect("a matching model should be cached");
+        assert_eq!(cached.database, DB);
     }
 
     #[test]

--- a/rust/foundation-api/src/foundation_chroma.rs
+++ b/rust/foundation-api/src/foundation_chroma.rs
@@ -143,10 +143,15 @@ impl FoundationChromaClient {
     /// reusing the cached collection identity when available so collection-id
     /// routes stay hot.
     ///
-    /// A cached entry is used only when its own tenant and database match the
-    /// request. The Chroma client builds its data-plane URL from the cached
-    /// collection model, so handing back an entry that belongs elsewhere would
-    /// read and write the wrong Foundation.
+    /// Invariants:
+    /// 1. A cached entry is served only when its own tenant and database match
+    ///    the request. The Chroma client builds its data-plane URL from the
+    ///    cached collection model, so handing back an entry that belongs
+    ///    elsewhere would read and write the wrong Foundation.
+    /// 2. Only a model that would pass that check is cached. A model the check
+    ///    rejects can never be served, so storing it costs every later request
+    ///    a warning, an invalidation and a fresh resolve while the entry is
+    ///    written back unchanged.
     pub async fn collection(
         &self,
         tenant: &str,
@@ -156,7 +161,7 @@ impl FoundationChromaClient {
     ) -> Result<ChromaCollection, FoundationChromaClientError> {
         let client = self.scoped_client(tenant, database, token)?;
         if let Some(collection) = self.cache.get(tenant, database, collection_name) {
-            if collection.tenant == tenant && collection.database == database {
+            if belongs_to(&collection, tenant, database) {
                 return Ok(ChromaCollection::from_collection_model(client, collection));
             }
             tracing::warn!(
@@ -170,12 +175,24 @@ impl FoundationChromaClient {
             self.cache.invalidate(tenant, database, collection_name);
         }
         let collection = client.get_collection(collection_name).await?;
-        self.cache.put(
-            tenant.to_string(),
-            database.to_string(),
-            collection_name.to_string(),
-            collection.to_collection_model(),
-        );
+        let resolved = collection.to_collection_model();
+        if belongs_to(&resolved, tenant, database) {
+            self.cache.put(
+                tenant.to_string(),
+                database.to_string(),
+                collection_name.to_string(),
+                resolved,
+            );
+        } else {
+            tracing::warn!(
+                requested_tenant = %tenant,
+                requested_database = %database,
+                resolved_tenant = %resolved.tenant,
+                resolved_database = %resolved.database,
+                collection = %collection_name,
+                "resolved foundation collection belongs to another tenant or database; not caching it"
+            );
+        }
         Ok(collection)
     }
 
@@ -221,6 +238,15 @@ impl FoundationChromaClient {
     pub fn invalidate_trajectories(&self, tenant: &str, database: &str) {
         self.invalidate(tenant, database, &self.trajectories_collection_name);
     }
+}
+
+/// Whether a collection model addresses the Foundation the request named.
+///
+/// The Chroma client builds its data-plane URL from the model's own tenant and
+/// database rather than from the pair the caller asked for, so a model that
+/// disagrees addresses a different Foundation than the request does.
+fn belongs_to(collection: &Collection, tenant: &str, database: &str) -> bool {
+    collection.tenant == tenant && collection.database == database
 }
 
 /// Whether a proxied call failed because the resource was not found (HTTP 404).
@@ -351,6 +377,7 @@ impl FoundationCollectionCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use httpmock::MockServer;
 
     const DB: &str = "FOUNDATION";
 
@@ -489,6 +516,41 @@ mod tests {
         assert!(matches!(err, FoundationChromaClientError::Client(_)));
         // The mismatched entry is dropped rather than left to be served again.
         assert!(client.cache.get("t1", DB, "wiki").is_none());
+    }
+
+    #[tokio::test]
+    async fn a_resolved_collection_from_another_database_is_not_cached() {
+        // A model the served-from-cache check rejects is one this call would
+        // never hand back, so caching it buys nothing and costs every later
+        // request a warning, an invalidation and a fresh resolve that writes the
+        // same unusable entry back.
+        let mock_server = MockServer::start_async().await;
+        let body = serde_json::to_value(collection_in("wiki", "t1", "other_foundation"))
+            .expect("a collection should serialize");
+        let resolve = mock_server
+            .mock_async(move |when, then| {
+                when.method("GET").path(format!(
+                    "/api/v2/tenants/t1/databases/{DB}/collections/wiki"
+                ));
+                then.status(200).json_body(body.clone());
+            })
+            .await;
+        let config = FoundationConfig {
+            frontend_ingress_url: Some(mock_server.base_url()),
+            ..FoundationConfig::default()
+        };
+        let client = FoundationChromaClient::from_config(&config).expect("valid url");
+
+        client
+            .collection("t1", DB, "ck-token", "wiki")
+            .await
+            .expect("the frontend answered, so the resolve succeeds");
+
+        assert_eq!(resolve.calls(), 1);
+        assert!(
+            client.cache.get("t1", DB, "wiki").is_none(),
+            "a model that could never be served must not be cached"
+        );
     }
 
     #[test]

--- a/rust/foundation-api/src/foundation_chroma.rs
+++ b/rust/foundation-api/src/foundation_chroma.rs
@@ -3,17 +3,17 @@
 //! A single long-lived [`ChromaHttpClient`] (one shared connection pool to the
 //! FE ingress) is built once at startup. Each request cheaply re-scopes it via
 //! [`ChromaHttpClient::with_scope`], which swaps the caller's auth method
-//! (forwarding their `x-chroma-token`), tenant, and the `FOUNDATION` database
-//! in one call, so the FE remains the single point that enforces auth, quota,
-//! metering, and billing while connections stay pooled across requests and
-//! tenants.
+//! (forwarding their `x-chroma-token`), tenant, and the database holding the
+//! request's Foundation in one call, so the FE remains the single point that
+//! enforces auth, quota, metering, and billing while connections stay pooled
+//! across requests and tenants.
 //!
 //! Requests target the FE's HAProxy ingress URL (not the internal ClusterIP)
 //! so the ingress can consistent-hash on the collection id in the request
 //! path. The one call the ingress cannot hash to the right replica is the
 //! initial get-collection-by-name lookup, so resolved Foundation collection
-//! identities (id + schema + metadata) are cached per tenant and collection
-//! name, then used to rebuild handles on subsequent requests.
+//! identities (id + schema + metadata) are cached per tenant, database and
+//! collection name, then used to rebuild handles on subsequent requests.
 
 use chroma::client::{ChromaAuthMethod, ChromaHttpClientError, ChromaHttpClientOptions};
 use chroma::{ChromaCollection, ChromaHttpClient};
@@ -64,9 +64,10 @@ impl ChromaError for FoundationChromaClientError {
 }
 
 impl FoundationChromaClientError {
-    /// Whether this is a 404 from the FE — i.e. the `FOUNDATION` database or
-    /// requested collection does not exist, so Foundation isn't provisioned for
-    /// this tenant (as opposed to a transient or internal failure).
+    /// Whether this is a 404 from the FE — i.e. the addressed database or
+    /// requested collection does not exist, so that Foundation isn't
+    /// provisioned for this tenant (as opposed to a transient or internal
+    /// failure).
     pub(crate) fn is_not_found(&self) -> bool {
         matches!(self, FoundationChromaClientError::Client(err) if is_not_found(err))
     }
@@ -74,11 +75,11 @@ impl FoundationChromaClientError {
 
 /// A cheaply-cloneable factory for per-request Chroma collection handles that
 /// proxy to the FE. Holds one long-lived client (shared connection pool) plus
-/// a tenant/collection-scoped cache of Foundation collection identities.
+/// a tenant/database/collection-scoped cache of Foundation collection
+/// identities.
 #[derive(Clone, Debug)]
 pub struct FoundationChromaClient {
     base_client: ChromaHttpClient,
-    database_name: String,
     wiki_collection_name: String,
     trajectories_collection_name: String,
     cache: Arc<FoundationCollectionCache>,
@@ -104,7 +105,7 @@ impl FoundationChromaClient {
                 })?;
         // One process-wide client/connection pool, with no credential or tenant
         // of its own. Per request we re-scope it to the caller's token, tenant,
-        // and the FOUNDATION database via `scoped_client`, which shares this
+        // and the request's database via `scoped_client`, which shares this
         // pool rather than opening a new one.
         let base_client = ChromaHttpClient::new(ChromaHttpClientOptions {
             endpoint,
@@ -115,7 +116,6 @@ impl FoundationChromaClient {
         });
         Ok(Self {
             base_client,
-            database_name: foundation.database_name.clone(),
             wiki_collection_name: foundation.wiki_collection.clone(),
             trajectories_collection_name: foundation.trajectories_collection.clone(),
             cache: Arc::new(FoundationCollectionCache::new(DEFAULT_CACHE_TTL)),
@@ -123,36 +123,56 @@ impl FoundationChromaClient {
     }
 
     /// Re-scopes the shared base client to the caller's token, `tenant`, and
-    /// the FOUNDATION database in one shot, reusing the existing connection
-    /// pool. Setting the tenant explicitly also avoids an identity lookup round
-    /// trip.
+    /// `database` in one shot, reusing the existing connection pool. Setting
+    /// the tenant explicitly also avoids an identity lookup round trip.
+    ///
+    /// The database is a parameter rather than a field so that one process can
+    /// serve every Foundation in a tenant.
     fn scoped_client(
         &self,
         tenant: &str,
+        database: &str,
         token: &str,
     ) -> Result<ChromaHttpClient, FoundationChromaClientError> {
         let auth_method = ChromaAuthMethod::cloud_api_key(token)
             .map_err(|err| FoundationChromaClientError::InvalidToken(err.to_string()))?;
-        Ok(self
-            .base_client
-            .with_scope(auth_method, tenant, &self.database_name))
+        Ok(self.base_client.with_scope(auth_method, tenant, database))
     }
 
-    /// Resolves a Foundation collection by configured name, reusing the cached
-    /// collection identity when available so collection-id routes stay hot.
+    /// Resolves a Foundation collection by configured name inside `database`,
+    /// reusing the cached collection identity when available so collection-id
+    /// routes stay hot.
+    ///
+    /// A cached entry is used only when its own tenant and database match the
+    /// request. The Chroma client builds its data-plane URL from the cached
+    /// collection model, so handing back an entry that belongs elsewhere would
+    /// read and write the wrong Foundation.
     pub async fn collection(
         &self,
         tenant: &str,
+        database: &str,
         token: &str,
         collection_name: &str,
     ) -> Result<ChromaCollection, FoundationChromaClientError> {
-        let client = self.scoped_client(tenant, token)?;
-        if let Some(collection) = self.cache.get(tenant, collection_name) {
-            return Ok(ChromaCollection::from_collection_model(client, collection));
+        let client = self.scoped_client(tenant, database, token)?;
+        if let Some(collection) = self.cache.get(tenant, database, collection_name) {
+            if collection.tenant == tenant && collection.database == database {
+                return Ok(ChromaCollection::from_collection_model(client, collection));
+            }
+            tracing::warn!(
+                requested_tenant = %tenant,
+                requested_database = %database,
+                cached_tenant = %collection.tenant,
+                cached_database = %collection.database,
+                collection = %collection_name,
+                "cached foundation collection belongs to another tenant or database; re-resolving"
+            );
+            self.cache.invalidate(tenant, database, collection_name);
         }
         let collection = client.get_collection(collection_name).await?;
         self.cache.put(
             tenant.to_string(),
+            database.to_string(),
             collection_name.to_string(),
             collection.to_collection_model(),
         );
@@ -165,9 +185,10 @@ impl FoundationChromaClient {
     pub async fn wiki_collection(
         &self,
         tenant: &str,
+        database: &str,
         token: &str,
     ) -> Result<ChromaCollection, FoundationChromaClientError> {
-        self.collection(tenant, token, &self.wiki_collection_name)
+        self.collection(tenant, database, token, &self.wiki_collection_name)
             .await
     }
 
@@ -175,28 +196,30 @@ impl FoundationChromaClient {
     pub async fn trajectories_collection(
         &self,
         tenant: &str,
+        database: &str,
         token: &str,
     ) -> Result<ChromaCollection, FoundationChromaClientError> {
-        self.collection(tenant, token, &self.trajectories_collection_name)
+        self.collection(tenant, database, token, &self.trajectories_collection_name)
             .await
     }
 
-    /// Drops one cached collection identity for `tenant`.
+    /// Drops one cached collection identity for `tenant` and `database`.
     ///
     /// Call this after a `NotFound` from the FE on a collection-id route, since
     /// that collection may have been recreated with a new id.
-    pub fn invalidate(&self, tenant: &str, collection_name: &str) {
-        self.cache.invalidate(tenant, collection_name);
+    pub fn invalidate(&self, tenant: &str, database: &str, collection_name: &str) {
+        self.cache.invalidate(tenant, database, collection_name);
     }
 
-    /// Drops the cached wiki collection identity for `tenant`.
-    pub fn invalidate_wiki(&self, tenant: &str) {
-        self.invalidate(tenant, &self.wiki_collection_name);
+    /// Drops the cached wiki collection identity for `tenant` and `database`.
+    pub fn invalidate_wiki(&self, tenant: &str, database: &str) {
+        self.invalidate(tenant, database, &self.wiki_collection_name);
     }
 
-    /// Drops the cached trajectory collection identity for `tenant`.
-    pub fn invalidate_trajectories(&self, tenant: &str) {
-        self.invalidate(tenant, &self.trajectories_collection_name);
+    /// Drops the cached trajectory collection identity for `tenant` and
+    /// `database`.
+    pub fn invalidate_trajectories(&self, tenant: &str, database: &str) {
+        self.invalidate(tenant, database, &self.trajectories_collection_name);
     }
 }
 
@@ -210,16 +233,20 @@ pub(crate) fn is_not_found(err: &ChromaHttpClientError) -> bool {
     )
 }
 
-/// A tenant/collection-keyed, TTL-bounded cache of resolved collection identities.
+/// A tenant/database/collection-keyed, TTL-bounded cache of resolved collection
+/// identities.
 #[derive(Debug)]
 struct FoundationCollectionCache {
     ttl: Duration,
     entries: Mutex<HashMap<CacheKey, CacheEntry>>,
 }
 
+/// The identity of one cached collection. The database is part of the key
+/// because the same collection name exists in every Foundation a tenant owns.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 struct CacheKey {
     tenant: String,
+    database: String,
     collection_name: String,
 }
 
@@ -237,13 +264,20 @@ impl FoundationCollectionCache {
         }
     }
 
-    fn get(&self, tenant: &str, collection_name: &str) -> Option<Collection> {
-        self.get_at(tenant, collection_name, Instant::now())
+    fn get(&self, tenant: &str, database: &str, collection_name: &str) -> Option<Collection> {
+        self.get_at(tenant, database, collection_name, Instant::now())
     }
 
-    fn get_at(&self, tenant: &str, collection_name: &str, now: Instant) -> Option<Collection> {
+    fn get_at(
+        &self,
+        tenant: &str,
+        database: &str,
+        collection_name: &str,
+        now: Instant,
+    ) -> Option<Collection> {
         let key = CacheKey {
             tenant: tenant.to_string(),
+            database: database.to_string(),
             collection_name: collection_name.to_string(),
         };
         let mut entries = self.lock();
@@ -259,13 +293,26 @@ impl FoundationCollectionCache {
         }
     }
 
-    fn put(&self, tenant: String, collection_name: String, collection: Collection) {
-        self.put_at(tenant, collection_name, collection, Instant::now());
+    fn put(
+        &self,
+        tenant: String,
+        database: String,
+        collection_name: String,
+        collection: Collection,
+    ) {
+        self.put_at(
+            tenant,
+            database,
+            collection_name,
+            collection,
+            Instant::now(),
+        );
     }
 
     fn put_at(
         &self,
         tenant: String,
+        database: String,
         collection_name: String,
         collection: Collection,
         now: Instant,
@@ -273,6 +320,7 @@ impl FoundationCollectionCache {
         self.lock().insert(
             CacheKey {
                 tenant,
+                database,
                 collection_name,
             },
             CacheEntry {
@@ -282,9 +330,10 @@ impl FoundationCollectionCache {
         );
     }
 
-    fn invalidate(&self, tenant: &str, collection_name: &str) {
+    fn invalidate(&self, tenant: &str, database: &str, collection_name: &str) {
         self.lock().remove(&CacheKey {
             tenant: tenant.to_string(),
+            database: database.to_string(),
             collection_name: collection_name.to_string(),
         });
     }
@@ -303,11 +352,17 @@ impl FoundationCollectionCache {
 mod tests {
     use super::*;
 
+    const DB: &str = "FOUNDATION";
+
     fn collection_named(name: &str) -> Collection {
+        collection_in(name, "tenant", DB)
+    }
+
+    fn collection_in(name: &str, tenant: &str, database: &str) -> Collection {
         Collection {
             name: name.to_string(),
-            tenant: "tenant".to_string(),
-            database: "FOUNDATION".to_string(),
+            tenant: tenant.to_string(),
+            database: database.to_string(),
             ..Default::default()
         }
     }
@@ -319,10 +374,16 @@ mod tests {
         let collection = collection_named("wiki");
         let id = collection.collection_id;
 
-        cache.put_at("t1".to_string(), "wiki".to_string(), collection, start);
+        cache.put_at(
+            "t1".to_string(),
+            DB.to_string(),
+            "wiki".to_string(),
+            collection,
+            start,
+        );
 
         let hit = cache
-            .get_at("t1", "wiki", start + Duration::from_secs(299))
+            .get_at("t1", DB, "wiki", start + Duration::from_secs(299))
             .expect("entry should be live within ttl");
         assert_eq!(hit.collection_id, id);
         assert_eq!(hit.name, "wiki");
@@ -334,13 +395,14 @@ mod tests {
         let start = Instant::now();
         cache.put_at(
             "t1".to_string(),
+            DB.to_string(),
             "wiki".to_string(),
             collection_named("wiki"),
             start,
         );
 
         assert!(cache
-            .get_at("t1", "wiki", start + Duration::from_secs(300))
+            .get_at("t1", DB, "wiki", start + Duration::from_secs(300))
             .is_none());
         // Expired entries are evicted, not just hidden.
         assert!(cache.entries.lock().unwrap().is_empty());
@@ -352,13 +414,35 @@ mod tests {
         let start = Instant::now();
         cache.put_at(
             "t1".to_string(),
+            DB.to_string(),
             "wiki".to_string(),
             collection_named("wiki"),
             start,
         );
 
-        assert!(cache.get_at("t1", "wiki", start).is_some());
-        assert!(cache.get_at("t2", "wiki", start).is_none());
+        assert!(cache.get_at("t1", DB, "wiki", start).is_some());
+        assert!(cache.get_at("t2", DB, "wiki", start).is_none());
+    }
+
+    #[test]
+    fn cache_is_keyed_per_database() {
+        // The same collection name exists in every Foundation a tenant owns, so
+        // the database has to be part of the key or one Foundation's handle
+        // would serve another's reads and writes.
+        let cache = FoundationCollectionCache::new(Duration::from_secs(300));
+        let start = Instant::now();
+        cache.put_at(
+            "t1".to_string(),
+            DB.to_string(),
+            "wiki".to_string(),
+            collection_named("wiki"),
+            start,
+        );
+
+        assert!(cache.get_at("t1", DB, "wiki", start).is_some());
+        assert!(cache
+            .get_at("t1", "other_foundation", "wiki", start)
+            .is_none());
     }
 
     #[test]
@@ -367,13 +451,44 @@ mod tests {
         let start = Instant::now();
         cache.put_at(
             "t1".to_string(),
+            DB.to_string(),
             "wiki".to_string(),
             collection_named("wiki"),
             start,
         );
 
-        assert!(cache.get_at("t1", "wiki", start).is_some());
-        assert!(cache.get_at("t1", "generate_trajectories", start).is_none());
+        assert!(cache.get_at("t1", DB, "wiki", start).is_some());
+        assert!(cache
+            .get_at("t1", DB, "generate_trajectories", start)
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn a_cached_entry_from_another_database_is_treated_as_a_miss() {
+        // A model whose own database disagrees with the request would send the
+        // Chroma client at the wrong Foundation's data plane, so `collection`
+        // drops it instead of returning it. The re-resolve then fails against
+        // the unreachable test ingress, which is what proves the cached entry
+        // was not used.
+        let config = FoundationConfig {
+            frontend_ingress_url: Some("http://127.0.0.1:1/".to_string()),
+            ..FoundationConfig::default()
+        };
+        let client = FoundationChromaClient::from_config(&config).expect("valid url");
+        client.cache.put(
+            "t1".to_string(),
+            DB.to_string(),
+            "wiki".to_string(),
+            collection_in("wiki", "t1", "other_foundation"),
+        );
+
+        let err = client
+            .collection("t1", DB, "ck-token", "wiki")
+            .await
+            .expect_err("a mismatched entry must not be served from cache");
+        assert!(matches!(err, FoundationChromaClientError::Client(_)));
+        // The mismatched entry is dropped rather than left to be served again.
+        assert!(client.cache.get("t1", DB, "wiki").is_none());
     }
 
     #[test]
@@ -382,13 +497,14 @@ mod tests {
         let start = Instant::now();
         cache.put_at(
             "t1".to_string(),
+            DB.to_string(),
             "wiki".to_string(),
             collection_named("wiki"),
             start,
         );
 
-        cache.invalidate("t1", "wiki");
-        assert!(cache.get_at("t1", "wiki", start).is_none());
+        cache.invalidate("t1", DB, "wiki");
+        assert!(cache.get_at("t1", DB, "wiki", start).is_none());
     }
 
     #[test]
@@ -397,17 +513,24 @@ mod tests {
         let start = Instant::now();
         let wiki = collection_named("wiki");
         let trajectories = collection_named("generate_trajectories");
-        cache.put_at("t1".to_string(), "wiki".to_string(), wiki.clone(), start);
         cache.put_at(
             "t1".to_string(),
+            DB.to_string(),
+            "wiki".to_string(),
+            wiki.clone(),
+            start,
+        );
+        cache.put_at(
+            "t1".to_string(),
+            DB.to_string(),
             "generate_trajectories".to_string(),
             trajectories,
             start,
         );
 
-        cache.invalidate("t1", "generate_trajectories");
-        assert_eq!(cache.get_at("t1", "wiki", start), Some(wiki));
-        assert_eq!(cache.get_at("t1", "generate_trajectories", start), None);
+        cache.invalidate("t1", DB, "generate_trajectories");
+        assert_eq!(cache.get_at("t1", DB, "wiki", start), Some(wiki));
+        assert_eq!(cache.get_at("t1", DB, "generate_trajectories", start), None);
     }
 
     #[test]
@@ -420,28 +543,69 @@ mod tests {
         let start = Instant::now();
         let wiki = collection_named("wiki");
         let trajectories = collection_named("generate_trajectories");
-        client
-            .cache
-            .put_at("t1".to_string(), "wiki".to_string(), wiki.clone(), start);
         client.cache.put_at(
             "t1".to_string(),
+            DB.to_string(),
+            "wiki".to_string(),
+            wiki.clone(),
+            start,
+        );
+        client.cache.put_at(
+            "t1".to_string(),
+            DB.to_string(),
             "generate_trajectories".to_string(),
             trajectories.clone(),
             start,
         );
 
-        client.invalidate_wiki("t1");
-        assert_eq!(client.cache.get_at("t1", "wiki", start), None);
+        client.invalidate_wiki("t1", DB);
+        assert_eq!(client.cache.get_at("t1", DB, "wiki", start), None);
         assert_eq!(
-            client.cache.get_at("t1", "generate_trajectories", start),
+            client
+                .cache
+                .get_at("t1", DB, "generate_trajectories", start),
             Some(trajectories.clone())
         );
 
-        client.invalidate_trajectories("t1");
-        assert_eq!(client.cache.get_at("t1", "wiki", start), None);
+        client.invalidate_trajectories("t1", DB);
+        assert_eq!(client.cache.get_at("t1", DB, "wiki", start), None);
         assert_eq!(
-            client.cache.get_at("t1", "generate_trajectories", start),
+            client
+                .cache
+                .get_at("t1", DB, "generate_trajectories", start),
             None
+        );
+    }
+
+    #[test]
+    fn client_invalidation_is_scoped_to_one_database() {
+        let config = FoundationConfig {
+            frontend_ingress_url: Some("https://foundation-fe.internal".to_string()),
+            ..FoundationConfig::default()
+        };
+        let client = FoundationChromaClient::from_config(&config).expect("valid url");
+        let start = Instant::now();
+        let other = collection_in("wiki", "t1", "other_foundation");
+        client.cache.put_at(
+            "t1".to_string(),
+            DB.to_string(),
+            "wiki".to_string(),
+            collection_named("wiki"),
+            start,
+        );
+        client.cache.put_at(
+            "t1".to_string(),
+            "other_foundation".to_string(),
+            "wiki".to_string(),
+            other.clone(),
+            start,
+        );
+
+        client.invalidate_wiki("t1", DB);
+        assert_eq!(client.cache.get_at("t1", DB, "wiki", start), None);
+        assert_eq!(
+            client.cache.get_at("t1", "other_foundation", "wiki", start),
+            Some(other)
         );
     }
 
@@ -462,7 +626,7 @@ mod tests {
     #[test]
     fn foundation_chroma_client_error_is_not_found_only_on_client_404() {
         use reqwest::StatusCode;
-        // A 404 from the FE (missing FOUNDATION db / requested collection).
+        // A 404 from the FE (missing database / requested collection).
         assert!(
             FoundationChromaClientError::Client(ChromaHttpClientError::ApiError(
                 "missing".to_string(),
@@ -512,7 +676,6 @@ mod tests {
             ..FoundationConfig::default()
         };
         let client = FoundationChromaClient::from_config(&config).expect("valid url");
-        assert_eq!(client.database_name, "FOUNDATION");
         assert_eq!(client.wiki_collection_name, "wiki");
         assert_eq!(client.trajectories_collection_name, "generate_trajectories");
     }

--- a/rust/foundation-api/src/routes/agent/mod.rs
+++ b/rust/foundation-api/src/routes/agent/mod.rs
@@ -28,7 +28,11 @@ mod events;
 use std::collections::HashMap;
 
 use axum::response::sse::{Event, KeepAlive, Sse};
-use axum::{extract::State, http::HeaderMap, Json};
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
 use chroma_error::{ChromaError, ChromaValidationError, ErrorCodes};
 use chroma_metering::{MeterEvent, SearchAgentUsageContext};
 use futures::{Stream, StreamExt};
@@ -44,7 +48,8 @@ use events::{action_event, action_text, observation_event, AgentSseEvent};
 
 use crate::agent_tools::{ReadPageTool, SearchTool, SubagentSearchTool};
 use crate::routes::subagent_search::SubagentSearchCreds;
-use crate::routes::{caller_token, to_sse_event, whoami::whoami_and_authorize};
+use crate::routes::whoami::{authorize_scope, ScopePolicy};
+use crate::routes::{caller_token, to_sse_event, ui_origin_for, FoundationScope};
 use crate::wiki::embed::WikiEmbedder;
 use crate::wiki::WikiClientError;
 use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
@@ -142,12 +147,19 @@ pub struct AgentSseError(String);
 pub async fn foundation_agent(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
+    Path(scope): Path<FoundationScope>,
     Json(request): Json<AgentRequest>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, AgentSseError>>>, ServerError> {
-    let identity = whoami_and_authorize(&*server.auth, &headers, AuthzAction::ViewFoundation)
-        .instrument(tracing::info_span!("foundation_agent.authorize"))
-        .await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::ViewFoundation,
+        &scope,
+        &server.config.foundation.database_name,
+        ScopePolicy::DefaultToConfig,
+    )
+    .instrument(tracing::info_span!("foundation_agent.authorize"))
+    .await?;
 
     let _guard = server.scorecard_request(&["op:foundation_agent", &format!("tenant:{tenant}")])?;
 
@@ -158,15 +170,21 @@ pub async fn foundation_agent(
         .parse::<AnthropicModel>()
         .map_err(|_| AgentRouteError::UnknownModel(request.model.clone()))?;
 
-    let (agent, collection_id) = build_agent(&server, &headers, &tenant, &request, model).await?;
-    let stream = drive_agent(
-        agent,
-        request.input,
-        tenant,
-        server.config.foundation.database_name.clone(),
-        collection_id,
+    let (agent, collection_id) = build_agent(
+        &server,
+        &headers,
+        &tenant,
+        &database,
+        ui_origin_for(&server, &scope),
+        &request,
+        model,
     )
-    .map(|event| sse_event(&event));
+    .await?;
+    // The database drives both which Foundation the agent reads and which
+    // database the usage meter bills, so it is the resolved one, never the
+    // configured default.
+    let stream = drive_agent(agent, request.input, tenant, database, collection_id)
+        .map(|event| sse_event(&event));
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }
 
@@ -175,19 +193,21 @@ pub async fn foundation_agent(
 /// `subagent_search` tool, which is registered only when the dependency is
 /// configured. The Anthropic model reuses the shared HTTP pool, and the system
 /// prompt is taken from the request (which defaults to [`DEFAULT_SYSTEM_PROMPT`]
-/// when the caller omits it). The configured `foundation_ui_origin` is handed
-/// to each tool so retrieved documents carry resolvable page URLs the agent
-/// can cite (mirroring the MCP tools' deterministic link stamping).
+/// when the caller omits it). `ui_origin` is handed to each tool so retrieved
+/// documents carry resolvable page URLs the agent can cite (mirroring the MCP
+/// tools' deterministic link stamping).
 #[tracing::instrument(
     name = "foundation_agent.build",
     skip_all,
-    fields(tenant = %tenant, model = %request.model),
+    fields(tenant = %tenant, database = %database, model = %request.model),
     err(Display)
 )]
 async fn build_agent(
     server: &FoundationApiServer,
     headers: &HeaderMap,
     tenant: &str,
+    database: &str,
+    ui_origin: Option<&str>,
     request: &AgentRequest,
     model: AnthropicModel,
 ) -> Result<(Agent, String), AgentRouteError> {
@@ -198,10 +218,12 @@ async fn build_agent(
     let token = caller_token(headers)
         .ok_or(AgentRouteError::MissingToken)?
         .to_string();
-    let collection = wiki_client.wiki_collection(tenant, &token).await?;
+    let collection = wiki_client
+        .wiki_collection(tenant, database, &token)
+        .await?;
     let collection_id = collection.id().to_string();
 
-    let ui_origin = server.config.foundation.foundation_ui_origin.clone();
+    let ui_origin = ui_origin.map(str::to_string);
 
     let mut toolset = ToolSet::new();
     toolset.add(SearchTool::new(
@@ -220,7 +242,12 @@ async fn build_agent(
     // The deep-research tool is optional: register it only when the dependency
     // is configured, so the agent still runs (search-only) without it.
     if let Some(url) = server.config.foundation.deep_research_api_url.clone() {
-        let creds = SubagentSearchCreds::from_config(&server.config.foundation, tenant, token);
+        let creds = SubagentSearchCreds::new(
+            tenant,
+            database,
+            &server.config.foundation.wiki_collection,
+            token,
+        );
         toolset.add(SubagentSearchTool::new(
             server.shared_http_client.clone(),
             url,

--- a/rust/foundation-api/src/routes/apply_patch.rs
+++ b/rust/foundation-api/src/routes/apply_patch.rs
@@ -10,9 +10,14 @@ use crate::routes::upsert_page::{
     validate_slug as validate_upsert_slug, validate_source_ids as validate_upsert_source_ids,
     UpsertPageError, UpsertPageRequest, UpsertPageResponse,
 };
-use crate::routes::whoami::whoami_and_authorize;
+use crate::routes::whoami::authorize_scope;
+use crate::routes::{write_scope_policy, FoundationScope};
 use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
-use axum::{extract::State, http::HeaderMap, Json};
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
 use chroma_error::{ChromaError, ChromaValidationError, ErrorCodes};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -106,22 +111,29 @@ impl ChromaError for ApplyPatchError {
 }
 
 /// `POST /api/apply-patch` handler.
-#[tracing::instrument(skip(headers, server, request))]
+#[tracing::instrument(skip(headers, server, scope, request))]
 pub async fn foundation_apply_patch(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
+    Path(scope): Path<FoundationScope>,
     Json(request): Json<ApplyPatchRequest>,
 ) -> Result<Json<ApplyPatchResponse>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::UpsertFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::UpsertFoundation,
+        &scope,
+        &server.config.foundation.database_name,
+        write_scope_policy(&server),
+    )
+    .await?;
 
     let _guard =
         server.scorecard_request(&["op:foundation_apply_patch", &format!("tenant:{tenant}")])?;
 
     request.validate().map_err(ChromaValidationError::from)?;
 
-    match run_apply_patch(&server, &headers, &tenant, &request).await {
+    match run_apply_patch(&server, &headers, &tenant, &database, &request).await {
         Ok(response) => Ok(Json(response)),
         Err(err) => Err(err.into()),
     }
@@ -132,16 +144,24 @@ pub async fn foundation_apply_patch(
     name = "foundation_run_apply_patch",
     level = "debug",
     skip_all,
-    fields(tenant = %tenant, slug = %request.slug, expected_version = ?request.expected_version),
+    fields(
+        tenant = %tenant,
+        database = %database,
+        slug = %request.slug,
+        expected_version = ?request.expected_version
+    ),
     err(Display)
 )]
 pub(crate) async fn run_apply_patch(
     server: &FoundationApiServer,
     headers: &HeaderMap,
     tenant: &str,
+    database: &str,
     request: &ApplyPatchRequest,
 ) -> Result<ApplyPatchResponse, ApplyPatchError> {
-    let page = run_read_page(server, headers, tenant, &request.slug)
+    // No link origin: the patch flow discards the page's `url`, so building one
+    // would be work whose result is thrown away.
+    let page = run_read_page(server, headers, tenant, database, None, &request.slug)
         .await?
         .ok_or_else(|| ApplyPatchError::MissingPage {
             slug: request.slug.clone(),
@@ -160,7 +180,7 @@ pub(crate) async fn run_apply_patch(
         expected_version: request.expected_version.unwrap_or(patched.base_version),
     };
     let categories = normalize_categories(&upsert.categories);
-    let upsert = run_upsert_page(server, headers, tenant, &upsert, &categories).await?;
+    let upsert = run_upsert_page(server, headers, tenant, database, &upsert, &categories).await?;
 
     Ok(ApplyPatchResponse {
         upsert,

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -2,13 +2,14 @@ use super::init_schema::{
     foundation_collection_schema, qwen_embedding_function, splade_embedding_function,
     CollectionEmbeddingFunctions,
 };
-use super::whoami::whoami_and_authorize;
+use super::whoami::{authorize_scope, ScopePolicy};
+use super::FoundationScope;
 use crate::collections::{create_planned_collection, ensure_database, ensure_slack_raw_collection};
 use crate::{
     auth::AuthzAction, config::FoundationConfig, errors::ServerError, server::FoundationApiServer,
 };
 use axum::{
-    extract::{Query, State},
+    extract::{Path, Query, State},
     http::HeaderMap,
     Json,
 };
@@ -72,16 +73,25 @@ pub struct FoundationInitParams {
 pub async fn foundation_init(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
+    Path(scope): Path<FoundationScope>,
     Query(params): Query<FoundationInitParams>,
 ) -> Result<Json<FoundationInitResponse>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::InitFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::InitFoundation,
+        &scope,
+        &server.config.foundation.database_name,
+        ScopePolicy::DefaultToConfig,
+    )
+    .await?;
+    // The workspace belongs to the tenant in the path, but the owner recorded
+    // in the response is whoever called, which only the identity knows.
     let user_id = identity.user_id;
     tracing::info!(
         tenant = %tenant,
         user_id = %user_id,
-        database = %server.config.foundation.database_name,
+        database = %database,
         mock_wiki = params.mock_wiki,
         "foundation init starting"
     );
@@ -91,8 +101,7 @@ pub async fn foundation_init(
 
     let foundation_cfg = &server.config.foundation;
     let function_endpoint_url = configured_function_endpoint_url(foundation_cfg, params.mock_wiki)?;
-    let db_name = DatabaseName::new(&foundation_cfg.database_name)
-        .ok_or(FoundationInitError::DatabaseNameTooShort)?;
+    let db_name = DatabaseName::new(&database).ok_or(FoundationInitError::DatabaseNameTooShort)?;
 
     let mut sysdb = server.sysdb.clone();
     let database_id = ensure_database(&mut sysdb, db_name.clone(), tenant.clone()).await?;
@@ -149,6 +158,7 @@ pub async fn foundation_init(
     ensure_revision_history_function(
         &mut sysdb,
         tenant.clone(),
+        &db_name,
         wiki.collection_id,
         foundation_cfg,
     )
@@ -157,6 +167,7 @@ pub async fn foundation_init(
         ensure_currents_function(
             &mut sysdb,
             tenant.clone(),
+            &db_name,
             wiki.collection_id,
             foundation_cfg,
             function_endpoint_url,
@@ -260,6 +271,7 @@ pub async fn foundation_init(
     let already_initialized = ensure_attached_function(
         &mut sysdb,
         tenant.clone(),
+        &db_name,
         slack_raw.collection_id,
         SLACK_RAW_COLLECTION_NAME,
         foundation_cfg,
@@ -298,7 +310,7 @@ pub async fn foundation_init(
     Ok(Json(FoundationInitResponse {
         tenant,
         user_id,
-        database: foundation_cfg.database_name.clone(),
+        database: database.clone(),
         database_id: database_id.to_string(),
         wiki_collection_id: wiki.collection_id.to_string(),
         trajectories_collection_id: trajectories.collection_id.to_string(),
@@ -448,6 +460,7 @@ impl ChromaError for PersistedFunctionEndpointError {
 async fn ensure_attached_function(
     sysdb: &mut SysDb,
     tenant: String,
+    database_name: &DatabaseName,
     input_collection_id: CollectionUuid,
     base_source_name: &str,
     cfg: &FoundationConfig,
@@ -483,7 +496,7 @@ async fn ensure_attached_function(
         cfg.wiki_collection.clone(),
         params,
         tenant,
-        cfg.database_name.clone(),
+        database_name.as_ref().to_string(),
         cfg.min_records_for_invocation,
         output_schema,
     )
@@ -557,6 +570,7 @@ fn foundation_attached_function_name() -> String {
 async fn ensure_revision_history_function(
     sysdb: &mut SysDb,
     tenant: String,
+    database_name: &DatabaseName,
     wiki_collection_id: CollectionUuid,
     cfg: &FoundationConfig,
 ) -> Result<(), ServerError> {
@@ -572,7 +586,7 @@ async fn ensure_revision_history_function(
         cfg.wiki_revisions_collection.clone(),
         params,
         tenant,
-        cfg.database_name.clone(),
+        database_name.as_ref().to_string(),
         cfg.min_records_for_invocation,
         output_schema,
     )
@@ -585,6 +599,7 @@ async fn ensure_revision_history_function(
 async fn ensure_currents_function(
     sysdb: &mut SysDb,
     tenant: String,
+    database_name: &DatabaseName,
     wiki_collection_id: CollectionUuid,
     cfg: &FoundationConfig,
     endpoint_url: &str,
@@ -603,9 +618,12 @@ async fn ensure_currents_function(
         return Ok(());
     }
 
+    // The currents function persists its database into its stored parameters,
+    // so a name taken from config here would write currents into the default
+    // Foundation no matter which one was initialized.
     let params = serde_json::json!({
         "endpoint_url": endpoint_url,
-        "database_name": cfg.database_name,
+        "database_name": database_name.as_ref(),
     });
     let output_schema = Schema::new_record_only();
     attached_function_ops::create_attached_function(
@@ -616,7 +634,7 @@ async fn ensure_currents_function(
         cfg.currents_collection.clone(),
         params,
         tenant,
-        cfg.database_name.clone(),
+        database_name.as_ref().to_string(),
         cfg.min_records_for_invocation,
         output_schema,
     )
@@ -854,6 +872,7 @@ mod tests {
         let error = match ensure_attached_function(
             &mut sysdb,
             "tenant".to_string(),
+            &DatabaseName::new("FOUNDATION").expect("valid database name"),
             collection_id,
             SLACK_RAW_COLLECTION_NAME,
             &FoundationConfig::default(),
@@ -879,6 +898,7 @@ mod tests {
         let error = match ensure_currents_function(
             &mut sysdb,
             "tenant".to_string(),
+            &DatabaseName::new("FOUNDATION").expect("valid database name"),
             collection_id,
             &FoundationConfig::default(),
             "https://mock-wiki.example",

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -516,29 +516,40 @@ async fn ensure_attached_function(
 /// Find an attached function by name on `collection_id`.
 ///
 /// Whether a create repeats an attachment the input collection already carries
-/// is not a question sysdb can be left to answer on its own. sysdb compares the
-/// request against each stored row field by field — the attachment's name, the
-/// tenant, the output collection name, the minimum records per invocation, the
-/// function the row runs, and the database. It never compares the
-/// attached-function id, which `/init` mints fresh on every call, so a repeat
-/// whose six fields all still agree is recognized as one. A repeat that differs
-/// in any one of them is not: it falls through to the execution-mode check,
-/// which refuses it with `AlreadyExists`:
+/// is not a question sysdb can be left to answer on its own. A create request
+/// carries no attached-function id — sysdb mints one server-side — so sysdb
+/// decides by comparing the request against each stored row field by field: the
+/// attachment's name, the tenant, the output collection name, the minimum
+/// records per invocation, the function the row runs, and the database. A repeat
+/// whose six fields all still agree is recognized as one.
+///
+/// A repeat that differs in any one of them is not. It falls through to a second
+/// check, which refuses it with `AlreadyExists` when the stored row runs a
+/// function of the same execution mode — asynchronous or synchronous — as the
+/// one requested:
 ///
 /// ```text
-/// collection already has an attached function with the same execution mode:
-/// name=foundation_sources_to_wiki, function=http_generate, output_collection=wiki
+/// collection already has an attached function with the same execution mode
+/// (pre-lock validation): name=foundation_sources_to_wiki,
+/// function=http_generate, output_collection=wiki
 /// ```
 ///
-/// Three of those six — the output collection name, the minimum records per
+/// Three of the six — the output collection name, the minimum records per
 /// invocation, and the function name — are read from configuration, so raising
 /// the record threshold or renaming the wiki collection is enough to make the
 /// next `/init` differ. The refusal reaches a user as a flat "the Chroma API
 /// rejected the sync request" and stops onboarding from ever finishing for a
 /// workspace that was set up before. Settling the question here, by name, is
-/// what delivers the idempotency `/init` advertises whatever the configuration
-/// has been retuned to, and it is what tells the caller the workspace was
+/// what delivers the idempotency `/init` advertises however the configuration
+/// has since been retuned, and it is what tells the caller the workspace was
 /// already set up.
+///
+/// Matching on the name alone is also what bounds that promise: a workspace
+/// whose attachment predates a configuration change keeps the values it was
+/// built with, and `/init` reports it as already set up rather than rewriting
+/// it. Only the endpoint URL is re-checked, by
+/// [`validate_persisted_function_endpoint`]. Changing one of the other five
+/// therefore needs the attachment rebuilt, not another `/init`.
 ///
 /// A backend that cannot list attachments answers `None`, which leaves the
 /// decision to the create call rather than failing the request: the sqlite

--- a/rust/foundation-api/src/routes/init.rs
+++ b/rust/foundation-api/src/routes/init.rs
@@ -515,24 +515,34 @@ async fn ensure_attached_function(
 
 /// Find an attached function by name on `collection_id`.
 ///
-/// Attaching cannot be left to fail harmlessly. sysdb decides whether a create
-/// is a repeat by comparing the *attached-function id*, and `/init` mints a
-/// fresh one on every call, so a second `/init` never matches. It falls through
-/// to the execution-mode check instead and is refused with `AlreadyExists`:
+/// Whether a create repeats an attachment the input collection already carries
+/// is not a question sysdb can be left to answer on its own. sysdb compares the
+/// request against each stored row field by field — the attachment's name, the
+/// tenant, the output collection name, the minimum records per invocation, the
+/// function the row runs, and the database. It never compares the
+/// attached-function id, which `/init` mints fresh on every call, so a repeat
+/// whose six fields all still agree is recognized as one. A repeat that differs
+/// in any one of them is not: it falls through to the execution-mode check,
+/// which refuses it with `AlreadyExists`:
 ///
 /// ```text
 /// collection already has an attached function with the same execution mode:
 /// name=foundation_sources_to_wiki, function=http_generate, output_collection=wiki
 /// ```
 ///
-/// That reaches a user as a flat "the Chroma API rejected the sync request",
-/// and it means onboarding can never finish for a workspace that was set up
-/// before — which is every returning user. Looking the attachment up by name
-/// first is what actually delivers the idempotency `/init` advertises.
+/// Three of those six — the output collection name, the minimum records per
+/// invocation, and the function name — are read from configuration, so raising
+/// the record threshold or renaming the wiki collection is enough to make the
+/// next `/init` differ. The refusal reaches a user as a flat "the Chroma API
+/// rejected the sync request" and stops onboarding from ever finishing for a
+/// workspace that was set up before. Settling the question here, by name, is
+/// what delivers the idempotency `/init` advertises whatever the configuration
+/// has been retuned to, and it is what tells the caller the workspace was
+/// already set up.
 ///
-/// A backend that cannot list attachments answers `None`, so this reduces to
-/// the previous behaviour rather than failing: the sqlite backend used for
-/// local development does not implement the call.
+/// A backend that cannot list attachments answers `None`, which leaves the
+/// decision to the create call rather than failing the request: the sqlite
+/// backend used for local development does not implement the call.
 async fn attached_function_by_name(
     sysdb: &mut SysDb,
     collection_id: CollectionUuid,

--- a/rust/foundation-api/src/routes/mcp/mod.rs
+++ b/rust/foundation-api/src/routes/mcp/mod.rs
@@ -25,7 +25,10 @@ use tower_http::cors::{Any, CorsLayer};
 
 use crate::{
     auth::AuthzAction,
-    routes::{whoami::whoami_and_authorize, CHROMA_TOKEN_HEADER},
+    routes::{
+        whoami::{authorize_scope, ScopePolicy},
+        FoundationScope, CHROMA_TOKEN_HEADER,
+    },
     server::FoundationApiServer,
 };
 
@@ -129,9 +132,18 @@ async fn mcp_authenticate(
     // is cheap.
     let mut auth_headers = HeaderMap::new();
     auth_headers.insert(CHROMA_TOKEN_HEADER, value);
-    if whoami_and_authorize(&*server.auth, &auth_headers, AuthzAction::ViewFoundation)
-        .await
-        .is_err()
+    // This path names no Foundation, so the empty scope resolves to the key's
+    // tenant and the configured default Foundation.
+    if authorize_scope(
+        &*server.auth,
+        &auth_headers,
+        AuthzAction::ViewFoundation,
+        &FoundationScope::default(),
+        &server.config.foundation.database_name,
+        ScopePolicy::DefaultToConfig,
+    )
+    .await
+    .is_err()
     {
         return mcp_unauthorized(&server);
     }

--- a/rust/foundation-api/src/routes/mcp/server.rs
+++ b/rust/foundation-api/src/routes/mcp/server.rs
@@ -24,8 +24,9 @@ use crate::{
         subagent_search::{
             collect_subagent_search_final, RankedDocument, SubagentSearchCreds, SubagentSearchError,
         },
-        whoami::whoami_and_authorize,
-        CHROMA_TOKEN_HEADER,
+        ui_origin_for,
+        whoami::{authorize_scope, ScopePolicy},
+        FoundationScope, CHROMA_TOKEN_HEADER,
     },
     server::FoundationApiServer,
     wiki::chunking::ChunkRecordId,
@@ -50,29 +51,38 @@ impl FoundationMcpServer {
     /// Shared prelude for every MCP tool: lift the caller's token out of the
     /// request context, authorize it for `ViewFoundation`, and open a
     /// scorecard slot tagged with `op`. Returns the per-request headers, the
-    /// resolved tenant, and the scorecard guard — which the caller must hold
-    /// for the duration of the tool run. On failure the `Err` is the
+    /// resolved tenant and database, and the scorecard guard — which the caller
+    /// must hold for the duration of the tool run. On failure the `Err` is the
     /// `CallToolResult` to return verbatim.
+    ///
+    /// This endpoint names no Foundation, so the empty scope resolves to the
+    /// key's tenant and the configured default Foundation.
     async fn authorize_and_scorecard(
         &self,
         ctx: &RequestContext<RoleServer>,
         op: &str,
-    ) -> Result<(HeaderMap, String, ScorecardGuard), CallToolResult> {
+    ) -> Result<(HeaderMap, String, String, ScorecardGuard), CallToolResult> {
         let headers = request_headers(ctx)
             .map_err(|message| CallToolResult::error(vec![Content::text(message)]))?;
-        let identity =
-            whoami_and_authorize(&*self.server.auth, &headers, AuthzAction::ViewFoundation)
-                .await
-                .map_err(|_| {
-                    CallToolResult::error(vec![Content::text(
-                        "Foundation access is no longer available.",
-                    )])
-                })?;
+        let (tenant, database, _identity) = authorize_scope(
+            &*self.server.auth,
+            &headers,
+            AuthzAction::ViewFoundation,
+            &FoundationScope::default(),
+            &self.server.config.foundation.database_name,
+            ScopePolicy::DefaultToConfig,
+        )
+        .await
+        .map_err(|_| {
+            CallToolResult::error(vec![Content::text(
+                "Foundation access is no longer available.",
+            )])
+        })?;
         let guard = self
             .server
-            .scorecard_request(&[op, &format!("tenant:{}", identity.tenant)])
+            .scorecard_request(&[op, &format!("tenant:{tenant}")])
             .map_err(|err| CallToolResult::error(vec![Content::text(err.to_string())]))?;
-        Ok((headers, identity.tenant, guard))
+        Ok((headers, tenant, database, guard))
     }
 
     /// Turns the subagent's ranked chunk documents into client-facing pages:
@@ -205,7 +215,7 @@ impl FoundationMcpServer {
         ctx: RequestContext<RoleServer>,
         Parameters(params): Parameters<SubagentSearchParams>,
     ) -> CallToolResult {
-        let (headers, tenant, _guard) = match self
+        let (headers, tenant, database, _guard) = match self
             .authorize_and_scorecard(&ctx, "op:foundation_mcp_subagent_search")
             .await
         {
@@ -227,8 +237,12 @@ impl FoundationMcpServer {
             )]);
         };
 
-        let creds =
-            SubagentSearchCreds::from_config(&self.server.config.foundation, tenant.clone(), token);
+        let creds = SubagentSearchCreds::new(
+            tenant.clone(),
+            database,
+            &self.server.config.foundation.wiki_collection,
+            token,
+        );
 
         let documents = match collect_subagent_search_final(
             self.server.shared_http_client.clone(),
@@ -274,7 +288,7 @@ impl FoundationMcpServer {
         ctx: RequestContext<RoleServer>,
         Parameters(params): Parameters<SearchParams>,
     ) -> CallToolResult {
-        let (headers, tenant, _guard) = match self
+        let (headers, tenant, database, _guard) = match self
             .authorize_and_scorecard(&ctx, "op:foundation_mcp_search")
             .await
         {
@@ -292,10 +306,13 @@ impl FoundationMcpServer {
             return CallToolResult::error(vec![Content::text(err.to_string())]);
         }
 
+        let scope = FoundationScope::default();
         match run_page_search(
             &self.server,
             &headers,
             &tenant,
+            &database,
+            ui_origin_for(&self.server, &scope),
             &request.query,
             request.limit,
         )
@@ -330,7 +347,7 @@ impl FoundationMcpServer {
         ctx: RequestContext<RoleServer>,
         Parameters(params): Parameters<ReadPageParams>,
     ) -> CallToolResult {
-        let (headers, tenant, _guard) = match self
+        let (headers, tenant, database, _guard) = match self
             .authorize_and_scorecard(&ctx, "op:foundation_mcp_read_page")
             .await
         {
@@ -343,7 +360,17 @@ impl FoundationMcpServer {
             return CallToolResult::error(vec![Content::text(err.to_string())]);
         }
 
-        match run_read_page(&self.server, &headers, &tenant, &request.slug).await {
+        let scope = FoundationScope::default();
+        match run_read_page(
+            &self.server,
+            &headers,
+            &tenant,
+            &database,
+            ui_origin_for(&self.server, &scope),
+            &request.slug,
+        )
+        .await
+        {
             Ok(Some(page)) => match serde_json::to_value(page) {
                 Ok(value) => CallToolResult::structured(value),
                 Err(err) => CallToolResult::error(vec![Content::text(err.to_string())]),

--- a/rust/foundation-api/src/routes/mod.rs
+++ b/rust/foundation-api/src/routes/mod.rs
@@ -2,10 +2,11 @@ use crate::server::FoundationApiServer;
 use axum::response::sse::Event;
 use axum::{
     http::HeaderMap,
-    routing::{get, post},
+    routing::{get, post, MethodRouter},
     Router,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// HTTP header carrying the caller's Chroma Cloud token, forwarded to the FE
 /// and the embedding service so authz/quota/billing key off the user.
@@ -56,46 +57,607 @@ pub(crate) mod trajectories;
 pub(crate) mod upsert_page;
 pub(super) mod whoami;
 
+/// Path prefix that names a request's tenant and Foundation.
+///
+/// A request reaches the same handler at its bare `/api/...` path or under this
+/// prefix; the prefix is what lets one key address any Foundation in its
+/// tenant.
+pub(crate) const SCOPE_PREFIX: &str = "/api/f/{tenant}/{foundation}";
+
+/// The tenant and Foundation a request named in its path. Both fields are
+/// absent on a bare `/api/...` request, which means "the key's tenant and the
+/// configured default Foundation".
+///
+/// Deserialized with `Path<FoundationScope>`, never `Option<Path<_>>`. axum
+/// records an empty parameter set on a route that declares no parameters, and
+/// deserializes a struct from that set as a map, so a struct whose every field
+/// is optional resolves to its default on a bare path and to the named pair on
+/// a prefixed one. The option wrapper buys nothing here: it answers `None` only
+/// when deserialization reports zero parameters, which a struct never does
+/// because it defaults them instead.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct FoundationScope {
+    #[serde(default)]
+    pub(crate) tenant: Option<String>,
+    #[serde(default)]
+    pub(crate) foundation: Option<String>,
+}
+
+/// The path parameters of a trajectory route: the trajectory id plus the same
+/// optional scope every route carries.
+///
+/// A handler may declare one path extractor, so the trajectory routes carry
+/// their id and their scope in one struct rather than two.
+#[derive(Debug, Deserialize)]
+pub(crate) struct TrajectoryScope {
+    pub(crate) id: Uuid,
+    #[serde(default)]
+    pub(crate) tenant: Option<String>,
+    #[serde(default)]
+    pub(crate) foundation: Option<String>,
+}
+
+impl TrajectoryScope {
+    /// The scope half of the path parameters, for [`whoami::authorize_scope`].
+    pub(crate) fn scope(&self) -> FoundationScope {
+        FoundationScope {
+            tenant: self.tenant.clone(),
+            foundation: self.foundation.clone(),
+        }
+    }
+}
+
+/// The web origin that page links are built from, or `None` when no link can be
+/// built for this request.
+///
+/// The page-redirect route resolves a tenant and a slug and has no Foundation
+/// parameter, so every link it builds opens the default Foundation's page. A
+/// request addressing any other Foundation therefore gets no link, because the
+/// link would resolve to the wrong page. Naming the default Foundation in the
+/// path is not one of those cases: it addresses the same database the bare path
+/// does, so it keeps its links and the two paths answer alike.
+pub(crate) fn ui_origin_for<'a>(
+    server: &'a FoundationApiServer,
+    scope: &FoundationScope,
+) -> Option<&'a str> {
+    let foundation = &server.config.foundation;
+    match scope.foundation.as_deref() {
+        Some(named) if named != foundation.database_name => None,
+        _ => foundation.foundation_ui_origin.as_deref(),
+    }
+}
+
+/// The scope policy a write route runs under.
+///
+/// A write that names no Foundation resolves to the configured default one
+/// while `require_scope_for_writes` is unset, and is refused with a 400 once it
+/// is set.
+pub(in crate::routes) fn write_scope_policy(server: &FoundationApiServer) -> whoami::ScopePolicy {
+    if server.config.foundation.require_scope_for_writes {
+        whoami::ScopePolicy::Required
+    } else {
+        whoami::ScopePolicy::DefaultToConfig
+    }
+}
+
+/// Registers `handler` at both `/api{suffix}` and `{SCOPE_PREFIX}{suffix}`.
+///
+/// Both registrations share one `MethodRouter`, which is `Clone`, so the two
+/// paths cannot drift onto different handlers and the prefixed path spells the
+/// scope parameters exactly once. Spelling them differently across routes makes
+/// the router panic when it is built.
+fn dual(
+    router: Router<FoundationApiServer>,
+    suffix: &str,
+    handler: MethodRouter<FoundationApiServer>,
+) -> Router<FoundationApiServer> {
+    router
+        .route(&format!("/api{suffix}"), handler.clone())
+        .route(&format!("{SCOPE_PREFIX}{suffix}"), handler)
+}
+
 pub(crate) fn router() -> Router<FoundationApiServer> {
-    Router::new()
-        .route("/api/init", post(init::foundation_init))
-        .route(
-            "/api/upsert-page",
-            post(upsert_page::foundation_upsert_page),
+    // Initialize is registered only at its bare path, so the database it
+    // provisions is always the configured default. It creates a database, seven
+    // collections and two attached functions while checking only the initialize
+    // permission, so a prefixed registration would let any key holding that
+    // permission create unlimited arbitrarily-named databases in its tenant
+    // without holding the create-database permission. Provisioning a
+    // caller-named Foundation needs a route that checks for that permission.
+    let router = Router::new().route("/api/init", post(init::foundation_init));
+    let router = dual(
+        router,
+        "/upsert-page",
+        post(upsert_page::foundation_upsert_page),
+    );
+    let router = dual(
+        router,
+        "/apply-patch",
+        post(apply_patch::foundation_apply_patch),
+    );
+    let router = dual(router, "/search", post(search::foundation_search));
+    let router = dual(router, "/read-page", post(read_page::foundation_read_page));
+    let router = dual(
+        router,
+        "/trajectories/save",
+        post(trajectories::foundation_save_trajectory),
+    );
+    let router = dual(
+        router,
+        "/trajectories/open",
+        post(trajectories::foundation_open_trajectory),
+    );
+    let router = dual(
+        router,
+        "/trajectories/{id}/entries",
+        post(trajectories::foundation_append_trajectory_entries),
+    );
+    let router = dual(
+        router,
+        "/trajectories/{id}/finalize",
+        post(trajectories::foundation_finalize_trajectory),
+    );
+    let router = dual(
+        router,
+        "/trajectories/{id}/reasoning",
+        get(trajectories::foundation_get_trajectory_reasoning),
+    );
+    let router = dual(
+        router,
+        "/trajectories/{id}",
+        get(trajectories::foundation_get_trajectory),
+    );
+    let router = dual(
+        router,
+        "/subagent_search",
+        post(subagent_search::foundation_subagent_search),
+    );
+    dual(router, "/agent", post(agent::foundation_agent))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::FoundationApiConfig;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use chroma_sysdb::{SysDb, TestSysDb};
+    use chroma_system::System;
+    use httpmock::MockServer;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    /// The tenant the no-op auth impl reports for every caller, which is what a
+    /// bare path resolves to.
+    const DEFAULT_TENANT: &str = "default_tenant";
+
+    fn test_server(
+        frontend_ingress_url: String,
+        require_scope_for_writes: bool,
+    ) -> FoundationApiServer {
+        let mut config = FoundationApiConfig::default();
+        config.foundation.frontend_ingress_url = Some(frontend_ingress_url);
+        config.foundation.require_scope_for_writes = require_scope_for_writes;
+
+        FoundationApiServer::new(
+            config,
+            Arc::new(()),
+            SysDb::Test(TestSysDb::new()),
+            vec![],
+            System::new(),
         )
-        .route(
-            "/api/apply-patch",
-            post(apply_patch::foundation_apply_patch),
-        )
-        .route("/api/search", post(search::foundation_search))
-        .route("/api/read-page", post(read_page::foundation_read_page))
-        .route(
-            "/api/trajectories/save",
-            post(trajectories::foundation_save_trajectory),
-        )
-        .route(
-            "/api/trajectories/open",
-            post(trajectories::foundation_open_trajectory),
-        )
-        .route(
-            "/api/trajectories/{id}/entries",
-            post(trajectories::foundation_append_trajectory_entries),
-        )
-        .route(
-            "/api/trajectories/{id}/finalize",
-            post(trajectories::foundation_finalize_trajectory),
-        )
-        .route(
-            "/api/trajectories/{id}/reasoning",
-            get(trajectories::foundation_get_trajectory_reasoning),
-        )
-        .route(
-            "/api/trajectories/{id}",
-            get(trajectories::foundation_get_trajectory),
-        )
-        .route(
-            "/api/subagent_search",
-            post(subagent_search::foundation_subagent_search),
-        )
-        .route("/api/agent", post(agent::foundation_agent))
+    }
+
+    /// The FE path that resolves a collection by name. It carries the tenant and
+    /// the database, so hitting it is proof of which pair a route resolved to.
+    fn get_collection_path(tenant: &str, database: &str, collection: &str) -> String {
+        format!("/api/v2/tenants/{tenant}/databases/{database}/collections/{collection}")
+    }
+
+    /// A mock matching every request, so a test can assert that a route refused
+    /// a request before it reached the frontend.
+    async fn any_request_mock(mock_server: &MockServer) -> httpmock::Mock<'_> {
+        mock_server
+            .mock_async(|when, then| {
+                when.any_request();
+                then.status(500);
+            })
+            .await
+    }
+
+    fn json_post(uri: &str, body: serde_json::Value) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header(CHROMA_TOKEN_HEADER, "user-token")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request should build")
+    }
+
+    fn upsert_body() -> serde_json::Value {
+        serde_json::json!({
+            "slug": "onboarding",
+            "content": "# Onboarding",
+            "source_ids": [],
+            "categories": [],
+            "last_written_by": "00000000-0000-0000-0000-000000000001",
+            "expected_version": 0,
+        })
+    }
+
+    fn get(uri: &str) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri(uri)
+            .header(CHROMA_TOKEN_HEADER, "user-token")
+            .body(Body::empty())
+            .expect("request should build")
+    }
+
+    #[test]
+    fn router_builds_without_conflicting_routes() {
+        // Two routes that spell the same path, or a prefixed route whose
+        // parameters differ from its siblings', make the router panic as it is
+        // built.
+        let _ = router();
+    }
+
+    #[tokio::test]
+    async fn a_prefixed_read_route_reaches_the_handler_with_the_path_pair() {
+        let mock_server = MockServer::start_async().await;
+        let resolve = mock_server
+            .mock_async(|when, then| {
+                when.method("GET")
+                    .path(get_collection_path("team-1", "other_foundation", "wiki"));
+                then.status(404).json_body(serde_json::json!({
+                    "error": "NotFoundError",
+                    "message": "collection not found",
+                }));
+            })
+            .await;
+        let app = router().with_state(test_server(mock_server.base_url(), false));
+
+        let response = app
+            .oneshot(json_post(
+                "/api/f/team-1/other_foundation/read-page",
+                serde_json::json!({ "slug": "onboarding" }),
+            ))
+            .await
+            .expect("router should answer");
+
+        assert_ne!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(resolve.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_bare_read_route_resolves_to_the_key_tenant_and_configured_database() {
+        let mock_server = MockServer::start_async().await;
+        let resolve = mock_server
+            .mock_async(|when, then| {
+                when.method("GET")
+                    .path(get_collection_path(DEFAULT_TENANT, "FOUNDATION", "wiki"));
+                then.status(404).json_body(serde_json::json!({
+                    "error": "NotFoundError",
+                    "message": "collection not found",
+                }));
+            })
+            .await;
+        let app = router().with_state(test_server(mock_server.base_url(), false));
+
+        app.oneshot(json_post(
+            "/api/search",
+            serde_json::json!({ "query": "onboarding" }),
+        ))
+        .await
+        .expect("router should answer");
+
+        assert_eq!(resolve.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_bare_write_is_refused_once_the_scope_is_required() {
+        let mock_server = MockServer::start_async().await;
+        let downstream = any_request_mock(&mock_server).await;
+        let app = router().with_state(test_server(mock_server.base_url(), true));
+
+        let response = app
+            .oneshot(json_post("/api/upsert-page", upsert_body()))
+            .await
+            .expect("router should answer");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        // The refusal is decided on the request's shape, so nothing downstream
+        // is contacted.
+        assert_eq!(downstream.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn a_bare_write_is_accepted_while_the_scope_is_optional() {
+        // This is the shipped default: the policy lands disabled because two
+        // clients still post to bare paths. A change that made the scope
+        // unconditionally required would break both on deploy, and every other
+        // write test here runs with the flag on.
+        let mock_server = MockServer::start_async().await;
+        let resolve = mock_server
+            .mock_async(|when, then| {
+                when.method("GET")
+                    .path(get_collection_path(DEFAULT_TENANT, "FOUNDATION", "wiki"));
+                then.status(404).json_body(serde_json::json!({
+                    "error": "NotFoundError",
+                    "message": "collection not found",
+                }));
+            })
+            .await;
+        let app = router().with_state(test_server(mock_server.base_url(), false));
+
+        let response = app
+            .oneshot(json_post("/api/upsert-page", upsert_body()))
+            .await
+            .expect("router should answer");
+
+        assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(resolve.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_bare_trajectory_write_is_refused_once_the_scope_is_required() {
+        // Every write route reads the same policy, so the refusal must not be
+        // specific to upsert-page.
+        let mock_server = MockServer::start_async().await;
+        let downstream = any_request_mock(&mock_server).await;
+        let app = router().with_state(test_server(mock_server.base_url(), true));
+
+        let response = app
+            .oneshot(json_post(
+                "/api/trajectories/open",
+                serde_json::json!({
+                    "trajectory": {
+                        "id": "00000000-0000-0000-0000-000000000001",
+                        "entries": [],
+                    },
+                }),
+            ))
+            .await
+            .expect("router should answer");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(downstream.calls(), 0);
+    }
+
+    #[test]
+    fn only_a_foundation_the_redirect_cannot_resolve_loses_its_page_links() {
+        // The page-redirect route carries no Foundation, so it always resolves
+        // to the default one. Naming that same Foundation in the path must
+        // therefore keep its links: it addresses the database the bare path
+        // does, and the two must answer alike.
+        let mut config = FoundationApiConfig::default();
+        config.foundation.foundation_ui_origin = Some("https://wiki.example.com".to_string());
+        let server = FoundationApiServer::new(
+            config,
+            Arc::new(()),
+            SysDb::Test(TestSysDb::new()),
+            vec![],
+            System::new(),
+        );
+
+        let named = |foundation: &str| FoundationScope {
+            tenant: Some("team-1".to_string()),
+            foundation: Some(foundation.to_string()),
+        };
+
+        assert_eq!(
+            ui_origin_for(&server, &FoundationScope::default()),
+            Some("https://wiki.example.com")
+        );
+        assert_eq!(
+            ui_origin_for(&server, &named("FOUNDATION")),
+            Some("https://wiki.example.com")
+        );
+        assert_eq!(ui_origin_for(&server, &named("other_foundation")), None);
+    }
+
+    #[test]
+    fn the_write_policy_follows_the_config_flag() {
+        let mock_url = "https://foundation-fe.internal".to_string();
+        assert_eq!(
+            write_scope_policy(&test_server(mock_url.clone(), false)),
+            whoami::ScopePolicy::DefaultToConfig
+        );
+        assert_eq!(
+            write_scope_policy(&test_server(mock_url, true)),
+            whoami::ScopePolicy::Required
+        );
+    }
+
+    #[tokio::test]
+    async fn a_prefixed_write_is_accepted_once_the_scope_is_required() {
+        let mock_server = MockServer::start_async().await;
+        let resolve = mock_server
+            .mock_async(|when, then| {
+                when.method("GET")
+                    .path(get_collection_path("team-1", "other_foundation", "wiki"));
+                then.status(404).json_body(serde_json::json!({
+                    "error": "NotFoundError",
+                    "message": "collection not found",
+                }));
+            })
+            .await;
+        let app = router().with_state(test_server(mock_server.base_url(), true));
+
+        let response = app
+            .oneshot(json_post(
+                "/api/f/team-1/other_foundation/upsert-page",
+                upsert_body(),
+            ))
+            .await
+            .expect("router should answer");
+
+        assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(resolve.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_prefixed_trajectory_route_extracts_both_the_id_and_the_scope() {
+        // Regression guard for the path extractor: one handler may declare one
+        // path extractor, so the id and the scope arrive in a single struct. A
+        // handler that asked for them separately would reject this request
+        // before reaching the collection lookup.
+        let mock_server = MockServer::start_async().await;
+        let resolve = mock_server
+            .mock_async(|when, then| {
+                when.method("GET").path(get_collection_path(
+                    "team-1",
+                    "other_foundation",
+                    "generate_trajectories",
+                ));
+                then.status(404).json_body(serde_json::json!({
+                    "error": "NotFoundError",
+                    "message": "collection not found",
+                }));
+            })
+            .await;
+        let app = router().with_state(test_server(mock_server.base_url(), false));
+
+        let response = app
+            .oneshot(get(
+                "/api/f/team-1/other_foundation/trajectories/00000000-0000-0000-0000-000000000001",
+            ))
+            .await
+            .expect("router should answer");
+
+        assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(resolve.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_bare_trajectory_route_still_extracts_its_id() {
+        let mock_server = MockServer::start_async().await;
+        let resolve = mock_server
+            .mock_async(|when, then| {
+                when.method("GET").path(get_collection_path(
+                    DEFAULT_TENANT,
+                    "FOUNDATION",
+                    "generate_trajectories",
+                ));
+                then.status(404).json_body(serde_json::json!({
+                    "error": "NotFoundError",
+                    "message": "collection not found",
+                }));
+            })
+            .await;
+        let app = router().with_state(test_server(mock_server.base_url(), false));
+
+        let response = app
+            .oneshot(get(
+                "/api/trajectories/00000000-0000-0000-0000-000000000001",
+            ))
+            .await
+            .expect("router should answer");
+
+        assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(resolve.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn an_invalid_foundation_name_in_the_path_is_a_bad_request() {
+        let mock_server = MockServer::start_async().await;
+        let downstream = any_request_mock(&mock_server).await;
+        let app = router().with_state(test_server(mock_server.base_url(), false));
+
+        let response = app
+            .oneshot(json_post(
+                "/api/f/team-1/my..db/read-page",
+                serde_json::json!({ "slug": "onboarding" }),
+            ))
+            .await
+            .expect("router should answer");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(downstream.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn a_percent_encoded_topology_prefix_is_still_rejected() {
+        // axum percent-decodes a path parameter before the handler sees it, so
+        // the ban on `+` has to hold against `%2B` as well or a caller could
+        // address a different database than the name spells.
+        let mock_server = MockServer::start_async().await;
+        let downstream = any_request_mock(&mock_server).await;
+        let app = router().with_state(test_server(mock_server.base_url(), false));
+
+        let response = app
+            .oneshot(json_post(
+                "/api/f/team-1/topo%2Bdatabase/read-page",
+                serde_json::json!({ "slug": "onboarding" }),
+            ))
+            .await
+            .expect("router should answer");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(downstream.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn the_reserved_foundations_segment_is_rejected() {
+        // The Foundation CRUD routes occupy `/api/f/{tenant}/foundations`, so a
+        // Foundation with that name would be shadowed by them.
+        let mock_server = MockServer::start_async().await;
+        let downstream = any_request_mock(&mock_server).await;
+        let app = router().with_state(test_server(mock_server.base_url(), false));
+
+        let response = app
+            .oneshot(json_post(
+                "/api/f/team-1/foundations/read-page",
+                serde_json::json!({ "slug": "onboarding" }),
+            ))
+            .await
+            .expect("router should answer");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(downstream.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn the_bare_init_route_still_extracts_an_empty_scope() {
+        // `/api/init` declares no path parameters, so its `Path<FoundationScope>`
+        // has to resolve to the default rather than reject the request. The
+        // handler is reached when the response carries its own configuration
+        // error instead of a path-extraction rejection.
+        let mock_server = MockServer::start_async().await;
+        let app = router().with_state(test_server(mock_server.base_url(), false));
+
+        let response = app
+            .oneshot(json_post("/api/init", serde_json::json!({})))
+            .await
+            .expect("router should answer");
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should read");
+        let body = String::from_utf8_lossy(&body);
+        assert!(
+            body.contains("function_endpoint_url"),
+            "expected the handler's own error, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn init_is_reachable_only_at_its_bare_path() {
+        // Initialize creates a database while checking only the initialize
+        // permission, so it must not be callable with a tenant and Foundation
+        // chosen by the caller.
+        let mock_server = MockServer::start_async().await;
+        let app = router().with_state(test_server(mock_server.base_url(), false));
+
+        let response = app
+            .oneshot(json_post(
+                "/api/f/team-1/other_foundation/init",
+                serde_json::json!({}),
+            ))
+            .await
+            .expect("router should answer");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
 }

--- a/rust/foundation-api/src/routes/mod.rs
+++ b/rust/foundation-api/src/routes/mod.rs
@@ -53,6 +53,8 @@ pub(crate) mod mcp;
 pub(crate) mod read_page;
 pub(crate) mod search;
 pub(crate) mod subagent_search;
+#[cfg(test)]
+mod test_auth;
 pub(crate) mod trajectories;
 pub(crate) mod upsert_page;
 pub(super) mod whoami;

--- a/rust/foundation-api/src/routes/read_page.rs
+++ b/rust/foundation-api/src/routes/read_page.rs
@@ -10,11 +10,16 @@
 //! metering, and billing.
 
 use crate::routes::links::page_url;
-use crate::routes::{caller_token, whoami::whoami_and_authorize};
+use crate::routes::whoami::{authorize_scope, ScopePolicy};
+use crate::routes::{caller_token, ui_origin_for, FoundationScope};
 use crate::wiki::page::{meta_int, meta_str};
 use crate::wiki::WikiClientError;
 use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
-use axum::{extract::State, http::HeaderMap, Json};
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
 use chroma::client::ChromaHttpClientError;
 use chroma::types::{Key, SearchPayload, SearchResponse};
 use chroma::ChromaCollection;
@@ -96,30 +101,46 @@ impl ChromaError for ReadPageError {
 pub async fn foundation_read_page(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
+    Path(scope): Path<FoundationScope>,
     Json(request): Json<ReadPageRequest>,
 ) -> Result<Json<FoundationPage>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::ViewFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::ViewFoundation,
+        &scope,
+        &server.config.foundation.database_name,
+        ScopePolicy::DefaultToConfig,
+    )
+    .await?;
 
     let _guard =
         server.scorecard_request(&["op:foundation_read_page", &format!("tenant:{tenant}")])?;
 
     request.validate().map_err(ChromaValidationError::from)?;
 
-    let page = run_read_page(&server, &headers, &tenant, &request.slug)
-        .await?
-        .ok_or(ReadPageError::PageNotFound)?;
+    let page = run_read_page(
+        &server,
+        &headers,
+        &tenant,
+        &database,
+        ui_origin_for(&server, &scope),
+        &request.slug,
+    )
+    .await?
+    .ok_or(ReadPageError::PageNotFound)?;
     Ok(Json(page))
 }
 
-/// Resolves the wiki collection and reconstructs the full page for `slug`,
-/// returning `None` when no such page exists. Stamps the page's `url` from the
-/// configured `foundation_ui_origin` (left `None` when the origin is unset).
+/// Resolves the wiki collection in `database` and reconstructs the full page
+/// for `slug`, returning `None` when no such page exists. Stamps the page's
+/// `url` from `ui_origin` (left `None` when the caller passes no origin).
 pub(crate) async fn run_read_page(
     server: &FoundationApiServer,
     headers: &HeaderMap,
     tenant: &str,
+    database: &str,
+    ui_origin: Option<&str>,
     slug: &str,
 ) -> Result<Option<FoundationPage>, ReadPageError> {
     let wiki_client = server
@@ -127,15 +148,9 @@ pub(crate) async fn run_read_page(
         .as_ref()
         .ok_or(ReadPageError::RouteDisabled)?;
     let token = caller_token(headers).ok_or(ReadPageError::MissingToken)?;
-    let collection = wiki_client.wiki_collection(tenant, token).await?;
+    let collection = wiki_client.wiki_collection(tenant, database, token).await?;
 
-    read_page_from_collection(
-        &collection,
-        tenant,
-        server.config.foundation.foundation_ui_origin.as_deref(),
-        slug,
-    )
-    .await
+    read_page_from_collection(&collection, tenant, ui_origin, slug).await
 }
 
 /// Reconstructs the full page for `slug` from an already-resolved wiki

--- a/rust/foundation-api/src/routes/search.rs
+++ b/rust/foundation-api/src/routes/search.rs
@@ -12,12 +12,17 @@
 //! client-side here before the query is issued.
 
 use crate::routes::links::page_url;
-use crate::routes::{caller_token, whoami::whoami_and_authorize};
+use crate::routes::whoami::{authorize_scope, ScopePolicy};
+use crate::routes::{caller_token, ui_origin_for, FoundationScope};
 use crate::wiki::embed::{WikiEmbedder, SPARSE_KEY};
 use crate::wiki::page::{meta_str, meta_str_array};
 use crate::wiki::WikiClientError;
 use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
-use axum::{extract::State, http::HeaderMap, Json};
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
 use chroma::client::ChromaHttpClientError;
 use chroma::types::{
     rrf, Aggregate, GroupBy, Key, QueryVector, RankExpr, SearchPayload, SearchResponse,
@@ -124,18 +129,34 @@ impl ChromaError for SearchError {
 pub async fn foundation_search(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
+    Path(scope): Path<FoundationScope>,
     Json(request): Json<SearchRequest>,
 ) -> Result<Json<PageSearchResponseBody>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::ViewFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::ViewFoundation,
+        &scope,
+        &server.config.foundation.database_name,
+        ScopePolicy::DefaultToConfig,
+    )
+    .await?;
 
     let _guard =
         server.scorecard_request(&["op:foundation_search", &format!("tenant:{tenant}")])?;
 
     request.validate().map_err(ChromaValidationError::from)?;
 
-    let hits = run_page_search(&server, &headers, &tenant, &request.query, request.limit).await?;
+    let hits = run_page_search(
+        &server,
+        &headers,
+        &tenant,
+        &database,
+        ui_origin_for(&server, &scope),
+        &request.query,
+        request.limit,
+    )
+    .await?;
     Ok(Json(PageSearchResponseBody { hits }))
 }
 
@@ -296,12 +317,14 @@ pub struct PageSearchResponseBody {
 /// a slim, one-per-page result list (best chunk per page) in fused-rank order.
 /// Does not reconstruct full pages — that is the job of [`run_read_page`].
 /// `limit` caps the number of unique pages (clamped to [`MAX_PAGE_LIMIT`]).
-/// Each hit's `url` is stamped from the configured `foundation_ui_origin` (left
-/// `None` when the origin is unset).
+/// Each hit's `url` is stamped from `ui_origin` (left `None` when the caller
+/// passes no origin).
 pub(crate) async fn run_page_search(
     server: &FoundationApiServer,
     headers: &HeaderMap,
     tenant: &str,
+    database: &str,
+    ui_origin: Option<&str>,
     query: &str,
     limit: u32,
 ) -> Result<Vec<PageSearchHit>, SearchError> {
@@ -310,7 +333,7 @@ pub(crate) async fn run_page_search(
         .as_ref()
         .ok_or(SearchError::RouteDisabled)?;
     let token = caller_token(headers).ok_or(SearchError::MissingToken)?;
-    let collection = wiki_client.wiki_collection(tenant, token).await?;
+    let collection = wiki_client.wiki_collection(tenant, database, token).await?;
     let embedder = WikiEmbedder::new(None);
 
     // `group_by_slug` collapses the candidate chunks to one (best) chunk per
@@ -325,11 +348,7 @@ pub(crate) async fn run_page_search(
     )
     .await?;
 
-    Ok(hits_to_page_hits(
-        hits,
-        server.config.foundation.foundation_ui_origin.as_deref(),
-        tenant,
-    ))
+    Ok(hits_to_page_hits(hits, ui_origin, tenant))
 }
 
 /// Maps the (already grouped-by-slug) search records into slim per-page hits.

--- a/rust/foundation-api/src/routes/subagent_search/mod.rs
+++ b/rust/foundation-api/src/routes/subagent_search/mod.rs
@@ -21,16 +21,21 @@
 //! `data: {"type": action|observation|done|error, "data": {...}}` lines.
 //!
 //! Credentials are taken from the request: the caller's `x-chroma-token` is the
-//! Chroma API key, the tenant comes from the resolved identity, and the
-//! database/collection come from foundation config.
+//! Chroma API key, and the tenant and database are the pair the request
+//! resolved to, so the subagent researches the Foundation the caller named.
 
 mod events;
 use crate::routes::links::page_url;
-use crate::routes::{caller_token, to_sse_event, whoami::whoami_and_authorize};
+use crate::routes::whoami::{authorize_scope, ScopePolicy};
+use crate::routes::{caller_token, to_sse_event, FoundationScope};
 use crate::wiki::chunking::ChunkRecordId;
 use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
 use axum::response::sse::{Event, KeepAlive, Sse};
-use axum::{extract::State, http::HeaderMap, Json};
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
 use chroma_error::{ChromaError, ErrorCodes};
 pub(crate) use events::RankedDocument;
 use events::{
@@ -63,20 +68,26 @@ pub struct SubagentSearchCreds {
 }
 
 impl SubagentSearchCreds {
-    /// Builds the deep-research credentials from Foundation config, the resolved
-    /// tenant, and the caller's Chroma token. The single place that maps config
-    /// onto the forwarded creds, shared by the REST route, the agent tool, and
-    /// the MCP tool so the three entry points can't send divergent payloads.
-    pub fn from_config(
-        config: &crate::config::FoundationConfig,
+    /// Builds the deep-research credentials from the resolved tenant and
+    /// database, the wiki collection name, and the caller's Chroma token. The
+    /// single place that assembles the forwarded creds, shared by the REST
+    /// route, the agent tool, and the MCP tool so the three entry points can't
+    /// send divergent payloads.
+    ///
+    /// The database is a parameter rather than a config read: reading it from
+    /// config here would silently re-pin every caller to the default
+    /// Foundation, whatever Foundation their request named.
+    pub fn new(
         tenant: impl Into<String>,
+        database: impl Into<String>,
+        collection_name: impl Into<String>,
         token: impl Into<String>,
     ) -> Self {
         Self {
             chroma_api_key: token.into(),
             chroma_tenant: tenant.into(),
-            chroma_database: config.database_name.clone(),
-            collection_name: config.wiki_collection.clone(),
+            chroma_database: database.into(),
+            collection_name: collection_name.into(),
         }
     }
 }
@@ -110,11 +121,18 @@ impl ChromaError for SubagentSearchError {
 pub async fn foundation_subagent_search(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
+    Path(scope): Path<FoundationScope>,
     Json(request): Json<SubagentSearchRequest>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, SubagentStreamError>>>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::ViewFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::ViewFoundation,
+        &scope,
+        &server.config.foundation.database_name,
+        ScopePolicy::DefaultToConfig,
+    )
+    .await?;
 
     let _guard = server
         .scorecard_request(&["op:foundation_subagent_search", &format!("tenant:{tenant}")])?;
@@ -129,7 +147,12 @@ pub async fn foundation_subagent_search(
         .ok_or(SubagentSearchError::MissingToken)?
         .to_string();
 
-    let creds = SubagentSearchCreds::from_config(&server.config.foundation, tenant, token);
+    let creds = SubagentSearchCreds::new(
+        tenant,
+        database,
+        &server.config.foundation.wiki_collection,
+        token,
+    );
 
     let stream =
         stream_subagent_search(server.shared_http_client.clone(), url, creds, request.query);

--- a/rust/foundation-api/src/routes/test_auth.rs
+++ b/rust/foundation-api/src/routes/test_auth.rs
@@ -1,0 +1,227 @@
+//! Test doubles shared by the route tests.
+//!
+//! Authorization is the one thing every route does the same way and gets wrong
+//! differently, so the recording stub below lives here rather than inside one
+//! route's test module.
+//!
+//! The module allows dead code because each affordance serves the routes that
+//! can enter the mode it models: a stub that refuses every token is meaningless
+//! to a route with no token gate, and a key fenced to named databases is
+//! meaningless to a route that never filters by reach. An accessor with no
+//! caller therefore says that no route needs that mode, not that the double is
+//! wrong.
+#![allow(dead_code)]
+
+use std::collections::HashSet;
+use std::future::{ready, Future};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use axum::http::{HeaderMap, StatusCode};
+use chroma_api_types::GetUserIdentityResponse;
+use chroma_sysdb::SysDb;
+use chroma_system::System;
+
+use crate::auth::{AuthError, AuthenticateAndAuthorize, AuthzAction, AuthzResource};
+use crate::config::FoundationApiConfig;
+use crate::errors::ServerError;
+use crate::server::FoundationApiServer;
+
+/// Authorization stub that answers with a fixed identity and records every
+/// authorization it was asked for, in order.
+///
+/// Invariants:
+/// 1. Every `authenticate_and_authorize` call is recorded, refused ones
+///    included, so a test can tell "asked and denied" from "never asked".
+/// 2. Authorization calls and identity lookups count separately, so a test can
+///    prove a route resolved a pair without an identity round trip. The
+///    collection entry point counts under neither, because no route here
+///    authorizes through it.
+/// 3. Refusals are opt-in. [`FakeAuth::enforcing_tenant_match`] reproduces the
+///    Cloud implementation's 403 on a resource tenant the key does not own, and
+///    [`FakeAuth::refusing`] reproduces its refusal of a token it will not
+///    accept. The no-op implementation enforces neither, so only a stub can
+///    produce either refusal.
+/// 4. A blanket refusal outranks the tenant check: a stub built by
+///    [`FakeAuth::refusing`] answers with that status whatever the resource
+///    names.
+/// 5. `databases` is the set of database names the key's permissions name. It
+///    is empty for a tenant-wide key, which is what a reachability filter reads
+///    as "every Foundation".
+pub(in crate::routes) struct FakeAuth {
+    user_id: String,
+    tenant: String,
+    databases: HashSet<String>,
+    enforce_tenant_match: bool,
+    refuse: Option<StatusCode>,
+    authorizations: Mutex<Vec<(AuthzAction, AuthzResource)>>,
+    identity_calls: AtomicUsize,
+}
+
+impl FakeAuth {
+    /// A stub that authorizes every call and reports `tenant` as the key's own.
+    pub(in crate::routes) fn new(user_id: &str, tenant: &str) -> Self {
+        Self {
+            user_id: user_id.to_string(),
+            tenant: tenant.to_string(),
+            databases: HashSet::new(),
+            enforce_tenant_match: false,
+            refuse: None,
+            authorizations: Mutex::new(Vec::new()),
+            identity_calls: AtomicUsize::new(0),
+        }
+    }
+
+    /// A stub that answers 403 for a resource tenant other than `tenant`.
+    pub(in crate::routes) fn enforcing_tenant_match(user_id: &str, tenant: &str) -> Self {
+        Self {
+            enforce_tenant_match: true,
+            ..Self::new(user_id, tenant)
+        }
+    }
+
+    /// A stub that refuses every authorization call with `status`.
+    pub(in crate::routes) fn refusing(status: StatusCode) -> Self {
+        Self {
+            refuse: Some(status),
+            ..Self::new("user_99", "team_abc")
+        }
+    }
+
+    /// Scopes the key to the named databases, the way a database-scoped
+    /// permission does. A key built without this is tenant-wide.
+    pub(in crate::routes) fn scoped_to_databases(self, databases: &[&str]) -> Self {
+        Self {
+            databases: databases.iter().map(|name| name.to_string()).collect(),
+            ..self
+        }
+    }
+
+    fn identity(&self) -> GetUserIdentityResponse {
+        GetUserIdentityResponse {
+            user_id: self.user_id.clone(),
+            tenant: self.tenant.clone(),
+            databases: self.databases.clone(),
+        }
+    }
+
+    /// Every authorization asked for, in the order it was asked.
+    pub(in crate::routes) fn authorizations(&self) -> Vec<(AuthzAction, AuthzResource)> {
+        self.authorizations
+            .lock()
+            .expect("lock should not be poisoned")
+            .clone()
+    }
+
+    pub(in crate::routes) fn identity_calls(&self) -> usize {
+        self.identity_calls.load(Ordering::SeqCst)
+    }
+
+    pub(in crate::routes) fn authorize_calls(&self) -> usize {
+        self.authorizations
+            .lock()
+            .expect("lock should not be poisoned")
+            .len()
+    }
+
+    /// The action of the single authorization the route asked for. Panics when
+    /// the route asked for none or for more than one, because a test that
+    /// reaches for "the" action is asserting there was exactly one. A route
+    /// that authorizes more than once is read through
+    /// [`FakeAuth::authorizations`] instead.
+    pub(in crate::routes) fn captured_action(&self) -> AuthzAction {
+        let authorizations = self.authorizations();
+        assert_eq!(
+            authorizations.len(),
+            1,
+            "expected exactly one authorization, got {}",
+            authorizations.len()
+        );
+        authorizations[0].0
+    }
+
+    /// The resource of the single authorization the route asked for. Panics
+    /// under the same condition as [`FakeAuth::captured_action`].
+    pub(in crate::routes) fn captured_resource(&self) -> AuthzResource {
+        let authorizations = self.authorizations();
+        assert_eq!(
+            authorizations.len(),
+            1,
+            "expected exactly one authorization, got {}",
+            authorizations.len()
+        );
+        authorizations[0].1.clone()
+    }
+}
+
+impl AuthenticateAndAuthorize for FakeAuth {
+    fn authenticate_and_authorize(
+        &self,
+        _headers: &HeaderMap,
+        action: AuthzAction,
+        resource: AuthzResource,
+    ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>> {
+        let refusal = self.refuse.or_else(|| {
+            let foreign_tenant =
+                self.enforce_tenant_match && resource.tenant.as_deref() != Some(&self.tenant);
+            foreign_tenant.then_some(StatusCode::FORBIDDEN)
+        });
+        self.authorizations
+            .lock()
+            .expect("lock should not be poisoned")
+            .push((action, resource));
+        if let Some(status) = refusal {
+            return Box::pin(ready(Err(AuthError(status))));
+        }
+        let identity = self.identity();
+        Box::pin(ready(Ok(identity)))
+    }
+
+    fn authenticate_and_authorize_collection(
+        &self,
+        _headers: &HeaderMap,
+        _action: AuthzAction,
+        _resource: AuthzResource,
+        _collection: chroma_types::Collection,
+    ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>> {
+        let identity = self.identity();
+        Box::pin(ready(Ok(identity)))
+    }
+
+    fn get_user_identity(
+        &self,
+        _headers: &HeaderMap,
+    ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>> {
+        self.identity_calls.fetch_add(1, Ordering::SeqCst);
+        let identity = self.identity();
+        Box::pin(ready(Ok(identity)))
+    }
+}
+
+/// A server wired to `auth` and `sysdb`, with the default Foundation
+/// configuration. Routes that reach the frontend are disabled, because no
+/// ingress URL is configured.
+pub(in crate::routes) fn server_with(auth: Arc<FakeAuth>, sysdb: SysDb) -> FoundationApiServer {
+    server_with_config(FoundationApiConfig::default(), auth, sysdb)
+}
+
+/// A server wired to `auth`, `sysdb` and an explicit configuration.
+pub(in crate::routes) fn server_with_config(
+    config: FoundationApiConfig,
+    auth: Arc<FakeAuth>,
+    sysdb: SysDb,
+) -> FoundationApiServer {
+    FoundationApiServer::new(config, auth, sysdb, vec![], System::new())
+}
+
+/// Unwraps a handler result, reporting the error when a test expected success.
+///
+/// `ServerError` carries no `Debug`, so `unwrap` and `expect` are unavailable
+/// on a result that holds one.
+pub(in crate::routes) fn expect_ok<T>(result: Result<T, ServerError>, context: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => panic!("{context}: {error}"),
+    }
+}

--- a/rust/foundation-api/src/routes/trajectories.rs
+++ b/rust/foundation-api/src/routes/trajectories.rs
@@ -15,13 +15,16 @@ use axum::{
 };
 use chroma_error::{ChromaError, ErrorCodes};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::{
     auth::AuthzAction,
     errors::ServerError,
     foundation_chroma::{FoundationChromaClient, FoundationChromaClientError},
-    routes::{caller_token, whoami::whoami_and_authorize},
+    routes::{
+        caller_token,
+        whoami::{authorize_scope, ScopePolicy},
+        write_scope_policy, FoundationScope, TrajectoryScope,
+    },
     server::FoundationApiServer,
     trajectories::{
         append_open_generate_trajectory, create_open_generate_trajectory,
@@ -101,18 +104,26 @@ impl ChromaError for TrajectoryRouteError {
 pub async fn foundation_save_trajectory(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
+    Path(scope): Path<FoundationScope>,
     Json(file): Json<ReasoningTrajectoryFile>,
 ) -> Result<Json<TrajectoryWriteResponse>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::UpsertFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::UpsertFoundation,
+        &scope,
+        &server.config.foundation.database_name,
+        write_scope_policy(&server),
+    )
+    .await?;
     let _guard = server
         .scorecard_request(&["op:foundation_save_trajectory", &format!("tenant:{tenant}")])?;
 
-    let (client, collection) = trajectory_collection(&server, &headers, &tenant).await?;
+    let (client, collection) = trajectory_collection(&server, &headers, &tenant, &database).await?;
     let response = trajectory_op(
         client,
         &tenant,
+        &database,
         save_generate_trajectory(&collection, &file),
     )
     .await?;
@@ -123,18 +134,26 @@ pub async fn foundation_save_trajectory(
 pub async fn foundation_open_trajectory(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
+    Path(scope): Path<FoundationScope>,
     Json(file): Json<ReasoningTrajectoryFile>,
 ) -> Result<Json<TrajectoryWriteResponse>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::UpsertFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::UpsertFoundation,
+        &scope,
+        &server.config.foundation.database_name,
+        write_scope_policy(&server),
+    )
+    .await?;
     let _guard = server
         .scorecard_request(&["op:foundation_open_trajectory", &format!("tenant:{tenant}")])?;
 
-    let (client, collection) = trajectory_collection(&server, &headers, &tenant).await?;
+    let (client, collection) = trajectory_collection(&server, &headers, &tenant, &database).await?;
     let response = trajectory_op(
         client,
         &tenant,
+        &database,
         create_open_generate_trajectory(&collection, &file),
     )
     .await?;
@@ -145,22 +164,29 @@ pub async fn foundation_open_trajectory(
 pub async fn foundation_append_trajectory_entries(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
-    Path(id): Path<Uuid>,
+    Path(path): Path<TrajectoryScope>,
     Json(request): Json<AppendTrajectoryEntriesRequest>,
 ) -> Result<Json<TrajectoryWriteResponse>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::UpsertFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::UpsertFoundation,
+        &path.scope(),
+        &server.config.foundation.database_name,
+        write_scope_policy(&server),
+    )
+    .await?;
     let _guard = server.scorecard_request(&[
         "op:foundation_append_trajectory_entries",
         &format!("tenant:{tenant}"),
     ])?;
 
-    let (client, collection) = trajectory_collection(&server, &headers, &tenant).await?;
+    let (client, collection) = trajectory_collection(&server, &headers, &tenant, &database).await?;
     let response = trajectory_op(
         client,
         &tenant,
-        append_open_generate_trajectory(&collection, id, &request),
+        &database,
+        append_open_generate_trajectory(&collection, path.id, &request),
     )
     .await?;
     Ok(Json(response))
@@ -170,22 +196,29 @@ pub async fn foundation_append_trajectory_entries(
 pub async fn foundation_finalize_trajectory(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
-    Path(id): Path<Uuid>,
+    Path(path): Path<TrajectoryScope>,
     Json(file): Json<ReasoningTrajectoryFile>,
 ) -> Result<Json<TrajectoryWriteResponse>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::UpsertFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::UpsertFoundation,
+        &path.scope(),
+        &server.config.foundation.database_name,
+        write_scope_policy(&server),
+    )
+    .await?;
     let _guard = server.scorecard_request(&[
         "op:foundation_finalize_trajectory",
         &format!("tenant:{tenant}"),
     ])?;
 
-    let (client, collection) = trajectory_collection(&server, &headers, &tenant).await?;
+    let (client, collection) = trajectory_collection(&server, &headers, &tenant, &database).await?;
     let response = trajectory_op(
         client,
         &tenant,
-        finalize_open_generate_trajectory(&collection, id, &file),
+        &database,
+        finalize_open_generate_trajectory(&collection, path.id, &file),
     )
     .await?;
     Ok(Json(response))
@@ -195,20 +228,27 @@ pub async fn foundation_finalize_trajectory(
 pub async fn foundation_get_trajectory(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
-    Path(id): Path<Uuid>,
+    Path(path): Path<TrajectoryScope>,
     Query(query): Query<ReadTrajectoryQuery>,
 ) -> Result<Json<ReasoningTrajectoryFile>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::ViewFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::ViewFoundation,
+        &path.scope(),
+        &server.config.foundation.database_name,
+        ScopePolicy::DefaultToConfig,
+    )
+    .await?;
     let _guard =
         server.scorecard_request(&["op:foundation_get_trajectory", &format!("tenant:{tenant}")])?;
 
-    let (client, collection) = trajectory_collection(&server, &headers, &tenant).await?;
+    let (client, collection) = trajectory_collection(&server, &headers, &tenant, &database).await?;
     let response = trajectory_op(
         client,
         &tenant,
-        load_generate_trajectory(&collection, id, query.require_finalized),
+        &database,
+        load_generate_trajectory(&collection, path.id, query.require_finalized),
     )
     .await?;
     Ok(Json(response))
@@ -218,23 +258,30 @@ pub async fn foundation_get_trajectory(
 pub async fn foundation_get_trajectory_reasoning(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
-    Path(id): Path<Uuid>,
+    Path(path): Path<TrajectoryScope>,
     Query(query): Query<ReadTrajectoryReasoningQuery>,
 ) -> Result<Json<Option<TrajectoryReasoningResponse>>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::ViewFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::ViewFoundation,
+        &path.scope(),
+        &server.config.foundation.database_name,
+        ScopePolicy::DefaultToConfig,
+    )
+    .await?;
     let _guard = server.scorecard_request(&[
         "op:foundation_get_trajectory_reasoning",
         &format!("tenant:{tenant}"),
     ])?;
     let slug = query.slug.ok_or(TrajectoryRouteError::MissingSlug)?;
 
-    let (client, collection) = trajectory_collection(&server, &headers, &tenant).await?;
+    let (client, collection) = trajectory_collection(&server, &headers, &tenant, &database).await?;
     let file = trajectory_op(
         client,
         &tenant,
-        load_generate_trajectory(&collection, id, query.require_finalized),
+        &database,
+        load_generate_trajectory(&collection, path.id, query.require_finalized),
     )
     .await?;
     Ok(Json(reasoning_for_slug(&file, &slug)))
@@ -274,23 +321,32 @@ fn reasoning_for_slug(
     })
 }
 
+/// Resolves the trajectory collection inside the Foundation named by `tenant`
+/// and `database`.
 async fn trajectory_collection<'a>(
     server: &'a FoundationApiServer,
     headers: &HeaderMap,
     tenant: &str,
+    database: &str,
 ) -> Result<(&'a FoundationChromaClient, chroma::ChromaCollection), TrajectoryRouteError> {
     let client = server
         .foundation_chroma_client
         .as_ref()
         .ok_or(TrajectoryRouteError::RouteDisabled)?;
     let token = caller_token(headers).ok_or(TrajectoryRouteError::MissingToken)?;
-    let collection = client.trajectories_collection(tenant, token).await?;
+    let collection = client
+        .trajectories_collection(tenant, database, token)
+        .await?;
     Ok((client, collection))
 }
 
+/// Awaits one trajectory operation, dropping the cached collection identity for
+/// this Foundation when the proxied call answers `NotFound`, since the cached
+/// id is then stale.
 async fn trajectory_op<T, F>(
     client: &FoundationChromaClient,
     tenant: &str,
+    database: &str,
     fut: F,
 ) -> Result<T, TrajectoryRouteError>
 where
@@ -298,7 +354,7 @@ where
 {
     fut.await.map_err(|err| {
         if err.is_chroma_not_found() {
-            client.invalidate_trajectories(tenant);
+            client.invalidate_trajectories(tenant, database);
         }
         TrajectoryRouteError::Trajectory(err)
     })
@@ -312,6 +368,7 @@ mod tests {
     };
     use chroma::client::ChromaHttpClientError;
     use serde_json::json;
+    use uuid::Uuid;
 
     fn minimal_file(entries: Vec<ReasoningEntry>) -> ReasoningTrajectoryFile {
         ReasoningTrajectoryFile {

--- a/rust/foundation-api/src/routes/upsert_page.rs
+++ b/rust/foundation-api/src/routes/upsert_page.rs
@@ -9,13 +9,18 @@
 //! every proxied call.
 
 use crate::foundation_chroma::{is_not_found, FoundationChromaClient};
-use crate::routes::{caller_token, whoami::whoami_and_authorize};
+use crate::routes::whoami::authorize_scope;
+use crate::routes::{caller_token, write_scope_policy, FoundationScope};
 use crate::wiki::chunking::{chunk_content, title_from_content, ChunkRecordId, ChunkingConfig};
 use crate::wiki::embed::WikiEmbedder;
 use crate::wiki::page::{build_metadatas, kind_for, PageMetadataError};
 use crate::wiki::WikiClientError;
 use crate::{auth::AuthzAction, errors::ServerError, server::FoundationApiServer};
-use axum::{extract::State, http::HeaderMap, Json};
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
 use chroma::client::ChromaHttpClientError;
 use chroma::ChromaCollection;
 use chroma_error::{ChromaError, ChromaValidationError, ErrorCodes};
@@ -184,11 +189,18 @@ impl ChromaError for UpsertPageError {
 pub async fn foundation_upsert_page(
     headers: HeaderMap,
     State(server): State<FoundationApiServer>,
+    Path(scope): Path<FoundationScope>,
     Json(request): Json<UpsertPageRequest>,
 ) -> Result<Json<UpsertPageResponse>, ServerError> {
-    let identity =
-        whoami_and_authorize(&*server.auth, &headers, AuthzAction::UpsertFoundation).await?;
-    let tenant = identity.tenant;
+    let (tenant, database, _identity) = authorize_scope(
+        &*server.auth,
+        &headers,
+        AuthzAction::UpsertFoundation,
+        &scope,
+        &server.config.foundation.database_name,
+        write_scope_policy(&server),
+    )
+    .await?;
 
     let _guard =
         server.scorecard_request(&["op:foundation_upsert_page", &format!("tenant:{tenant}")])?;
@@ -196,7 +208,7 @@ pub async fn foundation_upsert_page(
     request.validate().map_err(ChromaValidationError::from)?;
     let categories = normalize_categories(&request.categories);
 
-    match run_upsert_page(&server, &headers, &tenant, &request, &categories).await {
+    match run_upsert_page(&server, &headers, &tenant, &database, &request, &categories).await {
         Ok(response) => Ok(Json(response)),
         Err(err) => Err(err.into()),
     }
@@ -207,13 +219,19 @@ pub async fn foundation_upsert_page(
     name = "foundation_run_upsert_page",
     level = "debug",
     skip_all,
-    fields(tenant = %tenant, slug = %request.slug, expected_version = request.expected_version),
+    fields(
+        tenant = %tenant,
+        database = %database,
+        slug = %request.slug,
+        expected_version = request.expected_version
+    ),
     err(Display)
 )]
 pub(crate) async fn run_upsert_page(
     server: &FoundationApiServer,
     headers: &HeaderMap,
     tenant: &str,
+    database: &str,
     request: &UpsertPageRequest,
     categories: &[String],
 ) -> Result<UpsertPageResponse, UpsertPageError> {
@@ -227,7 +245,7 @@ pub(crate) async fn run_upsert_page(
 
     // Resolve (cache-first) the wiki collection identity, then derive the
     // chunker from its metadata so writes match how the collection was created.
-    let collection = wiki_client.wiki_collection(tenant, token).await?;
+    let collection = wiki_client.wiki_collection(tenant, database, token).await?;
     let chunking = ChunkingConfig::from_collection_metadata(collection.metadata().as_ref());
 
     let mut txn = collection.conditional();
@@ -235,6 +253,7 @@ pub(crate) async fn run_upsert_page(
     let chunk0_response = record_op(
         wiki_client,
         tenant,
+        database,
         txn.get(
             Some(vec![chunk0]),
             None,
@@ -248,6 +267,7 @@ pub(crate) async fn run_upsert_page(
     let existing = record_op(
         wiki_client,
         tenant,
+        database,
         txn.get(
             None,
             Some(where_slug(slug)),
@@ -261,6 +281,7 @@ pub(crate) async fn run_upsert_page(
         let overflow = record_op(
             wiki_client,
             tenant,
+            database,
             txn.get(
                 None,
                 Some(where_slug(slug)),
@@ -393,6 +414,7 @@ pub(crate) async fn run_upsert_page(
     record_op(
         wiki_client,
         tenant,
+        database,
         txn.upsert(
             ids.clone(),
             Some(dense),
@@ -404,10 +426,10 @@ pub(crate) async fn run_upsert_page(
     .await?;
 
     if !stale_ids.is_empty() {
-        record_op(wiki_client, tenant, txn.delete(stale_ids)).await?;
+        record_op(wiki_client, tenant, database, txn.delete(stale_ids)).await?;
     }
 
-    record_op(wiki_client, tenant, txn.commit()).await?;
+    record_op(wiki_client, tenant, database, txn.commit()).await?;
 
     Ok(UpsertPageResponse {
         slug: slug.to_string(),
@@ -431,6 +453,7 @@ pub(crate) async fn run_upsert_page(
 async fn record_op<T, F>(
     wiki_client: &FoundationChromaClient,
     tenant: &str,
+    database: &str,
     fut: F,
 ) -> Result<T, UpsertPageError>
 where
@@ -438,7 +461,7 @@ where
 {
     fut.await.map_err(|err| {
         if is_not_found(&err) {
-            wiki_client.invalidate_wiki(tenant);
+            wiki_client.invalidate_wiki(tenant, database);
         }
         UpsertPageError::RecordIo(err)
     })
@@ -1010,6 +1033,7 @@ mod tests {
             &server,
             &headers,
             "tenant",
+            "FOUNDATION",
             &request(slug, "# Title\n\nBody", &[], &[]),
             &[],
         )

--- a/rust/foundation-api/src/routes/whoami.rs
+++ b/rust/foundation-api/src/routes/whoami.rs
@@ -1,33 +1,197 @@
 use axum::http::HeaderMap;
 use chroma_api_types::GetUserIdentityResponse;
+use chroma_error::{ChromaError, ErrorCodes};
 
 use crate::auth::{AuthError, AuthenticateAndAuthorize, AuthzAction, AuthzResource};
+use crate::routes::FoundationScope;
 
-/// Resolve the caller's identity from the auth token, then check that the
-/// caller is allowed to perform `action` against their tenant.
+/// Longest Foundation name that can ever be deleted.
 ///
-/// The two-step shape exists because the Cloud `authenticate_and_authorize`
-/// impl enforces `resource.tenant == user_identity.tenant` (returns 403 on
-/// mismatch, including `resource.tenant == None`). The Noop impl ignores
-/// resource entirely, which is why a single-call handler that passed
-/// `tenant: None` looked fine in tests but 403'd under Cloud auth.
-pub(super) async fn whoami_and_authorize(
+/// Soft-deleting a database rewrites its name as `_deleted_{name}_{uuid}`,
+/// which adds 46 characters, into a `varchar(128)` column. A name that leaves
+/// less than that much headroom makes the rewrite overflow the column, so the
+/// delete rolls back on every attempt and the Foundation can never be removed.
+const MAX_FOUNDATION_NAME_BYTES: usize = 128 - 46;
+
+/// Name reserved so that `/api/f/{tenant}/foundations` stays free to address the
+/// set of Foundations in a tenant rather than one Foundation named
+/// `foundations`. A Foundation carrying this name would collide with that path.
+const RESERVED_FOUNDATION_NAME: &str = "foundations";
+
+/// Whether a request must name its tenant and Foundation in the path.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ScopePolicy {
+    /// An absent scope resolves to the key's tenant and the configured default
+    /// Foundation.
+    DefaultToConfig,
+    /// An absent scope is refused.
+    Required,
+}
+
+/// Why a request could not be resolved and authorized against one Foundation.
+#[derive(Debug, thiserror::Error)]
+pub(super) enum ScopeError {
+    /// The route demands a path scope and the request carried none.
+    #[error("this route requires a tenant and Foundation in the path")]
+    ScopeRequired,
+    /// The path named a Foundation that is not a legal name.
+    #[error("invalid foundation name '{name}': {message}")]
+    InvalidFoundation { name: String, message: String },
+    /// The path named a tenant that cannot be a tenant id.
+    #[error("invalid tenant '{name}': {message}")]
+    InvalidTenant { name: String, message: String },
+    /// Authentication or authorization refused the request.
+    #[error(transparent)]
+    Auth(#[from] AuthError),
+}
+
+impl ChromaError for ScopeError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            ScopeError::ScopeRequired
+            | ScopeError::InvalidFoundation { .. }
+            | ScopeError::InvalidTenant { .. } => ErrorCodes::InvalidArgument,
+            ScopeError::Auth(err) => err.code(),
+        }
+    }
+}
+
+/// Resolves the tenant and database from the path scope, then authorizes the
+/// caller against exactly that pair in one call. Returns the resolved tenant,
+/// the resolved database, and the caller's identity.
+///
+/// Invariants:
+/// 1. Callers use the returned tenant and database, never the identity's
+///    tenant, so a prefixed request cannot silently act on another Foundation.
+/// 2. The identity round trip happens only on a bare path, where the tenant is
+///    not in the URL. On a prefixed path the single authorization call also
+///    enforces that the path tenant equals the key's tenant.
+/// 3. The returned identity is the one the auth layer answered with, which on a
+///    prefixed path is whatever the authorization call returned rather than a
+///    separate identity lookup. Read `user_id` from it only where the two are
+///    the same caller.
+///
+/// The resource passed to authorization names both the tenant and the database.
+/// `tenant` must be `Some`: the Cloud `authenticate_and_authorize` impl enforces
+/// `resource.tenant == user_identity.tenant` and answers 403 on a mismatch,
+/// including `resource.tenant == None`. The Noop impl ignores the resource
+/// entirely, which is why a handler that passed `tenant: None` looked fine in
+/// tests but 403'd under Cloud auth.
+///
+/// `database` is `Some` so the resource names the Foundation the request
+/// addresses. That decides nothing on its own: the Cloud impl accepts a
+/// permission claim when the claim's database equals the resource's *or* the
+/// claim names no database, and a Foundation permission claim names no database,
+/// so both a named and an absent resource database are accepted. Naming it is
+/// what makes the decision follow the request for a claim that does carry one.
+/// The Foundation boundary itself is enforced downstream, by the frontend, which
+/// re-checks the caller's data-plane claims on every proxied call.
+pub(super) async fn authorize_scope(
     auth: &dyn AuthenticateAndAuthorize,
     headers: &HeaderMap,
     action: AuthzAction,
-) -> Result<GetUserIdentityResponse, AuthError> {
-    let identity = auth.get_user_identity(headers).await?;
-    auth.authenticate_and_authorize(
-        headers,
-        action,
-        AuthzResource {
-            tenant: Some(identity.tenant.clone()),
-            database: None,
-            collection: None,
-        },
-    )
-    .await?;
-    Ok(identity)
+    scope: &FoundationScope,
+    default_database: &str,
+    policy: ScopePolicy,
+) -> Result<(String, String, GetUserIdentityResponse), ScopeError> {
+    if policy == ScopePolicy::Required && (scope.tenant.is_none() || scope.foundation.is_none()) {
+        // Refuse before any round trip: an unscoped write is rejected on its
+        // shape alone, so it costs neither an identity nor an authorization
+        // call.
+        return Err(ScopeError::ScopeRequired);
+    }
+
+    if let Some(name) = scope.foundation.as_deref() {
+        validate_foundation_name(name).map_err(|message| ScopeError::InvalidFoundation {
+            name: name.to_string(),
+            message,
+        })?;
+    }
+
+    if let Some(tenant) = scope.tenant.as_deref() {
+        validate_path_tenant(tenant).map_err(|message| ScopeError::InvalidTenant {
+            name: tenant.to_string(),
+            message,
+        })?;
+    }
+
+    // Only a bare path needs the identity round trip to learn the tenant. On a
+    // prefixed path the authorization call below both checks the permission and
+    // rejects a tenant the key does not own.
+    let (tenant, identity) = match scope.tenant.as_deref() {
+        Some(tenant) => (tenant.to_string(), None),
+        None => {
+            let identity = auth.get_user_identity(headers).await?;
+            (identity.tenant.clone(), Some(identity))
+        }
+    };
+    let database = scope
+        .foundation
+        .clone()
+        .unwrap_or_else(|| default_database.to_string());
+
+    let authorized = auth
+        .authenticate_and_authorize(
+            headers,
+            action,
+            AuthzResource {
+                tenant: Some(tenant.clone()),
+                database: Some(database.clone()),
+                collection: None,
+            },
+        )
+        .await?;
+
+    Ok((tenant, database, identity.unwrap_or(authorized)))
+}
+
+/// Checks that `name` is a legal Foundation name.
+///
+/// A Foundation is a Chroma database and its name is the database name, so this
+/// is [`chroma_types::validate_name`] plus three rules that database names alone
+/// do not carry:
+/// 1. At most [`MAX_FOUNDATION_NAME_BYTES`] bytes, so the Foundation stays
+///    deletable.
+/// 2. No `+`. The data plane reads a leading `topology+` as a multi-region
+///    topology prefix, and `validate_name` deliberately accepts one `+`, so a
+///    name carrying it addresses a different database than it spells.
+/// 3. Not [`RESERVED_FOUNDATION_NAME`], which the CRUD routes occupy.
+pub(super) fn validate_foundation_name(name: &str) -> Result<(), String> {
+    if name.len() > MAX_FOUNDATION_NAME_BYTES {
+        return Err(format!(
+            "name must be at most {MAX_FOUNDATION_NAME_BYTES} bytes, got {}",
+            name.len()
+        ));
+    }
+    if name.contains('+') {
+        return Err("name must not contain '+'".to_string());
+    }
+    if name == RESERVED_FOUNDATION_NAME {
+        return Err(format!("'{RESERVED_FOUNDATION_NAME}' is a reserved name"));
+    }
+    chroma_types::validate_name(name).map_err(|err| {
+        err.message
+            .map(|message| message.to_string())
+            .unwrap_or_else(|| "name is not a valid database name".to_string())
+    })
+}
+
+/// Checks that `name` can be a tenant id.
+///
+/// Authorization is the real gate on the path tenant: it refuses any tenant the
+/// caller's key does not own. This is the shape check underneath it, because the
+/// tenant is interpolated into the data-plane URL without escaping, so a value
+/// carrying a path separator would address a different route than it spells.
+/// A deployment whose auth implementation enforces nothing would otherwise have
+/// no guard at all.
+fn validate_path_tenant(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("tenant must not be empty".to_string());
+    }
+    if name.contains('/') || name.contains('?') || name.contains('#') {
+        return Err("tenant must not contain a URL path or query separator".to_string());
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -36,16 +200,24 @@ mod tests {
     use std::collections::HashSet;
     use std::future::{ready, Future};
     use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     /// Fake auth that returns a fixed identity and records the action /
     /// resource passed to `authenticate_and_authorize` so tests can
     /// assert on it.
+    ///
+    /// `enforce_tenant_match` reproduces the Cloud impl's 403 on a resource
+    /// tenant the key does not own. The Noop impl enforces nothing, so only a
+    /// fake can produce that refusal.
     struct FakeAuth {
         user_id: String,
         tenant: String,
+        enforce_tenant_match: bool,
         captured_action: Mutex<Option<AuthzAction>>,
         captured_resource: Mutex<Option<AuthzResource>>,
+        identity_calls: AtomicUsize,
+        authorize_calls: AtomicUsize,
     }
 
     impl FakeAuth {
@@ -53,8 +225,18 @@ mod tests {
             Self {
                 user_id: user_id.to_string(),
                 tenant: tenant.to_string(),
+                enforce_tenant_match: false,
                 captured_action: Mutex::new(None),
                 captured_resource: Mutex::new(None),
+                identity_calls: AtomicUsize::new(0),
+                authorize_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn enforcing_tenant_match(user_id: &str, tenant: &str) -> Self {
+            Self {
+                enforce_tenant_match: true,
+                ..Self::new(user_id, tenant)
             }
         }
 
@@ -64,6 +246,22 @@ mod tests {
                 tenant: self.tenant.clone(),
                 databases: HashSet::new(),
             }
+        }
+
+        fn identity_calls(&self) -> usize {
+            self.identity_calls.load(Ordering::SeqCst)
+        }
+
+        fn authorize_calls(&self) -> usize {
+            self.authorize_calls.load(Ordering::SeqCst)
+        }
+
+        fn captured_resource(&self) -> AuthzResource {
+            self.captured_resource
+                .lock()
+                .unwrap()
+                .clone()
+                .expect("authenticate_and_authorize should have been called")
         }
     }
 
@@ -75,8 +273,12 @@ mod tests {
             resource: AuthzResource,
         ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
         {
+            self.authorize_calls.fetch_add(1, Ordering::SeqCst);
             *self.captured_action.lock().unwrap() = Some(action);
-            *self.captured_resource.lock().unwrap() = Some(resource);
+            *self.captured_resource.lock().unwrap() = Some(resource.clone());
+            if self.enforce_tenant_match && resource.tenant.as_deref() != Some(&self.tenant) {
+                return Box::pin(ready(Err(AuthError(axum::http::StatusCode::FORBIDDEN))));
+            }
             let identity = self.identity();
             Box::pin(ready(Ok(identity)))
         }
@@ -98,22 +300,40 @@ mod tests {
             _headers: &HeaderMap,
         ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
         {
+            self.identity_calls.fetch_add(1, Ordering::SeqCst);
             let identity = self.identity();
             Box::pin(ready(Ok(identity)))
         }
     }
 
+    fn scope(tenant: Option<&str>, foundation: Option<&str>) -> FoundationScope {
+        FoundationScope {
+            tenant: tenant.map(str::to_string),
+            foundation: foundation.map(str::to_string),
+        }
+    }
+
     #[tokio::test]
-    async fn passes_resolved_tenant_to_authz_and_returns_full_identity() {
+    async fn bare_path_resolves_key_tenant_and_configured_database() {
         let fake = FakeAuth::new("user_99", "team_abc");
         let headers = HeaderMap::new();
 
-        let identity = whoami_and_authorize(&fake, &headers, AuthzAction::InitFoundation)
-            .await
-            .expect("auth should succeed");
+        let (tenant, database, identity) = authorize_scope(
+            &fake,
+            &headers,
+            AuthzAction::InitFoundation,
+            &FoundationScope::default(),
+            "FOUNDATION",
+            ScopePolicy::DefaultToConfig,
+        )
+        .await
+        .expect("auth should succeed");
 
-        assert_eq!(identity.tenant, "team_abc");
+        assert_eq!(tenant, "team_abc");
+        assert_eq!(database, "FOUNDATION");
         assert_eq!(identity.user_id, "user_99");
+        // The tenant is not in the URL, so it has to be looked up once.
+        assert_eq!(fake.identity_calls(), 1);
 
         let captured_action = fake
             .captured_action
@@ -122,16 +342,174 @@ mod tests {
             .expect("authenticate_and_authorize should have been called");
         assert_eq!(captured_action, AuthzAction::InitFoundation);
 
-        let captured = fake
-            .captured_resource
-            .lock()
-            .unwrap()
-            .clone()
-            .expect("authenticate_and_authorize should have been called");
-        // Regression: before this fix the handler passed `tenant: None`,
-        // which the Cloud authz impl always rejects with 403.
+        let captured = fake.captured_resource();
+        // Regression: a handler that passed `tenant: None` is always refused by
+        // the Cloud authz impl.
         assert_eq!(captured.tenant, Some("team_abc".to_string()));
-        assert_eq!(captured.database, None);
+        assert_eq!(captured.database, Some("FOUNDATION".to_string()));
         assert_eq!(captured.collection, None);
+    }
+
+    #[tokio::test]
+    async fn prefixed_path_uses_path_pair_without_an_identity_call() {
+        let fake = FakeAuth::new("user_99", "team_abc");
+        let headers = HeaderMap::new();
+
+        let (tenant, database, identity) = authorize_scope(
+            &fake,
+            &headers,
+            AuthzAction::ViewFoundation,
+            &scope(Some("team_abc"), Some("wiki_team")),
+            "FOUNDATION",
+            ScopePolicy::Required,
+        )
+        .await
+        .expect("auth should succeed");
+
+        assert_eq!(tenant, "team_abc");
+        assert_eq!(database, "wiki_team");
+        assert_eq!(identity.user_id, "user_99");
+        // The single authorization call also settles whether the key owns the
+        // path tenant, so no separate identity lookup is made.
+        assert_eq!(fake.identity_calls(), 0);
+        assert_eq!(fake.authorize_calls(), 1);
+
+        let captured = fake.captured_resource();
+        assert_eq!(captured.tenant, Some("team_abc".to_string()));
+        assert_eq!(captured.database, Some("wiki_team".to_string()));
+    }
+
+    #[tokio::test]
+    async fn path_tenant_the_key_does_not_own_is_refused() {
+        let fake = FakeAuth::enforcing_tenant_match("user_99", "team_abc");
+        let headers = HeaderMap::new();
+
+        let err = authorize_scope(
+            &fake,
+            &headers,
+            AuthzAction::ViewFoundation,
+            &scope(Some("team_other"), Some("wiki_team")),
+            "FOUNDATION",
+            ScopePolicy::Required,
+        )
+        .await
+        .expect_err("a foreign tenant should be refused");
+
+        assert_eq!(err.code(), ErrorCodes::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn required_policy_rejects_an_absent_scope_without_calling_auth() {
+        let fake = FakeAuth::new("user_99", "team_abc");
+        let headers = HeaderMap::new();
+
+        let err = authorize_scope(
+            &fake,
+            &headers,
+            AuthzAction::UpsertFoundation,
+            &FoundationScope::default(),
+            "FOUNDATION",
+            ScopePolicy::Required,
+        )
+        .await
+        .expect_err("an unscoped write should be refused");
+
+        assert!(matches!(err, ScopeError::ScopeRequired));
+        assert_eq!(err.code(), ErrorCodes::InvalidArgument);
+        assert_eq!(fake.identity_calls(), 0);
+        assert_eq!(fake.authorize_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn an_invalid_foundation_name_is_rejected_before_authorization() {
+        let fake = FakeAuth::new("user_99", "team_abc");
+        let headers = HeaderMap::new();
+
+        let err = authorize_scope(
+            &fake,
+            &headers,
+            AuthzAction::ViewFoundation,
+            &scope(Some("team_abc"), Some("my..db")),
+            "FOUNDATION",
+            ScopePolicy::Required,
+        )
+        .await
+        .expect_err("an invalid name should be refused");
+
+        assert!(matches!(err, ScopeError::InvalidFoundation { .. }));
+        assert_eq!(err.code(), ErrorCodes::InvalidArgument);
+        assert_eq!(fake.authorize_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn a_path_tenant_carrying_a_separator_is_rejected_before_authorization() {
+        let fake = FakeAuth::new("user_99", "team_abc");
+        let headers = HeaderMap::new();
+
+        let err = authorize_scope(
+            &fake,
+            &headers,
+            AuthzAction::ViewFoundation,
+            &scope(Some("team_abc/../other"), Some("wiki_team")),
+            "FOUNDATION",
+            ScopePolicy::Required,
+        )
+        .await
+        .expect_err("a tenant carrying a path separator should be refused");
+
+        assert!(matches!(err, ScopeError::InvalidTenant { .. }));
+        assert_eq!(err.code(), ErrorCodes::InvalidArgument);
+        assert_eq!(fake.authorize_calls(), 0);
+    }
+
+    #[test]
+    fn tenant_validator_accepts_a_uuid_and_rejects_separators() {
+        assert_eq!(
+            validate_path_tenant("2f1e0d9c-8b7a-4655-9443-2211aabbccdd"),
+            Ok(())
+        );
+        assert!(validate_path_tenant("").is_err());
+        assert!(validate_path_tenant("a/b").is_err());
+        assert!(validate_path_tenant("a?b").is_err());
+        assert!(validate_path_tenant("a#b").is_err());
+    }
+
+    #[test]
+    fn validator_accepts_a_plain_name() {
+        assert_eq!(validate_foundation_name("wiki_team"), Ok(()));
+    }
+
+    #[test]
+    fn validator_rejects_a_name_below_the_database_minimum() {
+        assert!(validate_foundation_name("ab").is_err());
+    }
+
+    #[test]
+    fn validator_rejects_a_topology_prefix() {
+        // `validate_name` accepts a single `+` because a database name may
+        // carry a topology prefix, so the Foundation rule has to reject it
+        // separately or a name would address a different database than it
+        // spells. Both halves still have to be valid names on their own, which
+        // is why the suffix here is longer than the three-character minimum.
+        assert!(chroma_types::validate_name("topo+database").is_ok());
+        assert!(validate_foundation_name("topo+database").is_err());
+    }
+
+    #[test]
+    fn validator_rejects_a_name_that_could_never_be_deleted() {
+        let at_limit = "a".repeat(MAX_FOUNDATION_NAME_BYTES);
+        let over_limit = "a".repeat(MAX_FOUNDATION_NAME_BYTES + 1);
+        assert_eq!(validate_foundation_name(&at_limit), Ok(()));
+        assert!(validate_foundation_name(&over_limit).is_err());
+    }
+
+    #[test]
+    fn validator_rejects_consecutive_periods() {
+        assert!(validate_foundation_name("my..db").is_err());
+    }
+
+    #[test]
+    fn validator_rejects_the_reserved_crud_path_segment() {
+        assert!(validate_foundation_name(RESERVED_FOUNDATION_NAME).is_err());
     }
 }

--- a/rust/foundation-api/src/routes/whoami.rs
+++ b/rust/foundation-api/src/routes/whoami.rs
@@ -181,15 +181,42 @@ pub(super) fn validate_foundation_name(name: &str) -> Result<(), String> {
 /// Authorization is the real gate on the path tenant: it refuses any tenant the
 /// caller's key does not own. This is the shape check underneath it, because the
 /// tenant is interpolated into the data-plane URL without escaping, so a value
-/// carrying a path separator would address a different route than it spells.
-/// A deployment whose auth implementation enforces nothing would otherwise have
-/// no guard at all.
+/// carrying a path separator would address a different route than it spells. A
+/// deployment whose auth implementation enforces nothing would otherwise have no
+/// guard at all.
+///
+/// The rule is an allow-list rather than a list of forbidden characters, because
+/// the URL parser that builds the data-plane request rewrites the path before
+/// sending it. It reads `\` as a separator and drops a segment of `.` or `..`,
+/// so `x\..\victim` resolves to the tenant `victim`. It decodes `%2e` first, so
+/// the text `%2e%2e` resolves the way `..` does, and a caller writing
+/// `%252e%252e` reaches this check as exactly that text. Every one of those
+/// spellings clears a list that forbids `/`, `?` and `#`.
+///
+/// Letters, digits, `.`, `_` and `-`, with both ends alphanumeric, leave the
+/// parser nothing to rewrite: the only segments it drops are exactly `.` and
+/// `..`, which the ends rule refuses, and every separator and escape it honours
+/// falls outside the allowed set.
 fn validate_path_tenant(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("tenant must not be empty".to_string());
     }
-    if name.contains('/') || name.contains('?') || name.contains('#') {
-        return Err("tenant must not contain a URL path or query separator".to_string());
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+    {
+        return Err("tenant must contain only letters, digits, '.', '_' and '-'".to_string());
+    }
+    let ends_are_alphanumeric = name
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+        && name
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_ascii_alphanumeric());
+    if !ends_are_alphanumeric {
+        return Err("tenant must start and end with a letter or digit".to_string());
     }
     Ok(())
 }
@@ -468,10 +495,39 @@ mod tests {
             validate_path_tenant("2f1e0d9c-8b7a-4655-9443-2211aabbccdd"),
             Ok(())
         );
+        assert_eq!(validate_path_tenant("default_tenant"), Ok(()));
         assert!(validate_path_tenant("").is_err());
         assert!(validate_path_tenant("a/b").is_err());
         assert!(validate_path_tenant("a?b").is_err());
         assert!(validate_path_tenant("a#b").is_err());
+        // The ends rule is what refuses a bare `.` or `..`, so it has to hold
+        // on a name that merely starts or finishes with a separator character.
+        assert!(validate_path_tenant("_team").is_err());
+        assert!(validate_path_tenant("team-").is_err());
+    }
+
+    #[test]
+    fn tenant_validator_rejects_a_spelling_the_url_parser_would_rewrite() {
+        // Each of these clears a check that forbids `/`, `?` and `#`, and each
+        // is rewritten by the URL parser that builds the data-plane request.
+
+        // A backslash is a separator to that parser, which then drops the `..`
+        // segment beside it, so this one resolves to the tenant `victim`.
+        assert!(validate_path_tenant("x\\..\\victim").is_err());
+        // `%2e` decodes to `.`, so this resolves the way `..` does. A caller
+        // writing `%252e%252e` reaches the validator as exactly this text.
+        assert!(validate_path_tenant("%2e%2e").is_err());
+        // A percent escape has no place in a tenant id whatever it spells, so
+        // no second decoding round can reach a separator.
+        assert!(validate_path_tenant("team%2F..%2Fother").is_err());
+        // A segment the parser drops outright addresses a shorter path than
+        // the URL spells.
+        assert!(validate_path_tenant("..").is_err());
+        assert!(validate_path_tenant(".").is_err());
+        assert!(validate_path_tenant("team 1").is_err());
+        // Two periods inside a segment are not a traversal, so the rule does
+        // not reach further than it needs to.
+        assert_eq!(validate_path_tenant("team..1"), Ok(()));
     }
 
     #[test]

--- a/rust/foundation-api/src/routes/whoami.rs
+++ b/rust/foundation-api/src/routes/whoami.rs
@@ -224,114 +224,7 @@ fn validate_path_tenant(name: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
-    use std::future::{ready, Future};
-    use std::pin::Pin;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Mutex;
-
-    /// Fake auth that returns a fixed identity and records the action /
-    /// resource passed to `authenticate_and_authorize` so tests can
-    /// assert on it.
-    ///
-    /// `enforce_tenant_match` reproduces the Cloud impl's 403 on a resource
-    /// tenant the key does not own. The Noop impl enforces nothing, so only a
-    /// fake can produce that refusal.
-    struct FakeAuth {
-        user_id: String,
-        tenant: String,
-        enforce_tenant_match: bool,
-        captured_action: Mutex<Option<AuthzAction>>,
-        captured_resource: Mutex<Option<AuthzResource>>,
-        identity_calls: AtomicUsize,
-        authorize_calls: AtomicUsize,
-    }
-
-    impl FakeAuth {
-        fn new(user_id: &str, tenant: &str) -> Self {
-            Self {
-                user_id: user_id.to_string(),
-                tenant: tenant.to_string(),
-                enforce_tenant_match: false,
-                captured_action: Mutex::new(None),
-                captured_resource: Mutex::new(None),
-                identity_calls: AtomicUsize::new(0),
-                authorize_calls: AtomicUsize::new(0),
-            }
-        }
-
-        fn enforcing_tenant_match(user_id: &str, tenant: &str) -> Self {
-            Self {
-                enforce_tenant_match: true,
-                ..Self::new(user_id, tenant)
-            }
-        }
-
-        fn identity(&self) -> GetUserIdentityResponse {
-            GetUserIdentityResponse {
-                user_id: self.user_id.clone(),
-                tenant: self.tenant.clone(),
-                databases: HashSet::new(),
-            }
-        }
-
-        fn identity_calls(&self) -> usize {
-            self.identity_calls.load(Ordering::SeqCst)
-        }
-
-        fn authorize_calls(&self) -> usize {
-            self.authorize_calls.load(Ordering::SeqCst)
-        }
-
-        fn captured_resource(&self) -> AuthzResource {
-            self.captured_resource
-                .lock()
-                .unwrap()
-                .clone()
-                .expect("authenticate_and_authorize should have been called")
-        }
-    }
-
-    impl AuthenticateAndAuthorize for FakeAuth {
-        fn authenticate_and_authorize(
-            &self,
-            _headers: &HeaderMap,
-            action: AuthzAction,
-            resource: AuthzResource,
-        ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
-        {
-            self.authorize_calls.fetch_add(1, Ordering::SeqCst);
-            *self.captured_action.lock().unwrap() = Some(action);
-            *self.captured_resource.lock().unwrap() = Some(resource.clone());
-            if self.enforce_tenant_match && resource.tenant.as_deref() != Some(&self.tenant) {
-                return Box::pin(ready(Err(AuthError(axum::http::StatusCode::FORBIDDEN))));
-            }
-            let identity = self.identity();
-            Box::pin(ready(Ok(identity)))
-        }
-
-        fn authenticate_and_authorize_collection(
-            &self,
-            _headers: &HeaderMap,
-            _action: AuthzAction,
-            _resource: AuthzResource,
-            _collection: chroma_types::Collection,
-        ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
-        {
-            let identity = self.identity();
-            Box::pin(ready(Ok(identity)))
-        }
-
-        fn get_user_identity(
-            &self,
-            _headers: &HeaderMap,
-        ) -> Pin<Box<dyn Future<Output = Result<GetUserIdentityResponse, AuthError>> + Send>>
-        {
-            self.identity_calls.fetch_add(1, Ordering::SeqCst);
-            let identity = self.identity();
-            Box::pin(ready(Ok(identity)))
-        }
-    }
+    use crate::routes::test_auth::FakeAuth;
 
     fn scope(tenant: Option<&str>, foundation: Option<&str>) -> FoundationScope {
         FoundationScope {
@@ -362,12 +255,7 @@ mod tests {
         // The tenant is not in the URL, so it has to be looked up once.
         assert_eq!(fake.identity_calls(), 1);
 
-        let captured_action = fake
-            .captured_action
-            .lock()
-            .unwrap()
-            .expect("authenticate_and_authorize should have been called");
-        assert_eq!(captured_action, AuthzAction::InitFoundation);
+        assert_eq!(fake.captured_action(), AuthzAction::InitFoundation);
 
         let captured = fake.captured_resource();
         // Regression: a handler that passed `tenant: None` is always refused by

--- a/rust/worker/src/execution/functions/count_to_file_async.rs
+++ b/rust/worker/src/execution/functions/count_to_file_async.rs
@@ -279,6 +279,7 @@ mod tests {
                     input_collection_name: "test-input".to_string(),
                     tenant_id: "test-tenant".to_string(),
                     database_id: "test-database".to_string(),
+                    database_name: Some("test_database_name".to_string()),
                     pulled_log_offset,
                     records: Chunk::new(Arc::from(records)),
                 }],

--- a/rust/worker/src/execution/functions/http_generate.rs
+++ b/rust/worker/src/execution/functions/http_generate.rs
@@ -33,6 +33,11 @@ struct GenerateRecord {
 struct GenerateRecordSet {
     tenant_id: String,
     database_id: String,
+    /// The name of the database the source collection lives in, which names the
+    /// Foundation the generated pages belong to. `None` when the caller could
+    /// not resolve one; the endpoint then has to fall back to its own
+    /// configuration.
+    database_name: Option<String>,
     source_collection: String,
     source_kind: String,
     output_collection: String,
@@ -313,6 +318,7 @@ impl HttpGenerateExecutor {
             let template = GenerateRecordSet {
                 tenant_id: record_set.tenant_id,
                 database_id: record_set.database_id,
+                database_name: record_set.database_name,
                 source_collection: record_set.source_collection,
                 source_kind: record_set.source_kind,
                 output_collection: record_set.output_collection,
@@ -414,6 +420,7 @@ impl AttachedFunctionExecutor for HttpGenerateExecutor {
             record_sets.push(GenerateRecordSet {
                 tenant_id: batch.tenant_id.clone(),
                 database_id: batch.database_id.clone(),
+                database_name: batch.database_name.clone(),
                 source_collection: batch.input_collection_name.clone(),
                 source_kind: source_kind_for_collection_name(&batch.input_collection_name)
                     .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?
@@ -475,8 +482,8 @@ impl AttachedFunctionExecutor for HttpGenerateExecutor {
 #[cfg(test)]
 mod tests {
     use super::{
-        GenerateRecord, GenerateRecordSet, HttpGenerateError, HttpGenerateExecutor,
-        DEFAULT_GENERATE_BATCH_SIZE, MAX_GENERATE_REQUEST_BYTES,
+        GenerateRecord, GenerateRecordSet, GenerateRequest, HttpGenerateError,
+        HttpGenerateExecutor, DEFAULT_GENERATE_BATCH_SIZE, MAX_GENERATE_REQUEST_BYTES,
     };
     use frontend_core::foundation::source_kind_for_collection_name;
     use std::collections::HashMap;
@@ -486,6 +493,7 @@ mod tests {
         let record_set = GenerateRecordSet {
             tenant_id: "tenant".to_string(),
             database_id: "database".to_string(),
+            database_name: Some("FOUNDATION".to_string()),
             source_collection: "slack_master".to_string(),
             source_kind: source_kind_for_collection_name("slack_master")
                 .unwrap()
@@ -504,6 +512,7 @@ mod tests {
         GenerateRecordSet {
             tenant_id: "tenant".to_string(),
             database_id: "database".to_string(),
+            database_name: Some("FOUNDATION".to_string()),
             source_collection: "slack_master".to_string(),
             source_kind: "slack".to_string(),
             output_collection: "wiki".to_string(),
@@ -552,6 +561,42 @@ mod tests {
         assert_eq!(requests.len(), 2);
         assert_eq!(requests[0].record_sets[0].records.len(), 2);
         assert_eq!(requests[1].record_sets[0].records.len(), 1);
+    }
+
+    #[test]
+    fn every_split_request_keeps_the_source_database_name() {
+        // Splitting a record set rebuilds its envelope for each batch, which is
+        // the one place the database name could be dropped. A batch that lost it
+        // would have its pages written into whichever Foundation the endpoint
+        // falls back to.
+        let requests = HttpGenerateExecutor::batch_requests(
+            vec![record_set_with_documents(vec![
+                "one".to_string(),
+                "two".to_string(),
+                "three".to_string(),
+            ])],
+            2,
+        )
+        .unwrap();
+
+        assert_eq!(requests.len(), 2);
+        assert!(requests
+            .iter()
+            .all(|request| request.record_sets[0].database_name.as_deref() == Some("FOUNDATION")));
+    }
+
+    #[test]
+    fn the_source_database_name_is_serialized_for_the_endpoint() {
+        let record_set = record_set_with_documents(vec!["one".to_string()]);
+        let body = serde_json::to_value(GenerateRequest {
+            record_sets: vec![record_set],
+        })
+        .expect("request should serialize");
+
+        assert_eq!(
+            body["record_sets"][0]["database_name"],
+            serde_json::json!("FOUNDATION")
+        );
     }
 
     #[test]

--- a/rust/worker/src/execution/functions/revision_history.rs
+++ b/rust/worker/src/execution/functions/revision_history.rs
@@ -560,6 +560,7 @@ mod tests {
             input_collection_name: "test-input".to_string(),
             tenant_id: "test-tenant".to_string(),
             database_id: "test-database".to_string(),
+            database_name: Some("test_database_name".to_string()),
             pulled_log_offset: 0,
             records,
         }

--- a/rust/worker/src/execution/functions/statistics.rs
+++ b/rust/worker/src/execution/functions/statistics.rs
@@ -560,6 +560,7 @@ mod tests {
             input_collection_name: "test-input".to_string(),
             tenant_id: "test-tenant".to_string(),
             database_id: "test-database".to_string(),
+            database_name: Some("test_database_name".to_string()),
             pulled_log_offset: 0,
             records,
         }

--- a/rust/worker/src/execution/operators/execute_task.rs
+++ b/rust/worker/src/execution/operators/execute_task.rs
@@ -268,6 +268,10 @@ pub struct ExecuteAttachedFunctionBatchInput {
     pub input_collection_name: String,
     pub tenant_id: String,
     pub database_id: String,
+    /// The name of the database holding the input collection. `None` when the
+    /// caller cannot supply one; executors that address a database by name must
+    /// then fall back to their own configuration.
+    pub database_name: Option<String>,
     pub pulled_log_offset: u64,
 }
 
@@ -277,6 +281,9 @@ pub struct HydratedInputBatch<'me, 'q> {
     pub input_collection_name: String,
     pub tenant_id: String,
     pub database_id: String,
+    /// Carried verbatim from the batch input, so an executor sees the same
+    /// database name the orchestrator resolved.
+    pub database_name: Option<String>,
     pub pulled_log_offset: u64,
     pub records: Chunk<HydratedMaterializedLogRecord<'me, 'q>>,
 }
@@ -434,6 +441,7 @@ impl Operator<ExecuteAttachedFunctionInput, ExecuteAttachedFunctionOutput>
                 input_collection_name: batch.input_collection_name.clone(),
                 tenant_id: batch.tenant_id.clone(),
                 database_id: batch.database_id.clone(),
+                database_name: batch.database_name.clone(),
                 pulled_log_offset: batch.pulled_log_offset,
                 records: Chunk::new(std::sync::Arc::from(hydrated_records)),
             });
@@ -604,6 +612,7 @@ mod tests {
                         input_collection_name: "input-a".to_string(),
                         tenant_id: output_segment.collection.tenant.clone(),
                         database_id: output_segment.collection.database_id.to_string(),
+                        database_name: Some(output_segment.collection.database.clone()),
                         pulled_log_offset: 0,
                     },
                     ExecuteAttachedFunctionBatchInput {
@@ -613,6 +622,7 @@ mod tests {
                         input_collection_name: "input-b".to_string(),
                         tenant_id: output_segment.collection.tenant.clone(),
                         database_id: output_segment.collection.database_id.to_string(),
+                        database_name: Some(output_segment.collection.database.clone()),
                         pulled_log_offset: 0,
                     },
                 ],

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -1132,6 +1132,7 @@ impl Handler<TaskResult<CollectionAndSegments, GetCollectionAndSegmentsError>>
                         input_collection_name: collection_info.collection.name.clone(),
                         tenant_id: collection_info.collection.tenant.clone(),
                         database_id: collection_info.collection.database_id.to_string(),
+                        database_name: Some(collection_info.collection.database.clone()),
                         pulled_log_offset: resolve_pulled_log_offset(
                             self.is_for_backfill,
                             collection_info.pulled_log_offset,


### PR DESCRIPTION
A tenant can contain multiple private memory resources, each backed by its own Chroma database. This PR lets API callers select a tenant and Foundation explicitly. Foundation product identity is supplied by the catalog in #7713.

## What changes

Foundation memory routes use the explicit tenant/Foundation hierarchy: `/api/tenants/{tenant}/foundations/{foundation}/...` alongside the existing paths. Shared scope resolution reads the tenant and database from the path, or resolves the caller's tenant and configured default for an unprefixed request. Authorization receives that exact pair. Prefixed requests avoid the identity lookup needed by the default alias.

Collection lookups and cache keys carry the database name. Cached models whose tenant or database disagrees with the request are rejected and fetched again. The generation worker includes the source database name in every outgoing record batch so the generator can write pages to the correct Foundation.

Path components use allowlists because they become parts of downstream URLs. Tenant names require alphanumeric ends and allow only ASCII letters, digits, dots, underscores, and hyphens. Foundation names also enforce the database naming rules. Encoded separators cannot survive into another decoding step.

## Deliberate choices

Initialization keeps its unprefixed registration; named creation and catalog provisioning are handled directly by #7713. A configuration flag can require explicit Foundation prefixes for writes and defaults to permissive. Page links remain available for the configured default Foundation; other Foundations omit links because the web interface cannot address them. Rate limits remain per tenant.

The hosted authorization implementation checks the caller's tenant and permissions. The standalone authorization implementation remains permissive; the integrated catalog consumer requires an explicitly injected registry and otherwise returns an unavailable error for catalog-dependent operations.

## Validation and rollout

The explicit-route update passes all 318 Foundation API tests (two live tests ignored), including the API and MCP routing and catalog-identity checks. The previous integration also passes 24 sysdb and six worker HTTP-generation tests; this route-only change leaves those implementations unchanged. Clippy passes for Foundation API and worker with all targets/features and `-D warnings -D clippy::large_futures -D clippy::all`. Formatting and commit hooks pass. These are local integrated-stack results; remote CI and deployed acceptance remain separate gates.

The Chroma stack is #7712 → #7713 → #7714, rebased on main `0dad2c71e`. The combined MCP head is `ac541188702af60829736272fca338c03b8f6f9b`; its tree is identical to the verified explicit-route implementation. This branch includes the base API route change; the lifecycle and MCP branches extend the same hierarchy. Every service that checks Foundation permissions must name its database before hosted-chroma #8382 begins issuing database-scoped Foundation grants. The product table, reviewed backfill, and hosted adapter must be ready before catalog-enforced consumers roll out. Explicit-write enforcement remains permissive until writers migrate.

The [living project tracker](https://app.notion.com/p/3e258a6d81918162b7dfdc1f3274815c) records dependencies and remaining rollout gates.
