### PR TITLE
[BUG] Validate and normalize embedding function input (#3566)

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -51,7 +51,7 @@ from inspect import signature
 from tenacity import retry
 from abc import abstractmethod
 import pybase64
-from functools import lru_cache
+from functools import lru_cache, wraps
 import struct
 import math
 import re
@@ -826,6 +826,31 @@ class ReadLevel(str, Enum):
     INDEX_AND_BOUNDED_WAL = "index_and_bounded_wal"
 
 
+def _validate_and_normalize_ef_input(input: Any) -> Any:
+    """Validates and normalizes input to embedding functions."""
+    if input is None:
+        raise ValueError(
+            "Expected input to be a non-empty string, image, or list, got None"
+        )
+
+    if is_document(input) or is_image(input):
+        return [input]
+
+    if not isinstance(input, (list, tuple)):
+        raise ValueError(
+            f"Expected input to be a list or str, got {type(input).__name__}"
+        )
+
+    if len(input) == 0:
+        return []
+
+    for item in input:
+        if not is_document(item) and not is_image(item):
+            raise ValueError(f"Expected document to be a str, got {item}")
+
+    return list(input)
+
+
 # TODO: make warnings prettier and add link to migration docs
 @runtime_checkable
 class EmbeddingFunction(Protocol[D]):
@@ -867,12 +892,32 @@ class EmbeddingFunction(Protocol[D]):
         # Raise an exception if __call__ is not defined since it is expected to be defined
         call = getattr(cls, "__call__")
 
+        @wraps(call)
         def __call__(self: EmbeddingFunction[D], input: D) -> Embeddings:
-            result = call(self, input)
+            normalized_input = cast(D, _validate_and_normalize_ef_input(input))
+            if len(normalized_input) == 0:
+                return []
+            result = call(self, normalized_input)
             assert result is not None
             return validate_embeddings(cast(Embeddings, normalize_embeddings(result)))
 
         setattr(cls, "__call__", __call__)
+
+        if "embed_query" in cls.__dict__:
+            embed_query = getattr(cls, "embed_query")
+
+            @wraps(embed_query)
+            def _embed_query(self: EmbeddingFunction[D], input: D) -> Embeddings:
+                normalized_input = cast(D, _validate_and_normalize_ef_input(input))
+                if len(normalized_input) == 0:
+                    return []
+                result = embed_query(self, normalized_input)
+                assert result is not None
+                return validate_embeddings(
+                    cast(Embeddings, normalize_embeddings(result))
+                )
+
+            setattr(cls, "embed_query", _embed_query)
 
     def embed_with_retries(
         self, input: D, **retry_kwargs: Dict[str, Any]

--- a/chromadb/test/api/test_types.py
+++ b/chromadb/test/api/test_types.py
@@ -103,3 +103,55 @@ def test_embedding_function_results_format_when_response_is_invalid() -> None:
         from chromadb.api.types import normalize_embeddings
 
         normalize_embeddings(result)
+
+
+def test_embedding_function_input_validation_and_normalization() -> None:
+    @register_embedding_function
+    class MockIdentityEF(EmbeddingFunction[Documents]):
+        def __init__(self) -> None:
+            pass
+
+        @staticmethod
+        def name() -> str:
+            return "mock_identity"
+
+        @staticmethod
+        def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+            return MockIdentityEF()
+
+        def get_config(self) -> Dict[str, Any]:
+            return {}
+
+        @staticmethod
+        def validate_config(config: Dict[str, Any]) -> None:
+            pass
+
+        def validate_config_update(
+            self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+        ) -> None:
+            pass
+
+        def __call__(self, input: Documents) -> Embeddings:
+            # Under the wrapper, input must always arrive as a List[Document]
+            assert isinstance(input, list)
+            return [np.ones(10, dtype=np.float32) for _ in input]
+
+    ef = MockIdentityEF()
+
+    res_str = ef("test sentence")  # type: ignore[arg-type]
+    assert len(res_str) == 1
+    assert res_str[0].shape == (10,)
+
+    res_list = ef(["doc1", "doc2", "doc3"])
+    assert len(res_list) == 3
+
+    assert ef([]) == []
+
+    with pytest.raises(ValueError, match="Expected input to be a non-empty string"):
+        ef(None)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Expected input to be a list or str"):
+        ef(42)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Expected document to be a str"):
+        ef(["valid", 123])  # type: ignore[list-item]

--- a/chromadb/test/ef/test_onnx_mini_lm_l6_v2.py
+++ b/chromadb/test/ef/test_onnx_mini_lm_l6_v2.py
@@ -202,3 +202,54 @@ class TestONNXMiniLM_L6_V2:
 
         # The similarity between text1 and text2 should be higher than between text1 and text3
         assert sim_1_2 > sim_1_3
+
+    @patch.object(ONNXMiniLM_L6_V2, "_download_model_if_not_exists")
+    @patch.object(ONNXMiniLM_L6_V2, "_forward")
+    def test_single_string_input_normalizes_to_single_embedding(
+        self, mock_forward: MagicMock, mock_download: MagicMock
+    ) -> None:
+        ef = ONNXMiniLM_L6_V2()
+        text = "hello world"
+
+        mock_forward.side_effect = lambda docs: np.ones(
+            (len(docs), 384), dtype=np.float32
+        )
+
+        single_str_result = ef(text)  # type: ignore[arg-type]
+        assert mock_forward.call_args[0][0] == [text]
+
+        list_result = ef([text])
+        assert isinstance(single_str_result, list)
+        assert len(single_str_result) == 1
+        assert len(single_str_result[0]) == 384
+
+        np.testing.assert_allclose(single_str_result[0], list_result[0], atol=1e-5)
+
+    @patch.object(ONNXMiniLM_L6_V2, "_download_model_if_not_exists")
+    @patch.object(ONNXMiniLM_L6_V2, "_forward")
+    def test_embed_query_with_single_string(
+        self, mock_forward: MagicMock, mock_download: MagicMock
+    ) -> None:
+        ef = ONNXMiniLM_L6_V2()
+        query = "search query"
+        mock_forward.side_effect = lambda docs: np.ones(
+            (len(docs), 384), dtype=np.float32
+        )
+
+        embeddings = ef.embed_query(query)  # type: ignore[arg-type]
+        assert mock_forward.call_args[0][0] == [query]
+        assert isinstance(embeddings, list)
+        assert len(embeddings) == 1
+        assert len(embeddings[0]) == 384
+
+    def test_invalid_input_types_raise_value_error(self) -> None:
+        ef = ONNXMiniLM_L6_V2()
+
+        with pytest.raises(ValueError, match="Expected input to be a non-empty string"):
+            ef(None)  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError, match="Expected input to be a list or str"):
+            ef(12345)  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError, match="Expected document to be a str"):
+            ef(["valid document", 999])  # type: ignore[list-item]


