### PR TITLE
[DOC]: Fix stale TS method names in docs

### DIFF
--- a/docs/mintlify/docs/overview/getting-started.mdx
+++ b/docs/mintlify/docs/overview/getting-started.mdx
@@ -389,7 +389,7 @@ summary.
       name: "my_collection",
     });
 
-    // switch `addRecords` to `upsertRecords` to avoid adding the same documents every time
+    // switch `add` to `upsert` to avoid adding the same documents every time
     await collection.upsert({
       documents: [
         "This is a document about pineapple",


### PR DESCRIPTION
The comment above the `upsert` call in the TypeScript getting-started guide references `addRecords`/`upsertRecords`, but `Collection`'s actual methods are `add`/`upsert` (see `clients/js/packages/chromadb-core/src/Collection.ts:81,116`) — the equivalent Python snippet just above it correctly says "switch `add` to `upsert`".

Verified by reading the current `Collection` class source, which only defines `add` and `upsert`, not `addRecords`/`upsertRecords`.

This pull request was prepared with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)