### PR TITLE
[BUG](benchmark): Flush a cached dataset file before renaming it into place

### DIFF
--- a/rust/benchmark/src/datasets/gist.rs
+++ b/rust/benchmark/src/datasets/gist.rs
@@ -31,7 +31,7 @@ impl RecordDataset for GistDataset {
             |mut writer| async move {
                 let mut file = tokio::fs::File::open(current_path).await?;
                 tokio::io::copy(&mut file, &mut writer).await?;
-                Ok(())
+                Ok(writer)
             },
         )
         .await?;

--- a/rust/benchmark/src/datasets/ms_marco_queries.rs
+++ b/rust/benchmark/src/datasets/ms_marco_queries.rs
@@ -47,7 +47,7 @@ impl RecordDataset for MicrosoftMarcoQueriesDataset {
                 );
                 tokio::io::copy(&mut stream_reader, &mut writer).await?;
 
-                Ok(())
+                Ok(writer)
             }
             .boxed()
         })

--- a/rust/benchmark/src/datasets/scidocs.rs
+++ b/rust/benchmark/src/datasets/scidocs.rs
@@ -57,7 +57,7 @@ impl RecordDataset for SciDocsDataset {
                     let mut decoder = GzipDecoder::new(stream_reader);
                     tokio::io::copy(&mut decoder, &mut writer).await?;
 
-                    Ok(())
+                    Ok(writer)
                 }
                 .boxed()
             })

--- a/rust/benchmark/src/datasets/sift.rs
+++ b/rust/benchmark/src/datasets/sift.rs
@@ -41,7 +41,7 @@ impl Sift1MData {
 
                 writer.write_all(&response.bytes().await?).await?;
 
-                Ok(())
+                Ok(writer)
             },
         ).await?;
         let query = get_or_populate_cached_dataset_file(
@@ -66,7 +66,7 @@ impl Sift1MData {
 
                 writer.write_all(&response.bytes().await?).await?;
 
-                Ok(())
+                Ok(writer)
             },
         ).await?;
         let ground = get_or_populate_cached_dataset_file(
@@ -91,7 +91,7 @@ impl Sift1MData {
 
                 writer.write_all(&response.bytes().await?).await?;
 
-                Ok(())
+                Ok(writer)
             },
         ).await?;
         Ok(Self {

--- a/rust/benchmark/src/datasets/types.rs
+++ b/rust/benchmark/src/datasets/types.rs
@@ -176,7 +176,7 @@ where
                     let serialized = bincode::serialize(&frozen_query_subset)?;
                     file.write_all(&serialized).await?;
 
-                    Ok(())
+                    Ok(file)
                 },
             )
             .await?;

--- a/rust/benchmark/src/datasets/util.rs
+++ b/rust/benchmark/src/datasets/util.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_tempfile::TempFile;
 use std::{future::Future, path::PathBuf};
-use tokio::io::AsyncWrite;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 pub(crate) fn get_dir_for_persistent_dataset_files() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("dataset_files")
@@ -24,6 +24,18 @@ async fn get_dataset_cache_path(
 }
 
 /// Calls the populate callback to create a cached dataset file if it doesn't exist, and returns the path to the cached file.
