### PR TITLE
[ENH](mdac): Deploy mdac-service via Tilt and Helm

### DIFF
--- a/.github/actions/tilt-setup-prebuild/docker-bake.hcl
+++ b/.github/actions/tilt-setup-prebuild/docker-bake.hcl
@@ -109,6 +109,15 @@ target "fn-consumer" {
   tags = [ "fn-consumer:ci" ]
 }
 
+target "mdac-service" {
+  dockerfile = "rust/Dockerfile"
+  target = "mdac_service"
+  args = {
+    LOG_SERVICE_CARGO_FEATURES = "faults"
+  }
+  tags = [ "mdac-service:ci" ]
+}
+
 group "default" {
   targets = [
     "rust-log-service",
@@ -122,6 +131,7 @@ group "default" {
     "garbage-collector",
     "load-service",
     "work-queue-service",
-    "fn-consumer"
+    "fn-consumer",
+    "mdac-service"
   ]
 }

--- a/.github/actions/tilt/action.yaml
+++ b/.github/actions/tilt/action.yaml
@@ -39,3 +39,4 @@ runs:
         kubectl -n chroma port-forward svc/minio 9000:9000 &
         kubectl -n chroma port-forward svc/jaeger 16686:16686 &
         kubectl -n chroma port-forward svc/work-queue-service 50058:50051 &
+        kubectl -n chroma port-forward svc/mdac-service 8002:8000 &

--- a/Tiltfile
+++ b/Tiltfile
@@ -197,6 +197,23 @@ else:
   )
 
 
+if config.tilt_subcommand == "ci":
+  custom_build(
+    'mdac-service',
+    'docker image tag mdac-service:ci $EXPECTED_REF',
+    ['./rust/', './idl/', './Cargo.toml', './Cargo.lock'],
+    disable_push=True
+  )
+else:
+  docker_build(
+    'mdac-service',
+    '.',
+    only=["rust/", "idl/", "Cargo.toml", "Cargo.lock"],
+    dockerfile='./rust/Dockerfile',
+    target='mdac_service'
+  )
+
+
 # First install the CRD
 k8s_yaml(
   ['k8s/distributed-chroma/crds/memberlist_crd.yaml'],
@@ -218,7 +235,7 @@ if os.path.exists('k8s/distributed-chroma/values.foundation.local.yaml'):
 # We manually call helm template so we can call set-file
 k8s_yaml(
   local(
-    'helm template --set-file rustFrontendService.configuration=' + rfe_config_file + ',rustLogService.configuration=' + worker_config_file + ',heapTenderService.configuration=' + worker_config_file + ',compactionService.configuration=' + worker_config_file + ',queryService.configuration=' + worker_config_file + ',garbageCollector.configuration=' + worker_config_file + ',rustSysdbService.configuration=' + worker_config_file + ',workQueueService.configuration=' + worker_config_file + ',fnConsumer.configuration=' + worker_config_file + foundation_config_set_file + ' --values ' + distributed_chroma_values + ' k8s/distributed-chroma'
+    'helm template --set-file rustFrontendService.configuration=' + rfe_config_file + ',rustLogService.configuration=' + worker_config_file + ',heapTenderService.configuration=' + worker_config_file + ',compactionService.configuration=' + worker_config_file + ',queryService.configuration=' + worker_config_file + ',garbageCollector.configuration=' + worker_config_file + ',rustSysdbService.configuration=' + worker_config_file + ',workQueueService.configuration=' + worker_config_file + ',fnConsumer.configuration=' + worker_config_file + ',mdacService.configuration=rust/mdac-service/config/modal-main.yaml' + foundation_config_set_file + ' --values ' + distributed_chroma_values + ' k8s/distributed-chroma'
   ),
 )
 
@@ -234,6 +251,7 @@ k8s_yaml(
   ),
 )
 
+watch_file('rust/mdac-service/config/modal-main.yaml')
 watch_file('rust/frontend/sample_configs/distributed.yaml')
 watch_file('rust/frontend/sample_configs/distributed_mcmr.yaml')
 watch_file('rust/frontend/sample_configs/distributed2.yaml')
