### PR TITLE
[BUG](wal3): Bound the backoff test by elapsed time, not a fixed duration

### DIFF
--- a/rust/wal3/src/backoff.rs
+++ b/rust/wal3/src/backoff.rs
@@ -10,10 +10,10 @@
 //! │                            HHHHHHHHHHHHHHHHHHHHH
 //! │                            HHHHHHHHHHHHHHHHHHHHH
 //! ├────────────┐              ┌─────────────────────
-//! │            │DDDDDDDDDDDDDD│          
-//! │            │DDDDDDDDDDDDDD│          
-//! │            │DDDDDDDDDDDDDD│          
-//! │            └──────────────┘          
+//! │            │DDDDDDDDDDDDDD│
+//! │            │DDDDDDDDDDDDDD│
+//! │            │DDDDDDDDDDDDDD│
+//! │            └──────────────┘
 //! └────────────────────────────────────────────────
 //! ```
 //!
@@ -101,12 +101,34 @@ impl ExponentialBackoff {
 mod tests {
     use super::*;
 
+    /// The upper bound `next` can return at this instant.
+    ///
+    /// `next` scales the time since construction by the ratio of throughput to
+    /// reserve capacity, then by a random fraction below one, so the scaled
+    /// elapsed time is the bound that holds on any machine. Sampling it after
+    /// the call keeps it an upper bound, since elapsed time only grows.
+    fn ceiling(backoff: &ExponentialBackoff) -> Duration {
+        backoff
+            .start
+            .elapsed()
+            .mul_f64(backoff.throughput_ops_sec / backoff.reserve_capacity)
+    }
+
     #[test]
     fn test_with_exponential_backoff() {
         let exp_backoff = ExponentialBackoff::new(1_000.0, 100.0);
-        assert!(exp_backoff.next() < Duration::from_secs(1));
-        assert!(exp_backoff.next() < Duration::from_secs(1));
-        assert!(exp_backoff.next() < Duration::from_secs(1));
+        // A fixed bound here would hold only while construction and these calls
+        // stay within a few milliseconds of each other, which a loaded machine
+        // does not promise: the window this backs off over is the elapsed time
+        // itself, so a slow scheduler raises the value being asserted about.
+        for _ in 0..3 {
+            let backoff = exp_backoff.next();
+            let ceiling = ceiling(&exp_backoff);
+            assert!(
+                backoff <= ceiling,
+                "backoff {backoff:?} exceeded the scaled recovery window {ceiling:?}"
+            );
+        }
         std::thread::sleep(Duration::from_secs(10));
         let mut durations = (0..100).map(|_| exp_backoff.next()).collect::<Vec<_>>();
         durations.sort();


### PR DESCRIPTION
`ExponentialBackoff::next` backs off over the time since the backoff was constructed. It scales that elapsed time by the ratio of throughput to reserve capacity, then by a random fraction below one.

## The defect

The test asserted that the first three values were each under one second. That holds only while construction and the calls stay within a few milliseconds of each other, because the elapsed time is itself the quantity being scaled. A machine that schedules the test slowly raises the value the assertion is made about, so the test fails for a reason unrelated to the code it covers.

It failed that way on the `Rust tests` job of an unrelated pull request, with `assertion failed: exp_backoff.next() < Duration::from_secs(1)`.

## The change

Assert the bound the implementation actually guarantees: a returned value never exceeds the scaled elapsed time. The bound is sampled after the call so it stays an upper bound, since elapsed time only grows.

The second half of the test, which sleeps and then checks the mean of a hundred samples, is untouched. Its elapsed time is dominated by the sleep, so it does not have this problem.

## On whether the test still catches anything

I checked rather than assumed. Making `next` return more than its recovery window makes this assertion fail:

```
backoff 3.163ms exceeded the scaled recovery window 1.66042ms
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)