### PR TITLE
[ENH] Enable mypy in CI (#2054)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -283,6 +283,9 @@ jobs:
           pre-commit run --all-files prettier
           pre-commit run --all-files check-yaml
         continue-on-error: true
+      - name: Run mypy
+        shell: bash
+        run: pre-commit run --all-files mypy
       - name: Cargo fmt check
         shell: bash
         run: cargo fmt -- --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
     rev: "v1.10.0"
     hooks:
       - id: mypy
+        exclude: "^(sample_apps|examples)/"
         args:
           [
             --strict,
@@ -58,8 +59,13 @@ repos:
             "hypothesis",
             "pytest",
             "pypika",
-            "numpy",
+            # Pinned: numpy 2 changed its stubs, which both silences the
+            # type: ignore comments in chromadb/utils/results.py and surfaces
+            # ten further errors elsewhere. Unpinned, this hook's result drifts
+            # with whatever numpy pre-commit resolves at env-creation time.
+            "numpy<2",
             "types-protobuf",
+            "types-PyYAML",
             "kubernetes",
           ]
 

--- a/chromadb/chromadb_rust_bindings.pyi
+++ b/chromadb/chromadb_rust_bindings.pyi
@@ -269,7 +269,7 @@ class Bindings:
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         where_document: Optional[str] = None,
-        include: Include = ["metadatas", "documents"],  # type: ignore[list-item]
+        include: Include = ["metadatas", "documents"],
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> GetResponse: ...
@@ -280,7 +280,7 @@ class Bindings:
         n_results: int = 10,
         where: Optional[str] = None,
         where_document: Optional[str] = None,
-        include: Include = ["metadatas", "documents", "distances"],  # type: ignore[list-item]
+        include: Include = ["metadatas", "documents", "distances"],
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> QueryResponse: ...

--- a/chromadb/cli/cli.py
+++ b/chromadb/cli/cli.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from typing import Any, List
 
 import chromadb_rust_bindings
 import requests
@@ -8,8 +9,8 @@ from packaging.version import parse
 import chromadb
 
 
-def build_cli_args(**kwargs):
-    args = []
+def build_cli_args(**kwargs: Any) -> List[str]:
+    args: List[str] = []
     for key, value in kwargs.items():
         if isinstance(value, bool):
             if value:
@@ -19,9 +20,9 @@ def build_cli_args(**kwargs):
     return args
 
 
-def update():
+def update() -> None:
     try:
-        url = f"https://api.github.com/repos/chroma-core/chroma/releases"
+        url = "https://api.github.com/repos/chroma-core/chroma/releases"
         response = requests.get(url)
         response.raise_for_status()
         releases = response.json()
@@ -41,15 +42,12 @@ def update():
         print(
             f"A new version of Chroma is available!\nIf you're using pip, run 'pip install --upgrade chromadb' to upgrade to version {latest}")
 
-    except Exception as e:
+    except Exception:
         print("Couldn't fetch the latest Chroma version")
 
 
-def app():
+def app() -> None:
     args = sys.argv
-    if ["chroma", "update"] in args:
-        update()
-        return
     try:
         chromadb_rust_bindings.cli(args)
     except KeyboardInterrupt:

--- a/chromadb/cli/utils.py
+++ b/chromadb/cli/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import os
 import yaml
@@ -10,7 +10,7 @@ def set_log_file_path(
     """This works with the standard log_config.yml file.
     It will not work with custom log configs that may use different handlers"""
     with open(f"{log_config_path}", "r") as file:
-        log_config = yaml.safe_load(file)
+        log_config = cast(Dict[str, Any], yaml.safe_load(file))
     for handler in log_config["handlers"].values():
         if handler.get("class") == "logging.handlers.RotatingFileHandler":
             handler["filename"] = new_filename

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -126,7 +126,7 @@ class Settings(BaseSettings):  # type: ignore
     def empty_str_to_none(cls, v: Any) -> Optional[int]:
         if isinstance(v, str) and v.strip() == "":
             return None
-        return v
+        return cast(Optional[int], v)
 
     # the number of maximum threads to handle synchronous tasks in the FastAPI server
     chroma_server_thread_pool_size: int = 40

--- a/chromadb/ingest/impl/utils.py
+++ b/chromadb/ingest/impl/utils.py
@@ -1,9 +1,12 @@
 import re
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple
 from uuid import UUID
 
 from chromadb.db.base import SqlDB
-from chromadb.segment import SegmentManager, VectorReader
+from chromadb.segment import VectorReader
+
+if TYPE_CHECKING:
+    from chromadb.segment.impl.manager.local import LocalSegmentManager
 
 topic_regex = r"persistent:\/\/(?P<tenant>.+)\/(?P<namespace>.+)\/(?P<topic>.+)"
 
@@ -21,7 +24,7 @@ def create_topic_name(tenant: str, namespace: str, collection_id: UUID) -> str:
 
 
 def trigger_vector_segments_max_seq_id_migration(
-    db: SqlDB, segment_manager: SegmentManager
+    db: SqlDB, segment_manager: "LocalSegmentManager"
 ) -> None:
     """
     Trigger the migration of vector segments' max_seq_id from the pickled metadata file to SQLite.

--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -59,7 +59,7 @@ class LogService(Producer, Consumer):
         )
         interceptors = [OtelInterceptor(), RetryOnRpcErrorClientInterceptor()]
         self._channel = grpc.intercept_channel(self._channel, *interceptors)
-        self._log_service_stub = LogServiceStub(self._channel)  # type: ignore
+        self._log_service_stub = LogServiceStub(self._channel)
         super().start()
 
     @trace_method("LogService.stop", OpenTelemetryGranularity.ALL)

--- a/chromadb/rate_limit/__init__.py
+++ b/chromadb/rate_limit/__init__.py
@@ -3,7 +3,7 @@ from typing import Awaitable, Callable, TypeVar, Any
 from chromadb.config import Component, System
 
 T = TypeVar("T", bound=Callable[..., Any])
-A = TypeVar("A", bound=Awaitable[Any])
+A = TypeVar("A", bound=Callable[..., Awaitable[Any]])
 
 
 class RateLimitEnforcer(Component):

--- a/chromadb/rate_limit/simple_rate_limit/__init__.py
+++ b/chromadb/rate_limit/simple_rate_limit/__init__.py
@@ -2,11 +2,11 @@ from overrides import override
 from typing import Any, Awaitable, Callable, TypeVar
 from functools import wraps
 
-from chromadb.rate_limit import RateLimitEnforcer
+from chromadb.rate_limit import AsyncRateLimitEnforcer, RateLimitEnforcer
 from chromadb.config import System
 
 T = TypeVar("T", bound=Callable[..., Any])
-A = TypeVar("A", bound=Awaitable[Any])
+A = TypeVar("A", bound=Callable[..., Awaitable[Any]])
 
 
 class SimpleRateLimitEnforcer(RateLimitEnforcer):
@@ -26,7 +26,7 @@ class SimpleRateLimitEnforcer(RateLimitEnforcer):
         return wrapper  # type: ignore
 
 
-class SimpleAsyncRateLimitEnforcer(RateLimitEnforcer):
+class SimpleAsyncRateLimitEnforcer(AsyncRateLimitEnforcer):
     """
     A naive implementation of a rate limit enforcer that allows all requests.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,28 @@ mypy_path = "rust/python_bindings"
 module = ["chromadb.proto.*"]
 ignore_errors = true
 
+# Modules that are not yet clean under `mypy --strict`. The mypy pre-commit
+# hook runs in CI (see .github/workflows/pr.yml), so every module NOT listed
+# here is type-checked on each PR and must stay clean. These are silenced only
+# so that enforcement can start now instead of waiting on one large sweep;
+# the list is meant to shrink. Remove an entry and fix what it surfaces.
+[[tool.mypy.overrides]]
+module = [
+    "chromadb.api.*",
+    "chromadb.db.*",
+    "chromadb.execution.*",
+    "chromadb.segment.*",
+    "chromadb.server.*",
+    "chromadb.telemetry.*",
+    "chromadb.test.*",
+    "chromadb.utils.embedding_functions.*",
+    # bin/ helper scripts, checked by the hook but not part of the package
+    "generate_cloudformation",
+    "merge_python_test_inventory",
+    "rust_python_compat_test",
+]
+ignore_errors = true
+
 [project.scripts]
 chroma = "chromadb.cli.cli:app"
 


### PR DESCRIPTION
Closes #2054

The mypy pre-commit hook has been configured but unenforced: `pr.yml` runs twelve hooks by name and mypy is not among them. Running it against `main` reports **542 errors across 88 files** — too many to fix in one change — so this starts enforcement now and stages the cleanup.

### Approach

Modules that are not yet clean are listed under a new `ignore_errors` override in `pyproject.toml`. Everything else is checked on every PR and must stay clean; shrinking that list is the follow-up work.

mypy runs as its own step rather than joining the existing pre-commit block, because that block is `continue-on-error: true` and would not gate a PR.

### Three latent defects the type checker surfaced

- **`SimpleAsyncRateLimitEnforcer` subclassed the sync `RateLimitEnforcer`**, so the FastAPI server's `require(AsyncRateLimitEnforcer)` returned an object that was not an instance of it. On `main`, `isinstance(inst, AsyncRateLimitEnforcer)` is `False`; it is `True` after.
- **The `A` TypeVar was bound to `Awaitable[Any]`**, but an async function is a callable *returning* an awaitable — which is why `wraps(func)` and `func(...)` did not type check. Now bound to `Callable[..., Awaitable[Any]]`.
- **`trigger_vector_segments_max_seq_id_migration` was annotated as taking a `SegmentManager`** and called `get_segment()` on it. That method lives on `LocalSegmentManager`; `DistributedSegmentManager` has no such attribute, so the interface could not simply gain it. The migration only queries `hnsw-local-persisted` segments, so the parameter is narrowed instead.

### Verification

On Python 3.11 with the hook's own dependency set:

| | `main` | this branch |
| --- | --- | --- |
| `mypy --strict` | 542 errors in 88 files | **no issues in 238 files** |
| `flake8` on changed files | 66 findings | 63 findings |

The remaining flake8 findings predate this change (there is no flake8 config in the repo, so it runs at the 79-column default). `chromadb/test/test_cli.py` needs the compiled `chromadb_rust_bindings` extension and was not run.

---

## Three things I would rather you decide than assume

**1. Should `update()` be deleted?**

`chromadb/cli/cli.py` had a dead dispatch:

```python
if ["chroma", "update"] in args:   # args is list[str]; always False
```

That compares a list against the *elements* of a `list[str]`, so the Python `update()` has been unreachable. The Rust CLI already owns the `update` subcommand, so I removed the dead dispatch rather than activating it, which keeps behaviour identical.

That leaves `update()` itself unreferenced — `grep` finds no caller, and `chromadb/test/test_cli.py` imports only `build_cli_args`. I left it in place because deleting public-ish surface is your call, not mine. Say the word and I will drop it.

**2. Is `continue-on-error: true` on the other twelve hooks deliberate?**

The existing `Run pre-commit` step runs trailing-whitespace, mixed-line-ending, end-of-file-fixer, requirements-txt-fixer, check-xml, check-merge-conflict, check-case-conflict, check-docstring-first, black, flake8, prettier and check-yaml — all under `continue-on-error: true`, so none of them can fail a PR today.

I did not change that, since flipping twelve hooks to gating is a much bigger decision than this issue. But if it is an accident rather than a policy, it is worth knowing, because it means `black` and `flake8` are advisory right now.

**3. Is pinning `numpy<2` in the hook acceptable?**

This one is mine, not part of the original change, and it is the part I am least sure you will want.

The hook pinned no numpy version, so pre-commit resolved whatever was newest when it built the env — and the result moved with it. On numpy 2 the stub changes silence the two `# type: ignore` comments in `chromadb/utils/results.py` *and* surface ten further errors in `distance_functions.py`, `base_types.py` and `ingest/__init__.py`. On numpy 1 the tree is clean.

So without a pin this gate is non-deterministic: it would pass or fail depending on when the CI env was built. I pinned `numpy<2` to make it deterministic and left `results.py` untouched.

**Being explicit about the cost:** the pin defers those ten numpy-2 errors rather than fixing them, and it freezes stub behaviour until someone lifts it. I am happy to do it the other way instead — drop the pin, fix the ten, and delete the two now-redundant `type: ignore` comments — if you would rather not carry a pin. That is a larger diff, which is why I did not assume it.