+///
+/// The callback returns the writer it was given so that this function can flush
+/// it. Two properties depend on that, and both break silently without it:
+///
+/// 1. The bytes the callback wrote are in the file before it is renamed into
+///    place. A file handle does not finish its pending writes just because it
+///    goes out of scope, and its own documentation requires a flush before it
+///    is dropped for that reason. Without one the rename can publish a short
+///    file, and the next reader gets a truncated one rather than an error.
+/// 2. A caller cannot forget. Taking the writer back is what makes the flush
+///    this function's responsibility instead of every callback's, which is why
+///    the callback returns it rather than being trusted to flush it.
 pub(crate) async fn get_or_populate_cached_dataset_file<F, Fut>(
     dataset_name: impl AsRef<str>,
     file_name: impl AsRef<str>,
@@ -32,7 +44,7 @@ pub(crate) async fn get_or_populate_cached_dataset_file<F, Fut>(
 ) -> Result<PathBuf>
 where
     F: FnOnce(Box<dyn AsyncWrite + Unpin + Send>) -> Fut,
-    Fut: Future<Output = Result<()>>,
+    Fut: Future<Output = Result<Box<dyn AsyncWrite + Unpin + Send>>>,
 {
     let dataset_dir = get_dataset_cache_path(dataset_name.as_ref(), cache_dir).await?;
     let file_path = dataset_dir.join(file_name.as_ref());
@@ -40,12 +52,78 @@ where
     if !file_path.exists() {
         // We assume that dataset creation was successful if the file exists, so we use a temporary file to avoid scenarios where the file is partially written and then the callback fails.
         let temp = TempFile::new().await?;
-        populate(Box::new(
+        let mut writer = populate(Box::new(
             temp.try_clone().await.expect("Failed to clone file handle"),
         ))
         .await?;
+        writer.flush().await?;
+        drop(writer);
         tokio::fs::rename(temp.file_path(), &file_path).await?;
     }
 
     Ok(file_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_tempfile::TempDir;
+
+    /// A cached file holds every byte the callback wrote.
+    ///
+    /// This covers the round trip, not the race it guards against. Losing the
+    /// tail of a write depends on a pending operation still being in flight
+    /// when the handle is dropped, which a test cannot force: on an idle
+    /// machine the write lands first and the assertion passes either way. The
+    /// flush is required by the file handle's own contract rather than by this
+    /// test.
+    #[tokio::test]
+    async fn a_cached_file_holds_every_byte_the_callback_wrote() {
+        let dir = TempDir::new().await.unwrap();
+        let payload = vec![7u8; 1 << 20];
+        let expected = payload.clone();
+
+        let path = get_or_populate_cached_dataset_file(
+            "flush_test",
+            "payload.bin",
+            Some(dir.to_path_buf()),
+            |mut writer| async move {
+                writer.write_all(&payload).await?;
+                Ok(writer)
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), expected);
+    }
+
+    /// A second call returns the first call's file rather than repopulating it.
+    #[tokio::test]
+    async fn an_existing_cached_file_is_not_repopulated() {
+        let dir = TempDir::new().await.unwrap();
+
+        let write = |bytes: Vec<u8>| {
+            let dir = dir.to_path_buf();
+            async move {
+                get_or_populate_cached_dataset_file(
+                    "flush_test",
+                    "once.bin",
+                    Some(dir),
+                    |mut writer| async move {
+                        writer.write_all(&bytes).await?;
+                        Ok(writer)
+                    },
+                )
+                .await
+                .unwrap()
+            }
+        };
+
+        let first = write(b"first".to_vec()).await;
+        let second = write(b"second".to_vec()).await;
+
+        assert_eq!(first, second);
+        assert_eq!(tokio::fs::read(&second).await.unwrap(), b"first");
+    }
 }

--- a/rust/benchmark/src/datasets/wikipedia.rs
+++ b/rust/benchmark/src/datasets/wikipedia.rs
@@ -61,7 +61,7 @@ impl RecordDataset for WikipediaDataset {
                     let mut decoder = BzDecoder::new(stream_reader);
                     tokio::io::copy(&mut decoder, &mut writer).await?;
 
-                    Ok(())
+                    Ok(writer)
                 }
                 .boxed()
             },


### PR DESCRIPTION
A benchmark dataset file is built once and cached: a callback writes the contents to a temporary file, that file is renamed to the cached path, and every later run reads the path instead of rebuilding.

## The defect

The callback was handed a file handle and trusted to have finished with it when it returned. A handle does not finish its pending writes just because it goes out of scope. Tokio's own documentation says so directly: a file is not closed immediately while it has operations that have not completed, and you should flush it before dropping it.

So the rename could publish a file whose tail had not been written. The next reader gets a short file rather than an error, which surfaces later as a deserialization failure with no obvious connection to the cause.

It depends on a write still being in flight when the handle is dropped, so it appears under load and not on an idle machine.

## Why it is worth fixing now

It is the cause of a `Rust tests` failure seen on several open pull requests, in `test_frozen_query_subset`, which writes a cache file and immediately reads it back and reports `unexpected end of file`. That test passes locally on an idle machine, on the default branch and on the branches where continuous integration failed.

All eight call sites had the same omission, which is the shape of a problem that wants fixing in one place rather than eight.

## The change

The callback now returns the writer it was given, and the helper flushes it before the rename. Returning the writer is the point: it moves the obligation from every callback to the one function that owns the file's lifecycle, so a new caller cannot omit it. The eight call sites each return their writer instead of the unit value.

## On the tests

The two tests added cover the round trip, not the race. A test cannot force a pending write to still be in flight, so on an idle machine they pass with or without the flush, and I have verified that rather than assuming it. The justification for the flush is the file handle's documented contract, not a failing test. I would rather say that than imply coverage this does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)