### PR DESCRIPTION
## Description of changes

Closes #3566

When passing a single string or image directly to an embedding function (e.g. `ef("hello world")` or `ef.embed_query("hello world")`), tokenizers iterate over characters (`['h', 'e', 'l', ...]`), generating character-level embeddings instead of a single document embedding.

This PR wraps inputs at the `EmbeddingFunction.__init_subclass__` level:
- Single `str` or `Image` inputs are coerced to `[input]` before `__call__` or `embed_query` runs.
- Empty list inputs (`[]`) return `[]` directly without calling the underlying model.
- Non-string/image scalars (like `int`, `None`) or collections with invalid items raise a `ValueError`.

Because this is handled in `__init_subclass__` alongside the existing output normalization, it applies across built-in functions and any registered custom embedding functions.

## Test plan

Added unit tests in `test_types.py` and `test_onnx_mini_lm_l6_v2.py`:
- Verified passing a raw `str` to `ONNXMiniLM_L6_V2` yields 1 embedding vector of dimension 384 identical to passing `[text]`.
- Verified `embed_query` with a raw string.
- Verified empty list fast-path and error raising for `None`, non-string scalars, and invalid elements in lists.

Passed locally:
- `pytest chromadb/test/api/test_types.py chromadb/test/ef/test_onnx_mini_lm_l6_v2.py`
- `flake8 chromadb/api/types.py chromadb/test/api/test_types.py chromadb/test/ef/test_onnx_mini_lm_l6_v2.py`

## Documentation Changes

N/A