@@ -381,6 +399,8 @@ k8s_resource('work-queue-service:statefulset:chroma', resource_deps=['sysdb:depl
 k8s_resource('fn-consumer:deployment:chroma', resource_deps=['sysdb:deployment:chroma', 'work-queue-service:statefulset:chroma'], labels=["chroma"], port_forwards="50059:50051")
 k8s_resource('garbage-collector:statefulset:chroma', resource_deps=['k8s_setup', 'minio-deployment', 'rust-log-service:statefulset:chroma'], labels=["chroma"], port_forwards='50055:50055')
 
+k8s_resource('mdac-service', resource_deps=['k8s_setup', 'otel-collector'], labels=["chroma"], port_forwards='8002:8000')
+
 # Production Chroma 2
 k8s_resource('postgres:deployment:chroma2', resource_deps=['k8s_setup2', 'postgres:deployment:chroma'], labels=["infrastructure2"], port_forwards='6432:5432')
 # Jobs are suffixed with the image tag to ensure they are unique. In this context, the image tag is defined in k8s/distributed-chroma/values.yaml.
@@ -423,6 +443,7 @@ groups = {
     'compaction-service:statefulset:chroma',
     'work-queue-service:statefulset:chroma',
     'fn-consumer:deployment:chroma',
+    'mdac-service',
     'garbage-collector:statefulset:chroma',
     'jaeger',
     'grafana',

--- a/k8s/distributed-chroma/templates/mdac-service.yaml
+++ b/k8s/distributed-chroma/templates/mdac-service.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.mdacService.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mdac-service-config
+  namespace: {{ .Values.namespace }}
+data:
+  config.yaml: |
+{{ .Values.mdacService.configuration | indent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mdac-service
+  namespace: {{ .Values.namespace }}
+spec:
+  # Token buckets are process-local; keep one instance, including during updates.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mdac-service
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ .Values.mdacService.configuration | sha256sum | quote }}
+      labels:
+        app: mdac-service
+    spec:
+      # Service variables such as MDAC_SERVICE_PORT collide with MDAC_ config.
+      enableServiceLinks: false
+      containers:
+        - name: mdac-service
+          image: "{{ .Values.mdacService.image.repository }}:{{ .Values.mdacService.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          readinessProbe:
+            periodSeconds: 1
+            failureThreshold: 30
+            httpGet:
+              port: http
+              path: /api/v1/healthcheck
+          livenessProbe:
+            httpGet:
+              port: http
+              path: /api/v1/healthcheck
+          env:
+            - name: CONFIG_PATH
+              value: /config/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /config/
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: mdac-service-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mdac-service
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: mdac-service
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+{{- end }}

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -127,3 +127,6 @@ rustSysdbService:
     requests:
       cpu: 100m
       memory: 128Mi
+
+mdacService:
+  enabled: true

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -141,3 +141,9 @@ rustSysdbService:
     requests:
       cpu: '1000m'
       memory: '512Mi'
+
+mdacService:
+  enabled: false
+  image:
+    repository: 'mdac-service'
+    tag: 'latest'

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -94,7 +94,7 @@ ENV EXCLUDED_PACKAGES="chromadb_rust_bindings chromadb-js-bindings chroma-benchm
 # Packages whose bins we ship in images. Used for `cargo chef cook -p ...`
 # because cook does not support `--exclude` (LukeMathWalker/cargo-chef#181);
 # cooking the full workspace would also pull in pyo3/napi build deps.
-ENV COOK_PACKAGES="chroma-cli garbage_collector chroma-load chroma-log-service s3heap-service worker rust-sysdb spanner-migrations"
+ENV COOK_PACKAGES="chroma-cli garbage_collector chroma-load chroma-log-service s3heap-service worker rust-sysdb spanner-migrations mdac-service"
 
 # --- Dependency compile (durable layer, keyed on recipe.json) ----------------
 # Note: cache mounts are kept ONLY for the crate download dirs (registry/git);
@@ -138,7 +138,7 @@ RUN --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
   fi && \
   build_dir=$( [ "$RELEASE_MODE" = "1" ] && echo release || echo debug ) && \
   build_dir=$( [ "${ADDRESS_SANITIZER}" = "1" ] && echo "x86_64-unknown-linux-gnu/${build_dir}" || echo "${build_dir}" ) && \
-  for bin in chroma garbage_collector_service chroma-load log_service heap_tender_service query_service compaction_service work_queue_service fn_consumer sysdb_service spanner_migration; do \
+  for bin in chroma garbage_collector_service chroma-load log_service heap_tender_service query_service compaction_service work_queue_service fn_consumer sysdb_service spanner_migration token_bucket_service; do \
   cp "target/${build_dir}/${bin}" "./${bin}"; \
   done
 
@@ -204,3 +204,8 @@ ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./sysdb_service" ]
 FROM runner AS rust-sysdb-migration
 COPY --from=builder /chroma/spanner_migration .
 ENTRYPOINT ["sh", "-c", "ulimit -c 0 && exec ./spanner_migration" ]
+
+FROM runner AS mdac_service
+COPY --from=builder /chroma/token_bucket_service .
+EXPOSE 8000
+ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./token_bucket_service" ]

--- a/rust/mdac-service/README.md
+++ b/rust/mdac-service/README.md
@@ -12,6 +12,15 @@ Run from the repository root:
 CONFIG_PATH=rust/mdac-service/sample_config.yaml cargo run -p mdac-service --bin token_bucket_service
 ```
 
+`tilt up` starts one `mdac-service` instance in the `chroma` namespace and
+forwards it to `http://localhost:8002`. Tilt loads the same configuration as Modal
+from `rust/mdac-service/config/modal-main.yaml`, including provider rate limits
+and stdout tracing. Config changes trigger a pod restart. Check readiness with:
+
+```sh
+curl --fail http://localhost:8002/api/v1/healthcheck
+```
+
 Test a deployment against Modal's staging environment from the repository root:
 
 ```sh

--- a/rust/mdac-service/src/bin/token_bucket_service.rs
+++ b/rust/mdac-service/src/bin/token_bucket_service.rs
@@ -6,6 +6,20 @@ use tokio::net::TcpListener;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::env::var_os("CONFIG_PATH").map(PathBuf::from);
+    if let Some(path) = &path {
+        eprintln!("MDAC configuration file: {}", path.display());
+        match std::fs::read_to_string(path) {
+            Ok(contents) => eprintln!("{contents}"),
+            Err(error) => eprintln!("Failed to read MDAC configuration: {error}"),
+        }
+    } else {
+        eprintln!("MDAC configuration file: none (CONFIG_PATH is unset)");
+    }
+    let mut overrides: Vec<_> = std::env::vars_os()
+        .filter(|(name, _)| name.to_string_lossy().starts_with("MDAC_"))
+        .collect();
+    overrides.sort_by(|a, b| a.0.cmp(&b.0));
+    eprintln!("MDAC environment overrides: {overrides:#?}");
     let config = Config::load(path.as_deref())?;
     mdac_service::init_otel_tracing(&config);
     let buckets = config.buckets()?;


### PR DESCRIPTION
## Description of changes

Wire the token bucket rate limiter into the local Tilt stack and the
distributed-chroma Helm chart so it runs alongside the other services.

- Add an mdac_service target to the Dockerfile that ships the
  token_bucket_service binary and exposes port 8000.
- Add build/CI plumbing: docker-bake target, Tiltfile custom/docker
  build, resource, port-forward (8002:8000), and group membership.
- Add a Helm template (ConfigMap, Deployment, Service) gated on
  mdacService.enabled; run a single Recreate replica since token
  buckets are process-local, and disable service links to avoid
  MDAC_ env collisions.
- Enable mdacService in values.dev.yaml; default it off in values.yaml.
- Log the resolved config path, file contents, and MDAC_ env overrides
  at startup to aid debugging deployed instances.
- Document the Tilt workflow in the mdac-service README.

## Test plan

CI

## Migration plan

N/A

## Observability plan

Improved:  now logs config on start

## Documentation Changes

N/A

Co-authored-by: AI
