### PR TITLE
[BUG](worker): Grow KNN result containers lazily to avoid aborts on huge limits

### DIFF
--- a/rust/types/src/execution/operator.rs
+++ b/rust/types/src/execution/operator.rs
@@ -471,8 +471,10 @@ impl Merge {
             .filter_map(|(idx, itr)| itr.next().map(|rec| (rec, idx)))
             .collect::<BinaryHeap<_>>();
 
-        let mut seen = HashSet::with_capacity(self.k as usize);
-        let mut fusion = Vec::with_capacity(self.k as usize);
+        // `k` is request-controlled and can be far larger than the input, so
+        // grow lazily instead of preallocating containers sized by it.
+        let mut seen = HashSet::new();
+        let mut fusion = Vec::new();
         while let Some((m, idx)) = max_heap.pop() {
             if self.k <= fusion.len() as u32 {
                 break;
@@ -3859,5 +3861,22 @@ mod tests {
                 Key::field("sparse_c"),
             ]
         );
+    }
+
+    #[test]
+    fn test_merge_with_request_sized_k() {
+        // `k` arrives from query `n_results` and search knn limits, so it can be
+        // far larger than the input. `merge` must not preallocate k-sized
+        // containers and must still return the full deduplicated input.
+        let merge = Merge { k: u32::MAX };
+        let out: Vec<u64> = merge.merge(vec![vec![3, 1, 2], vec![2, 4]]);
+        assert_eq!(out, vec![3, 2, 4, 1]);
+
+        let with_duplicates: Vec<u64> = merge.merge(vec![vec![1, 1, 2]]);
+        assert_eq!(with_duplicates, vec![1, 2]);
+
+        // k smaller than the input still truncates.
+        let truncated: Vec<u64> = Merge { k: 2 }.merge(vec![vec![1, 2], vec![3, 4]]);
+        assert_eq!(truncated, vec![3, 4]);
     }
 }

--- a/rust/worker/src/execution/operators/knn_log.rs
+++ b/rust/worker/src/execution/operators/knn_log.rs
@@ -97,7 +97,9 @@ impl Operator<KnnLogInput, KnnOutput> for Knn {
             &self.embedding
         };
 
-        let mut max_heap = BinaryHeap::with_capacity(self.fetch as usize);
+        // `fetch` is request-controlled and can be far larger than the number
+        // of logs, so grow the heap lazily instead of preallocating for it.
+        let mut max_heap = BinaryHeap::new();
 
         for log in &logs {
             if !matches!(

--- a/rust/worker/src/execution/operators/sparse_log_knn.rs
+++ b/rust/worker/src/execution/operators/sparse_log_knn.rs
@@ -102,8 +102,10 @@ impl Operator<SparseLogKnnInput, SparseLogKnnOutput> for SparseLogKnn {
             materialize_logs(&record_segment_reader, input.logs.clone(), None, &plan).await?;
 
         // We need the smallest results, so we keep a max heap to track the largest of them
-        // so that it can be replaced if we found a smaller one
-        let mut max_heap = BinaryHeap::with_capacity(self.limit as usize);
+        // so that it can be replaced if we found a smaller one.
+        // `limit` is request-controlled and can be far larger than the number of
+        // logs, so grow the heap lazily instead of preallocating for it.
+        let mut max_heap = BinaryHeap::new();
         for log in &logs {
             if !matches!(
                 log.get_operation(),


### PR DESCRIPTION
## Description of changes

A query request controls the KNN fetch value (`n_results` on `/query`) and the search KNN `limit` (in `$knn`) directly, and nothing bounds them today: `Merge::merge` preallocates a hash set and a vector sized by `k`, and the KNN log and sparse log KNN operators preallocate their heaps sized by `fetch`/`limit`. A ~60-byte request with `n_results=4294967295` therefore makes hashbrown attempt a ~77 GB table allocation and aborts the query service. Related to #7720, which fixes the same abort class on the regex literal-expansion path; also in the same family as #7225/#7646 (HNSW config bounds).

- Improvements & Bug fixes
  - `rust/types/src/execution/operator.rs`: `Merge::merge` grows `seen`/`fusion` lazily instead of preallocating for `k`.
  - `rust/worker/src/execution/operators/knn_log.rs` and `sparse_log_knn.rs`: build the max heap with `BinaryHeap::new()` instead of preallocating for `fetch`/`limit`.
  - None of these containers ever holds more elements than the operator's input, so results and behavior are otherwise unchanged.

## Test plan

- [x] Tests pass locally with `cargo test` for rust

- New unit test `test_merge_with_request_sized_k` in `rust/types/src/execution/operator.rs`: `Merge { k: u32::MAX }` merges and deduplicates without preallocating, `k` truncation still applies.
- `cargo test -p chroma-types --lib`: 427 passed, 0 failed.
- The worker-side changes are allocator-API equivalents (`BinaryHeap::with_capacity(n)` -> `BinaryHeap::new()`); the worker test suite runs in CI.

## Migration plan

None. No schema, config, or API changes.

## Observability plan

None needed; allocation sizes now track the operator input instead of the request-declared limit.

## Documentation Changes

None.